### PR TITLE
Add per-loop trace and per-function spans to sample debugger demo

### DIFF
--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -20,11 +20,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2786 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xd1166a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1222a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2787 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xd116a5", Frameless: false}]
+              InjectionPoints: [{PC: "0xd12265", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -40,11 +40,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2621 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0xd0b30a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b90a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2622 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0xd0b345", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b945", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -66,11 +66,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2624 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0xd0b3aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b9aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2625 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0xd0b3dd", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b9dd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -91,11 +91,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2755 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xd0fc6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1074e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2756 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xd0fd22", Frameless: false}]
+              InjectionPoints: [{PC: "0xd10802", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -183,7 +183,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2633 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xd0bc40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -248,11 +248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2657 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xd0dc20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e500", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2658 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xd0dc32", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e512", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -274,11 +274,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2585 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0xd06760", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06960", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2586 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0xd0677e", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0697e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -344,7 +344,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2784 EventRootType Probe[main.testByteSliceInvalidUtf8]
-              InjectionPoints: [{PC: "0xd10f20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -366,7 +366,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2785 EventRootType Probe[main.testByteSliceMultibyteUtf8]
-              InjectionPoints: [{PC: "0xd10f40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -387,7 +387,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2600 EventRootType Probe[main.testCaptureContextImpl]
-              InjectionPoints: [{PC: "0xd07560", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07860", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -414,11 +414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2808 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xd11b20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12900", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2809 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xd11b42", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12922", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -426,7 +426,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: ""
       segments: []
@@ -438,15 +438,15 @@ Probes:
             - Kind: Line
               Type: 2872 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xd0ab2e"
+                - PC: "0xd0b02e"
                   Frameless: false
-                - PC: "0xd0abb1"
+                - PC: "0xd0b0b1"
                   Frameless: false
-                - PC: "0xd0acf2"
+                - PC: "0xd0b1f2"
                   Frameless: false
-                - PC: "0xd0ad7c"
+                - PC: "0xd0b27c"
                   Frameless: false
-                - PC: "0xd0ae4f"
+                - PC: "0xd0b34f"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -455,7 +455,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       when: {dsl: x == 3, json: {eq: [{ref: x}, 3]}}
       sampling: {snapshotsPerSecond: 100}
       template: ""
@@ -468,15 +468,15 @@ Probes:
             - Kind: Line
               Type: 2873 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xd0ab2e"
+                - PC: "0xd0b02e"
                   Frameless: false
-                - PC: "0xd0abb1"
+                - PC: "0xd0b0b1"
                   Frameless: false
-                - PC: "0xd0acf2"
+                - PC: "0xd0b1f2"
                   Frameless: false
-                - PC: "0xd0ad7c"
+                - PC: "0xd0b27c"
                   Frameless: false
-                - PC: "0xd0ae4f"
+                - PC: "0xd0b34f"
                   Frameless: false
               Condition:
                 Type: 6 BaseType bool
@@ -502,7 +502,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: x={x}
       segments: [x=, {json: {ref: x}, dsl: x}]
@@ -514,15 +514,15 @@ Probes:
             - Kind: Line
               Type: 2874 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xd0ab2e"
+                - PC: "0xd0b02e"
                   Frameless: false
-                - PC: "0xd0abb1"
+                - PC: "0xd0b0b1"
                   Frameless: false
-                - PC: "0xd0acf2"
+                - PC: "0xd0b1f2"
                   Frameless: false
-                - PC: "0xd0ad7c"
+                - PC: "0xd0b27c"
                   Frameless: false
-                - PC: "0xd0ae4f"
+                - PC: "0xd0b34f"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -550,7 +550,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2652 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xd0d5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0dca0", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -569,7 +569,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2653 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xd0d5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0dca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -595,7 +595,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2816 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xd11c40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12a20", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -633,7 +633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2659 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xd0dc40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -663,7 +663,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2651 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xd0d580", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0dc60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -692,11 +692,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2720 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xd0eece", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f9ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2721 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xd0ef94", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0fa74", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -718,7 +718,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2667 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xd0e020", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e9e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -740,7 +740,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2592 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0xd06c60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -762,7 +762,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2593 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0xd06c80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -784,7 +784,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2588 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0xd06940", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06b40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -806,7 +806,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2589 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0xd06960", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06b60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -828,7 +828,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2590 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0xd06ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06ce0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -850,7 +850,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2591 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0xd06b00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06d00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -872,7 +872,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2772 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xd10d60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -899,7 +899,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2775 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xd10dc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd118a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -927,7 +927,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2800 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xd117a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -949,7 +949,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2817 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xd11ca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -970,7 +970,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2818 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xd11cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -992,7 +992,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2623 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0xd0b380", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1007,7 +1007,7 @@ Probes:
       where:
         methodName: main.testErrorAtLine
         sourceFile: complex.go
-        lines: ["108"]
+        lines: ["111"]
       tags:
         - config_diff:arch=amd64,toolchain=go1.26rc1
         - skip_integration:arch=arm64,toolchain=go1.25.0
@@ -1026,7 +1026,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2587 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0xd067fb", Frameless: false}]
+              InjectionPoints: [{PC: "0xd069fb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -1054,11 +1054,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2605 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0xd0960a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09b0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2606 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0xd0964c", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09b4c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1080,11 +1080,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2603 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0xd094ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd099ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2604 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0xd0957b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd09a7b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1106,11 +1106,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2615 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0xd0afe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b4e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2616 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0xd0afe5", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b4e5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1132,11 +1132,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2617 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0xd0b004", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b504", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2618 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0xd0b03d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b53d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1151,7 +1151,7 @@ Probes:
       where:
         methodName: main.testFramelessArray
         sourceFile: inlined.go
-        lines: ["93"]
+        lines: ["96"]
       sampling: {snapshotsPerSecond: 100}
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
@@ -1161,7 +1161,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2619 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0xd0b008", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b508", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1183,11 +1183,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2858 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xd14a40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15a40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2859 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd14a47", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15a47", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1201,11 +1201,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2860 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xd14a64", Frameless: false}]
+              InjectionPoints: [{PC: "0xd15a64", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2861 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xd14ab1", Frameless: false}]
+              InjectionPoints: [{PC: "0xd15ab1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1228,11 +1228,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2854 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xd149aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd159aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2855 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xd149b9", Frameless: false}]
+              InjectionPoints: [{PC: "0xd159b9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1246,11 +1246,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2856 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xd149ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xd159ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2857 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xd14a02", Frameless: false}]
+              InjectionPoints: [{PC: "0xd15a02", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1273,14 +1273,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2862 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xd14ac0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15ac0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2863 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xd14ae0"
+                - PC: "0xd15ae0"
                   Frameless: true
-                - PC: "0xd14ae3"
+                - PC: "0xd15ae3"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1295,14 +1295,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2864 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xd14b0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd15b0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2865 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xd14b6b"
+                - PC: "0xd15b6b"
                   Frameless: false
-                - PC: "0xd14b73"
+                - PC: "0xd15b73"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1329,7 +1329,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2866 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xd14ac5", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15ac5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1341,7 +1341,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2867 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xd14b1f", Frameless: false}]
+              InjectionPoints: [{PC: "0xd15b1f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1362,11 +1362,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2842 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xd14660", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15660", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2843 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xd14670", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15670", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1380,11 +1380,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2844 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xd14700", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15700", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2845 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xd14708", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15708", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1408,11 +1408,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2830 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xd141ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd151ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2831 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd142d4", Frameless: false}]
+              InjectionPoints: [{PC: "0xd152d4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1454,11 +1454,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2834 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xd1432a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1532a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2835 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd14339", Frameless: false}]
+              InjectionPoints: [{PC: "0xd15339", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1481,11 +1481,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2868 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xd14bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15bc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2869 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xd14bc6", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15bc6", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1499,11 +1499,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2870 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xd14c4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd15c4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2871 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xd14c6d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd15c6d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1526,11 +1526,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2826 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xd14140", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15140", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2827 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd14143", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15143", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1544,11 +1544,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2828 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xd14160", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15160", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2829 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd1416b", Frameless: true}]
+              InjectionPoints: [{PC: "0xd1516b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1571,11 +1571,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2846 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xd147c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd157c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2847 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xd147c7", Frameless: true}]
+              InjectionPoints: [{PC: "0xd157c7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1589,11 +1589,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2848 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xd1486a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1586a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2849 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xd14896", Frameless: false}]
+              InjectionPoints: [{PC: "0xd15896", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1616,11 +1616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2836 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xd14600", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15600", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2837 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd14603", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15603", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1634,11 +1634,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2838 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xd14620", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15620", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2839 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xd14623", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15623", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1652,11 +1652,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2840 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xd14640", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15640", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2841 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xd14643", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15643", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1679,11 +1679,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2850 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xd14960", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15960", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2851 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xd14967", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15967", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1697,11 +1697,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2852 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xd14980", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15980", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2853 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd1498e", Frameless: true}]
+              InjectionPoints: [{PC: "0xd1598e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1724,11 +1724,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2822 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xd14100", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15100", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2823 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd14103", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15103", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1742,11 +1742,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2824 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xd14120", Frameless: true}]
+              InjectionPoints: [{PC: "0xd15120", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2825 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd1412b", Frameless: true}]
+              InjectionPoints: [{PC: "0xd1512b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1769,14 +1769,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2655 EventRootType Probe[main.(*Server).handleOrder]
-              InjectionPoints: [{PC: "0xd0d973", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0e133", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2656 EventRootType Probe[main.(*Server).handleOrder]Return
               InjectionPoints:
-                - PC: "0xd0da5c"
+                - PC: "0xd0e21c"
                   Frameless: false
-                - PC: "0xd0db37"
+                - PC: "0xd0e2f7"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1799,11 +1799,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2607 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0xd0acca", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b1ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2608 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0xd0ad2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b22e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1830,11 +1830,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2609 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0xd0ad6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b26e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2610 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0xd0adfe", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b2fe", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1861,11 +1861,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2611 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0xd0ae4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b34a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2612 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0xd0ae8b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b38b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1887,7 +1887,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2878 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0xd0adc6", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b2c6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1905,11 +1905,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2613 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0xd0aece", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b3ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2614 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0xd0afbe", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b4be", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1927,7 +1927,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2879 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0xd0aed3", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b3d3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1938,7 +1938,7 @@ Probes:
       where:
         methodName: main.testInlinedBCA
         sourceFile: inlined.go
-        lines: ["63"]
+        lines: ["66"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCA
       segments: [testInlinedBCA]
@@ -1948,7 +1948,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2880 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0xd0aed3", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b3d3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1966,7 +1966,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2881 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0xd0af86", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b486", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1977,7 +1977,7 @@ Probes:
       where:
         methodName: main.testInlinedBCB
         sourceFile: inlined.go
-        lines: ["67"]
+        lines: ["70"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCB
       segments: [testInlinedBCB]
@@ -1987,7 +1987,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2882 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0xd0af86", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b486", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -2008,7 +2008,7 @@ Probes:
               InjectionPoints:
                 - PC: "0xd04af2"
                   Frameless: true
-                - PC: "0xd0bb06"
+                - PC: "0xd0c1c6"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2029,20 +2029,20 @@ Probes:
             - Kind: Entry
               Type: 2875 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0xd0ab2a"
+                - PC: "0xd0b02a"
                   Frameless: false
-                - PC: "0xd0abb1"
+                - PC: "0xd0b0b1"
                   Frameless: false
-                - PC: "0xd0acf2"
+                - PC: "0xd0b1f2"
                   Frameless: false
-                - PC: "0xd0ad7c"
+                - PC: "0xd0b27c"
                   Frameless: false
-                - PC: "0xd0ae4f"
+                - PC: "0xd0b34f"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 2876 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0xd0ab6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b06a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2057,7 +2057,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2068,15 +2068,15 @@ Probes:
             - Kind: Line
               Type: 2877 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xd0ab2e"
+                - PC: "0xd0b02e"
                   Frameless: false
-                - PC: "0xd0abb1"
+                - PC: "0xd0b0b1"
                   Frameless: false
-                - PC: "0xd0acf2"
+                - PC: "0xd0b1f2"
                   Frameless: false
-                - PC: "0xd0ad7c"
+                - PC: "0xd0b27c"
                   Frameless: false
-                - PC: "0xd0ae4f"
+                - PC: "0xd0b34f"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2099,7 +2099,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2883 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0xd0afe1", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b4e1", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2114,7 +2114,7 @@ Probes:
       where:
         methodName: main.testInlinedSq
         sourceFile: inlined.go
-        lines: ["75"]
+        lines: ["78"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2124,7 +2124,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2884 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0xd0afe1", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b4e1", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2148,9 +2148,9 @@ Probes:
             - Kind: Entry
               Type: 2885 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0xd0b025"
+                - PC: "0xd0b525"
                   Frameless: false
-                - PC: "0xd0b0c5"
+                - PC: "0xd0b635"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2283,7 +2283,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2620 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0xd0b2e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0b8e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2310,7 +2310,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2802 EventRootType Probe[main.testInvalidUtf8Strings]
-              InjectionPoints: [{PC: "0xd117e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd124c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2753 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xd0faee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd105ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2754 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xd0fc33", Frameless: false}]
+              InjectionPoints: [{PC: "0xd10713", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2362,7 +2362,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2661 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xd0de40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2377,7 +2377,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["230"]
+        lines: ["233"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
@@ -2387,7 +2387,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2596 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xd06cfa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06efa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2398,7 +2398,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["237"]
+        lines: ["240"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2409,7 +2409,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2597 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xd06dad", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06fad", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2420,7 +2420,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["242"]
+        lines: ["245"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2431,7 +2431,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2598 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xd06e74", Frameless: false}]
+              InjectionPoints: [{PC: "0xd07074", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2474,11 +2474,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2759 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xd0ff93", Frameless: false}]
+              InjectionPoints: [{PC: "0xd10a73", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2760 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xd101a2", Frameless: false}]
+              InjectionPoints: [{PC: "0xd10c82", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2541,7 +2541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2601 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0xd07840", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07b40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2565,7 +2565,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2602 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0xd09220", Frameless: true}]
+              InjectionPoints: [{PC: "0xd09620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2587,7 +2587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2631 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xd0bc00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c2e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2609,7 +2609,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2638 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xd0bcc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c3a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2631,7 +2631,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2648 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xd0be00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2653,7 +2653,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2650 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xd0be40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2675,7 +2675,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2649 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xd0be20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2697,7 +2697,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2635 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xd0bc80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2719,7 +2719,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2647 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xd0bde0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c4c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2741,7 +2741,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2646 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xd0bdc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c4a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2765,7 +2765,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2636 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xd0bca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2789,7 +2789,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2637 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xd0bca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2811,7 +2811,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2645 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xd0bda0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2833,7 +2833,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2644 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xd0bd80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2855,7 +2855,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2629 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xd0bbc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2877,7 +2877,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2630 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xd0bbe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c2c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2899,7 +2899,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2628 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xd0bba0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2921,7 +2921,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2639 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xd0bce0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c3c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2943,7 +2943,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2642 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xd0bd40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2965,7 +2965,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2643 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xd0bd60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2987,7 +2987,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2640 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xd0bd00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c3e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3011,7 +3011,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2641 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xd0bd20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -3033,7 +3033,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2797 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xd11760", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3056,7 +3056,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2798 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xd11760", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3103,11 +3103,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2761 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xd10233", Frameless: false}]
+              InjectionPoints: [{PC: "0xd10d13", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2762 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xd1046b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd10f4b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3169,7 +3169,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2803 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0xd11800", Frameless: true}]
+              InjectionPoints: [{PC: "0xd124e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3192,7 +3192,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2804 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0xd11800", Frameless: true}]
+              InjectionPoints: [{PC: "0xd124e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3218,11 +3218,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2765 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xd105ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1108e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2766 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xd10676", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11156", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3253,11 +3253,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2757 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xd0fd4e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1082e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2758 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xd0ff6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd10a4a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3283,11 +3283,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2698 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0ed0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f7ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2699 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0edaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f88f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3323,7 +3323,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2654 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xd0d740", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0de20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3364,11 +3364,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2692 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xd0ec6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f74a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2693 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0ecd5", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f7b5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3392,11 +3392,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2694 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xd0ec6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f74a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2695 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0ecd5", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f7b5", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3415,11 +3415,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2700 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0ed0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f7ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2701 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0edaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f88f", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3439,11 +3439,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2702 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0ed0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f7ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2703 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0edaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f88f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3476,11 +3476,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2696 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xd0ec6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f74a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2697 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0ecd5", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f7b5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3508,7 +3508,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2812 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd11c20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3533,7 +3533,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2813 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd11c20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3564,7 +3564,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2814 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd11c20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3589,7 +3589,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2815 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd11c20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3616,7 +3616,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2666 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xd0dfe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e9a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3643,7 +3643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2779 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xd10e40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3670,7 +3670,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2776 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xd10de0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd118c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3705,7 +3705,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2778 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xd10e20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3737,7 +3737,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2796 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xd11740", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3759,7 +3759,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2662 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xd0de60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3781,7 +3781,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2634 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xd0bc60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3803,7 +3803,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2660 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xd0de20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e7e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3827,11 +3827,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2668 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd0e52a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f00a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2669 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd0e57b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f05b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3851,11 +3851,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2712 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0edee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f8ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2713 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0ee8e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f96e", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3900,11 +3900,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2678 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xd0e64e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f12e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2679 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xd0e704", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f1e4", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3946,11 +3946,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2670 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd0e52a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f00a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2671 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd0e57b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f05b", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3995,11 +3995,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2680 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xd0e64e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f12e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2681 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xd0e704", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f1e4", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -4043,11 +4043,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2714 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0edee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f8ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2715 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0ee8e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f96e", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -4064,11 +4064,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2716 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0edee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f8ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2717 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0ee8e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f96e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -4090,11 +4090,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2672 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd0e52a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f00a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2673 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd0e57b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f05b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -4117,18 +4117,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2688 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xd0e8ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f3ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2689 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xd0e9a4"
+                - PC: "0xd0f484"
                   Frameless: false
-                - PC: "0xd0e9df"
+                - PC: "0xd0f4bf"
                   Frameless: false
-                - PC: "0xd0eaa2"
+                - PC: "0xd0f582"
                   Frameless: false
-                - PC: "0xd0eaac"
+                - PC: "0xd0f58c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4156,18 +4156,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2686 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xd0e78e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f26e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2687 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xd0e7f8"
+                - PC: "0xd0f2d8"
                   Frameless: false
-                - PC: "0xd0e833"
+                - PC: "0xd0f313"
                   Frameless: false
-                - PC: "0xd0e867"
+                - PC: "0xd0f347"
                   Frameless: false
-                - PC: "0xd0e899"
+                - PC: "0xd0f379"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4194,11 +4194,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2731 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xd0f58a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1006a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2732 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xd0f5ed", Frameless: false}]
+              InjectionPoints: [{PC: "0xd100cd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4215,11 +4215,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2733 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xd0f60a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd100ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2734 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xd0f64b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1012b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4236,11 +4236,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2735 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xd0f66a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1014a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2736 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xd0f6a6", Frameless: false}]
+              InjectionPoints: [{PC: "0xd10186", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4257,11 +4257,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2739 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xd0f74e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1022e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2740 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xd0f7ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xd102aa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4278,11 +4278,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2751 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xd0fa8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1056a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2752 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xd0fad0", Frameless: false}]
+              InjectionPoints: [{PC: "0xd105b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4299,11 +4299,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2727 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xd0f44a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ff2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2728 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xd0f4a6", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ff86", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4321,14 +4321,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2684 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xd0e72a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f20a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2685 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xd0e75a"
+                - PC: "0xd0f23a"
                   Frameless: false
-                - PC: "0xd0e765"
+                - PC: "0xd0f245"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4350,11 +4350,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2674 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xd0e52a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f00a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2675 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xd0e57b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f05b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4375,11 +4375,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2682 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xd0e64e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f12e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2683 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xd0e704", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f1e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4400,11 +4400,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2676 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xd0e5aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f08a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2677 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xd0e61b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f0fb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4426,14 +4426,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2690 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xd0eaee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f5ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2691 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xd0ebd1"
+                - PC: "0xd0f6b1"
                   Frameless: false
-                - PC: "0xd0ebdb"
+                - PC: "0xd0f6bb"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4455,11 +4455,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2729 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xd0f4ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ffae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2730 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xd0f553", Frameless: false}]
+              InjectionPoints: [{PC: "0xd10033", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4476,11 +4476,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2725 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xd0f34e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0fe2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2726 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xd0f425", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0ff05", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4497,11 +4497,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2743 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xd0f8aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1038a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2744 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xd0f90c", Frameless: false}]
+              InjectionPoints: [{PC: "0xd103ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4518,11 +4518,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2737 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xd0f6ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xd101aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2738 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xd0f718", Frameless: false}]
+              InjectionPoints: [{PC: "0xd101f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4539,11 +4539,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2749 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xd0fa0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd104ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2750 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xd0fa56", Frameless: false}]
+              InjectionPoints: [{PC: "0xd10536", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4563,7 +4563,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2722 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xd0f0cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0fbaf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4584,11 +4584,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2747 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xd0f9aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1048a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2748 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xd0f9ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd104ce", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4605,11 +4605,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2723 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xd0f2ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0fdaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2724 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xd0f331", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0fe11", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4626,11 +4626,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2745 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xd0f92a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1040a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2746 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xd0f98d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1046d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4647,11 +4647,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2741 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xd0f7ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd102ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2742 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xd0f874", Frameless: false}]
+              InjectionPoints: [{PC: "0xd10354", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4704,11 +4704,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2704 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0ed0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f7ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2705 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0edaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f88f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4754,7 +4754,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2571 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0xd06460", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4776,7 +4776,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2569 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0xd06420", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4798,7 +4798,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2582 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0xd065c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd066e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4816,7 +4816,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2583 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0xd065e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4834,7 +4834,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2572 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0xd06480", Frameless: true}]
+              InjectionPoints: [{PC: "0xd065a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4856,7 +4856,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2574 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0xd064c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd065e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4879,7 +4879,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2575 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0xd064e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4901,7 +4901,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2576 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0xd06500", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4930,7 +4930,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2573 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0xd064a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd065c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4961,7 +4961,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2570 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0xd06440", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4983,7 +4983,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2788 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xd116c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd123a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5005,7 +5005,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2577 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0xd06520", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5027,7 +5027,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2579 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0xd06560", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5049,7 +5049,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2580 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0xd06580", Frameless: true}]
+              InjectionPoints: [{PC: "0xd066a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5071,7 +5071,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2581 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0xd065a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd066c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5093,7 +5093,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2578 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0xd06540", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5115,7 +5115,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2782 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xd10e80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5137,7 +5137,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2773 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xd10d80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11860", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5159,7 +5159,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2632 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xd0bc20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -5180,11 +5180,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2718 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xd0edee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f8ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2719 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0ee8e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f96e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5205,11 +5205,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2763 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xd1050a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd10fea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2764 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xd1057c", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1105c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5253,7 +5253,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2665 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xd0dfa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5275,7 +5275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2777 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xd10e00", Frameless: true}]
+              InjectionPoints: [{PC: "0xd118e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5297,7 +5297,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2594 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0xd06ca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06ea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5319,7 +5319,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2595 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0xd06cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06ec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5341,11 +5341,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2810 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xd11b20", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12900", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2811 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xd11b42", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12922", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5372,7 +5372,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2774 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xd10da0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5399,7 +5399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2626 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0xd0b400", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0ba00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5420,11 +5420,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2767 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xd106ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1118e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2768 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xd1075a", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1123a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5446,11 +5446,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2806 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xd119e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd127c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2807 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0xd119fe", Frameless: true}]
+              InjectionPoints: [{PC: "0xd127de", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5471,7 +5471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2805 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xd119c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd127a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5498,7 +5498,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2627 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xd0bb80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0c260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5531,7 +5531,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2783 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xd10ea0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5571,7 +5571,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2801 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xd117c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd124a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2599 EventRootType Probe[main.testTakeContext]
-              InjectionPoints: [{PC: "0xd07360", Frameless: true}]
+              InjectionPoints: [{PC: "0xd07660", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
       version: 0
@@ -5619,11 +5619,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2706 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0ed0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f7ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2707 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0edaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f88f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5644,11 +5644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2708 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0ed0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f7ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2709 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0edaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f88f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5671,11 +5671,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2710 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xd0ed0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f7ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2711 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xd0edaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0f88f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5707,7 +5707,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2789 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xd116e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd123c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5739,11 +5739,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2790 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xd11700", Frameless: true}]
+              InjectionPoints: [{PC: "0xd123e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2791 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xd1171e", Frameless: true}]
+              InjectionPoints: [{PC: "0xd123fe", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5773,11 +5773,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2792 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xd11700", Frameless: true}]
+              InjectionPoints: [{PC: "0xd123e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2793 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xd1171e", Frameless: true}]
+              InjectionPoints: [{PC: "0xd123fe", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5809,7 +5809,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2794 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xd11720", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5839,7 +5839,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2795 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xd11720", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5871,7 +5871,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2820 EventRootType Probe[main.testTimeFixedZone]
-              InjectionPoints: [{PC: "0xd13040", Frameless: true}]
+              InjectionPoints: [{PC: "0xd13f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5893,7 +5893,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2821 EventRootType Probe[main.testTimeMonotonic]
-              InjectionPoints: [{PC: "0xd13060", Frameless: true}]
+              InjectionPoints: [{PC: "0xd13f40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -5915,7 +5915,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2819 EventRootType Probe[main.testTimeUTC]
-              InjectionPoints: [{PC: "0xd13020", Frameless: true}]
+              InjectionPoints: [{PC: "0xd13f00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5937,7 +5937,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2584 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0xd06600", Frameless: true}]
+              InjectionPoints: [{PC: "0xd06720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6069,7 +6069,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2664 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xd0dec0", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6091,7 +6091,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2771 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xd10d40", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -6113,7 +6113,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2799 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xd11780", Frameless: true}]
+              InjectionPoints: [{PC: "0xd12460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6135,7 +6135,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2663 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xd0de80", Frameless: true}]
+              InjectionPoints: [{PC: "0xd0e840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6179,7 +6179,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2780 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xd10e60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6201,7 +6201,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2781 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xd10e60", Frameless: true}]
+              InjectionPoints: [{PC: "0xd11940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6224,14 +6224,14 @@ Probes:
             - Kind: Entry
               Type: 2886 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0xd0b20a"
+                - PC: "0xd0b80a"
                   Frameless: false
-                - PC: "0xd14e83"
+                - PC: "0xd15e83"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 2887 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0xd0b250", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0b850", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -6253,11 +6253,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2769 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xd1078e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1126e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2770 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xd1080c", Frameless: false}]
+              InjectionPoints: [{PC: "0xd112ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -6554,132 +6554,6 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xd06420..0xd06421]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 5 BaseType uint8
-          Locations:
-            - Range: 0xd06420..0xd06421
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 22
-      Name: main.testSingleRune
-      OutOfLinePCRanges: [0xd06440..0xd06441]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 14 BaseType int32
-          Locations:
-            - Range: 0xd06440..0xd06441
-              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 23
-      Name: main.testSingleBool
-      OutOfLinePCRanges: [0xd06460..0xd06461]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 6 BaseType bool
-          Locations:
-            - Range: 0xd06460..0xd06461
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 24
-      Name: main.testSingleInt
-      OutOfLinePCRanges: [0xd06480..0xd06481]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 BaseType int
-          Locations:
-            - Range: 0xd06480..0xd06481
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 25
-      Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xd064a0..0xd064a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 16 BaseType int8
-          Locations:
-            - Range: 0xd064a0..0xd064a1
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 26
-      Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xd064c0..0xd064c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 100 BaseType int16
-          Locations:
-            - Range: 0xd064c0..0xd064c1
-              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 27
-      Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xd064e0..0xd064e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 14 BaseType int32
-          Locations:
-            - Range: 0xd064e0..0xd064e1
-              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 28
-      Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xd06500..0xd06501]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 15 BaseType int64
-          Locations:
-            - Range: 0xd06500..0xd06501
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 29
-      Name: main.testSingleUint
-      OutOfLinePCRanges: [0xd06520..0xd06521]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 17 BaseType uint
-          Locations:
-            - Range: 0xd06520..0xd06521
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 30
-      Name: main.testSingleUint8
       OutOfLinePCRanges: [0xd06540..0xd06541]
       InlinePCRanges: []
       Variables:
@@ -6692,41 +6566,41 @@ Subprograms:
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
-    - ID: 31
-      Name: main.testSingleUint16
+    - ID: 22
+      Name: main.testSingleRune
       OutOfLinePCRanges: [0xd06560..0xd06561]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 9 BaseType uint16
+          Type: 14 BaseType int32
           Locations:
             - Range: 0xd06560..0xd06561
-              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 32
-      Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xd06580..0xd06581]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 4 BaseType uint32
-          Locations:
-            - Range: 0xd06580..0xd06581
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
-    - ID: 33
-      Name: main.testSingleUint64
+    - ID: 23
+      Name: main.testSingleBool
+      OutOfLinePCRanges: [0xd06580..0xd06581]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 6 BaseType bool
+          Locations:
+            - Range: 0xd06580..0xd06581
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 24
+      Name: main.testSingleInt
       OutOfLinePCRanges: [0xd065a0..0xd065a1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 12 BaseType uint64
+          Type: 11 BaseType int
           Locations:
             - Range: 0xd065a0..0xd065a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -6734,15 +6608,141 @@ Subprograms:
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
+    - ID: 25
+      Name: main.testSingleInt8
+      OutOfLinePCRanges: [0xd065c0..0xd065c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 16 BaseType int8
+          Locations:
+            - Range: 0xd065c0..0xd065c1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 26
+      Name: main.testSingleInt16
+      OutOfLinePCRanges: [0xd065e0..0xd065e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 100 BaseType int16
+          Locations:
+            - Range: 0xd065e0..0xd065e1
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 27
+      Name: main.testSingleInt32
+      OutOfLinePCRanges: [0xd06600..0xd06601]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 14 BaseType int32
+          Locations:
+            - Range: 0xd06600..0xd06601
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 28
+      Name: main.testSingleInt64
+      OutOfLinePCRanges: [0xd06620..0xd06621]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 15 BaseType int64
+          Locations:
+            - Range: 0xd06620..0xd06621
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 29
+      Name: main.testSingleUint
+      OutOfLinePCRanges: [0xd06640..0xd06641]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 17 BaseType uint
+          Locations:
+            - Range: 0xd06640..0xd06641
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 30
+      Name: main.testSingleUint8
+      OutOfLinePCRanges: [0xd06660..0xd06661]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 5 BaseType uint8
+          Locations:
+            - Range: 0xd06660..0xd06661
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 31
+      Name: main.testSingleUint16
+      OutOfLinePCRanges: [0xd06680..0xd06681]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 BaseType uint16
+          Locations:
+            - Range: 0xd06680..0xd06681
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 32
+      Name: main.testSingleUint32
+      OutOfLinePCRanges: [0xd066a0..0xd066a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 4 BaseType uint32
+          Locations:
+            - Range: 0xd066a0..0xd066a1
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 33
+      Name: main.testSingleUint64
+      OutOfLinePCRanges: [0xd066c0..0xd066c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 12 BaseType uint64
+          Locations:
+            - Range: 0xd066c0..0xd066c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xd065c0..0xd065c1]
+      OutOfLinePCRanges: [0xd066e0..0xd066e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xd065c0..0xd065c1
+            - Range: 0xd066e0..0xd066e1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6750,13 +6750,13 @@ Subprograms:
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xd065e0..0xd065e1]
+      OutOfLinePCRanges: [0xd06700..0xd06701]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 BaseType float64
           Locations:
-            - Range: 0xd065e0..0xd065e1
+            - Range: 0xd06700..0xd06701
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6764,13 +6764,13 @@ Subprograms:
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xd06600..0xd06601]
+      OutOfLinePCRanges: [0xd06720..0xd06721]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 123 BaseType main.typeAlias
           Locations:
-            - Range: 0xd06600..0xd06601
+            - Range: 0xd06720..0xd06721
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6778,13 +6778,13 @@ Subprograms:
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xd06760..0xd0677f]
+      OutOfLinePCRanges: [0xd06960..0xd0697f]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 124 StructureType main.bigStruct
           Locations:
-            - Range: 0xd06760..0xd0677f
+            - Range: 0xd06960..0xd0697f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6804,51 +6804,51 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0xd067c0..0xd068d2]
+      OutOfLinePCRanges: [0xd069c0..0xd06ad2]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xd067c0..0xd067d8
+            - Range: 0xd069c0..0xd069d8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r0
           Type: 11 BaseType int
-          Locations: [{Range: 0xd067c0..0xd068d2, Pieces: []}]
+          Locations: [{Range: 0xd069c0..0xd06ad2, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: x
           Type: 11 BaseType int
-          Locations: [{Range: 0xd067c0..0xd068d2, Pieces: []}]
+          Locations: [{Range: 0xd069c0..0xd06ad2, Pieces: []}]
           Role: Local
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: err
           Type: 20 GoInterfaceType error
           Locations:
-            - Range: 0xd067e9..0xd06805
+            - Range: 0xd069e9..0xd06a05
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0xd06805..0xd0683e
+            - Range: 0xd06a05..0xd06a3e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd0683e..0xd06845
+            - Range: 0xd06a3e..0xd06a45
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0xd06845..0xd068d2
+            - Range: 0xd06a45..0xd06ad2
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -80}
@@ -6860,13 +6860,13 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xd06940..0xd06941]
+      OutOfLinePCRanges: [0xd06b40..0xd06b41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 128 StructureType main.deepPtr1
           Locations:
-            - Range: 0xd06940..0xd06941
+            - Range: 0xd06b40..0xd06b41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6874,13 +6874,13 @@ Subprograms:
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xd06960..0xd06961]
+      OutOfLinePCRanges: [0xd06b60..0xd06b61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 131 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xd06960..0xd06961
+            - Range: 0xd06b60..0xd06b61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6888,13 +6888,13 @@ Subprograms:
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xd06ae0..0xd06ae1]
+      OutOfLinePCRanges: [0xd06ce0..0xd06ce1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 133 StructureType main.deepSlice1
           Locations:
-            - Range: 0xd06ae0..0xd06ae1
+            - Range: 0xd06ce0..0xd06ce1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6908,13 +6908,13 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xd06b00..0xd06b01]
+      OutOfLinePCRanges: [0xd06d00..0xd06d01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 137 PointerType *main.deepSlice7
           Locations:
-            - Range: 0xd06b00..0xd06b01
+            - Range: 0xd06d00..0xd06d01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6922,13 +6922,13 @@ Subprograms:
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xd06c60..0xd06c61]
+      OutOfLinePCRanges: [0xd06e60..0xd06e61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 139 StructureType main.deepMap1
           Locations:
-            - Range: 0xd06c60..0xd06c61
+            - Range: 0xd06e60..0xd06e61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6936,13 +6936,13 @@ Subprograms:
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xd06c80..0xd06c81]
+      OutOfLinePCRanges: [0xd06e80..0xd06e81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 147 PointerType *main.deepMap7
           Locations:
-            - Range: 0xd06c80..0xd06c81
+            - Range: 0xd06e80..0xd06e81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6950,13 +6950,13 @@ Subprograms:
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0xd06ca0..0xd06ca1]
+      OutOfLinePCRanges: [0xd06ea0..0xd06ea1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 PointerType *main.stringType1
           Locations:
-            - Range: 0xd06ca0..0xd06ca1
+            - Range: 0xd06ea0..0xd06ea1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6964,13 +6964,13 @@ Subprograms:
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xd06cc0..0xd06cc1]
+      OutOfLinePCRanges: [0xd06ec0..0xd06ec1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 151 PointerType **main.stringType2
           Locations:
-            - Range: 0xd06cc0..0xd06cc1
+            - Range: 0xd06ec0..0xd06ec1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6978,15 +6978,15 @@ Subprograms:
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xd06ce0..0xd06f2a]
+      OutOfLinePCRanges: [0xd06ee0..0xd0712a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd06dc4..0xd06de5
+            - Range: 0xd06fc4..0xd06fe5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd06e98..0xd06eaf
+            - Range: 0xd07098..0xd070af
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -6994,15 +6994,15 @@ Subprograms:
         - Name: aPerArch
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd06dad..0xd06db0
+            - Range: 0xd06fad..0xd06fb0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd06db0..0xd06de5
+            - Range: 0xd06fb0..0xd06fe5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd06de5..0xd06e8b
+            - Range: 0xd06fe5..0xd0708b
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xd06e8b..0xd06e98
+            - Range: 0xd0708b..0xd07098
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xd06e98..0xd06f2a
+            - Range: 0xd07098..0xd0712a
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
           DictIndex: -1
@@ -7010,21 +7010,21 @@ Subprograms:
         - Name: b
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd06daa..0xd06db0
+            - Range: 0xd06faa..0xd06fb0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd06db0..0xd06db0
+            - Range: 0xd06fb0..0xd06fb0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd06db0..0xd06de5
+            - Range: 0xd06fb0..0xd06fe5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd06de5..0xd06e8b
+            - Range: 0xd06fe5..0xd0708b
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xd06e8b..0xd06e90
+            - Range: 0xd0708b..0xd07090
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xd06e90..0xd06e98
+            - Range: 0xd07090..0xd07098
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xd06e98..0xd06eaf
+            - Range: 0xd07098..0xd070af
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xd06eaf..0xd06f2a
+            - Range: 0xd070af..0xd0712a
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
           DictIndex: -1
@@ -7032,13 +7032,13 @@ Subprograms:
       DictRegister: null
     - ID: 48
       Name: main.testTakeContext
-      OutOfLinePCRanges: [0xd07360..0xd07361]
+      OutOfLinePCRanges: [0xd07660..0xd07661]
       InlinePCRanges: []
       Variables:
         - Name: ctx
           Type: 153 GoInterfaceType context.Context
           Locations:
-            - Range: 0xd07360..0xd07361
+            - Range: 0xd07660..0xd07661
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7050,13 +7050,13 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testCaptureContextImpl
-      OutOfLinePCRanges: [0xd07560..0xd07561]
+      OutOfLinePCRanges: [0xd07860..0xd07861]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 154 PointerType *main.contextImpl
           Locations:
-            - Range: 0xd07560..0xd07561
+            - Range: 0xd07860..0xd07861
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7064,13 +7064,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0xd07840..0xd07841]
+      OutOfLinePCRanges: [0xd07b40..0xd07b41]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 156 StructureType main.manyPointers
           Locations:
-            - Range: 0xd07840..0xd07841
+            - Range: 0xd07b40..0xd07b41
               Pieces: [{Size: 560, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7078,13 +7078,13 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0xd09220..0xd09221]
+      OutOfLinePCRanges: [0xd09620..0xd09621]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 159 GoSliceHeaderType []string
           Locations:
-            - Range: 0xd09220..0xd09221
+            - Range: 0xd09620..0xd09621
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7098,13 +7098,13 @@ Subprograms:
       DictRegister: null
     - ID: 52
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xd094e0..0xd095e5]
+      OutOfLinePCRanges: [0xd099e0..0xd09ae5]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 160 StructureType main.esotericStack
           Locations:
-            - Range: 0xd094e0..0xd09533
+            - Range: 0xd099e0..0xd09a33
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -7124,7 +7124,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xd09533..0xd09538
+            - Range: 0xd09a33..0xd09a38
               Pieces:
                 - Size: 4
                   Op: null
@@ -7144,7 +7144,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xd09538..0xd0953d
+            - Range: 0xd09a38..0xd09a3d
               Pieces:
                 - Size: 4
                   Op: null
@@ -7170,13 +7170,13 @@ Subprograms:
       DictRegister: null
     - ID: 53
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xd09600..0xd09663]
+      OutOfLinePCRanges: [0xd09b00..0xd09b63]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 163 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xd09600..0xd0962d
+            - Range: 0xd09b00..0xd09b2d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7184,13 +7184,13 @@ Subprograms:
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xd0acc0..0xd0ad48]
+      OutOfLinePCRanges: [0xd0b1c0..0xd0b248]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0acc0..0xd0acd5
+            - Range: 0xd0b1c0..0xd0b1d5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7198,13 +7198,13 @@ Subprograms:
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xd0ad60..0xd0ae25]
+      OutOfLinePCRanges: [0xd0b260..0xd0b325]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ad60..0xd0ad76
+            - Range: 0xd0b260..0xd0b276
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7212,7 +7212,7 @@ Subprograms:
         - Name: "y"
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ad60..0xd0ad87
+            - Range: 0xd0b260..0xd0b287
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7220,9 +7220,9 @@ Subprograms:
         - Name: z
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ad76..0xd0ad87
+            - Range: 0xd0b276..0xd0b287
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ad87..0xd0ae25
+            - Range: 0xd0b287..0xd0b325
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
@@ -7230,13 +7230,13 @@ Subprograms:
       DictRegister: null
     - ID: 56
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xd0ae40..0xd0aea2]
+      OutOfLinePCRanges: [0xd0b340..0xd0b3a2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ae40..0xd0ae5a
+            - Range: 0xd0b340..0xd0b35a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7244,17 +7244,17 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xd0aec0..0xd0afce]
+      OutOfLinePCRanges: [0xd0b3c0..0xd0b4ce]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0af1b..0xd0af25
+            - Range: 0xd0b41b..0xd0b425
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd0af25..0xd0af40
+            - Range: 0xd0b425..0xd0b440
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd0af40..0xd0af54
+            - Range: 0xd0b440..0xd0b454
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7262,11 +7262,11 @@ Subprograms:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0af16..0xd0af20
+            - Range: 0xd0b416..0xd0b420
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd0af20..0xd0af40
+            - Range: 0xd0b420..0xd0b440
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd0af40..0xd0af4f
+            - Range: 0xd0b440..0xd0b44f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7274,13 +7274,13 @@ Subprograms:
       DictRegister: null
     - ID: 58
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xd0afe0..0xd0afe6]
+      OutOfLinePCRanges: [0xd0b4e0..0xd0b4e6]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0afe0..0xd0afe5
+            - Range: 0xd0b4e0..0xd0b4e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7288,9 +7288,9 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0afe0..0xd0afe5
+            - Range: 0xd0b4e0..0xd0b4e5
               Pieces: []
-            - Range: 0xd0afe5..0xd0afe6
+            - Range: 0xd0b4e5..0xd0b4e6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -7298,13 +7298,13 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xd0b000..0xd0b043]
+      OutOfLinePCRanges: [0xd0b500..0xd0b543]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 165 ArrayType [5]int
           Locations:
-            - Range: 0xd0b000..0xd0b043
+            - Range: 0xd0b500..0xd0b543
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7312,11 +7312,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0b000..0xd0b03d
+            - Range: 0xd0b500..0xd0b53d
               Pieces: []
-            - Range: 0xd0b03d..0xd0b03e
+            - Range: 0xd0b53d..0xd0b53e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0b03e..0xd0b043
+            - Range: 0xd0b53e..0xd0b543
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7324,13 +7324,13 @@ Subprograms:
       DictRegister: null
     - ID: 60
       Name: main.testInterface
-      OutOfLinePCRanges: [0xd0b2e0..0xd0b2e1]
+      OutOfLinePCRanges: [0xd0b8e0..0xd0b8e1]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 166 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd0b2e0..0xd0b2e1
+            - Range: 0xd0b8e0..0xd0b8e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7342,19 +7342,19 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testAny
-      OutOfLinePCRanges: [0xd0b300..0xd0b366]
+      OutOfLinePCRanges: [0xd0b900..0xd0b966]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 55 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0b300..0xd0b329
+            - Range: 0xd0b900..0xd0b929
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0b329..0xd0b32e
+            - Range: 0xd0b929..0xd0b92e
               Pieces:
                 - Size: 8
                   Op: null
@@ -7366,15 +7366,15 @@ Subprograms:
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd0b300..0xd0b345
+            - Range: 0xd0b900..0xd0b945
               Pieces: []
-            - Range: 0xd0b345..0xd0b346
+            - Range: 0xd0b945..0xd0b946
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0b346..0xd0b366
+            - Range: 0xd0b946..0xd0b966
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7382,13 +7382,13 @@ Subprograms:
       DictRegister: null
     - ID: 62
       Name: main.testError
-      OutOfLinePCRanges: [0xd0b380..0xd0b381]
+      OutOfLinePCRanges: [0xd0b980..0xd0b981]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 20 GoInterfaceType error
           Locations:
-            - Range: 0xd0b380..0xd0b381
+            - Range: 0xd0b980..0xd0b981
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7400,13 +7400,13 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xd0b3a0..0xd0b3f4]
+      OutOfLinePCRanges: [0xd0b9a0..0xd0b9f4]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 167 PointerType *interface {}
           Locations:
-            - Range: 0xd0b3a0..0xd0b3c6
+            - Range: 0xd0b9a0..0xd0b9c6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7414,15 +7414,15 @@ Subprograms:
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd0b3a0..0xd0b3dd
+            - Range: 0xd0b9a0..0xd0b9dd
               Pieces: []
-            - Range: 0xd0b3dd..0xd0b3de
+            - Range: 0xd0b9dd..0xd0b9de
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0b3de..0xd0b3f4
+            - Range: 0xd0b9de..0xd0b9f4
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7430,13 +7430,13 @@ Subprograms:
       DictRegister: null
     - ID: 64
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xd0b400..0xd0b401]
+      OutOfLinePCRanges: [0xd0ba00..0xd0ba01]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 168 StructureType main.structWithAny
           Locations:
-            - Range: 0xd0b400..0xd0b401
+            - Range: 0xd0ba00..0xd0ba01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7448,13 +7448,13 @@ Subprograms:
       DictRegister: null
     - ID: 65
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xd0bb80..0xd0bb81]
+      OutOfLinePCRanges: [0xd0c260..0xd0c261]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 169 StructureType main.structWithMap
           Locations:
-            - Range: 0xd0bb80..0xd0bb81
+            - Range: 0xd0c260..0xd0c261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7462,13 +7462,13 @@ Subprograms:
       DictRegister: null
     - ID: 66
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xd0bba0..0xd0bba1]
+      OutOfLinePCRanges: [0xd0c280..0xd0c281]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 175 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xd0bba0..0xd0bba1
+            - Range: 0xd0c280..0xd0c281
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7476,13 +7476,13 @@ Subprograms:
       DictRegister: null
     - ID: 67
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xd0bbc0..0xd0bbc1]
+      OutOfLinePCRanges: [0xd0c2a0..0xd0c2a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 180 GoMapType map[string]int
           Locations:
-            - Range: 0xd0bbc0..0xd0bbc1
+            - Range: 0xd0c2a0..0xd0c2a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7490,13 +7490,13 @@ Subprograms:
       DictRegister: null
     - ID: 68
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xd0bbe0..0xd0bbe1]
+      OutOfLinePCRanges: [0xd0c2c0..0xd0c2c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 185 GoMapType map[string][]string
           Locations:
-            - Range: 0xd0bbe0..0xd0bbe1
+            - Range: 0xd0c2c0..0xd0c2c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7504,13 +7504,13 @@ Subprograms:
       DictRegister: null
     - ID: 69
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xd0bc00..0xd0bc01]
+      OutOfLinePCRanges: [0xd0c2e0..0xd0c2e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 190 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0xd0bc00..0xd0bc01
+            - Range: 0xd0c2e0..0xd0c2e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7518,13 +7518,13 @@ Subprograms:
       DictRegister: null
     - ID: 70
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0xd0bc20..0xd0bc21]
+      OutOfLinePCRanges: [0xd0c300..0xd0c301]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 180 GoMapType map[string]int
           Locations:
-            - Range: 0xd0bc20..0xd0bc21
+            - Range: 0xd0c300..0xd0c301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7532,13 +7532,13 @@ Subprograms:
       DictRegister: null
     - ID: 71
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xd0bc40..0xd0bc41]
+      OutOfLinePCRanges: [0xd0c320..0xd0c321]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 195 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xd0bc40..0xd0bc41
+            - Range: 0xd0c320..0xd0c321
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7546,13 +7546,13 @@ Subprograms:
       DictRegister: null
     - ID: 72
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xd0bc60..0xd0bc61]
+      OutOfLinePCRanges: [0xd0c340..0xd0c341]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 196 PointerType *map[string]int
           Locations:
-            - Range: 0xd0bc60..0xd0bc61
+            - Range: 0xd0c340..0xd0c341
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7560,13 +7560,13 @@ Subprograms:
       DictRegister: null
     - ID: 73
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xd0bc80..0xd0bc81]
+      OutOfLinePCRanges: [0xd0c360..0xd0c361]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 170 GoMapType map[int]int
           Locations:
-            - Range: 0xd0bc80..0xd0bc81
+            - Range: 0xd0c360..0xd0c361
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7574,13 +7574,13 @@ Subprograms:
       DictRegister: null
     - ID: 74
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0xd0bca0..0xd0bca1]
+      OutOfLinePCRanges: [0xd0c380..0xd0c381]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 197 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xd0bca0..0xd0bca1
+            - Range: 0xd0c380..0xd0c381
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7588,13 +7588,13 @@ Subprograms:
       DictRegister: null
     - ID: 75
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xd0bcc0..0xd0bcc1]
+      OutOfLinePCRanges: [0xd0c3a0..0xd0c3a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 197 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xd0bcc0..0xd0bcc1
+            - Range: 0xd0c3a0..0xd0c3a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7602,13 +7602,13 @@ Subprograms:
       DictRegister: null
     - ID: 76
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xd0bce0..0xd0bce1]
+      OutOfLinePCRanges: [0xd0c3c0..0xd0c3c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 202 GoMapType map[bool]main.node
           Locations:
-            - Range: 0xd0bce0..0xd0bce1
+            - Range: 0xd0c3c0..0xd0c3c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7616,13 +7616,13 @@ Subprograms:
       DictRegister: null
     - ID: 77
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xd0bd00..0xd0bd01]
+      OutOfLinePCRanges: [0xd0c3e0..0xd0c3e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 207 GoMapType map[int]uint8
           Locations:
-            - Range: 0xd0bd00..0xd0bd01
+            - Range: 0xd0c3e0..0xd0c3e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7630,13 +7630,13 @@ Subprograms:
       DictRegister: null
     - ID: 78
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xd0bd20..0xd0bd21]
+      OutOfLinePCRanges: [0xd0c400..0xd0c401]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 207 GoMapType map[int]uint8
           Locations:
-            - Range: 0xd0bd20..0xd0bd21
+            - Range: 0xd0c400..0xd0c401
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7644,13 +7644,13 @@ Subprograms:
       DictRegister: null
     - ID: 79
       Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xd0bd40..0xd0bd41]
+      OutOfLinePCRanges: [0xd0c420..0xd0c421]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 212 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xd0bd40..0xd0bd41
+            - Range: 0xd0c420..0xd0c421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7658,13 +7658,13 @@ Subprograms:
       DictRegister: null
     - ID: 80
       Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0xd0bd60..0xd0bd61]
+      OutOfLinePCRanges: [0xd0c440..0xd0c441]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 212 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xd0bd60..0xd0bd61
+            - Range: 0xd0c440..0xd0c441
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7672,13 +7672,13 @@ Subprograms:
       DictRegister: null
     - ID: 81
       Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0xd0bd80..0xd0bd81]
+      OutOfLinePCRanges: [0xd0c460..0xd0c461]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 212 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xd0bd80..0xd0bd81
+            - Range: 0xd0c460..0xd0c461
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7686,13 +7686,13 @@ Subprograms:
       DictRegister: null
     - ID: 82
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0xd0bda0..0xd0bda1]
+      OutOfLinePCRanges: [0xd0c480..0xd0c481]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 217 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0xd0bda0..0xd0bda1
+            - Range: 0xd0c480..0xd0c481
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7700,13 +7700,13 @@ Subprograms:
       DictRegister: null
     - ID: 83
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0xd0bdc0..0xd0bdc1]
+      OutOfLinePCRanges: [0xd0c4a0..0xd0c4a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 222 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0xd0bdc0..0xd0bdc1
+            - Range: 0xd0c4a0..0xd0c4a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7714,13 +7714,13 @@ Subprograms:
       DictRegister: null
     - ID: 84
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0xd0bde0..0xd0bde1]
+      OutOfLinePCRanges: [0xd0c4c0..0xd0c4c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 227 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0xd0bde0..0xd0bde1
+            - Range: 0xd0c4c0..0xd0c4c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7728,13 +7728,13 @@ Subprograms:
       DictRegister: null
     - ID: 85
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0xd0be00..0xd0be01]
+      OutOfLinePCRanges: [0xd0c4e0..0xd0c4e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 232 GoMapType map[struct {}]int
           Locations:
-            - Range: 0xd0be00..0xd0be01
+            - Range: 0xd0c4e0..0xd0c4e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7742,13 +7742,13 @@ Subprograms:
       DictRegister: null
     - ID: 86
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0xd0be20..0xd0be21]
+      OutOfLinePCRanges: [0xd0c500..0xd0c501]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 237 GoMapType map[int]struct {}
           Locations:
-            - Range: 0xd0be20..0xd0be21
+            - Range: 0xd0c500..0xd0c501
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7756,13 +7756,13 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0xd0be40..0xd0be41]
+      OutOfLinePCRanges: [0xd0c520..0xd0c521]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 242 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0xd0be40..0xd0be41
+            - Range: 0xd0c520..0xd0c521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7770,13 +7770,13 @@ Subprograms:
       DictRegister: null
     - ID: 88
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xd0d580..0xd0d581]
+      OutOfLinePCRanges: [0xd0dc60..0xd0dc61]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xd0d580..0xd0d581
+            - Range: 0xd0dc60..0xd0dc61
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7784,7 +7784,7 @@ Subprograms:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xd0d580..0xd0d581
+            - Range: 0xd0dc60..0xd0dc61
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7792,7 +7792,7 @@ Subprograms:
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xd0d580..0xd0d581
+            - Range: 0xd0dc60..0xd0dc61
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7800,13 +7800,13 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xd0d5c0..0xd0d5c1]
+      OutOfLinePCRanges: [0xd0dca0..0xd0dca1]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xd0d5c0..0xd0d5c1
+            - Range: 0xd0dca0..0xd0dca1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7814,7 +7814,7 @@ Subprograms:
         - Name: x
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd0d5c0..0xd0d5c1
+            - Range: 0xd0dca0..0xd0dca1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7826,7 +7826,7 @@ Subprograms:
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xd0d5c0..0xd0d5c1
+            - Range: 0xd0dca0..0xd0dca1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7834,13 +7834,13 @@ Subprograms:
       DictRegister: null
     - ID: 90
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xd0d740..0xd0d741]
+      OutOfLinePCRanges: [0xd0de20..0xd0de21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xd0d740..0xd0d741
+            - Range: 0xd0de20..0xd0de21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7848,7 +7848,7 @@ Subprograms:
         - Name: b
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xd0d740..0xd0d741
+            - Range: 0xd0de20..0xd0de21
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7856,7 +7856,7 @@ Subprograms:
         - Name: c
           Type: 14 BaseType int32
           Locations:
-            - Range: 0xd0d740..0xd0d741
+            - Range: 0xd0de20..0xd0de21
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7864,7 +7864,7 @@ Subprograms:
         - Name: d
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xd0d740..0xd0d741
+            - Range: 0xd0de20..0xd0de21
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7872,7 +7872,7 @@ Subprograms:
         - Name: e
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd0d740..0xd0d741
+            - Range: 0xd0de20..0xd0de21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7884,13 +7884,13 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.(*Server).handleOrder
-      OutOfLinePCRanges: [0xd0d960..0xd0db5f]
+      OutOfLinePCRanges: [0xd0e120..0xd0e31f]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 247 PointerType *main.Server
           Locations:
-            - Range: 0xd0d960..0xd0d9b6
+            - Range: 0xd0e120..0xd0e176
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7898,9 +7898,9 @@ Subprograms:
         - Name: req
           Type: 249 PointerType *main.Request
           Locations:
-            - Range: 0xd0d960..0xd0d9b3
+            - Range: 0xd0e120..0xd0e173
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0d9b3..0xd0db5f
+            - Range: 0xd0e173..0xd0e31f
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7908,23 +7908,23 @@ Subprograms:
         - Name: ~r0
           Type: 20 GoInterfaceType error
           Locations:
-            - Range: 0xd0d960..0xd0da5c
+            - Range: 0xd0e120..0xd0e21c
               Pieces: []
-            - Range: 0xd0da5c..0xd0da5d
+            - Range: 0xd0e21c..0xd0e21d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0da5d..0xd0db37
+            - Range: 0xd0e21d..0xd0e2f7
               Pieces: []
-            - Range: 0xd0db37..0xd0db38
+            - Range: 0xd0e2f7..0xd0e2f8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0db38..0xd0db5f
+            - Range: 0xd0e2f8..0xd0e31f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7932,13 +7932,13 @@ Subprograms:
       DictRegister: null
     - ID: 92
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xd0dc20..0xd0dc33]
+      OutOfLinePCRanges: [0xd0e500..0xd0e513]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType uint64
           Locations:
-            - Range: 0xd0dc20..0xd0dc32
+            - Range: 0xd0e500..0xd0e512
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7946,9 +7946,9 @@ Subprograms:
         - Name: ~r0
           Type: 12 BaseType uint64
           Locations:
-            - Range: 0xd0dc20..0xd0dc32
+            - Range: 0xd0e500..0xd0e512
               Pieces: []
-            - Range: 0xd0dc32..0xd0dc33
+            - Range: 0xd0e512..0xd0e513
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -7956,13 +7956,13 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testChannel
-      OutOfLinePCRanges: [0xd0dc40..0xd0dc41]
+      OutOfLinePCRanges: [0xd0e520..0xd0e521]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 251 GoChannelType chan bool
           Locations:
-            - Range: 0xd0dc40..0xd0dc41
+            - Range: 0xd0e520..0xd0e521
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7970,13 +7970,13 @@ Subprograms:
       DictRegister: null
     - ID: 94
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xd0de20..0xd0de21]
+      OutOfLinePCRanges: [0xd0e7e0..0xd0e7e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xd0de20..0xd0de21
+            - Range: 0xd0e7e0..0xd0e7e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7984,13 +7984,13 @@ Subprograms:
       DictRegister: null
     - ID: 95
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xd0de40..0xd0de41]
+      OutOfLinePCRanges: [0xd0e800..0xd0e801]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 254 StructureType main.node
           Locations:
-            - Range: 0xd0de40..0xd0de41
+            - Range: 0xd0e800..0xd0e801
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8002,13 +8002,13 @@ Subprograms:
       DictRegister: null
     - ID: 96
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xd0de60..0xd0de61]
+      OutOfLinePCRanges: [0xd0e820..0xd0e821]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 255 PointerType *main.node
           Locations:
-            - Range: 0xd0de60..0xd0de61
+            - Range: 0xd0e820..0xd0e821
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8016,13 +8016,13 @@ Subprograms:
       DictRegister: null
     - ID: 97
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xd0de80..0xd0de81]
+      OutOfLinePCRanges: [0xd0e840..0xd0e841]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 21 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xd0de80..0xd0de81
+            - Range: 0xd0e840..0xd0e841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8030,13 +8030,13 @@ Subprograms:
       DictRegister: null
     - ID: 98
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xd0dec0..0xd0dec1]
+      OutOfLinePCRanges: [0xd0e880..0xd0e881]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 PointerType *uint
           Locations:
-            - Range: 0xd0dec0..0xd0dec1
+            - Range: 0xd0e880..0xd0e881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8044,13 +8044,13 @@ Subprograms:
       DictRegister: null
     - ID: 99
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xd0dfa0..0xd0dfa1]
+      OutOfLinePCRanges: [0xd0e960..0xd0e961]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 91 PointerType *string
           Locations:
-            - Range: 0xd0dfa0..0xd0dfa1
+            - Range: 0xd0e960..0xd0e961
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8058,13 +8058,13 @@ Subprograms:
       DictRegister: null
     - ID: 100
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xd0dfe0..0xd0dfe1]
+      OutOfLinePCRanges: [0xd0e9a0..0xd0e9a1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 7 PointerType *bool
           Locations:
-            - Range: 0xd0dfe0..0xd0dfe1
+            - Range: 0xd0e9a0..0xd0e9a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8072,7 +8072,7 @@ Subprograms:
         - Name: a
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xd0dfe0..0xd0dfe1
+            - Range: 0xd0e9a0..0xd0e9a1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8080,13 +8080,13 @@ Subprograms:
       DictRegister: null
     - ID: 101
       Name: main.testCycle
-      OutOfLinePCRanges: [0xd0e020..0xd0e021]
+      OutOfLinePCRanges: [0xd0e9e0..0xd0e9e1]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 256 PointerType *main.t
           Locations:
-            - Range: 0xd0e020..0xd0e021
+            - Range: 0xd0e9e0..0xd0e9e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8094,13 +8094,13 @@ Subprograms:
       DictRegister: null
     - ID: 102
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xd0e520..0xd0e592]
+      OutOfLinePCRanges: [0xd0f000..0xd0f072]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0e520..0xd0e532
+            - Range: 0xd0f000..0xd0f012
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8108,11 +8108,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0e520..0xd0e57b
+            - Range: 0xd0f000..0xd0f05b
               Pieces: []
-            - Range: 0xd0e57b..0xd0e57c
+            - Range: 0xd0f05b..0xd0f05c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0e57c..0xd0e592
+            - Range: 0xd0f05c..0xd0f072
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8120,9 +8120,9 @@ Subprograms:
         - Name: result
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0e532..0xd0e545
+            - Range: 0xd0f012..0xd0f025
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0e545..0xd0e592
+            - Range: 0xd0f025..0xd0f072
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
@@ -8130,15 +8130,15 @@ Subprograms:
       DictRegister: null
     - ID: 103
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xd0e5a0..0xd0e635]
+      OutOfLinePCRanges: [0xd0f080..0xd0f115]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0e5a0..0xd0e5ba
+            - Range: 0xd0f080..0xd0f09a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0e5ba..0xd0e635
+            - Range: 0xd0f09a..0xd0f115
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8146,11 +8146,11 @@ Subprograms:
         - Name: ~r0
           Type: 96 PointerType *int
           Locations:
-            - Range: 0xd0e5a0..0xd0e61b
+            - Range: 0xd0f080..0xd0f0fb
               Pieces: []
-            - Range: 0xd0e61b..0xd0e61c
+            - Range: 0xd0f0fb..0xd0f0fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0e61c..0xd0e635
+            - Range: 0xd0f0fc..0xd0f115
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8158,9 +8158,9 @@ Subprograms:
         - Name: '&result'
           Type: 96 PointerType *int
           Locations:
-            - Range: 0xd0e5bf..0xd0e5dc
+            - Range: 0xd0f09f..0xd0f0bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0e5dc..0xd0e635
+            - Range: 0xd0f0bc..0xd0f115
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
@@ -8168,13 +8168,13 @@ Subprograms:
       DictRegister: null
     - ID: 104
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xd0e640..0xd0e71e]
+      OutOfLinePCRanges: [0xd0f120..0xd0f1fe]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0e640..0xd0e6a2
+            - Range: 0xd0f120..0xd0f182
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8182,27 +8182,27 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0e640..0xd0e704
+            - Range: 0xd0f120..0xd0f1e4
               Pieces: []
-            - Range: 0xd0e704..0xd0e705
+            - Range: 0xd0f1e4..0xd0f1e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0e705..0xd0e71e
+            - Range: 0xd0f1e5..0xd0f1fe
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0e640..0xd0e71e, Pieces: []}]
+          Locations: [{Range: 0xd0f120..0xd0f1fe, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: resultInt
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0e656..0xd0e6a7
+            - Range: 0xd0f136..0xd0f187
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0e6a7..0xd0e71e
+            - Range: 0xd0f187..0xd0f1fe
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
@@ -8210,9 +8210,9 @@ Subprograms:
         - Name: resultFloat
           Type: 19 BaseType float64
           Locations:
-            - Range: 0xd0e66f..0xd0e6a7
+            - Range: 0xd0f14f..0xd0f187
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xd0e6a7..0xd0e71e
+            - Range: 0xd0f187..0xd0f1fe
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
@@ -8220,13 +8220,13 @@ Subprograms:
       DictRegister: null
     - ID: 105
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xd0e720..0xd0e77b]
+      OutOfLinePCRanges: [0xd0f200..0xd0f25b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xd0e720..0xd0e739
+            - Range: 0xd0f200..0xd0f219
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8234,23 +8234,23 @@ Subprograms:
         - Name: ~r0
           Type: 20 GoInterfaceType error
           Locations:
-            - Range: 0xd0e720..0xd0e75a
+            - Range: 0xd0f200..0xd0f23a
               Pieces: []
-            - Range: 0xd0e75a..0xd0e75b
+            - Range: 0xd0f23a..0xd0f23b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0e75b..0xd0e765
+            - Range: 0xd0f23b..0xd0f245
               Pieces: []
-            - Range: 0xd0e765..0xd0e766
+            - Range: 0xd0f245..0xd0f246
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0e766..0xd0e77b
+            - Range: 0xd0f246..0xd0f25b
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8258,37 +8258,37 @@ Subprograms:
       DictRegister: null
     - ID: 106
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xd0e780..0xd0e8c6]
+      OutOfLinePCRanges: [0xd0f260..0xd0f3a6]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 55 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0e780..0xd0e7d1
+            - Range: 0xd0f260..0xd0f2b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0e7d1..0xd0e7d4
+            - Range: 0xd0f2b1..0xd0f2b4
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0e817..0xd0e825
+            - Range: 0xd0f2f7..0xd0f305
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0e840..0xd0e845
+            - Range: 0xd0f320..0xd0f325
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0e874..0xd0e879
+            - Range: 0xd0f354..0xd0f359
               Pieces:
                 - Size: 8
                   Op: null
@@ -8300,7 +8300,7 @@ Subprograms:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xd0e780..0xd0e7cf
+            - Range: 0xd0f260..0xd0f2af
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8308,39 +8308,39 @@ Subprograms:
         - Name: ~r0
           Type: 55 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0e780..0xd0e7f8
+            - Range: 0xd0f260..0xd0f2d8
               Pieces: []
-            - Range: 0xd0e7f8..0xd0e7f9
+            - Range: 0xd0f2d8..0xd0f2d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0e7f9..0xd0e833
+            - Range: 0xd0f2d9..0xd0f313
               Pieces: []
-            - Range: 0xd0e833..0xd0e834
+            - Range: 0xd0f313..0xd0f314
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0e834..0xd0e867
+            - Range: 0xd0f314..0xd0f347
               Pieces: []
-            - Range: 0xd0e867..0xd0e868
+            - Range: 0xd0f347..0xd0f348
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0e868..0xd0e899
+            - Range: 0xd0f348..0xd0f379
               Pieces: []
-            - Range: 0xd0e899..0xd0e89a
+            - Range: 0xd0f379..0xd0f37a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0e89a..0xd0e8c6
+            - Range: 0xd0f37a..0xd0f3a6
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8348,39 +8348,39 @@ Subprograms:
         - Name: ~r1
           Type: 20 GoInterfaceType error
           Locations:
-            - Range: 0xd0e780..0xd0e7f8
+            - Range: 0xd0f260..0xd0f2d8
               Pieces: []
-            - Range: 0xd0e7f8..0xd0e7f9
+            - Range: 0xd0f2d8..0xd0f2d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0e7f9..0xd0e833
+            - Range: 0xd0f2d9..0xd0f313
               Pieces: []
-            - Range: 0xd0e833..0xd0e834
+            - Range: 0xd0f313..0xd0f314
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0e834..0xd0e867
+            - Range: 0xd0f314..0xd0f347
               Pieces: []
-            - Range: 0xd0e867..0xd0e868
+            - Range: 0xd0f347..0xd0f348
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0e868..0xd0e899
+            - Range: 0xd0f348..0xd0f379
               Pieces: []
-            - Range: 0xd0e899..0xd0e89a
+            - Range: 0xd0f379..0xd0f37a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0e89a..0xd0e8c6
+            - Range: 0xd0f37a..0xd0f3a6
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8388,7 +8388,7 @@ Subprograms:
         - Name: val
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0e817..0xd0e820
+            - Range: 0xd0f2f7..0xd0f300
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8396,25 +8396,25 @@ Subprograms:
       DictRegister: null
     - ID: 107
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xd0e8e0..0xd0ead4]
+      OutOfLinePCRanges: [0xd0f3c0..0xd0f5b4]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 55 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0e8e0..0xd0e93f
+            - Range: 0xd0f3c0..0xd0f41f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0e93f..0xd0e942
+            - Range: 0xd0f41f..0xd0f422
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0e942..0xd0ead4
+            - Range: 0xd0f422..0xd0f5b4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -8426,39 +8426,39 @@ Subprograms:
         - Name: ~r0
           Type: 55 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0e8e0..0xd0e9a4
+            - Range: 0xd0f3c0..0xd0f484
               Pieces: []
-            - Range: 0xd0e9a4..0xd0e9a5
+            - Range: 0xd0f484..0xd0f485
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0e9a5..0xd0e9df
+            - Range: 0xd0f485..0xd0f4bf
               Pieces: []
-            - Range: 0xd0e9df..0xd0e9e0
+            - Range: 0xd0f4bf..0xd0f4c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0e9e0..0xd0eaa2
+            - Range: 0xd0f4c0..0xd0f582
               Pieces: []
-            - Range: 0xd0eaa2..0xd0eaa3
+            - Range: 0xd0f582..0xd0f583
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0eaa3..0xd0eaac
+            - Range: 0xd0f583..0xd0f58c
               Pieces: []
-            - Range: 0xd0eaac..0xd0eaad
+            - Range: 0xd0f58c..0xd0f58d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0eaad..0xd0ead4
+            - Range: 0xd0f58d..0xd0f5b4
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8466,7 +8466,7 @@ Subprograms:
         - Name: val
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0e9ca..0xd0e9d0
+            - Range: 0xd0f4aa..0xd0f4b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8474,7 +8474,7 @@ Subprograms:
         - Name: '&result'
           Type: 96 PointerType *int
           Locations:
-            - Range: 0xd0e985..0xd0e9a4
+            - Range: 0xd0f465..0xd0f484
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8482,35 +8482,35 @@ Subprograms:
       DictRegister: null
     - ID: 108
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xd0eae0..0xd0ec45]
+      OutOfLinePCRanges: [0xd0f5c0..0xd0f725]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 55 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd0eae0..0xd0eb20
+            - Range: 0xd0f5c0..0xd0f600
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0eb20..0xd0eb85
+            - Range: 0xd0f600..0xd0f665
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0eb85..0xd0ebe1
+            - Range: 0xd0f665..0xd0f6c1
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0ebe1..0xd0ec01
+            - Range: 0xd0f6c1..0xd0f6e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0ec01..0xd0ec08
+            - Range: 0xd0f6e1..0xd0f6e8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0ec08..0xd0ec45
+            - Range: 0xd0f6e8..0xd0f725
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8518,23 +8518,23 @@ Subprograms:
         - Name: ~r0
           Type: 166 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd0eae0..0xd0ebd1
+            - Range: 0xd0f5c0..0xd0f6b1
               Pieces: []
-            - Range: 0xd0ebd1..0xd0ebd2
+            - Range: 0xd0f6b1..0xd0f6b2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0ebd2..0xd0ebdb
+            - Range: 0xd0f6b2..0xd0f6bb
               Pieces: []
-            - Range: 0xd0ebdb..0xd0ebdc
+            - Range: 0xd0f6bb..0xd0f6bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0ebdc..0xd0ec45
+            - Range: 0xd0f6bc..0xd0f725
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8542,39 +8542,39 @@ Subprograms:
         - Name: b
           Type: 166 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd0eae0..0xd0eb20
+            - Range: 0xd0f5c0..0xd0f600
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0eb20..0xd0eb75
+            - Range: 0xd0f600..0xd0f655
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0eb75..0xd0eb85
+            - Range: 0xd0f655..0xd0f665
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0eb85..0xd0ebd7
+            - Range: 0xd0f665..0xd0f6b7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0ebd7..0xd0ebd9
+            - Range: 0xd0f6b7..0xd0f6b9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0ebd9..0xd0ebdb
+            - Range: 0xd0f6b9..0xd0f6bb
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0ebdb..0xd0ec45
+            - Range: 0xd0f6bb..0xd0f725
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
@@ -8582,13 +8582,13 @@ Subprograms:
       DictRegister: null
     - ID: 109
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xd0ec60..0xd0ecef]
+      OutOfLinePCRanges: [0xd0f740..0xd0f7cf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ec60..0xd0ec71
+            - Range: 0xd0f740..0xd0f751
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8596,11 +8596,11 @@ Subprograms:
         - Name: result
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ec60..0xd0ecd5
+            - Range: 0xd0f740..0xd0f7b5
               Pieces: []
-            - Range: 0xd0ecd5..0xd0ecd6
+            - Range: 0xd0f7b5..0xd0f7b6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ecd6..0xd0ecef
+            - Range: 0xd0f7b6..0xd0f7cf
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8608,13 +8608,13 @@ Subprograms:
       DictRegister: null
     - ID: 110
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xd0ed00..0xd0edc9]
+      OutOfLinePCRanges: [0xd0f7e0..0xd0f8a9]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ed00..0xd0ed53
+            - Range: 0xd0f7e0..0xd0f833
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8622,11 +8622,11 @@ Subprograms:
         - Name: result
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ed00..0xd0edaf
+            - Range: 0xd0f7e0..0xd0f88f
               Pieces: []
-            - Range: 0xd0edaf..0xd0edb0
+            - Range: 0xd0f88f..0xd0f890
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0edb0..0xd0edc9
+            - Range: 0xd0f890..0xd0f8a9
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8634,11 +8634,11 @@ Subprograms:
         - Name: result2
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ed00..0xd0edaf
+            - Range: 0xd0f7e0..0xd0f88f
               Pieces: []
-            - Range: 0xd0edaf..0xd0edb0
+            - Range: 0xd0f88f..0xd0f890
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0edb0..0xd0edc9
+            - Range: 0xd0f890..0xd0f8a9
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8646,15 +8646,15 @@ Subprograms:
       DictRegister: null
     - ID: 111
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xd0ede0..0xd0eea8]
+      OutOfLinePCRanges: [0xd0f8c0..0xd0f988]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ede0..0xd0ee25
+            - Range: 0xd0f8c0..0xd0f905
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ee25..0xd0eea8
+            - Range: 0xd0f905..0xd0f988
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8662,11 +8662,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ede0..0xd0ee8e
+            - Range: 0xd0f8c0..0xd0f96e
               Pieces: []
-            - Range: 0xd0ee8e..0xd0ee8f
+            - Range: 0xd0f96e..0xd0f96f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ee8f..0xd0eea8
+            - Range: 0xd0f96f..0xd0f988
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8674,11 +8674,11 @@ Subprograms:
         - Name: result2
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ede0..0xd0ee8e
+            - Range: 0xd0f8c0..0xd0f96e
               Pieces: []
-            - Range: 0xd0ee8e..0xd0ee8f
+            - Range: 0xd0f96e..0xd0f96f
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0ee8f..0xd0eea8
+            - Range: 0xd0f96f..0xd0f988
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8686,11 +8686,11 @@ Subprograms:
         - Name: ~r2
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ede0..0xd0ee8e
+            - Range: 0xd0f8c0..0xd0f96e
               Pieces: []
-            - Range: 0xd0ee8e..0xd0ee8f
+            - Range: 0xd0f96e..0xd0f96f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0ee8f..0xd0eea8
+            - Range: 0xd0f96f..0xd0f988
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8698,15 +8698,15 @@ Subprograms:
       DictRegister: null
     - ID: 112
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xd0eec0..0xd0efaf]
+      OutOfLinePCRanges: [0xd0f9a0..0xd0fa8f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0eec0..0xd0ef05
+            - Range: 0xd0f9a0..0xd0f9e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ef05..0xd0efaf
+            - Range: 0xd0f9e5..0xd0fa8f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8714,11 +8714,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0eec0..0xd0ef94
+            - Range: 0xd0f9a0..0xd0fa74
               Pieces: []
-            - Range: 0xd0ef94..0xd0ef95
+            - Range: 0xd0fa74..0xd0fa75
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ef95..0xd0efaf
+            - Range: 0xd0fa75..0xd0fa8f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8726,15 +8726,15 @@ Subprograms:
         - Name: r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd0eec0..0xd0ef94
+            - Range: 0xd0f9a0..0xd0fa74
               Pieces: []
-            - Range: 0xd0ef94..0xd0ef95
+            - Range: 0xd0fa74..0xd0fa75
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd0ef95..0xd0efaf
+            - Range: 0xd0fa75..0xd0fa8f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8742,15 +8742,15 @@ Subprograms:
       DictRegister: null
     - ID: 113
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xd0efc0..0xd0f1cf]
+      OutOfLinePCRanges: [0xd0faa0..0xd0fcaf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0efc0..0xd0f046
+            - Range: 0xd0faa0..0xd0fb26
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0f046..0xd0f1cf
+            - Range: 0xd0fb26..0xd0fcaf
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8758,7 +8758,7 @@ Subprograms:
         - Name: a
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd0eff7..0xd0f1cf
+            - Range: 0xd0fad7..0xd0fcaf
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
@@ -8766,7 +8766,7 @@ Subprograms:
         - Name: b
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd0effd..0xd0f1cf
+            - Range: 0xd0fadd..0xd0fcaf
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
@@ -8774,17 +8774,17 @@ Subprograms:
       DictRegister: null
     - ID: 114
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xd0f2c0..0xd0f33e]
+      OutOfLinePCRanges: [0xd0fda0..0xd0fe1e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xd0f2c0..0xd0f331
+            - Range: 0xd0fda0..0xd0fe11
               Pieces: []
-            - Range: 0xd0f331..0xd0f332
+            - Range: 0xd0fe11..0xd0fe12
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0f332..0xd0f33e
+            - Range: 0xd0fe12..0xd0fe1e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8792,11 +8792,11 @@ Subprograms:
         - Name: ~r1
           Type: 100 BaseType int16
           Locations:
-            - Range: 0xd0f2c0..0xd0f331
+            - Range: 0xd0fda0..0xd0fe11
               Pieces: []
-            - Range: 0xd0f331..0xd0f332
+            - Range: 0xd0fe11..0xd0fe12
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0f332..0xd0f33e
+            - Range: 0xd0fe12..0xd0fe1e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8804,11 +8804,11 @@ Subprograms:
         - Name: ~r2
           Type: 14 BaseType int32
           Locations:
-            - Range: 0xd0f2c0..0xd0f331
+            - Range: 0xd0fda0..0xd0fe11
               Pieces: []
-            - Range: 0xd0f331..0xd0f332
+            - Range: 0xd0fe11..0xd0fe12
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0f332..0xd0f33e
+            - Range: 0xd0fe12..0xd0fe1e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8816,11 +8816,11 @@ Subprograms:
         - Name: ~r3
           Type: 15 BaseType int64
           Locations:
-            - Range: 0xd0f2c0..0xd0f331
+            - Range: 0xd0fda0..0xd0fe11
               Pieces: []
-            - Range: 0xd0f331..0xd0f332
+            - Range: 0xd0fe11..0xd0fe12
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0f332..0xd0f33e
+            - Range: 0xd0fe12..0xd0fe1e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8828,11 +8828,11 @@ Subprograms:
         - Name: ~r4
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xd0f2c0..0xd0f331
+            - Range: 0xd0fda0..0xd0fe11
               Pieces: []
-            - Range: 0xd0f331..0xd0f332
+            - Range: 0xd0fe11..0xd0fe12
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0f332..0xd0f33e
+            - Range: 0xd0fe12..0xd0fe1e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8840,11 +8840,11 @@ Subprograms:
         - Name: ~r5
           Type: 9 BaseType uint16
           Locations:
-            - Range: 0xd0f2c0..0xd0f331
+            - Range: 0xd0fda0..0xd0fe11
               Pieces: []
-            - Range: 0xd0f331..0xd0f332
+            - Range: 0xd0fe11..0xd0fe12
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0f332..0xd0f33e
+            - Range: 0xd0fe12..0xd0fe1e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8852,11 +8852,11 @@ Subprograms:
         - Name: ~r6
           Type: 4 BaseType uint32
           Locations:
-            - Range: 0xd0f2c0..0xd0f331
+            - Range: 0xd0fda0..0xd0fe11
               Pieces: []
-            - Range: 0xd0f331..0xd0f332
+            - Range: 0xd0fe11..0xd0fe12
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0f332..0xd0f33e
+            - Range: 0xd0fe12..0xd0fe1e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8864,11 +8864,11 @@ Subprograms:
         - Name: ~r7
           Type: 12 BaseType uint64
           Locations:
-            - Range: 0xd0f2c0..0xd0f331
+            - Range: 0xd0fda0..0xd0fe11
               Pieces: []
-            - Range: 0xd0f331..0xd0f332
+            - Range: 0xd0fe11..0xd0fe12
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0f332..0xd0f33e
+            - Range: 0xd0fe12..0xd0fe1e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8876,107 +8876,107 @@ Subprograms:
       DictRegister: null
     - ID: 115
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xd0f340..0xd0f435]
+      OutOfLinePCRanges: [0xd0fe20..0xd0ff15]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f340..0xd0f435, Pieces: []}]
+          Locations: [{Range: 0xd0fe20..0xd0ff15, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f340..0xd0f435, Pieces: []}]
+          Locations: [{Range: 0xd0fe20..0xd0ff15, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f340..0xd0f435, Pieces: []}]
+          Locations: [{Range: 0xd0fe20..0xd0ff15, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f340..0xd0f435, Pieces: []}]
+          Locations: [{Range: 0xd0fe20..0xd0ff15, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f340..0xd0f435, Pieces: []}]
+          Locations: [{Range: 0xd0fe20..0xd0ff15, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r5
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f340..0xd0f435, Pieces: []}]
+          Locations: [{Range: 0xd0fe20..0xd0ff15, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r6
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f340..0xd0f435, Pieces: []}]
+          Locations: [{Range: 0xd0fe20..0xd0ff15, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r7
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f340..0xd0f435, Pieces: []}]
+          Locations: [{Range: 0xd0fe20..0xd0ff15, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r8
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f340..0xd0f435, Pieces: []}]
+          Locations: [{Range: 0xd0fe20..0xd0ff15, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r9
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f340..0xd0f435, Pieces: []}]
+          Locations: [{Range: 0xd0fe20..0xd0ff15, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r10
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f340..0xd0f435, Pieces: []}]
+          Locations: [{Range: 0xd0fe20..0xd0ff15, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r11
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f340..0xd0f435, Pieces: []}]
+          Locations: [{Range: 0xd0fe20..0xd0ff15, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r12
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f340..0xd0f435, Pieces: []}]
+          Locations: [{Range: 0xd0fe20..0xd0ff15, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r13
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f340..0xd0f435, Pieces: []}]
+          Locations: [{Range: 0xd0fe20..0xd0ff15, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r14
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f340..0xd0f435, Pieces: []}]
+          Locations: [{Range: 0xd0fe20..0xd0ff15, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: onlyOnAmd64_16
           Type: 19 BaseType float64
           Locations:
-            - Range: 0xd0f340..0xd0f425
+            - Range: 0xd0fe20..0xd0ff05
               Pieces: []
-            - Range: 0xd0f425..0xd0f426
+            - Range: 0xd0ff05..0xd0ff06
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xd0f426..0xd0f435
+            - Range: 0xd0ff06..0xd0ff15
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8984,11 +8984,11 @@ Subprograms:
         - Name: bothArmAndAmd64
           Type: 19 BaseType float64
           Locations:
-            - Range: 0xd0f340..0xd0f425
+            - Range: 0xd0fe20..0xd0ff05
               Pieces: []
-            - Range: 0xd0f425..0xd0f426
+            - Range: 0xd0ff05..0xd0ff06
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0f426..0xd0f435
+            - Range: 0xd0ff06..0xd0ff15
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8996,35 +8996,35 @@ Subprograms:
       DictRegister: null
     - ID: 116
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xd0f440..0xd0f4b3]
+      OutOfLinePCRanges: [0xd0ff20..0xd0ff93]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 92 BaseType complex64
-          Locations: [{Range: 0xd0f440..0xd0f4b3, Pieces: []}]
+          Locations: [{Range: 0xd0ff20..0xd0ff93, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 93 BaseType complex128
-          Locations: [{Range: 0xd0f440..0xd0f4b3, Pieces: []}]
+          Locations: [{Range: 0xd0ff20..0xd0ff93, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 117
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xd0f4c0..0xd0f565]
+      OutOfLinePCRanges: [0xd0ffa0..0xd10045]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0f4c0..0xd0f553
+            - Range: 0xd0ffa0..0xd10033
               Pieces: []
-            - Range: 0xd0f553..0xd0f554
+            - Range: 0xd10033..0xd10034
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xd0f554..0xd0f565
+            - Range: 0xd10034..0xd10045
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9032,17 +9032,17 @@ Subprograms:
       DictRegister: null
     - ID: 118
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xd0f580..0xd0f5fa]
+      OutOfLinePCRanges: [0xd10060..0xd100da]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 ArrayType [3]int
           Locations:
-            - Range: 0xd0f580..0xd0f5ed
+            - Range: 0xd10060..0xd100cd
               Pieces: []
-            - Range: 0xd0f5ed..0xd0f5ee
+            - Range: 0xd100cd..0xd100ce
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xd0f5ee..0xd0f5fa
+            - Range: 0xd100ce..0xd100da
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9050,17 +9050,17 @@ Subprograms:
       DictRegister: null
     - ID: 119
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xd0f600..0xd0f658]
+      OutOfLinePCRanges: [0xd100e0..0xd10138]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 260 ArrayType [1]int
           Locations:
-            - Range: 0xd0f600..0xd0f64b
+            - Range: 0xd100e0..0xd1012b
               Pieces: []
-            - Range: 0xd0f64b..0xd0f64c
+            - Range: 0xd1012b..0xd1012c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0f64c..0xd0f658
+            - Range: 0xd1012c..0xd10138
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9068,17 +9068,17 @@ Subprograms:
       DictRegister: null
     - ID: 120
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xd0f660..0xd0f6b3]
+      OutOfLinePCRanges: [0xd10140..0xd10193]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 ArrayType [0]int
           Locations:
-            - Range: 0xd0f660..0xd0f6a6
+            - Range: 0xd10140..0xd10186
               Pieces: []
-            - Range: 0xd0f6a6..0xd0f6a7
+            - Range: 0xd10186..0xd10187
               Pieces: []
-            - Range: 0xd0f6a7..0xd0f6b3
+            - Range: 0xd10187..0xd10193
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9086,29 +9086,29 @@ Subprograms:
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xd0f6c0..0xd0f727]
+      OutOfLinePCRanges: [0xd101a0..0xd10207]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 StructureType main.mixedStruct
-          Locations: [{Range: 0xd0f6c0..0xd0f727, Pieces: []}]
+          Locations: [{Range: 0xd101a0..0xd10207, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 122
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xd0f740..0xd0f7da]
+      OutOfLinePCRanges: [0xd10220..0xd102ba]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0f740..0xd0f7ca
+            - Range: 0xd10220..0xd102aa
               Pieces: []
-            - Range: 0xd0f7ca..0xd0f7cb
+            - Range: 0xd102aa..0xd102ab
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0f7cb..0xd0f7da
+            - Range: 0xd102ab..0xd102ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9116,11 +9116,11 @@ Subprograms:
         - Name: ~r1
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0f740..0xd0f7ca
+            - Range: 0xd10220..0xd102aa
               Pieces: []
-            - Range: 0xd0f7ca..0xd0f7cb
+            - Range: 0xd102aa..0xd102ab
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0f7cb..0xd0f7da
+            - Range: 0xd102ab..0xd102ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9128,11 +9128,11 @@ Subprograms:
         - Name: ~r2
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0f740..0xd0f7ca
+            - Range: 0xd10220..0xd102aa
               Pieces: []
-            - Range: 0xd0f7ca..0xd0f7cb
+            - Range: 0xd102aa..0xd102ab
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0f7cb..0xd0f7da
+            - Range: 0xd102ab..0xd102ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9140,11 +9140,11 @@ Subprograms:
         - Name: ~r3
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0f740..0xd0f7ca
+            - Range: 0xd10220..0xd102aa
               Pieces: []
-            - Range: 0xd0f7ca..0xd0f7cb
+            - Range: 0xd102aa..0xd102ab
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0f7cb..0xd0f7da
+            - Range: 0xd102ab..0xd102ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9152,11 +9152,11 @@ Subprograms:
         - Name: ~r4
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0f740..0xd0f7ca
+            - Range: 0xd10220..0xd102aa
               Pieces: []
-            - Range: 0xd0f7ca..0xd0f7cb
+            - Range: 0xd102aa..0xd102ab
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0f7cb..0xd0f7da
+            - Range: 0xd102ab..0xd102ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9164,11 +9164,11 @@ Subprograms:
         - Name: ~r5
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0f740..0xd0f7ca
+            - Range: 0xd10220..0xd102aa
               Pieces: []
-            - Range: 0xd0f7ca..0xd0f7cb
+            - Range: 0xd102aa..0xd102ab
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0f7cb..0xd0f7da
+            - Range: 0xd102ab..0xd102ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9176,11 +9176,11 @@ Subprograms:
         - Name: ~r6
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0f740..0xd0f7ca
+            - Range: 0xd10220..0xd102aa
               Pieces: []
-            - Range: 0xd0f7ca..0xd0f7cb
+            - Range: 0xd102aa..0xd102ab
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0f7cb..0xd0f7da
+            - Range: 0xd102ab..0xd102ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9188,11 +9188,11 @@ Subprograms:
         - Name: ~r7
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0f740..0xd0f7ca
+            - Range: 0xd10220..0xd102aa
               Pieces: []
-            - Range: 0xd0f7ca..0xd0f7cb
+            - Range: 0xd102aa..0xd102ab
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0f7cb..0xd0f7da
+            - Range: 0xd102ab..0xd102ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9200,11 +9200,11 @@ Subprograms:
         - Name: ~r8
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd0f740..0xd0f7ca
+            - Range: 0xd10220..0xd102aa
               Pieces: []
-            - Range: 0xd0f7ca..0xd0f7cb
+            - Range: 0xd102aa..0xd102ab
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xd0f7cb..0xd0f7da
+            - Range: 0xd102ab..0xd102ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9212,17 +9212,17 @@ Subprograms:
       DictRegister: null
     - ID: 123
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xd0f7e0..0xd0f885]
+      OutOfLinePCRanges: [0xd102c0..0xd10365]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 263 StructureType main.wideStruct
           Locations:
-            - Range: 0xd0f7e0..0xd0f874
+            - Range: 0xd102c0..0xd10354
               Pieces: []
-            - Range: 0xd0f874..0xd0f875
+            - Range: 0xd10354..0xd10355
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xd0f875..0xd0f885
+            - Range: 0xd10355..0xd10365
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9230,57 +9230,57 @@ Subprograms:
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xd0f8a0..0xd0f919]
+      OutOfLinePCRanges: [0xd10380..0xd103f9]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0f8a0..0xd0f90c
+            - Range: 0xd10380..0xd103ec
               Pieces: []
-            - Range: 0xd0f90c..0xd0f90d
+            - Range: 0xd103ec..0xd103ed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0f90d..0xd0f919
+            - Range: 0xd103ed..0xd103f9
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f8a0..0xd0f919, Pieces: []}]
+          Locations: [{Range: 0xd10380..0xd103f9, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0f8a0..0xd0f90c
+            - Range: 0xd10380..0xd103ec
               Pieces: []
-            - Range: 0xd0f90c..0xd0f90d
+            - Range: 0xd103ec..0xd103ed
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0f90d..0xd0f919
+            - Range: 0xd103ed..0xd103f9
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f8a0..0xd0f919, Pieces: []}]
+          Locations: [{Range: 0xd10380..0xd103f9, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd0f8a0..0xd0f90c
+            - Range: 0xd10380..0xd103ec
               Pieces: []
-            - Range: 0xd0f90c..0xd0f90d
+            - Range: 0xd103ec..0xd103ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0f90d..0xd0f919
+            - Range: 0xd103ed..0xd103f9
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9288,17 +9288,17 @@ Subprograms:
       DictRegister: null
     - ID: 125
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xd0f920..0xd0f99a]
+      OutOfLinePCRanges: [0xd10400..0xd1047a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 264 StructureType main.structWithArray
           Locations:
-            - Range: 0xd0f920..0xd0f98d
+            - Range: 0xd10400..0xd1046d
               Pieces: []
-            - Range: 0xd0f98d..0xd0f98e
+            - Range: 0xd1046d..0xd1046e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xd0f98e..0xd0f99a
+            - Range: 0xd1046e..0xd1047a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9306,47 +9306,47 @@ Subprograms:
       DictRegister: null
     - ID: 126
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xd0f9a0..0xd0f9fb]
+      OutOfLinePCRanges: [0xd10480..0xd104db]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0f9a0..0xd0f9fb, Pieces: []}]
+          Locations: [{Range: 0xd10480..0xd104db, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 127
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xd0fa00..0xd0fa67]
+      OutOfLinePCRanges: [0xd104e0..0xd10547]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0xd0fa00..0xd0fa67, Pieces: []}]
+          Locations: [{Range: 0xd104e0..0xd10547, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0xd0fa00..0xd0fa67, Pieces: []}]
+          Locations: [{Range: 0xd104e0..0xd10547, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 128
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xd0fa80..0xd0fadd]
+      OutOfLinePCRanges: [0xd10560..0xd105bd]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xd0fa80..0xd0fad0
+            - Range: 0xd10560..0xd105b0
               Pieces: []
-            - Range: 0xd0fad0..0xd0fad1
+            - Range: 0xd105b0..0xd105b1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0fad1..0xd0fadd
+            - Range: 0xd105b1..0xd105bd
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9354,11 +9354,11 @@ Subprograms:
         - Name: ~r1
           Type: 3 BaseType uintptr
           Locations:
-            - Range: 0xd0fa80..0xd0fad0
+            - Range: 0xd10560..0xd105b0
               Pieces: []
-            - Range: 0xd0fad0..0xd0fad1
+            - Range: 0xd105b0..0xd105b1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0fad1..0xd0fadd
+            - Range: 0xd105b1..0xd105bd
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9366,13 +9366,13 @@ Subprograms:
       DictRegister: null
     - ID: 129
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xd0fae0..0xd0fc45]
+      OutOfLinePCRanges: [0xd105c0..0xd10725]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 258 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0fae0..0xd0fc45
+            - Range: 0xd105c0..0xd10725
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9380,11 +9380,11 @@ Subprograms:
         - Name: ~r0
           Type: 258 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0fae0..0xd0fc33
+            - Range: 0xd105c0..0xd10713
               Pieces: []
-            - Range: 0xd0fc33..0xd0fc34
+            - Range: 0xd10713..0xd10714
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xd0fc34..0xd0fc45
+            - Range: 0xd10714..0xd10725
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9392,13 +9392,13 @@ Subprograms:
       DictRegister: null
     - ID: 130
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xd0fc60..0xd0fd32]
+      OutOfLinePCRanges: [0xd10740..0xd10812]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 259 ArrayType [3]int
           Locations:
-            - Range: 0xd0fc60..0xd0fd32
+            - Range: 0xd10740..0xd10812
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9406,11 +9406,11 @@ Subprograms:
         - Name: ~r0
           Type: 259 ArrayType [3]int
           Locations:
-            - Range: 0xd0fc60..0xd0fd22
+            - Range: 0xd10740..0xd10802
               Pieces: []
-            - Range: 0xd0fd22..0xd0fd23
+            - Range: 0xd10802..0xd10803
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xd0fd23..0xd0fd32
+            - Range: 0xd10803..0xd10812
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9418,13 +9418,13 @@ Subprograms:
       DictRegister: null
     - ID: 131
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xd0fd40..0xd0ff7a]
+      OutOfLinePCRanges: [0xd10820..0xd10a5a]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 258 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0fd40..0xd0ff7a
+            - Range: 0xd10820..0xd10a5a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9432,7 +9432,7 @@ Subprograms:
         - Name: s2
           Type: 258 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0fd40..0xd0ff7a
+            - Range: 0xd10820..0xd10a5a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
@@ -9440,11 +9440,11 @@ Subprograms:
         - Name: ~r0
           Type: 258 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0fd40..0xd0ff6a
+            - Range: 0xd10820..0xd10a4a
               Pieces: []
-            - Range: 0xd0ff6a..0xd0ff6b
+            - Range: 0xd10a4a..0xd10a4b
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xd0ff6b..0xd0ff7a
+            - Range: 0xd10a4b..0xd10a5a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9452,15 +9452,15 @@ Subprograms:
       DictRegister: null
     - ID: 132
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xd0ff80..0xd1020f]
+      OutOfLinePCRanges: [0xd10a60..0xd10cef]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ff80..0xd10030
+            - Range: 0xd10a60..0xd10b10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd10030..0xd1020f
+            - Range: 0xd10b10..0xd10cef
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -9468,9 +9468,9 @@ Subprograms:
         - Name: b
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ff80..0xd10030
+            - Range: 0xd10a60..0xd10b10
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd10030..0xd1020f
+            - Range: 0xd10b10..0xd10cef
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -9478,9 +9478,9 @@ Subprograms:
         - Name: c
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ff80..0xd10030
+            - Range: 0xd10a60..0xd10b10
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd10030..0xd1020f
+            - Range: 0xd10b10..0xd10cef
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
@@ -9488,9 +9488,9 @@ Subprograms:
         - Name: d
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ff80..0xd0fff0
+            - Range: 0xd10a60..0xd10ad0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0fff0..0xd1020f
+            - Range: 0xd10ad0..0xd10cef
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
@@ -9498,9 +9498,9 @@ Subprograms:
         - Name: e
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ff80..0xd10030
+            - Range: 0xd10a60..0xd10b10
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd10030..0xd1020f
+            - Range: 0xd10b10..0xd10cef
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
@@ -9508,9 +9508,9 @@ Subprograms:
         - Name: f
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ff80..0xd10030
+            - Range: 0xd10a60..0xd10b10
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd10030..0xd1020f
+            - Range: 0xd10b10..0xd10cef
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
@@ -9518,9 +9518,9 @@ Subprograms:
         - Name: g
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ff80..0xd10030
+            - Range: 0xd10a60..0xd10b10
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd10030..0xd1020f
+            - Range: 0xd10b10..0xd10cef
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
@@ -9528,9 +9528,9 @@ Subprograms:
         - Name: h
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ff80..0xd10030
+            - Range: 0xd10a60..0xd10b10
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd10030..0xd1020f
+            - Range: 0xd10b10..0xd10cef
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
@@ -9538,9 +9538,9 @@ Subprograms:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ff80..0xd10030
+            - Range: 0xd10a60..0xd10b10
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xd10030..0xd1020f
+            - Range: 0xd10b10..0xd10cef
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
@@ -9548,11 +9548,11 @@ Subprograms:
         - Name: ~r0
           Type: 109 ArrayType [2]int
           Locations:
-            - Range: 0xd0ff80..0xd101a2
+            - Range: 0xd10a60..0xd10c82
               Pieces: []
-            - Range: 0xd101a2..0xd101a3
+            - Range: 0xd10c82..0xd10c83
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xd101a3..0xd1020f
+            - Range: 0xd10c83..0xd10cef
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9560,15 +9560,15 @@ Subprograms:
       DictRegister: null
     - ID: 133
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xd10220..0xd104ec]
+      OutOfLinePCRanges: [0xd10d00..0xd10fcc]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10220..0xd102cb
+            - Range: 0xd10d00..0xd10dab
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd102cb..0xd104ec
+            - Range: 0xd10dab..0xd10fcc
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
@@ -9576,9 +9576,9 @@ Subprograms:
         - Name: b
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10220..0xd102cb
+            - Range: 0xd10d00..0xd10dab
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd102cb..0xd104ec
+            - Range: 0xd10dab..0xd10fcc
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
@@ -9586,9 +9586,9 @@ Subprograms:
         - Name: c
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10220..0xd102cb
+            - Range: 0xd10d00..0xd10dab
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd102cb..0xd104ec
+            - Range: 0xd10dab..0xd10fcc
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
@@ -9596,9 +9596,9 @@ Subprograms:
         - Name: d
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10220..0xd10282
+            - Range: 0xd10d00..0xd10d62
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd10282..0xd104ec
+            - Range: 0xd10d62..0xd10fcc
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
@@ -9606,9 +9606,9 @@ Subprograms:
         - Name: e
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10220..0xd102cb
+            - Range: 0xd10d00..0xd10dab
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd102cb..0xd104ec
+            - Range: 0xd10dab..0xd10fcc
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
@@ -9616,9 +9616,9 @@ Subprograms:
         - Name: f
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10220..0xd102cb
+            - Range: 0xd10d00..0xd10dab
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd102cb..0xd104ec
+            - Range: 0xd10dab..0xd10fcc
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
@@ -9626,9 +9626,9 @@ Subprograms:
         - Name: g
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10220..0xd102cb
+            - Range: 0xd10d00..0xd10dab
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd102cb..0xd104ec
+            - Range: 0xd10dab..0xd10fcc
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
@@ -9636,9 +9636,9 @@ Subprograms:
         - Name: h
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10220..0xd102cb
+            - Range: 0xd10d00..0xd10dab
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd102cb..0xd104ec
+            - Range: 0xd10dab..0xd10fcc
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
@@ -9646,7 +9646,7 @@ Subprograms:
         - Name: s
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd10220..0xd104ec
+            - Range: 0xd10d00..0xd10fcc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -9658,11 +9658,11 @@ Subprograms:
         - Name: ~r0
           Type: 258 StructureType main.largeStruct
           Locations:
-            - Range: 0xd10220..0xd1046b
+            - Range: 0xd10d00..0xd10f4b
               Pieces: []
-            - Range: 0xd1046b..0xd1046c
+            - Range: 0xd10f4b..0xd10f4c
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xd1046c..0xd104ec
+            - Range: 0xd10f4c..0xd10fcc
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9670,13 +9670,13 @@ Subprograms:
       DictRegister: null
     - ID: 134
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xd10500..0xd1058c]
+      OutOfLinePCRanges: [0xd10fe0..0xd1106c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 165 ArrayType [5]int
           Locations:
-            - Range: 0xd10500..0xd1058c
+            - Range: 0xd10fe0..0xd1106c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9684,11 +9684,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10500..0xd1057c
+            - Range: 0xd10fe0..0xd1105c
               Pieces: []
-            - Range: 0xd1057c..0xd1057d
+            - Range: 0xd1105c..0xd1105d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd1057d..0xd1058c
+            - Range: 0xd1105d..0xd1106c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9696,11 +9696,11 @@ Subprograms:
         - Name: ~r1
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10500..0xd1057c
+            - Range: 0xd10fe0..0xd1105c
               Pieces: []
-            - Range: 0xd1057c..0xd1057d
+            - Range: 0xd1105c..0xd1105d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd1057d..0xd1058c
+            - Range: 0xd1105d..0xd1106c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9708,11 +9708,11 @@ Subprograms:
         - Name: ~r2
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10500..0xd1057c
+            - Range: 0xd10fe0..0xd1105c
               Pieces: []
-            - Range: 0xd1057c..0xd1057d
+            - Range: 0xd1105c..0xd1105d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd1057d..0xd1058c
+            - Range: 0xd1105d..0xd1106c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9720,13 +9720,13 @@ Subprograms:
       DictRegister: null
     - ID: 135
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xd105a0..0xd1068a]
+      OutOfLinePCRanges: [0xd11080..0xd1116a]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 109 ArrayType [2]int
           Locations:
-            - Range: 0xd105a0..0xd1068a
+            - Range: 0xd11080..0xd1116a
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9734,7 +9734,7 @@ Subprograms:
         - Name: b
           Type: 259 ArrayType [3]int
           Locations:
-            - Range: 0xd105a0..0xd1068a
+            - Range: 0xd11080..0xd1116a
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -9742,11 +9742,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd105a0..0xd10676
+            - Range: 0xd11080..0xd11156
               Pieces: []
-            - Range: 0xd10676..0xd10677
+            - Range: 0xd11156..0xd11157
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd10677..0xd1068a
+            - Range: 0xd11157..0xd1116a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9754,11 +9754,11 @@ Subprograms:
         - Name: ~r1
           Type: 109 ArrayType [2]int
           Locations:
-            - Range: 0xd105a0..0xd10676
+            - Range: 0xd11080..0xd11156
               Pieces: []
-            - Range: 0xd10676..0xd10677
+            - Range: 0xd11156..0xd11157
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xd10677..0xd1068a
+            - Range: 0xd11157..0xd1116a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9766,13 +9766,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xd106a0..0xd1076b]
+      OutOfLinePCRanges: [0xd11180..0xd1124b]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 264 StructureType main.structWithArray
           Locations:
-            - Range: 0xd106a0..0xd1076b
+            - Range: 0xd11180..0xd1124b
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9780,11 +9780,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd106a0..0xd1075a
+            - Range: 0xd11180..0xd1123a
               Pieces: []
-            - Range: 0xd1075a..0xd1075b
+            - Range: 0xd1123a..0xd1123b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd1075b..0xd1076b
+            - Range: 0xd1123b..0xd1124b
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9792,11 +9792,11 @@ Subprograms:
         - Name: ~r1
           Type: 264 StructureType main.structWithArray
           Locations:
-            - Range: 0xd106a0..0xd1075a
+            - Range: 0xd11180..0xd1123a
               Pieces: []
-            - Range: 0xd1075a..0xd1075b
+            - Range: 0xd1123a..0xd1123b
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xd1075b..0xd1076b
+            - Range: 0xd1123b..0xd1124b
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9804,7 +9804,7 @@ Subprograms:
         - Name: x
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10726..0xd1076b
+            - Range: 0xd11206..0xd1124b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -9812,25 +9812,25 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xd10780..0xd10826]
+      OutOfLinePCRanges: [0xd11260..0xd11306]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 261 ArrayType [0]int
-          Locations: [{Range: 0xd10780..0xd10826, Pieces: []}]
+          Locations: [{Range: 0xd11260..0xd11306, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: b
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10780..0xd107c5
+            - Range: 0xd11260..0xd112a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd107c5..0xd107e7
+            - Range: 0xd112a5..0xd112c7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xd107e7..0xd10802
+            - Range: 0xd112c7..0xd112e2
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xd10802..0xd10826
+            - Range: 0xd112e2..0xd11306
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
@@ -9838,11 +9838,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10780..0xd1080c
+            - Range: 0xd11260..0xd112ec
               Pieces: []
-            - Range: 0xd1080c..0xd1080d
+            - Range: 0xd112ec..0xd112ed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd1080d..0xd10826
+            - Range: 0xd112ed..0xd11306
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9850,11 +9850,11 @@ Subprograms:
         - Name: ~r1
           Type: 261 ArrayType [0]int
           Locations:
-            - Range: 0xd10780..0xd1080c
+            - Range: 0xd11260..0xd112ec
               Pieces: []
-            - Range: 0xd1080c..0xd1080d
+            - Range: 0xd112ec..0xd112ed
               Pieces: []
-            - Range: 0xd1080d..0xd10826
+            - Range: 0xd112ed..0xd11306
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9862,13 +9862,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xd10d40..0xd10d41]
+      OutOfLinePCRanges: [0xd11820..0xd11821]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 265 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd10d40..0xd10d41
+            - Range: 0xd11820..0xd11821
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9882,13 +9882,13 @@ Subprograms:
       DictRegister: null
     - ID: 139
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xd10d60..0xd10d61]
+      OutOfLinePCRanges: [0xd11840..0xd11841]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 265 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd10d60..0xd10d61
+            - Range: 0xd11840..0xd11841
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9902,13 +9902,13 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xd10d80..0xd10d81]
+      OutOfLinePCRanges: [0xd11860..0xd11861]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 266 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xd10d80..0xd10d81
+            - Range: 0xd11860..0xd11861
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9922,13 +9922,13 @@ Subprograms:
       DictRegister: null
     - ID: 141
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0xd10da0..0xd10da1]
+      OutOfLinePCRanges: [0xd11880..0xd11881]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 268 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd10da0..0xd10da1
+            - Range: 0xd11880..0xd11881
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9942,7 +9942,7 @@ Subprograms:
         - Name: a
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10da0..0xd10da1
+            - Range: 0xd11880..0xd11881
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9950,13 +9950,13 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xd10dc0..0xd10dc1]
+      OutOfLinePCRanges: [0xd118a0..0xd118a1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 268 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd10dc0..0xd10dc1
+            - Range: 0xd118a0..0xd118a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9970,7 +9970,7 @@ Subprograms:
         - Name: a
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10dc0..0xd10dc1
+            - Range: 0xd118a0..0xd118a1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9978,13 +9978,13 @@ Subprograms:
       DictRegister: null
     - ID: 143
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xd10de0..0xd10de1]
+      OutOfLinePCRanges: [0xd118c0..0xd118c1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 268 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd10de0..0xd10de1
+            - Range: 0xd118c0..0xd118c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9998,7 +9998,7 @@ Subprograms:
         - Name: a
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd10de0..0xd10de1
+            - Range: 0xd118c0..0xd118c1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10006,13 +10006,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xd10e00..0xd10e01]
+      OutOfLinePCRanges: [0xd118e0..0xd118e1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 159 GoSliceHeaderType []string
           Locations:
-            - Range: 0xd10e00..0xd10e01
+            - Range: 0xd118e0..0xd118e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10026,13 +10026,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xd10e20..0xd10e21]
+      OutOfLinePCRanges: [0xd11900..0xd11901]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xd10e20..0xd10e21
+            - Range: 0xd11900..0xd11901
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10040,7 +10040,7 @@ Subprograms:
         - Name: s
           Type: 271 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xd10e20..0xd10e21
+            - Range: 0xd11900..0xd11901
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10054,7 +10054,7 @@ Subprograms:
         - Name: x
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xd10e20..0xd10e21
+            - Range: 0xd11900..0xd11901
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10062,13 +10062,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xd10e40..0xd10e41]
+      OutOfLinePCRanges: [0xd11920..0xd11921]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 272 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xd10e40..0xd10e41
+            - Range: 0xd11920..0xd11921
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10082,13 +10082,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xd10e60..0xd10e61]
+      OutOfLinePCRanges: [0xd11940..0xd11941]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 265 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd10e60..0xd10e61
+            - Range: 0xd11940..0xd11941
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10102,13 +10102,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xd10e80..0xd10e81]
+      OutOfLinePCRanges: [0xd11960..0xd11961]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 273 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0xd10e80..0xd10e81
+            - Range: 0xd11960..0xd11961
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10122,13 +10122,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xd10ea0..0xd10ea1]
+      OutOfLinePCRanges: [0xd11980..0xd11981]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 265 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd10ea0..0xd10ea1
+            - Range: 0xd11980..0xd11981
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10142,7 +10142,7 @@ Subprograms:
         - Name: bs
           Type: 265 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd10ea0..0xd10ea1
+            - Range: 0xd11980..0xd11981
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10156,7 +10156,7 @@ Subprograms:
         - Name: cs
           Type: 265 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd10ea0..0xd10ea1
+            - Range: 0xd11980..0xd11981
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -10170,13 +10170,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testByteSliceInvalidUtf8
-      OutOfLinePCRanges: [0xd10f20..0xd10f21]
+      OutOfLinePCRanges: [0xd11a00..0xd11a01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0xd10f20..0xd10f21
+            - Range: 0xd11a00..0xd11a01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10190,13 +10190,13 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testByteSliceMultibyteUtf8
-      OutOfLinePCRanges: [0xd10f40..0xd10f41]
+      OutOfLinePCRanges: [0xd11a20..0xd11a21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0xd10f40..0xd10f41
+            - Range: 0xd11a20..0xd11a21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10210,21 +10210,21 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.stackC
-      OutOfLinePCRanges: [0xd11660..0xd116b2]
+      OutOfLinePCRanges: [0xd12220..0xd12272]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd11660..0xd116a5
+            - Range: 0xd12220..0xd12265
               Pieces: []
-            - Range: 0xd116a5..0xd116a6
+            - Range: 0xd12265..0xd12266
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd116a6..0xd116b2
+            - Range: 0xd12266..0xd12272
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10232,13 +10232,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xd116c0..0xd116c1]
+      OutOfLinePCRanges: [0xd123a0..0xd123a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd116c0..0xd116c1
+            - Range: 0xd123a0..0xd123a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10250,13 +10250,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xd116e0..0xd116e1]
+      OutOfLinePCRanges: [0xd123c0..0xd123c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd116e0..0xd116e1
+            - Range: 0xd123c0..0xd123c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10268,7 +10268,7 @@ Subprograms:
         - Name: "y"
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd116e0..0xd116e1
+            - Range: 0xd123c0..0xd123c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10280,7 +10280,7 @@ Subprograms:
         - Name: z
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd116e0..0xd116e1
+            - Range: 0xd123c0..0xd123c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10292,13 +10292,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xd11700..0xd1171f]
+      OutOfLinePCRanges: [0xd123e0..0xd123ff]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 275 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xd11700..0xd1171f
+            - Range: 0xd123e0..0xd123ff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10318,13 +10318,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xd11720..0xd11721]
+      OutOfLinePCRanges: [0xd12400..0xd12401]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 276 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xd11720..0xd11721
+            - Range: 0xd12400..0xd12401
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10332,13 +10332,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xd11740..0xd11741]
+      OutOfLinePCRanges: [0xd12420..0xd12421]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 277 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xd11740..0xd11741
+            - Range: 0xd12420..0xd12421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10346,13 +10346,13 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xd11760..0xd11761]
+      OutOfLinePCRanges: [0xd12440..0xd12441]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd11760..0xd11761
+            - Range: 0xd12440..0xd12441
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10364,13 +10364,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xd11780..0xd11781]
+      OutOfLinePCRanges: [0xd12460..0xd12461]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd11780..0xd11781
+            - Range: 0xd12460..0xd12461
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10382,13 +10382,13 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xd117a0..0xd117a1]
+      OutOfLinePCRanges: [0xd12480..0xd12481]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd117a0..0xd117a1
+            - Range: 0xd12480..0xd12481
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10400,13 +10400,13 @@ Subprograms:
       DictRegister: null
     - ID: 161
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xd117c0..0xd117c1]
+      OutOfLinePCRanges: [0xd124a0..0xd124a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd117c0..0xd117c1
+            - Range: 0xd124a0..0xd124a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10418,7 +10418,7 @@ Subprograms:
         - Name: b
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd117c0..0xd117c1
+            - Range: 0xd124a0..0xd124a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10430,7 +10430,7 @@ Subprograms:
         - Name: c
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd117c0..0xd117c1
+            - Range: 0xd124a0..0xd124a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10442,13 +10442,13 @@ Subprograms:
       DictRegister: null
     - ID: 162
       Name: main.testInvalidUtf8Strings
-      OutOfLinePCRanges: [0xd117e0..0xd117e1]
+      OutOfLinePCRanges: [0xd124c0..0xd124c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd117e0..0xd117e1
+            - Range: 0xd124c0..0xd124c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10460,7 +10460,7 @@ Subprograms:
         - Name: b
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd117e0..0xd117e1
+            - Range: 0xd124c0..0xd124c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10472,13 +10472,13 @@ Subprograms:
       DictRegister: null
     - ID: 163
       Name: main.testMultibyteUtf8String
-      OutOfLinePCRanges: [0xd11800..0xd11801]
+      OutOfLinePCRanges: [0xd124e0..0xd124e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd11800..0xd11801
+            - Range: 0xd124e0..0xd124e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10490,13 +10490,13 @@ Subprograms:
       DictRegister: null
     - ID: 164
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xd119c0..0xd119c1]
+      OutOfLinePCRanges: [0xd127a0..0xd127a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 279 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xd119c0..0xd119c1
+            - Range: 0xd127a0..0xd127a1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10504,13 +10504,13 @@ Subprograms:
       DictRegister: null
     - ID: 165
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xd119e0..0xd119ff]
+      OutOfLinePCRanges: [0xd127c0..0xd127df]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 292 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xd119e0..0xd119ff
+            - Range: 0xd127c0..0xd127df
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10530,13 +10530,13 @@ Subprograms:
       DictRegister: null
     - ID: 166
       Name: main.testStruct
-      OutOfLinePCRanges: [0xd11b20..0xd11b43]
+      OutOfLinePCRanges: [0xd12900..0xd12923]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 StructureType main.aStruct
           Locations:
-            - Range: 0xd11b20..0xd11b43
+            - Range: 0xd12900..0xd12923
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10558,13 +10558,13 @@ Subprograms:
       DictRegister: null
     - ID: 167
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xd11c20..0xd11c21]
+      OutOfLinePCRanges: [0xd12a00..0xd12a01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 324 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xd11c20..0xd11c21
+            - Range: 0xd12a00..0xd12a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10572,13 +10572,13 @@ Subprograms:
       DictRegister: null
     - ID: 168
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xd11c40..0xd11c41]
+      OutOfLinePCRanges: [0xd12a20..0xd12a21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 326 StructureType main.tenStrings
           Locations:
-            - Range: 0xd11c40..0xd11c41
+            - Range: 0xd12a20..0xd12a21
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10586,25 +10586,25 @@ Subprograms:
       DictRegister: null
     - ID: 169
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xd11ca0..0xd11ca1]
+      OutOfLinePCRanges: [0xd12a80..0xd12a81]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 327 StructureType main.emptyStruct
-          Locations: [{Range: 0xd11ca0..0xd11ca1, Pieces: []}]
+          Locations: [{Range: 0xd12a80..0xd12a81, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 170
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xd11cc0..0xd11cc1]
+      OutOfLinePCRanges: [0xd12aa0..0xd12aa1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 328 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xd11cc0..0xd11cc1
+            - Range: 0xd12aa0..0xd12aa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10612,13 +10612,13 @@ Subprograms:
       DictRegister: null
     - ID: 171
       Name: main.testTimeUTC
-      OutOfLinePCRanges: [0xd13020..0xd13021]
+      OutOfLinePCRanges: [0xd13f00..0xd13f01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 GoTimeType time.Time
           Locations:
-            - Range: 0xd13020..0xd13021
+            - Range: 0xd13f00..0xd13f01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10632,13 +10632,13 @@ Subprograms:
       DictRegister: null
     - ID: 172
       Name: main.testTimeFixedZone
-      OutOfLinePCRanges: [0xd13040..0xd13041]
+      OutOfLinePCRanges: [0xd13f20..0xd13f21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 GoTimeType time.Time
           Locations:
-            - Range: 0xd13040..0xd13041
+            - Range: 0xd13f20..0xd13f21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10652,13 +10652,13 @@ Subprograms:
       DictRegister: null
     - ID: 173
       Name: main.testTimeMonotonic
-      OutOfLinePCRanges: [0xd13060..0xd13061]
+      OutOfLinePCRanges: [0xd13f40..0xd13f41]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 332 StructureType main.timeCapture
           Locations:
-            - Range: 0xd13060..0xd13061
+            - Range: 0xd13f40..0xd13f41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10672,13 +10672,13 @@ Subprograms:
       DictRegister: null
     - ID: 174
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xd14100..0xd14104]
+      OutOfLinePCRanges: [0xd15100..0xd15104]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0xd14100..0xd14104
+            - Range: 0xd15100..0xd15104
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10686,9 +10686,9 @@ Subprograms:
         - Name: ~r0
           Type: 334 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd14100..0xd14103
+            - Range: 0xd15100..0xd15103
               Pieces: []
-            - Range: 0xd14103..0xd14104
+            - Range: 0xd15103..0xd15104
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -10696,19 +10696,19 @@ Subprograms:
       DictRegister: 0
     - ID: 175
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xd14120..0xd1412c]
+      OutOfLinePCRanges: [0xd15120..0xd1512c]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd14120..0xd1412b
+            - Range: 0xd15120..0xd1512b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd1412b..0xd1412c
+            - Range: 0xd1512b..0xd1512c
               Pieces:
                 - Size: 8
                   Op: null
@@ -10720,9 +10720,9 @@ Subprograms:
         - Name: ~r0
           Type: 336 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xd14120..0xd1412b
+            - Range: 0xd15120..0xd1512b
               Pieces: []
-            - Range: 0xd1412b..0xd1412c
+            - Range: 0xd1512b..0xd1512c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10734,13 +10734,13 @@ Subprograms:
       DictRegister: 0
     - ID: 176
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xd14140..0xd14144]
+      OutOfLinePCRanges: [0xd15140..0xd15144]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 334 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd14140..0xd14144
+            - Range: 0xd15140..0xd15144
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10748,9 +10748,9 @@ Subprograms:
         - Name: ~r0
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0xd14140..0xd14143
+            - Range: 0xd15140..0xd15143
               Pieces: []
-            - Range: 0xd14143..0xd14144
+            - Range: 0xd15143..0xd15144
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -10758,19 +10758,19 @@ Subprograms:
       DictRegister: 0
     - ID: 177
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xd14160..0xd1416c]
+      OutOfLinePCRanges: [0xd15160..0xd1516c]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 336 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xd14160..0xd1416b
+            - Range: 0xd15160..0xd1516b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd1416b..0xd1416c
+            - Range: 0xd1516b..0xd1516c
               Pieces:
                 - Size: 8
                   Op: null
@@ -10782,9 +10782,9 @@ Subprograms:
         - Name: ~r0
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd14160..0xd1416b
+            - Range: 0xd15160..0xd1516b
               Pieces: []
-            - Range: 0xd1416b..0xd1416c
+            - Range: 0xd1516b..0xd1516c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10796,13 +10796,13 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xd141e0..0xd14316]
+      OutOfLinePCRanges: [0xd151e0..0xd15316]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 337 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd141e0..0xd14213
+            - Range: 0xd151e0..0xd15213
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10810,7 +10810,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd14213..0xd1421b
+            - Range: 0xd15213..0xd1521b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10818,7 +10818,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xd1421b..0xd14316
+            - Range: 0xd1521b..0xd15316
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10832,9 +10832,9 @@ Subprograms:
         - Name: pred
           Type: 339 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xd141e0..0xd1421b
+            - Range: 0xd151e0..0xd1521b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd1421b..0xd14316
+            - Range: 0xd1521b..0xd15316
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
@@ -10842,9 +10842,9 @@ Subprograms:
         - Name: ~r0
           Type: 337 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd141e0..0xd142d4
+            - Range: 0xd151e0..0xd152d4
               Pieces: []
-            - Range: 0xd142d4..0xd142d5
+            - Range: 0xd152d4..0xd152d5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10852,7 +10852,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd142d5..0xd14316
+            - Range: 0xd152d5..0xd15316
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -10860,7 +10860,7 @@ Subprograms:
         - Name: result
           Type: 337 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd1421b..0xd14239
+            - Range: 0xd1521b..0xd15239
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10868,7 +10868,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd14239..0xd14241
+            - Range: 0xd15239..0xd15241
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10876,7 +10876,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd14241..0xd14249
+            - Range: 0xd15241..0xd15249
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10884,7 +10884,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd14249..0xd14249
+            - Range: 0xd15249..0xd15249
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10892,7 +10892,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd14249..0xd14273
+            - Range: 0xd15249..0xd15273
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10900,7 +10900,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd14273..0xd142cb
+            - Range: 0xd15273..0xd152cb
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10908,7 +10908,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd142cb..0xd14316
+            - Range: 0xd152cb..0xd15316
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10922,9 +10922,9 @@ Subprograms:
         - Name: item
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0xd14266..0xd14273
+            - Range: 0xd15266..0xd15273
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd14273..0xd142cb
+            - Range: 0xd15273..0xd152cb
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
@@ -10932,13 +10932,13 @@ Subprograms:
       DictRegister: 0
     - ID: 179
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xd14320..0xd14364]
+      OutOfLinePCRanges: [0xd15320..0xd15364]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 334 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd14320..0xd14339
+            - Range: 0xd15320..0xd15339
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10946,7 +10946,7 @@ Subprograms:
         - Name: f
           Type: 340 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xd14320..0xd14339
+            - Range: 0xd15320..0xd15339
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -10954,15 +10954,15 @@ Subprograms:
         - Name: ~r0
           Type: 336 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xd14320..0xd14339
+            - Range: 0xd15320..0xd15339
               Pieces: []
-            - Range: 0xd14339..0xd1433a
+            - Range: 0xd15339..0xd1533a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd1433a..0xd14364
+            - Range: 0xd1533a..0xd15364
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -10970,13 +10970,13 @@ Subprograms:
       DictRegister: 0
     - ID: 180
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xd14600..0xd14604]
+      OutOfLinePCRanges: [0xd15600..0xd15604]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 338 PointerType *go.shape.int
           Locations:
-            - Range: 0xd14600..0xd14604
+            - Range: 0xd15600..0xd15604
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10984,9 +10984,9 @@ Subprograms:
         - Name: ~r0
           Type: 338 PointerType *go.shape.int
           Locations:
-            - Range: 0xd14600..0xd14603
+            - Range: 0xd15600..0xd15603
               Pieces: []
-            - Range: 0xd14603..0xd14604
+            - Range: 0xd15603..0xd15604
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -10994,13 +10994,13 @@ Subprograms:
       DictRegister: 0
     - ID: 181
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xd14620..0xd14624]
+      OutOfLinePCRanges: [0xd15620..0xd15624]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 341 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xd14620..0xd14624
+            - Range: 0xd15620..0xd15624
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11008,9 +11008,9 @@ Subprograms:
         - Name: ~r0
           Type: 341 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xd14620..0xd14623
+            - Range: 0xd15620..0xd15623
               Pieces: []
-            - Range: 0xd14623..0xd14624
+            - Range: 0xd15623..0xd15624
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11018,13 +11018,13 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xd14640..0xd14644]
+      OutOfLinePCRanges: [0xd15640..0xd15644]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 343 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xd14640..0xd14644
+            - Range: 0xd15640..0xd15644
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11032,9 +11032,9 @@ Subprograms:
         - Name: ~r0
           Type: 343 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xd14640..0xd14643
+            - Range: 0xd15640..0xd15643
               Pieces: []
-            - Range: 0xd14643..0xd14644
+            - Range: 0xd15643..0xd15644
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11042,13 +11042,13 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xd14660..0xd14671]
+      OutOfLinePCRanges: [0xd15660..0xd15671]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 345 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xd14660..0xd14671
+            - Range: 0xd15660..0xd15671
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11056,9 +11056,9 @@ Subprograms:
         - Name: ~r0
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd14660..0xd14670
+            - Range: 0xd15660..0xd15670
               Pieces: []
-            - Range: 0xd14670..0xd14671
+            - Range: 0xd15670..0xd15671
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11070,13 +11070,13 @@ Subprograms:
       DictRegister: 0
     - ID: 184
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xd14700..0xd14709]
+      OutOfLinePCRanges: [0xd15700..0xd15709]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 347 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xd14700..0xd14709
+            - Range: 0xd15700..0xd15709
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11084,9 +11084,9 @@ Subprograms:
         - Name: ~r0
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0xd14700..0xd14708
+            - Range: 0xd15700..0xd15708
               Pieces: []
-            - Range: 0xd14708..0xd14709
+            - Range: 0xd15708..0xd15709
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11094,13 +11094,13 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xd147c0..0xd147c8]
+      OutOfLinePCRanges: [0xd157c0..0xd157c8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 348 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xd147c0..0xd147c8
+            - Range: 0xd157c0..0xd157c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11108,7 +11108,7 @@ Subprograms:
         - Name: k
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0xd147c0..0xd147c8
+            - Range: 0xd157c0..0xd157c8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11116,7 +11116,7 @@ Subprograms:
         - Name: v
           Type: 350 BaseType go.shape.bool
           Locations:
-            - Range: 0xd147c0..0xd147c8
+            - Range: 0xd157c0..0xd157c8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11124,13 +11124,13 @@ Subprograms:
       DictRegister: 3
     - ID: 186
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xd14860..0xd148d1]
+      OutOfLinePCRanges: [0xd15860..0xd158d1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 351 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xd14860..0xd148d1
+            - Range: 0xd15860..0xd158d1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11138,7 +11138,7 @@ Subprograms:
         - Name: k
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd14860..0xd148d1
+            - Range: 0xd15860..0xd158d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -11150,7 +11150,7 @@ Subprograms:
         - Name: v
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0xd14860..0xd148d1
+            - Range: 0xd15860..0xd158d1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11158,13 +11158,13 @@ Subprograms:
       DictRegister: 3
     - ID: 187
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xd14960..0xd14968]
+      OutOfLinePCRanges: [0xd15960..0xd15968]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd14960..0xd14968
+            - Range: 0xd15960..0xd15968
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11176,7 +11176,7 @@ Subprograms:
         - Name: b
           Type: 350 BaseType go.shape.bool
           Locations:
-            - Range: 0xd14960..0xd14968
+            - Range: 0xd15960..0xd15968
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11184,9 +11184,9 @@ Subprograms:
         - Name: ~r0
           Type: 350 BaseType go.shape.bool
           Locations:
-            - Range: 0xd14960..0xd14967
+            - Range: 0xd15960..0xd15967
               Pieces: []
-            - Range: 0xd14967..0xd14968
+            - Range: 0xd15967..0xd15968
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11194,9 +11194,9 @@ Subprograms:
         - Name: ~r1
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd14960..0xd14967
+            - Range: 0xd15960..0xd15967
               Pieces: []
-            - Range: 0xd14967..0xd14968
+            - Range: 0xd15967..0xd15968
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11208,13 +11208,13 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xd14980..0xd1498f]
+      OutOfLinePCRanges: [0xd15980..0xd1598f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0xd14980..0xd1498e
+            - Range: 0xd15980..0xd1598e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11222,13 +11222,13 @@ Subprograms:
         - Name: b
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd14980..0xd1498b
+            - Range: 0xd15980..0xd1598b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd1498b..0xd1498f
+            - Range: 0xd1598b..0xd1598f
               Pieces:
                 - Size: 8
                   Op: null
@@ -11240,9 +11240,9 @@ Subprograms:
         - Name: ~r0
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd14980..0xd1498e
+            - Range: 0xd15980..0xd1598e
               Pieces: []
-            - Range: 0xd1498e..0xd1498f
+            - Range: 0xd1598e..0xd1598f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11254,9 +11254,9 @@ Subprograms:
         - Name: ~r1
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0xd14980..0xd1498e
+            - Range: 0xd15980..0xd1598e
               Pieces: []
-            - Range: 0xd1498e..0xd1498f
+            - Range: 0xd1598e..0xd1598f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
@@ -11264,13 +11264,13 @@ Subprograms:
       DictRegister: 0
     - ID: 189
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xd149a0..0xd149da]
+      OutOfLinePCRanges: [0xd159a0..0xd159da]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 353 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xd149a0..0xd149b9
+            - Range: 0xd159a0..0xd159b9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11278,15 +11278,15 @@ Subprograms:
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd149a0..0xd149b9
+            - Range: 0xd159a0..0xd159b9
               Pieces: []
-            - Range: 0xd149b9..0xd149ba
+            - Range: 0xd159b9..0xd159ba
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd149ba..0xd149da
+            - Range: 0xd159ba..0xd159da
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11294,19 +11294,19 @@ Subprograms:
       DictRegister: 0
     - ID: 190
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xd149e0..0xd14a2d]
+      OutOfLinePCRanges: [0xd159e0..0xd15a2d]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 354 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xd149e0..0xd149ff
+            - Range: 0xd159e0..0xd159ff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd149ff..0xd14a02
+            - Range: 0xd159ff..0xd15a02
               Pieces:
                 - Size: 8
                   Op: null
@@ -11318,15 +11318,15 @@ Subprograms:
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd149e0..0xd14a02
+            - Range: 0xd159e0..0xd15a02
               Pieces: []
-            - Range: 0xd14a02..0xd14a03
+            - Range: 0xd15a02..0xd15a03
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd14a03..0xd14a2d
+            - Range: 0xd15a03..0xd15a2d
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11334,13 +11334,13 @@ Subprograms:
       DictRegister: 0
     - ID: 191
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xd14a40..0xd14a48]
+      OutOfLinePCRanges: [0xd15a40..0xd15a48]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 355 PointerType *go.shape.string
           Locations:
-            - Range: 0xd14a40..0xd14a47
+            - Range: 0xd15a40..0xd15a47
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11348,9 +11348,9 @@ Subprograms:
         - Name: ~r0
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd14a40..0xd14a47
+            - Range: 0xd15a40..0xd15a47
               Pieces: []
-            - Range: 0xd14a47..0xd14a48
+            - Range: 0xd15a47..0xd15a48
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11362,13 +11362,13 @@ Subprograms:
       DictRegister: 0
     - ID: 192
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xd14a60..0xd14ab7]
+      OutOfLinePCRanges: [0xd15a60..0xd15ab7]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 356 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xd14a60..0xd14a9d
+            - Range: 0xd15a60..0xd15a9d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11376,9 +11376,9 @@ Subprograms:
         - Name: ~r0
           Type: 357 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xd14a60..0xd14ab1
+            - Range: 0xd15a60..0xd15ab1
               Pieces: []
-            - Range: 0xd14ab1..0xd14ab2
+            - Range: 0xd15ab1..0xd15ab2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11392,7 +11392,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xd14ab2..0xd14ab7
+            - Range: 0xd15ab2..0xd15ab7
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11400,13 +11400,13 @@ Subprograms:
       DictRegister: 0
     - ID: 193
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xd14ac0..0xd14ae4]
+      OutOfLinePCRanges: [0xd15ac0..0xd15ae4]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 337 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd14ac0..0xd14ae4
+            - Range: 0xd15ac0..0xd15ae4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11420,7 +11420,7 @@ Subprograms:
         - Name: needle
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0xd14ac0..0xd14ae4
+            - Range: 0xd15ac0..0xd15ae4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11428,13 +11428,13 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xd14ac0..0xd14ae0
+            - Range: 0xd15ac0..0xd15ae0
               Pieces: []
-            - Range: 0xd14ae0..0xd14ae1
+            - Range: 0xd15ae0..0xd15ae1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd14ae1..0xd14ae3
+            - Range: 0xd15ae1..0xd15ae3
               Pieces: []
-            - Range: 0xd14ae3..0xd14ae4
+            - Range: 0xd15ae3..0xd15ae4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -11442,13 +11442,13 @@ Subprograms:
       DictRegister: 0
     - ID: 194
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xd14b00..0xd14bbf]
+      OutOfLinePCRanges: [0xd15b00..0xd15bbf]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 358 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xd14b00..0xd14b1d
+            - Range: 0xd15b00..0xd15b1d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11456,7 +11456,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd14b1d..0xd14b1f
+            - Range: 0xd15b1d..0xd15b1f
               Pieces:
                 - Size: 8
                   Op: null
@@ -11470,13 +11470,13 @@ Subprograms:
         - Name: needle
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd14b00..0xd14b4c
+            - Range: 0xd15b00..0xd15b4c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xd14b4c..0xd14bbf
+            - Range: 0xd15b4c..0xd15bbf
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -11488,15 +11488,15 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xd14b00..0xd14b6b
+            - Range: 0xd15b00..0xd15b6b
               Pieces: []
-            - Range: 0xd14b6b..0xd14b6c
+            - Range: 0xd15b6b..0xd15b6c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd14b6c..0xd14b73
+            - Range: 0xd15b6c..0xd15b73
               Pieces: []
-            - Range: 0xd14b73..0xd14b74
+            - Range: 0xd15b73..0xd15b74
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd14b74..0xd14bbf
+            - Range: 0xd15b74..0xd15bbf
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11504,13 +11504,13 @@ Subprograms:
         - Name: v
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd14b2f..0xd14b41
+            - Range: 0xd15b2f..0xd15b41
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xd14b41..0xd14b4c
+            - Range: 0xd15b41..0xd15b4c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11522,13 +11522,13 @@ Subprograms:
       DictRegister: 0
     - ID: 195
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xd14bc0..0xd14bc7]
+      OutOfLinePCRanges: [0xd15bc0..0xd15bc7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 359 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xd14bc0..0xd14bc6
+            - Range: 0xd15bc0..0xd15bc6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11536,7 +11536,7 @@ Subprograms:
         - Name: value
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0xd14bc0..0xd14bc7
+            - Range: 0xd15bc0..0xd15bc7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11544,9 +11544,9 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xd14bc0..0xd14bc6
+            - Range: 0xd15bc0..0xd15bc6
               Pieces: []
-            - Range: 0xd14bc6..0xd14bc7
+            - Range: 0xd15bc6..0xd15bc7
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -11554,25 +11554,25 @@ Subprograms:
       DictRegister: 3
     - ID: 196
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xd14c40..0xd14cac]
+      OutOfLinePCRanges: [0xd15c40..0xd15cac]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 360 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xd14c40..0xd14c60
+            - Range: 0xd15c40..0xd15c60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd14c60..0xd14c68
+            - Range: 0xd15c60..0xd15c68
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd14c68..0xd14c6d
+            - Range: 0xd15c68..0xd15c6d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11584,7 +11584,7 @@ Subprograms:
         - Name: value
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd14c40..0xd14c6d
+            - Range: 0xd15c40..0xd15c6d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -11596,11 +11596,11 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xd14c40..0xd14c6d
+            - Range: 0xd15c40..0xd15c6d
               Pieces: []
-            - Range: 0xd14c6d..0xd14c6e
+            - Range: 0xd15c6d..0xd15c6e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd14c6e..0xd14cac
+            - Range: 0xd15c6e..0xd15cac
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11832,31 +11832,31 @@ Subprograms:
       DictRegister: null
     - ID: 199
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xd0ab20..0xd0ab82]
+      OutOfLinePCRanges: [0xd0b020..0xd0b082]
       InlinePCRanges:
-        - Ranges: [0xd0abb1..0xd0abed]
-          RootRanges: [0xd0aba0..0xd0ac11]
-        - Ranges: [0xd0acf2..0xd0ad2e]
-          RootRanges: [0xd0acc0..0xd0ad48]
-        - Ranges: [0xd0ad7c..0xd0adb8]
-          RootRanges: [0xd0ad60..0xd0ae25]
-        - Ranges: [0xd0ae4f..0xd0ae8b]
-          RootRanges: [0xd0ae40..0xd0aea2]
+        - Ranges: [0xd0b0b1..0xd0b0ed]
+          RootRanges: [0xd0b0a0..0xd0b111]
+        - Ranges: [0xd0b1f2..0xd0b22e]
+          RootRanges: [0xd0b1c0..0xd0b248]
+        - Ranges: [0xd0b27c..0xd0b2b8]
+          RootRanges: [0xd0b260..0xd0b325]
+        - Ranges: [0xd0b34f..0xd0b38b]
+          RootRanges: [0xd0b340..0xd0b3a2]
       Variables:
         - Name: x
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0ab20..0xd0ab39
+            - Range: 0xd0b020..0xd0b039
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0abb1..0xd0abbc
+            - Range: 0xd0b0b1..0xd0b0bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0acf2..0xd0acfd
+            - Range: 0xd0b1f2..0xd0b1fd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ad76..0xd0ad87
+            - Range: 0xd0b276..0xd0b287
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ad87..0xd0ae25
+            - Range: 0xd0b287..0xd0b325
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xd0ae40..0xd0ae5a
+            - Range: 0xd0b340..0xd0b35a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11866,37 +11866,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd0adc6..0xd0adfe]
-          RootRanges: [0xd0ad60..0xd0ae25]
+        - Ranges: [0xd0b2c6..0xd0b2fe]
+          RootRanges: [0xd0b260..0xd0b325]
       Variables: []
       DictRegister: null
     - ID: 201
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd0aed3..0xd0af11]
-          RootRanges: [0xd0aec0..0xd0afce]
+        - Ranges: [0xd0b3d3..0xd0b411]
+          RootRanges: [0xd0b3c0..0xd0b4ce]
       Variables: []
       DictRegister: null
     - ID: 202
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd0af86..0xd0afbe]
-          RootRanges: [0xd0aec0..0xd0afce]
+        - Ranges: [0xd0b486..0xd0b4be]
+          RootRanges: [0xd0b3c0..0xd0b4ce]
       Variables: []
       DictRegister: null
     - ID: 203
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd0afe1..0xd0afe5]
-          RootRanges: [0xd0afe0..0xd0afe6]
+        - Ranges: [0xd0b4e1..0xd0b4e5]
+          RootRanges: [0xd0b4e0..0xd0b4e6]
       Variables:
         - Name: x
           Type: 11 BaseType int
           Locations:
-            - Range: 0xd0afe0..0xd0afe5
+            - Range: 0xd0b4e0..0xd0b4e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11906,39 +11906,39 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd0b025..0xd0b03d]
-          RootRanges: [0xd0b000..0xd0b043]
-        - Ranges: [0xd0b0c5..0xd0b0e3]
-          RootRanges: [0xd0b060..0xd0b1e5]
+        - Ranges: [0xd0b525..0xd0b53d]
+          RootRanges: [0xd0b500..0xd0b543]
+        - Ranges: [0xd0b635..0xd0b653]
+          RootRanges: [0xd0b560..0xd0b78c]
       Variables:
         - Name: a
           Type: 165 ArrayType [5]int
           Locations:
-            - Range: 0xd0b00d..0xd0b043
+            - Range: 0xd0b50d..0xd0b543
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xd0b0ac..0xd0b1e5
-              Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
+            - Range: 0xd0b619..0xd0b78c
+              Pieces: [{Size: 40, Op: {CfaOffset: -152}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 205
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xd0b200..0xd0b271]
+      OutOfLinePCRanges: [0xd0b800..0xd0b871]
       InlinePCRanges:
-        - Ranges: [0xd14e83..0xd14ec5]
-          RootRanges: [0xd14e60..0xd14ef6]
+        - Ranges: [0xd15e83..0xd15ec5]
+          RootRanges: [0xd15e60..0xd15ef6]
       Variables:
         - Name: b
           Type: 365 StructureType main.firstBehavior
           Locations:
-            - Range: 0xd0b200..0xd0b228
+            - Range: 0xd0b800..0xd0b828
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0b228..0xd0b22d
+            - Range: 0xd0b828..0xd0b82d
               Pieces:
                 - Size: 8
                   Op: null
@@ -11950,15 +11950,15 @@ Subprograms:
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd0b200..0xd0b250
+            - Range: 0xd0b800..0xd0b850
               Pieces: []
-            - Range: 0xd0b250..0xd0b251
+            - Range: 0xd0b850..0xd0b851
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0b251..0xd0b271
+            - Range: 0xd0b851..0xd0b871
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11968,8 +11968,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd0bb06..0xd0bb0d]
-          RootRanges: [0xd0ba60..0xd0bb6a]
+        - Ranges: [0xd0c1c6..0xd0c1cd]
+          RootRanges: [0xd0c0a0..0xd0c25a]
         - Ranges: [0xd04af2..0xd04af6, 0xd04af7..0xd04afe]
           RootRanges: [0xd04ae0..0xd04aff]
       Variables: []
@@ -12639,7 +12639,7 @@ Types:
       ID: 2446
       Name: '*compress/gzip.Reader'
       ByteSize: 8
-      GoRuntimeType: 1442112
+      GoRuntimeType: 1441344
       GoKind: 22
       Pointee: 2447 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
@@ -12653,63 +12653,63 @@ Types:
       ID: 413
       Name: '*context.backgroundCtx'
       ByteSize: 8
-      GoRuntimeType: 1371328
+      GoRuntimeType: 1371008
       GoKind: 22
       Pointee: 414 GoContextImplementationType context.backgroundCtx
     - __kind: PointerType
       ID: 417
       Name: '*context.cancelCtx'
       ByteSize: 8
-      GoRuntimeType: 1608864
+      GoRuntimeType: 1608672
       GoKind: 22
       Pointee: 418 GoContextImplementationType context.cancelCtx
     - __kind: PointerType
       ID: 898
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1111168
+      GoRuntimeType: 1109504
       GoKind: 22
       Pointee: 899 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 400
       Name: '*context.emptyCtx'
       ByteSize: 8
-      GoRuntimeType: 1239776
+      GoRuntimeType: 1239616
       GoKind: 22
       Pointee: 401 GoContextImplementationType context.emptyCtx
     - __kind: PointerType
       ID: 402
       Name: '*context.stopCtx'
       ByteSize: 8
-      GoRuntimeType: 1239936
+      GoRuntimeType: 1239776
       GoKind: 22
       Pointee: 403 GoContextImplementationType context.stopCtx
     - __kind: PointerType
       ID: 425
       Name: '*context.timerCtx'
       ByteSize: 8
-      GoRuntimeType: 1609056
+      GoRuntimeType: 1608864
       GoKind: 22
       Pointee: 426 GoContextImplementationType context.timerCtx
     - __kind: PointerType
       ID: 415
       Name: '*context.todoCtx'
       ByteSize: 8
-      GoRuntimeType: 1371488
+      GoRuntimeType: 1371168
       GoKind: 22
       Pointee: 416 GoContextImplementationType context.todoCtx
     - __kind: PointerType
       ID: 409
       Name: '*context.valueCtx'
       ByteSize: 8
-      GoRuntimeType: 1371008
+      GoRuntimeType: 1370688
       GoKind: 22
       Pointee: 410 GoContextImplementationType context.valueCtx
     - __kind: PointerType
       ID: 411
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
-      GoRuntimeType: 1371168
+      GoRuntimeType: 1370848
       GoKind: 22
       Pointee: 412 GoContextImplementationType context.withoutCancelCtx
     - __kind: PointerType
@@ -13078,17 +13078,17 @@ Types:
       GoKind: 22
       Pointee: 793 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 691
+      ID: 689
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 842784
+      GoRuntimeType: 842016
       GoKind: 22
       Pointee: 592 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
       ID: 1037
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1004288
+      GoRuntimeType: 1004160
       GoKind: 22
       Pointee: 1038 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -13099,31 +13099,31 @@ Types:
       GoKind: 22
       Pointee: 593 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 1298
+      ID: 1296
       Name: '*encoding/json.Delim'
       ByteSize: 8
-      GoRuntimeType: 837600
+      GoRuntimeType: 836832
       GoKind: 22
-      Pointee: 1228 BaseType encoding/json.Delim
+      Pointee: 1226 BaseType encoding/json.Delim
     - __kind: PointerType
-      ID: 662
+      ID: 660
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 837504
+      GoRuntimeType: 836736
       GoKind: 22
-      Pointee: 663 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 661 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
       ID: 861
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 999936
+      GoRuntimeType: 999808
       GoKind: 22
       Pointee: 862 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
       ID: 1470
       Name: '*encoding/json.Number'
       ByteSize: 8
-      GoRuntimeType: 1125888
+      GoRuntimeType: 1125248
       GoKind: 22
       Pointee: 1451 GoStringHeaderType encoding/json.Number
     - __kind: PointerType
@@ -13132,33 +13132,33 @@ Types:
       ByteSize: 8
       Pointee: 1452 GoStringDataType encoding/json.Number.str
     - __kind: PointerType
-      ID: 654
+      ID: 652
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 837120
+      GoRuntimeType: 836352
       GoKind: 22
-      Pointee: 655 UnresolvedPointeeType encoding/json.SyntaxError
-    - __kind: PointerType
-      ID: 660
-      Name: '*encoding/json.UnmarshalTypeError'
-      ByteSize: 8
-      GoRuntimeType: 837408
-      GoKind: 22
-      Pointee: 661 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 653 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
       ID: 658
-      Name: '*encoding/json.UnsupportedTypeError'
+      Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
-      GoRuntimeType: 837312
+      GoRuntimeType: 836640
       GoKind: 22
-      Pointee: 659 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 659 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
       ID: 656
+      Name: '*encoding/json.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 836544
+      GoKind: 22
+      Pointee: 657 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 654
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
-      GoRuntimeType: 837216
+      GoRuntimeType: 836448
       GoKind: 22
-      Pointee: 657 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 655 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
       ID: 1172
       Name: '*encoding/json.encodeState'
@@ -13167,12 +13167,12 @@ Types:
       GoKind: 22
       Pointee: 1173 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 664
+      ID: 662
       Name: '*encoding/json.jsonError'
       ByteSize: 8
-      GoRuntimeType: 837888
+      GoRuntimeType: 837120
       GoKind: 22
-      Pointee: 665 StructureType encoding/json.jsonError
+      Pointee: 663 StructureType encoding/json.jsonError
     - __kind: PointerType
       ID: 1045
       Name: '*encoding/pem.lineBreaker'
@@ -13231,14 +13231,14 @@ Types:
       ID: 632
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 828480
+      GoRuntimeType: 829344
       GoKind: 22
       Pointee: 633 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 828
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 985472
+      GoRuntimeType: 986624
       GoKind: 22
       Pointee: 829 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -13273,21 +13273,21 @@ Types:
       ID: 2343
       Name: '*fmt.stringReader'
       ByteSize: 8
-      GoRuntimeType: 828576
+      GoRuntimeType: 829440
       GoKind: 22
       Pointee: 2344 UnresolvedPointeeType fmt.stringReader
     - __kind: PointerType
       ID: 830
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 985600
+      GoRuntimeType: 986752
       GoKind: 22
       Pointee: 831 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 832
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 985728
+      GoRuntimeType: 986880
       GoKind: 22
       Pointee: 833 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -13315,7 +13315,7 @@ Types:
       ID: 2191
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AgentPayload'
       ByteSize: 8
-      GoRuntimeType: 2063808
+      GoRuntimeType: 2062976
       GoKind: 22
       Pointee: 2192 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AgentPayload
     - __kind: PointerType
@@ -13329,7 +13329,7 @@ Types:
       ID: 1872
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType'
       ByteSize: 8
-      GoRuntimeType: 1726400
+      GoRuntimeType: 1726176
       GoKind: 22
       Pointee: 1821 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
     - __kind: PointerType
@@ -13350,7 +13350,7 @@ Types:
       ID: 1873
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType'
       ByteSize: 8
-      GoRuntimeType: 1726624
+      GoRuntimeType: 1726400
       GoKind: 22
       Pointee: 1822 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
     - __kind: PointerType
@@ -13399,7 +13399,7 @@ Types:
       ID: 2189
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.StatsPayload'
       ByteSize: 8
-      GoRuntimeType: 2062976
+      GoRuntimeType: 2062144
       GoKind: 22
       Pointee: 2190 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.StatsPayload
     - __kind: PointerType
@@ -13420,7 +13420,7 @@ Types:
       ID: 2255
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.TracerPayload'
       ByteSize: 8
-      GoRuntimeType: 2112480
+      GoRuntimeType: 2111520
       GoKind: 22
       Pointee: 2256 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.TracerPayload
     - __kind: PointerType
@@ -13438,45 +13438,45 @@ Types:
       GoKind: 22
       Pointee: 1528 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/version.Version
     - __kind: PointerType
-      ID: 673
+      ID: 671
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
-      GoRuntimeType: 840288
+      GoRuntimeType: 839520
       GoKind: 22
-      Pointee: 674 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 672 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 675
+      ID: 673
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
-      GoRuntimeType: 840384
+      GoRuntimeType: 839616
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 674 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
       ID: 989
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
-      GoRuntimeType: 840096
+      GoRuntimeType: 839328
       GoKind: 22
       Pointee: 990 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 679
+      ID: 677
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
-      GoRuntimeType: 840672
+      GoRuntimeType: 839904
       GoKind: 22
-      Pointee: 680 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 678 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
       ID: 991
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
-      GoRuntimeType: 840192
+      GoRuntimeType: 839424
       GoKind: 22
       Pointee: 992 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 677
+      ID: 675
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
-      GoRuntimeType: 840480
+      GoRuntimeType: 839712
       GoKind: 22
       Pointee: 586 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
@@ -13485,10 +13485,10 @@ Types:
       ByteSize: 8
       Pointee: 587 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 672
+      ID: 670
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
-      GoRuntimeType: 840000
+      GoRuntimeType: 839232
       GoKind: 22
       Pointee: 583 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
@@ -13497,10 +13497,10 @@ Types:
       ByteSize: 8
       Pointee: 584 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 678
+      ID: 676
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
-      GoRuntimeType: 840576
+      GoRuntimeType: 839808
       GoKind: 22
       Pointee: 589 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
@@ -13512,7 +13512,7 @@ Types:
       ID: 1059
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1129472
+      GoRuntimeType: 1128832
       GoKind: 22
       Pointee: 1060 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
@@ -13533,14 +13533,14 @@ Types:
       ID: 1584
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule'
       ByteSize: 8
-      GoRuntimeType: 1371648
+      GoRuntimeType: 1371328
       GoKind: 22
       Pointee: 1585 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule
     - __kind: PointerType
       ID: 1281
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType'
       ByteSize: 8
-      GoRuntimeType: 829056
+      GoRuntimeType: 828576
       GoKind: 22
       Pointee: 1219 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType
     - __kind: PointerType
@@ -13561,14 +13561,14 @@ Types:
       ID: 387
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
-      GoRuntimeType: 1111424
+      GoRuntimeType: 1109760
       GoKind: 22
       Pointee: 388 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
       ID: 1284
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate'
       ByteSize: 8
-      GoRuntimeType: 829344
+      GoRuntimeType: 828864
       GoKind: 22
       Pointee: 1285 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate
     - __kind: PointerType
@@ -13582,7 +13582,7 @@ Types:
       ID: 1282
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule'
       ByteSize: 8
-      GoRuntimeType: 829248
+      GoRuntimeType: 828768
       GoKind: 22
       Pointee: 1283 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule
     - __kind: PointerType
@@ -13596,35 +13596,35 @@ Types:
       ID: 1468
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance'
       ByteSize: 8
-      GoRuntimeType: 1112832
+      GoRuntimeType: 1111168
       GoKind: 22
       Pointee: 1376 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance
     - __kind: PointerType
       ID: 2147
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter'
       ByteSize: 8
-      GoRuntimeType: 829152
+      GoRuntimeType: 828672
       GoKind: 22
       Pointee: 2148 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter
     - __kind: PointerType
       ID: 390
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
-      GoRuntimeType: 1111552
+      GoRuntimeType: 1109888
       GoKind: 22
       Pointee: 391 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
       ID: 2501
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
-      GoRuntimeType: 1112192
+      GoRuntimeType: 1110528
       GoKind: 22
       Pointee: 2502 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
       ID: 558
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      GoRuntimeType: 1112320
+      GoRuntimeType: 1110656
       GoKind: 22
       Pointee: 559 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
@@ -13652,7 +13652,7 @@ Types:
       ID: 1547
       Name: '*github.com/DataDog/dd-trace-go/v2/internal.TraceSource'
       ByteSize: 8
-      GoRuntimeType: 1244896
+      GoRuntimeType: 1244736
       GoKind: 22
       Pointee: 1377 BaseType github.com/DataDog/dd-trace-go/v2/internal.TraceSource
     - __kind: PointerType
@@ -13736,7 +13736,7 @@ Types:
       ID: 405
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
-      GoRuntimeType: 1245216
+      GoRuntimeType: 1245056
       GoKind: 22
       Pointee: 406 GoContextImplementationType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
@@ -13750,21 +13750,21 @@ Types:
       ID: 1408
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource'
       ByteSize: 8
-      GoRuntimeType: 1002368
+      GoRuntimeType: 1002240
       GoKind: 22
       Pointee: 1409 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource
     - __kind: PointerType
       ID: 1410
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource'
       ByteSize: 8
-      GoRuntimeType: 1002496
+      GoRuntimeType: 1002368
       GoKind: 22
       Pointee: 1411 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource
     - __kind: PointerType
       ID: 1402
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey'
       ByteSize: 8
-      GoRuntimeType: 999552
+      GoRuntimeType: 999424
       GoKind: 22
       Pointee: 1403 StructureType github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey
     - __kind: PointerType
@@ -13979,47 +13979,47 @@ Types:
       GoKind: 22
       Pointee: 2258 StructureType github.com/Masterminds/semver/v3.Version
     - __kind: PointerType
-      ID: 1310
+      ID: 1308
       Name: '*github.com/cihub/seelog.CfgParseParams'
       ByteSize: 8
-      GoRuntimeType: 842496
+      GoRuntimeType: 841728
       GoKind: 22
-      Pointee: 1311 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
+      Pointee: 1309 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
     - __kind: PointerType
-      ID: 1309
+      ID: 1307
       Name: '*github.com/cihub/seelog.LogLevel'
       ByteSize: 8
-      GoRuntimeType: 841632
+      GoRuntimeType: 840864
       GoKind: 22
-      Pointee: 1231 BaseType github.com/cihub/seelog.LogLevel
+      Pointee: 1229 BaseType github.com/cihub/seelog.LogLevel
     - __kind: PointerType
       ID: 1830
       Name: '*github.com/cihub/seelog.LogLevelException'
       ByteSize: 8
-      GoRuntimeType: 1686976
+      GoRuntimeType: 1686528
       GoKind: 22
       Pointee: 1831 UnresolvedPointeeType github.com/cihub/seelog.LogLevelException
     - __kind: PointerType
-      ID: 681
+      ID: 679
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
-      GoRuntimeType: 841824
+      GoRuntimeType: 841056
       GoKind: 22
-      Pointee: 682 StructureType github.com/cihub/seelog.baseError
+      Pointee: 680 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 1098
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1687424
+      GoRuntimeType: 1686976
       GoKind: 22
       Pointee: 1099 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 683
+      ID: 681
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
-      GoRuntimeType: 841920
+      GoRuntimeType: 841152
       GoKind: 22
-      Pointee: 684 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 682 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 1077
       Name: '*github.com/cihub/seelog.connWriter'
@@ -14031,42 +14031,42 @@ Types:
       ID: 1033
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1003264
+      GoRuntimeType: 1003136
       GoKind: 22
       Pointee: 1034 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1552
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1249376
+      GoRuntimeType: 1249216
       GoKind: 22
       Pointee: 1553 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
       ID: 1656
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
-      GoRuntimeType: 1453248
+      GoRuntimeType: 1452480
       GoKind: 22
       Pointee: 1657 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
       ID: 1067
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1248896
+      GoRuntimeType: 1248736
       GoKind: 22
       Pointee: 1068 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
       ID: 1660
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1454016
+      GoRuntimeType: 1453248
       GoKind: 22
       Pointee: 1661 UnresolvedPointeeType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
       ID: 1548
       Name: '*github.com/cihub/seelog.formattedWriter'
       ByteSize: 8
-      GoRuntimeType: 1249056
+      GoRuntimeType: 1248896
       GoKind: 22
       Pointee: 1549 UnresolvedPointeeType github.com/cihub/seelog.formattedWriter
     - __kind: PointerType
@@ -14080,42 +14080,42 @@ Types:
       ID: 1475
       Name: '*github.com/cihub/seelog.listConstraints'
       ByteSize: 8
-      GoRuntimeType: 1131776
+      GoRuntimeType: 1131136
       GoKind: 22
       Pointee: 1476 UnresolvedPointeeType github.com/cihub/seelog.listConstraints
     - __kind: PointerType
-      ID: 1307
+      ID: 1305
       Name: '*github.com/cihub/seelog.logFormattedMessage'
       ByteSize: 8
-      GoRuntimeType: 841536
+      GoRuntimeType: 840768
       GoKind: 22
-      Pointee: 1308 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
+      Pointee: 1306 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
     - __kind: PointerType
-      ID: 1305
+      ID: 1303
       Name: '*github.com/cihub/seelog.logMessage'
       ByteSize: 8
-      GoRuntimeType: 841440
+      GoRuntimeType: 840672
       GoKind: 22
-      Pointee: 1306 UnresolvedPointeeType github.com/cihub/seelog.logMessage
+      Pointee: 1304 UnresolvedPointeeType github.com/cihub/seelog.logMessage
     - __kind: PointerType
       ID: 1414
       Name: '*github.com/cihub/seelog.minMaxConstraints'
       ByteSize: 8
-      GoRuntimeType: 1003776
+      GoRuntimeType: 1003648
       GoKind: 22
       Pointee: 1415 UnresolvedPointeeType github.com/cihub/seelog.minMaxConstraints
     - __kind: PointerType
-      ID: 687
+      ID: 685
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
-      GoRuntimeType: 842112
+      GoRuntimeType: 841344
       GoKind: 22
-      Pointee: 688 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 686 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 1412
       Name: '*github.com/cihub/seelog.offConstraints'
       ByteSize: 8
-      GoRuntimeType: 1003648
+      GoRuntimeType: 1003520
       GoKind: 22
       Pointee: 1413 UnresolvedPointeeType github.com/cihub/seelog.offConstraints
     - __kind: PointerType
@@ -14143,35 +14143,35 @@ Types:
       ID: 1035
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1003392
+      GoRuntimeType: 1003264
       GoKind: 22
       Pointee: 1036 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
       ID: 1658
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1453440
+      GoRuntimeType: 1452672
       GoKind: 22
       Pointee: 1659 UnresolvedPointeeType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 685
+      ID: 683
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
-      GoRuntimeType: 842016
+      GoRuntimeType: 841248
       GoKind: 22
-      Pointee: 686 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 684 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 689
+      ID: 687
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
-      GoRuntimeType: 842208
+      GoRuntimeType: 841440
       GoKind: 22
-      Pointee: 690 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 688 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 1550
       Name: '*github.com/cihub/seelog.xmlNode'
       ByteSize: 8
-      GoRuntimeType: 1249216
+      GoRuntimeType: 1249056
       GoKind: 22
       Pointee: 1551 UnresolvedPointeeType github.com/cihub/seelog.xmlNode
     - __kind: PointerType
@@ -15023,42 +15023,42 @@ Types:
       ID: 910
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1120000
+      GoRuntimeType: 1119360
       GoKind: 22
       Pointee: 911 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 904
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1119616
+      GoRuntimeType: 1118976
       GoKind: 22
       Pointee: 905 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 847
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 994048
+      GoRuntimeType: 993920
       GoKind: 22
       Pointee: 848 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 916
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1120384
+      GoRuntimeType: 1119744
       GoKind: 22
       Pointee: 917 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 846
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 993920
+      GoRuntimeType: 993792
       GoKind: 22
       Pointee: 825 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 908
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1119872
+      GoRuntimeType: 1119232
       GoKind: 22
       Pointee: 909 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
@@ -15069,31 +15069,31 @@ Types:
       GoKind: 22
       Pointee: 2483 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Reader
     - __kind: PointerType
-      ID: 1291
+      ID: 1289
       Name: '*github.com/tinylib/msgp/msgp.Type'
       ByteSize: 8
-      GoRuntimeType: 833664
+      GoRuntimeType: 832896
       GoKind: 22
       Pointee: 997 BaseType github.com/tinylib/msgp/msgp.Type
     - __kind: PointerType
       ID: 906
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1119744
+      GoRuntimeType: 1119104
       GoKind: 22
       Pointee: 907 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 914
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1120256
+      GoRuntimeType: 1119616
       GoKind: 22
       Pointee: 915 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 912
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1120128
+      GoRuntimeType: 1119488
       GoKind: 22
       Pointee: 913 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
@@ -15107,28 +15107,28 @@ Types:
       ID: 920
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1120768
+      GoRuntimeType: 1120128
       GoKind: 22
       Pointee: 921 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 851
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 994304
+      GoRuntimeType: 994176
       GoKind: 22
       Pointee: 852 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 849
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 994176
+      GoRuntimeType: 994048
       GoKind: 22
       Pointee: 850 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 918
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1120640
+      GoRuntimeType: 1120000
       GoKind: 22
       Pointee: 919 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -17323,77 +17323,77 @@ Types:
       ID: 2347
       Name: '*io.LimitedReader'
       ByteSize: 8
-      GoRuntimeType: 828768
+      GoRuntimeType: 829632
       GoKind: 22
       Pointee: 2348 UnresolvedPointeeType io.LimitedReader
     - __kind: PointerType
       ID: 2459
       Name: '*io.PipeReader'
       ByteSize: 8
-      GoRuntimeType: 1717888
+      GoRuntimeType: 1720128
       GoKind: 22
       Pointee: 2460 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
       ID: 1055
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1110912
+      GoRuntimeType: 1114112
       GoKind: 22
       Pointee: 1056 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 2439
       Name: '*io.SectionReader'
       ByteSize: 8
-      GoRuntimeType: 1370848
+      GoRuntimeType: 1372448
       GoKind: 22
       Pointee: 2440 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
       ID: 1053
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1110528
+      GoRuntimeType: 1113728
       GoKind: 22
       Pointee: 1054 StructureType io.discard
     - __kind: PointerType
       ID: 2349
       Name: '*io.eofReader'
       ByteSize: 8
-      GoRuntimeType: 828864
+      GoRuntimeType: 829728
       GoKind: 22
       Pointee: 2350 StructureType io.eofReader
     - __kind: PointerType
       ID: 2413
       Name: '*io.multiReader'
       ByteSize: 8
-      GoRuntimeType: 1110272
+      GoRuntimeType: 1113472
       GoKind: 22
       Pointee: 2414 UnresolvedPointeeType io.multiReader
     - __kind: PointerType
       ID: 1027
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 986496
+      GoRuntimeType: 987648
       GoKind: 22
       Pointee: 1028 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 2383
       Name: '*io.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 986752
+      GoRuntimeType: 987904
       GoKind: 22
       Pointee: 2384 StructureType io.nopCloser
     - __kind: PointerType
       ID: 2415
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
-      GoRuntimeType: 1110400
+      GoRuntimeType: 1113600
       GoKind: 22
       Pointee: 2416 StructureType io.nopCloserWriterTo
     - __kind: PointerType
       ID: 2345
       Name: '*io.teeReader'
       ByteSize: 8
-      GoRuntimeType: 828672
+      GoRuntimeType: 829536
       GoKind: 22
       Pointee: 2346 UnresolvedPointeeType io.teeReader
     - __kind: PointerType
@@ -17421,16 +17421,16 @@ Types:
       ID: 1477
       Name: '*log/slog.Attr'
       ByteSize: 8
-      GoRuntimeType: 1132416
+      GoRuntimeType: 1131776
       GoKind: 22
       Pointee: 1478 StructureType log/slog.Attr
     - __kind: PointerType
-      ID: 1312
+      ID: 1310
       Name: '*log/slog.Kind'
       ByteSize: 8
-      GoRuntimeType: 842592
+      GoRuntimeType: 841824
       GoKind: 22
-      Pointee: 1232 BaseType log/slog.Kind
+      Pointee: 1230 BaseType log/slog.Kind
     - __kind: PointerType
       ID: 1752
       Name: '*log/slog.Level'
@@ -17442,7 +17442,7 @@ Types:
       ID: 2193
       Name: '*log/slog.Value'
       ByteSize: 8
-      GoRuntimeType: 2064224
+      GoRuntimeType: 2063392
       GoKind: 22
       Pointee: 1823 StructureType log/slog.Value
     - __kind: PointerType
@@ -17843,21 +17843,21 @@ Types:
       ID: 927
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1127040
+      GoRuntimeType: 1126400
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 958
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1247136
+      GoRuntimeType: 1246976
       GoKind: 22
       Pointee: 959 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1303
+      ID: 1301
       Name: '*net.HardwareAddr.array'
       ByteSize: 8
-      Pointee: 1302 GoSliceDataType net.HardwareAddr.array
+      Pointee: 1300 GoSliceDataType net.HardwareAddr.array
     - __kind: PointerType
       ID: 2088
       Name: '*net.IP'
@@ -17881,14 +17881,14 @@ Types:
       ID: 1154
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2099072
+      GoRuntimeType: 2098112
       GoKind: 22
       Pointee: 1155 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 1404
       Name: '*net.IPMask'
       ByteSize: 8
-      GoRuntimeType: 1000448
+      GoRuntimeType: 1000320
       GoKind: 22
       Pointee: 1405 GoSliceHeaderType net.IPMask
     - __kind: PointerType
@@ -17900,28 +17900,28 @@ Types:
       ID: 1471
       Name: '*net.IPNet'
       ByteSize: 8
-      GoRuntimeType: 1126784
+      GoRuntimeType: 1126144
       GoKind: 22
       Pointee: 1472 UnresolvedPointeeType net.IPNet
     - __kind: PointerType
       ID: 956
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1246816
+      GoRuntimeType: 1246656
       GoKind: 22
       Pointee: 957 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 929
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1127168
+      GoRuntimeType: 1126528
       GoKind: 22
       Pointee: 930 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1828
       Name: '*net.TCPAddr'
       ByteSize: 8
-      GoRuntimeType: 1686080
+      GoRuntimeType: 1685632
       GoKind: 22
       Pointee: 1829 UnresolvedPointeeType net.TCPAddr
     - __kind: PointerType
@@ -17935,7 +17935,7 @@ Types:
       ID: 1826
       Name: '*net.UDPAddr'
       ByteSize: 8
-      GoRuntimeType: 1685856
+      GoRuntimeType: 1685408
       GoKind: 22
       Pointee: 1827 UnresolvedPointeeType net.UDPAddr
     - __kind: PointerType
@@ -17963,7 +17963,7 @@ Types:
       ID: 926
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1126272
+      GoRuntimeType: 1125632
       GoKind: 22
       Pointee: 895 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -17982,30 +17982,30 @@ Types:
       ID: 863
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1000704
+      GoRuntimeType: 1000576
       GoKind: 22
       Pointee: 864 StructureType net.canceledError
     - __kind: PointerType
       ID: 1132
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 1884832
+      GoRuntimeType: 1884544
       GoKind: 22
       Pointee: 1133 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 998
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1728192
+      GoRuntimeType: 1727968
       GoKind: 22
       Pointee: 999 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1304
+      ID: 1302
       Name: '*net.hostLookupOrder'
       ByteSize: 8
-      GoRuntimeType: 839232
+      GoRuntimeType: 838464
       GoKind: 22
-      Pointee: 1230 BaseType net.hostLookupOrder
+      Pointee: 1228 BaseType net.hostLookupOrder
     - __kind: PointerType
       ID: 1176
       Name: '*net.netFD'
@@ -18014,150 +18014,150 @@ Types:
       GoKind: 22
       Pointee: 1177 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 666
+      ID: 664
       Name: '*net.notFoundError'
       ByteSize: 8
-      GoRuntimeType: 838848
+      GoRuntimeType: 838080
       GoKind: 22
-      Pointee: 667 UnresolvedPointeeType net.notFoundError
+      Pointee: 665 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 407
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
-      GoRuntimeType: 1246976
+      GoRuntimeType: 1246816
       GoKind: 22
       Pointee: 408 GoContextImplementationType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 668
+      ID: 666
       Name: '*net.result·2'
       ByteSize: 8
-      GoRuntimeType: 839520
+      GoRuntimeType: 838752
       GoKind: 22
-      Pointee: 669 StructureType net.result·2
+      Pointee: 667 StructureType net.result·2
     - __kind: PointerType
       ID: 1158
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2113440
+      GoRuntimeType: 2112480
       GoKind: 22
       Pointee: 1159 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1156
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2112960
+      GoRuntimeType: 2112000
       GoKind: 22
       Pointee: 1157 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 931
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1127808
+      GoRuntimeType: 1127168
       GoKind: 22
       Pointee: 932 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 960
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1247296
+      GoRuntimeType: 1247136
       GoKind: 22
       Pointee: 961 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 1398
       Name: '*net/http.Cookie'
       ByteSize: 8
-      GoRuntimeType: 995072
+      GoRuntimeType: 994944
       GoKind: 22
       Pointee: 1399 UnresolvedPointeeType net/http.Cookie
     - __kind: PointerType
       ID: 853
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 996736
+      GoRuntimeType: 996608
       GoKind: 22
       Pointee: 854 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 2427
       Name: '*net/http.body'
       ByteSize: 8
-      GoRuntimeType: 1685632
+      GoRuntimeType: 1685184
       GoKind: 22
       Pointee: 2428 UnresolvedPointeeType net/http.body
     - __kind: PointerType
       ID: 2417
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
-      GoRuntimeType: 1121792
+      GoRuntimeType: 1121152
       GoKind: 22
       Pointee: 2418 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
       ID: 2351
       Name: '*net/http.bodyLocked'
       ByteSize: 8
-      GoRuntimeType: 834528
+      GoRuntimeType: 833760
       GoKind: 22
       Pointee: 2352 StructureType net/http.bodyLocked
     - __kind: PointerType
       ID: 1009
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
-      GoRuntimeType: 834720
+      GoRuntimeType: 833952
       GoKind: 22
       Pointee: 1010 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
       ID: 2353
       Name: '*net/http.byteReader'
       ByteSize: 8
-      GoRuntimeType: 834816
+      GoRuntimeType: 834048
       GoKind: 22
       Pointee: 2354 UnresolvedPointeeType net/http.byteReader
     - __kind: PointerType
       ID: 2395
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
-      GoRuntimeType: 996608
+      GoRuntimeType: 996480
       GoKind: 22
       Pointee: 2396 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 1294
+      ID: 1292
       Name: '*net/http.connectMethodKey'
       ByteSize: 8
-      GoRuntimeType: 835296
+      GoRuntimeType: 834528
       GoKind: 22
-      Pointee: 1295 StructureType net/http.connectMethodKey
+      Pointee: 1293 StructureType net/http.connectMethodKey
     - __kind: PointerType
-      ID: 1296
+      ID: 1294
       Name: '*net/http.contextKey'
       ByteSize: 8
-      GoRuntimeType: 836544
+      GoRuntimeType: 835776
       GoKind: 22
-      Pointee: 1297 UnresolvedPointeeType net/http.contextKey
+      Pointee: 1295 UnresolvedPointeeType net/http.contextKey
     - __kind: PointerType
       ID: 2355
       Name: '*net/http.errorReader'
       ByteSize: 8
-      GoRuntimeType: 834912
+      GoRuntimeType: 834144
       GoKind: 22
       Pointee: 2356 StructureType net/http.errorReader
     - __kind: PointerType
       ID: 2357
       Name: '*net/http.finishAsyncByteRead'
       ByteSize: 8
-      GoRuntimeType: 835008
+      GoRuntimeType: 834240
       GoKind: 22
       Pointee: 2358 StructureType net/http.finishAsyncByteRead
     - __kind: PointerType
       ID: 2397
       Name: '*net/http.gzipReader'
       ByteSize: 8
-      GoRuntimeType: 997248
+      GoRuntimeType: 997120
       GoKind: 22
       Pointee: 2398 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 643
+      ID: 641
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 835392
+      GoRuntimeType: 834624
       GoKind: 22
       Pointee: 564 BaseType net/http.http2ConnectionError
     - __kind: PointerType
@@ -18178,7 +18178,7 @@ Types:
       ID: 1395
       Name: '*net/http.http2ErrCode'
       ByteSize: 8
-      GoRuntimeType: 994816
+      GoRuntimeType: 994688
       GoKind: 22
       Pointee: 971 BaseType net/http.http2ErrCode
     - __kind: PointerType
@@ -18189,52 +18189,52 @@ Types:
       GoKind: 22
       Pointee: 1589 StructureType net/http.http2FrameHeader
     - __kind: PointerType
-      ID: 1292
+      ID: 1290
       Name: '*net/http.http2FrameType'
       ByteSize: 8
-      GoRuntimeType: 833856
+      GoRuntimeType: 833088
       GoKind: 22
-      Pointee: 1225 BaseType net/http.http2FrameType
+      Pointee: 1223 BaseType net/http.http2FrameType
     - __kind: PointerType
-      ID: 644
+      ID: 642
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
-      GoRuntimeType: 835488
+      GoRuntimeType: 834720
       GoKind: 22
-      Pointee: 645 StructureType net/http.http2GoAwayError
+      Pointee: 643 StructureType net/http.http2GoAwayError
     - __kind: PointerType
       ID: 1648
       Name: '*net/http.http2GoAwayFrame'
       ByteSize: 8
-      GoRuntimeType: 1442880
+      GoRuntimeType: 1442112
       GoKind: 22
       Pointee: 1649 StructureType net/http.http2GoAwayFrame
     - __kind: PointerType
       ID: 1871
       Name: '*net/http.http2HeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 1724832
+      GoRuntimeType: 1724608
       GoKind: 22
       Pointee: 1870 StructureType net/http.http2HeadersFrame
     - __kind: PointerType
       ID: 1975
       Name: '*net/http.http2MetaHeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 1883968
+      GoRuntimeType: 1883680
       GoKind: 22
       Pointee: 1976 StructureType net/http.http2MetaHeadersFrame
     - __kind: PointerType
       ID: 1650
       Name: '*net/http.http2PingFrame'
       ByteSize: 8
-      GoRuntimeType: 1443072
+      GoRuntimeType: 1442304
       GoKind: 22
       Pointee: 1651 StructureType net/http.http2PingFrame
     - __kind: PointerType
       ID: 1652
       Name: '*net/http.http2PriorityFrame'
       ByteSize: 8
-      GoRuntimeType: 1443264
+      GoRuntimeType: 1442496
       GoKind: 22
       Pointee: 1653 StructureType net/http.http2PriorityFrame
     - __kind: PointerType
@@ -18255,16 +18255,16 @@ Types:
       ID: 1396
       Name: '*net/http.http2Setting'
       ByteSize: 8
-      GoRuntimeType: 994944
+      GoRuntimeType: 994816
       GoKind: 22
       Pointee: 1397 StructureType net/http.http2Setting
     - __kind: PointerType
-      ID: 1293
+      ID: 1291
       Name: '*net/http.http2SettingID'
       ByteSize: 8
-      GoRuntimeType: 834144
+      GoRuntimeType: 833376
       GoKind: 22
-      Pointee: 1226 BaseType net/http.http2SettingID
+      Pointee: 1224 BaseType net/http.http2SettingID
     - __kind: PointerType
       ID: 1932
       Name: '*net/http.http2SettingsFrame'
@@ -18276,14 +18276,14 @@ Types:
       ID: 952
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1243296
+      GoRuntimeType: 1243136
       GoKind: 22
       Pointee: 953 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 1654
       Name: '*net/http.http2UnknownFrame'
       ByteSize: 8
-      GoRuntimeType: 1444608
+      GoRuntimeType: 1443840
       GoKind: 22
       Pointee: 1655 StructureType net/http.http2UnknownFrame
     - __kind: PointerType
@@ -18297,16 +18297,16 @@ Types:
       ID: 2441
       Name: '*net/http.http2clientStream'
       ByteSize: 8
-      GoRuntimeType: 1884256
+      GoRuntimeType: 1883968
       GoKind: 22
       Pointee: 2442 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 648
+      ID: 646
       Name: '*net/http.http2connError'
       ByteSize: 8
-      GoRuntimeType: 835968
+      GoRuntimeType: 835200
       GoKind: 22
-      Pointee: 649 StructureType net/http.http2connError
+      Pointee: 647 StructureType net/http.http2connError
     - __kind: PointerType
       ID: 1073
       Name: '*net/http.http2dataBuffer'
@@ -18315,10 +18315,10 @@ Types:
       GoKind: 22
       Pointee: 1074 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 647
+      ID: 645
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 835872
+      GoRuntimeType: 835104
       GoKind: 22
       Pointee: 568 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
@@ -18330,14 +18330,14 @@ Types:
       ID: 2393
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
-      GoRuntimeType: 996352
+      GoRuntimeType: 996224
       GoKind: 22
       Pointee: 2394 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 651
+      ID: 649
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 836160
+      GoRuntimeType: 835392
       GoKind: 22
       Pointee: 574 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
@@ -18346,10 +18346,10 @@ Types:
       ByteSize: 8
       Pointee: 575 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 650
+      ID: 648
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 836064
+      GoRuntimeType: 835296
       GoKind: 22
       Pointee: 571 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
@@ -18361,28 +18361,28 @@ Types:
       ID: 924
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1122944
+      GoRuntimeType: 1122304
       GoKind: 22
       Pointee: 925 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 2389
       Name: '*net/http.http2missingBody'
       ByteSize: 8
-      GoRuntimeType: 996096
+      GoRuntimeType: 995968
       GoKind: 22
       Pointee: 2390 StructureType net/http.http2missingBody
     - __kind: PointerType
       ID: 2399
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
-      GoRuntimeType: 997504
+      GoRuntimeType: 997376
       GoKind: 22
       Pointee: 2400 StructureType net/http.http2noBodyReader
     - __kind: PointerType
       ID: 859
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 997376
+      GoRuntimeType: 997248
       GoKind: 22
       Pointee: 860 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
@@ -18393,10 +18393,10 @@ Types:
       GoKind: 22
       Pointee: 1125 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 646
+      ID: 644
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 835776
+      GoRuntimeType: 835008
       GoKind: 22
       Pointee: 565 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
@@ -18408,98 +18408,98 @@ Types:
       ID: 1011
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
-      GoRuntimeType: 836256
+      GoRuntimeType: 835488
       GoKind: 22
       Pointee: 1012 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
       ID: 2391
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
-      GoRuntimeType: 996224
+      GoRuntimeType: 996096
       GoKind: 22
       Pointee: 2392 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
       ID: 2387
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
-      GoRuntimeType: 995712
+      GoRuntimeType: 995584
       GoKind: 22
       Pointee: 2388 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
       ID: 2419
       Name: '*net/http.noBody'
       ByteSize: 8
-      GoRuntimeType: 1122048
+      GoRuntimeType: 1121408
       GoKind: 22
       Pointee: 2420 StructureType net/http.noBody
     - __kind: PointerType
       ID: 855
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 996992
+      GoRuntimeType: 996864
       GoKind: 22
       Pointee: 856 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1646
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1442496
+      GoRuntimeType: 1441728
       GoKind: 22
       Pointee: 1647 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 1075
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2043840
+      GoRuntimeType: 2043424
       GoKind: 22
       Pointee: 1076 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1031
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 996864
+      GoRuntimeType: 996736
       GoKind: 22
       Pointee: 1032 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 2385
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
-      GoRuntimeType: 995328
+      GoRuntimeType: 995200
       GoKind: 22
       Pointee: 2386 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
       ID: 1057
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1121920
+      GoRuntimeType: 1121280
       GoKind: 22
       Pointee: 1058 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 652
+      ID: 650
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
-      GoRuntimeType: 836352
+      GoRuntimeType: 835584
       GoKind: 22
-      Pointee: 653 StructureType net/http.requestBodyReadError
+      Pointee: 651 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 1400
       Name: '*net/http.socksAddr'
       ByteSize: 8
-      GoRuntimeType: 995456
+      GoRuntimeType: 995328
       GoKind: 22
       Pointee: 1401 UnresolvedPointeeType net/http.socksAddr
     - __kind: PointerType
       ID: 954
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1244416
+      GoRuntimeType: 1244256
       GoKind: 22
       Pointee: 955 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 922
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1122816
+      GoRuntimeType: 1122176
       GoKind: 22
       Pointee: 923 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
@@ -18513,16 +18513,16 @@ Types:
       ID: 857
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 997120
+      GoRuntimeType: 996992
       GoKind: 22
       Pointee: 858 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 641
+      ID: 639
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
-      GoRuntimeType: 834624
+      GoRuntimeType: 833856
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 640 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 2407
       Name: '*net/http/httputil.failureToReadBody'
@@ -18644,14 +18644,14 @@ Types:
       ID: 962
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1247616
+      GoRuntimeType: 1247456
       GoKind: 22
       Pointee: 963 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 670
+      ID: 668
       Name: '*net/url.EscapeError'
       ByteSize: 8
-      GoRuntimeType: 839616
+      GoRuntimeType: 838848
       GoKind: 22
       Pointee: 577 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
@@ -18660,10 +18660,10 @@ Types:
       ByteSize: 8
       Pointee: 578 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 671
+      ID: 669
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
-      GoRuntimeType: 839712
+      GoRuntimeType: 838944
       GoKind: 22
       Pointee: 580 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
@@ -18682,7 +18682,7 @@ Types:
       ID: 1473
       Name: '*net/url.Userinfo'
       ByteSize: 8
-      GoRuntimeType: 1128704
+      GoRuntimeType: 1128064
       GoKind: 22
       Pointee: 1474 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
@@ -18789,19 +18789,19 @@ Types:
       GoKind: 22
       Pointee: 611 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 1289
+      ID: 1311
       Name: '*reflect.ChanDir'
       ByteSize: 8
-      GoRuntimeType: 832704
+      GoRuntimeType: 842112
       GoKind: 22
-      Pointee: 1222 BaseType reflect.ChanDir
+      Pointee: 1231 BaseType reflect.ChanDir
     - __kind: PointerType
-      ID: 1290
+      ID: 1312
       Name: '*reflect.Kind'
       ByteSize: 8
-      GoRuntimeType: 832896
+      GoRuntimeType: 842304
       GoKind: 22
-      Pointee: 1223 BaseType reflect.Kind
+      Pointee: 1232 BaseType reflect.Kind
     - __kind: PointerType
       ID: 2322
       Name: '*reflect.Value'
@@ -18810,12 +18810,12 @@ Types:
       GoKind: 22
       Pointee: 2323 StructureType reflect.Value
     - __kind: PointerType
-      ID: 639
+      ID: 690
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 833376
+      GoRuntimeType: 842784
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType reflect.ValueError
+      Pointee: 691 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 2306
       Name: '*reflect.rtype'
@@ -19028,12 +19028,12 @@ Types:
       GoKind: 22
       Pointee: 36 BaseType runtime.waitReason
     - __kind: PointerType
-      ID: 1299
+      ID: 1297
       Name: '*runtime/debug.BuildInfo'
       ByteSize: 8
-      GoRuntimeType: 838560
+      GoRuntimeType: 837792
       GoKind: 22
-      Pointee: 1300 UnresolvedPointeeType runtime/debug.BuildInfo
+      Pointee: 1298 UnresolvedPointeeType runtime/debug.BuildInfo
     - __kind: PointerType
       ID: 1313
       Name: '*runtime/pprof.labelMap'
@@ -30965,7 +30965,7 @@ Types:
     - __kind: ArrayType
       ID: 1739
       Name: '[0]func()'
-      GoRuntimeType: 673088
+      GoRuntimeType: 671168
       GoKind: 17
       HasCount: true
       Element: 60 GoSubroutineType func()
@@ -31287,7 +31287,7 @@ Types:
       ID: 1214
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
-      GoRuntimeType: 452544
+      GoRuntimeType: 452352
       GoKind: 23
       RawFields:
         - Name: array
@@ -31824,7 +31824,7 @@ Types:
       ID: 386
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
-      GoRuntimeType: 452096
+      GoRuntimeType: 451904
       GoKind: 23
       RawFields:
         - Name: array
@@ -31847,7 +31847,7 @@ Types:
       ID: 389
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
-      GoRuntimeType: 452288
+      GoRuntimeType: 452096
       GoKind: 23
       RawFields:
         - Name: array
@@ -31893,7 +31893,7 @@ Types:
       ID: 361
       Name: '[]go.shape.float64'
       ByteSize: 24
-      GoRuntimeType: 454528
+      GoRuntimeType: 454336
       GoKind: 23
       RawFields:
         - Name: array
@@ -32513,7 +32513,7 @@ Types:
       ID: 2001
       Name: '[]vendor/golang.org/x/net/http2/hpack.HeaderField'
       ByteSize: 24
-      GoRuntimeType: 461504
+      GoRuntimeType: 460864
       GoKind: 23
       RawFields:
         - Name: array
@@ -33383,7 +33383,7 @@ Types:
       ID: 153
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1201600
+      GoRuntimeType: 1201472
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33435,7 +33435,7 @@ Types:
       ID: 549
       Name: context.canceler
       ByteSize: 16
-      GoRuntimeType: 1075584
+      GoRuntimeType: 1074688
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33447,7 +33447,7 @@ Types:
     - __kind: StructureType
       ID: 899
       Name: context.deadlineExceededError
-      GoRuntimeType: 1289824
+      GoRuntimeType: 1288704
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
@@ -33478,7 +33478,7 @@ Types:
       ID: 426
       Name: context.timerCtx
       ByteSize: 112
-      GoRuntimeType: 1431552
+      GoRuntimeType: 1431168
       GoKind: 25
       RawFields:
         - Name: cancelCtx
@@ -33508,7 +33508,7 @@ Types:
       ID: 410
       Name: context.valueCtx
       ByteSize: 48
-      GoRuntimeType: 1718112
+      GoRuntimeType: 1716992
       GoKind: 25
       RawFields:
         - Name: Context
@@ -33975,7 +33975,7 @@ Types:
       ID: 592
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 768096
+      GoRuntimeType: 767904
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1038
@@ -33988,13 +33988,13 @@ Types:
       GoRuntimeType: 768288
       GoKind: 8
     - __kind: BaseType
-      ID: 1228
+      ID: 1226
       Name: encoding/json.Delim
       ByteSize: 4
-      GoRuntimeType: 766752
+      GoRuntimeType: 766560
       GoKind: 5
     - __kind: UnresolvedPointeeType
-      ID: 663
+      ID: 661
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34021,19 +34021,19 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 655
+      ID: 653
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 661
+      ID: 659
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 659
+      ID: 657
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 657
+      ID: 655
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34041,10 +34041,10 @@ Types:
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 665
+      ID: 663
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1245856
+      GoRuntimeType: 1245696
       GoKind: 25
       RawFields:
         - Name: error
@@ -34126,7 +34126,7 @@ Types:
       ID: 2473
       Name: fmt.ScanState
       ByteSize: 16
-      GoRuntimeType: 1289024
+      GoRuntimeType: 1291104
       GoKind: 20
       RawFields:
         - Name: tab
@@ -34139,7 +34139,7 @@ Types:
       ID: 398
       Name: fmt.Stringer
       ByteSize: 16
-      GoRuntimeType: 986240
+      GoRuntimeType: 987392
       GoKind: 20
       RawFields:
         - Name: tab
@@ -34247,7 +34247,7 @@ Types:
       ID: 1821
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
       ByteSize: 4
-      GoRuntimeType: 1643392
+      GoRuntimeType: 1642816
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 1989
@@ -34261,7 +34261,7 @@ Types:
       ID: 1822
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
       ByteSize: 4
-      GoRuntimeType: 1643584
+      GoRuntimeType: 1643008
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 2286
@@ -34322,7 +34322,7 @@ Types:
       Name: github.com/DataDog/datadog-agent/pkg/version.Version
       ByteSize: 8
     - __kind: StructureType
-      ID: 674
+      ID: 672
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1614432
@@ -34338,7 +34338,7 @@ Types:
           Offset: 200
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 674
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34346,7 +34346,7 @@ Types:
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 680
+      ID: 678
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1078400
       GoKind: 25
@@ -34359,7 +34359,7 @@ Types:
       ID: 586
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
-      GoRuntimeType: 767520
+      GoRuntimeType: 767328
       GoKind: 24
       RawFields:
         - Name: str
@@ -34427,13 +34427,13 @@ Types:
       ID: 987
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
-      GoRuntimeType: 536736
+      GoRuntimeType: 536672
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 583
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
-      GoRuntimeType: 767424
+      GoRuntimeType: 767232
       GoKind: 24
       RawFields:
         - Name: str
@@ -34452,7 +34452,7 @@ Types:
       ID: 589
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
-      GoRuntimeType: 767616
+      GoRuntimeType: 767424
       GoKind: 24
       RawFields:
         - Name: str
@@ -34663,7 +34663,7 @@ Types:
       ID: 388
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
-      GoRuntimeType: 1791200
+      GoRuntimeType: 1790944
       GoKind: 25
       RawFields:
         - Name: TraceID
@@ -34736,7 +34736,7 @@ Types:
       ID: 376
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 988288
+      GoRuntimeType: 985728
       GoKind: 21
       HeaderType: 378 GoHMapHeaderType hash<string,interface {}>
     - __kind: UnresolvedPointeeType
@@ -34757,7 +34757,7 @@ Types:
       ID: 1216
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
-      GoRuntimeType: 533856
+      GoRuntimeType: 533792
       GoKind: 10
     - __kind: StructureType
       ID: 391
@@ -34786,7 +34786,7 @@ Types:
       ID: 559
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
-      GoRuntimeType: 1791456
+      GoRuntimeType: 1791200
       GoKind: 25
       RawFields:
         - Name: Type
@@ -34817,7 +34817,7 @@ Types:
       ID: 396
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
-      GoRuntimeType: 1979456
+      GoRuntimeType: 1979104
       GoKind: 25
       RawFields:
         - Name: mu
@@ -34854,7 +34854,7 @@ Types:
       ID: 397
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
-      GoRuntimeType: 829440
+      GoRuntimeType: 828960
       GoKind: 17
       Count: 16
       HasCount: true
@@ -34873,7 +34873,7 @@ Types:
       ID: 1377
       Name: github.com/DataDog/dd-trace-go/v2/internal.TraceSource
       ByteSize: 1
-      GoRuntimeType: 954656
+      GoRuntimeType: 954560
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1169
@@ -34920,16 +34920,16 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/waf.Feature
       ByteSize: 8
     - __kind: BaseType
-      ID: 1224
+      ID: 1222
       Name: github.com/DataDog/dd-trace-go/v2/internal/log.Level
       ByteSize: 8
-      GoRuntimeType: 765696
+      GoRuntimeType: 765504
       GoKind: 2
     - __kind: GoContextImplementationType
       ID: 406
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
-      GoRuntimeType: 1445760
+      GoRuntimeType: 1444992
       GoKind: 25
       RawFields:
         - Name: Context
@@ -35321,24 +35321,24 @@ Types:
           Offset: 56
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1311
+      ID: 1309
       Name: github.com/cihub/seelog.CfgParseParams
       ByteSize: 8
     - __kind: BaseType
-      ID: 1231
+      ID: 1229
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
-      GoRuntimeType: 767904
+      GoRuntimeType: 767712
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1831
       Name: github.com/cihub/seelog.LogLevelException
       ByteSize: 8
     - __kind: StructureType
-      ID: 682
+      ID: 680
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1248096
+      GoRuntimeType: 1247936
       GoKind: 25
       RawFields:
         - Name: message
@@ -35349,15 +35349,15 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 684
+      ID: 682
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1248256
+      GoRuntimeType: 1248096
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 682 StructureType github.com/cihub/seelog.baseError
+          Type: 680 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1078
       Name: github.com/cihub/seelog.connWriter
@@ -35395,11 +35395,11 @@ Types:
       Name: github.com/cihub/seelog.listConstraints
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1308
+      ID: 1306
       Name: github.com/cihub/seelog.logFormattedMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1306
+      ID: 1304
       Name: github.com/cihub/seelog.logMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -35407,15 +35407,15 @@ Types:
       Name: github.com/cihub/seelog.minMaxConstraints
       ByteSize: 8
     - __kind: StructureType
-      ID: 688
+      ID: 686
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1248576
+      GoRuntimeType: 1248416
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 682 StructureType github.com/cihub/seelog.baseError
+          Type: 680 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1413
       Name: github.com/cihub/seelog.offConstraints
@@ -35462,25 +35462,25 @@ Types:
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 686
+      ID: 684
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1248416
+      GoRuntimeType: 1248256
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 682 StructureType github.com/cihub/seelog.baseError
+          Type: 680 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 690
+      ID: 688
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1248736
+      GoRuntimeType: 1248576
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 682 StructureType github.com/cihub/seelog.baseError
+          Type: 680 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1551
       Name: github.com/cihub/seelog.xmlNode
@@ -36105,7 +36105,7 @@ Types:
       ID: 911
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1723488
+      GoRuntimeType: 1723264
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -36138,7 +36138,7 @@ Types:
       ID: 917
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1723936
+      GoRuntimeType: 1723712
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36154,13 +36154,13 @@ Types:
       ID: 825
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 954080
+      GoRuntimeType: 953984
       GoKind: 8
     - __kind: StructureType
       ID: 909
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1723264
+      GoRuntimeType: 1723040
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -36180,13 +36180,13 @@ Types:
       ID: 997
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
-      GoRuntimeType: 765792
+      GoRuntimeType: 765600
       GoKind: 8
     - __kind: StructureType
       ID: 907
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1723040
+      GoRuntimeType: 1722816
       GoKind: 25
       RawFields:
         - Name: Method
@@ -36202,7 +36202,7 @@ Types:
       ID: 915
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1640704
+      GoRuntimeType: 1640128
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36215,7 +36215,7 @@ Types:
       ID: 913
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1723712
+      GoRuntimeType: 1723488
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36235,7 +36235,7 @@ Types:
       ID: 921
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1441536
+      GoRuntimeType: 1440768
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -36257,7 +36257,7 @@ Types:
       ID: 919
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1640896
+      GoRuntimeType: 1640320
       GoKind: 25
       RawFields:
         - Name: cause
@@ -39537,7 +39537,7 @@ Types:
       ID: 2452
       Name: io.Closer
       ByteSize: 16
-      GoRuntimeType: 987264
+      GoRuntimeType: 988416
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39562,7 +39562,7 @@ Types:
       ID: 1097
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1110656
+      GoRuntimeType: 1113856
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39575,7 +39575,7 @@ Types:
       ID: 399
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 986624
+      GoRuntimeType: 987776
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39592,7 +39592,7 @@ Types:
       ID: 1085
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1075072
+      GoRuntimeType: 1075328
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39605,7 +39605,7 @@ Types:
       ID: 127
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 986368
+      GoRuntimeType: 987520
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39618,7 +39618,7 @@ Types:
       ID: 2451
       Name: io.WriterTo
       ByteSize: 16
-      GoRuntimeType: 987136
+      GoRuntimeType: 988288
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39630,13 +39630,13 @@ Types:
     - __kind: StructureType
       ID: 1054
       Name: io.discard
-      GoRuntimeType: 1289504
+      GoRuntimeType: 1291584
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 2350
       Name: io.eofReader
-      GoRuntimeType: 1074816
+      GoRuntimeType: 1075072
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -39651,7 +39651,7 @@ Types:
       ID: 2384
       Name: io.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1370688
+      GoRuntimeType: 1372288
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -39661,7 +39661,7 @@ Types:
       ID: 2416
       Name: io.nopCloserWriterTo
       ByteSize: 16
-      GoRuntimeType: 1431168
+      GoRuntimeType: 1432320
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -39708,7 +39708,7 @@ Types:
       ID: 1478
       Name: log/slog.Attr
       ByteSize: 40
-      GoRuntimeType: 1648768
+      GoRuntimeType: 1648192
       GoKind: 25
       RawFields:
         - Name: Key
@@ -39718,10 +39718,10 @@ Types:
           Offset: 16
           Type: 1823 StructureType log/slog.Value
     - __kind: BaseType
-      ID: 1232
+      ID: 1230
       Name: log/slog.Kind
       ByteSize: 8
-      GoRuntimeType: 768000
+      GoRuntimeType: 767808
       GoKind: 2
     - __kind: BaseType
       ID: 1544
@@ -40825,7 +40825,7 @@ Types:
       ID: 420
       Name: map[context.canceler]struct {}
       ByteSize: 8
-      GoRuntimeType: 887328
+      GoRuntimeType: 886656
       GoKind: 21
       HeaderType: 422 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: GoMapType
@@ -40888,14 +40888,14 @@ Types:
       ID: 540
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
-      GoRuntimeType: 887520
+      GoRuntimeType: 886848
       GoKind: 21
       HeaderType: 542 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 2142
       Name: map[string]*regexp.Regexp
       ByteSize: 8
-      GoRuntimeType: 887808
+      GoRuntimeType: 887136
       GoKind: 21
       HeaderType: 2144 GoHMapHeaderType hash<string,*regexp.Regexp>
     - __kind: GoMapType
@@ -40916,7 +40916,7 @@ Types:
       ID: 381
       Name: map[string]float64
       ByteSize: 8
-      GoRuntimeType: 887424
+      GoRuntimeType: 886752
       GoKind: 21
       HeaderType: 383 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
@@ -41155,16 +41155,16 @@ Types:
       Name: net.DNSError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1229
+      ID: 1227
       Name: net.Flags
       ByteSize: 8
-      GoRuntimeType: 766944
+      GoRuntimeType: 766752
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 1301
+      ID: 1299
       Name: net.HardwareAddr
       ByteSize: 24
-      GoRuntimeType: 839040
+      GoRuntimeType: 838272
       GoKind: 23
       RawFields:
         - Name: array
@@ -41176,9 +41176,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1302 GoSliceDataType net.HardwareAddr.array
+      Data: 1300 GoSliceDataType net.HardwareAddr.array
     - __kind: GoSliceDataType
-      ID: 1302
+      ID: 1300
       Name: net.HardwareAddr.array
       DynamicSizeClass: slice
       ByteSize: 1
@@ -41218,7 +41218,7 @@ Types:
       ID: 1405
       Name: net.IPMask
       ByteSize: 24
-      GoRuntimeType: 1000576
+      GoRuntimeType: 1000448
       GoKind: 23
       RawFields:
         - Name: array
@@ -41332,10 +41332,10 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: BaseType
-      ID: 1230
+      ID: 1228
       Name: net.hostLookupOrder
       ByteSize: 8
-      GoRuntimeType: 767040
+      GoRuntimeType: 766848
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1177
@@ -41354,14 +41354,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 667
+      ID: 665
       Name: net.notFoundError
       ByteSize: 8
     - __kind: GoContextImplementationType
       ID: 408
       Name: net.onlyValuesCtx
       ByteSize: 32
-      GoRuntimeType: 1645696
+      GoRuntimeType: 1645120
       GoKind: 25
       RawFields:
         - Name: Context
@@ -41373,7 +41373,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: StructureType
-      ID: 669
+      ID: 667
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1614240
@@ -41423,10 +41423,10 @@ Types:
       Name: net.timeoutError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1227
+      ID: 1225
       Name: net/http.ConnState
       ByteSize: 8
-      GoRuntimeType: 766176
+      GoRuntimeType: 765984
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1399
@@ -41448,7 +41448,7 @@ Types:
       ID: 2352
       Name: net/http.bodyLocked
       ByteSize: 8
-      GoRuntimeType: 1243456
+      GoRuntimeType: 1243296
       GoKind: 25
       RawFields:
         - Name: b
@@ -41458,7 +41458,7 @@ Types:
       ID: 1010
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1243616
+      GoRuntimeType: 1243456
       GoKind: 25
       RawFields:
         - Name: w
@@ -41473,7 +41473,7 @@ Types:
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 1295
+      ID: 1293
       Name: net/http.connectMethodKey
       ByteSize: 56
       GoRuntimeType: 1707296
@@ -41492,14 +41492,14 @@ Types:
           Offset: 48
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1297
+      ID: 1295
       Name: net/http.contextKey
       ByteSize: 8
     - __kind: StructureType
       ID: 2356
       Name: net/http.errorReader
       ByteSize: 16
-      GoRuntimeType: 1243776
+      GoRuntimeType: 1243616
       GoKind: 25
       RawFields:
         - Name: err
@@ -41509,7 +41509,7 @@ Types:
       ID: 2358
       Name: net/http.finishAsyncByteRead
       ByteSize: 8
-      GoRuntimeType: 1243936
+      GoRuntimeType: 1243776
       GoKind: 25
       RawFields:
         - Name: tw
@@ -41523,13 +41523,13 @@ Types:
       ID: 564
       Name: net/http.http2ConnectionError
       ByteSize: 4
-      GoRuntimeType: 766272
+      GoRuntimeType: 766080
       GoKind: 10
     - __kind: StructureType
       ID: 1745
       Name: net/http.http2ContinuationFrame
       ByteSize: 40
-      GoRuntimeType: 1642816
+      GoRuntimeType: 1642240
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41542,7 +41542,7 @@ Types:
       ID: 1741
       Name: net/http.http2DataFrame
       ByteSize: 40
-      GoRuntimeType: 1641088
+      GoRuntimeType: 1640512
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41555,13 +41555,13 @@ Types:
       ID: 971
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 954176
+      GoRuntimeType: 954080
       GoKind: 10
     - __kind: BaseType
       ID: 1819
       Name: net/http.http2Flags
       ByteSize: 1
-      GoRuntimeType: 765984
+      GoRuntimeType: 765792
       GoKind: 8
     - __kind: StructureType
       ID: 1589
@@ -41575,7 +41575,7 @@ Types:
           Type: 6 BaseType bool
         - Name: Type
           Offset: 1
-          Type: 1225 BaseType net/http.http2FrameType
+          Type: 1223 BaseType net/http.http2FrameType
         - Name: Flags
           Offset: 2
           Type: 1819 BaseType net/http.http2Flags
@@ -41586,13 +41586,13 @@ Types:
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1225
+      ID: 1223
       Name: net/http.http2FrameType
       ByteSize: 1
-      GoRuntimeType: 765888
+      GoRuntimeType: 765696
       GoKind: 8
     - __kind: StructureType
-      ID: 645
+      ID: 643
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1612704
@@ -41611,7 +41611,7 @@ Types:
       ID: 1649
       Name: net/http.http2GoAwayFrame
       ByteSize: 48
-      GoRuntimeType: 1795040
+      GoRuntimeType: 1794784
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41630,7 +41630,7 @@ Types:
       ID: 1870
       Name: net/http.http2HeadersFrame
       ByteSize: 48
-      GoRuntimeType: 1724608
+      GoRuntimeType: 1724384
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41662,7 +41662,7 @@ Types:
       ID: 1651
       Name: net/http.http2PingFrame
       ByteSize: 20
-      GoRuntimeType: 1641280
+      GoRuntimeType: 1640704
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41704,7 +41704,7 @@ Types:
       ID: 1743
       Name: net/http.http2PushPromiseFrame
       ByteSize: 40
-      GoRuntimeType: 1726176
+      GoRuntimeType: 1725952
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41720,7 +41720,7 @@ Types:
       ID: 1591
       Name: net/http.http2RSTStreamFrame
       ByteSize: 16
-      GoRuntimeType: 1641472
+      GoRuntimeType: 1640896
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41738,21 +41738,21 @@ Types:
       RawFields:
         - Name: ID
           Offset: 0
-          Type: 1226 BaseType net/http.http2SettingID
+          Type: 1224 BaseType net/http.http2SettingID
         - Name: Val
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1226
+      ID: 1224
       Name: net/http.http2SettingID
       ByteSize: 2
-      GoRuntimeType: 766080
+      GoRuntimeType: 765888
       GoKind: 9
     - __kind: StructureType
       ID: 1820
       Name: net/http.http2SettingsFrame
       ByteSize: 40
-      GoRuntimeType: 1641664
+      GoRuntimeType: 1641088
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41765,7 +41765,7 @@ Types:
       ID: 953
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1778944
+      GoRuntimeType: 1778688
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -41781,7 +41781,7 @@ Types:
       ID: 1655
       Name: net/http.http2UnknownFrame
       ByteSize: 40
-      GoRuntimeType: 1642624
+      GoRuntimeType: 1642048
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41794,7 +41794,7 @@ Types:
       ID: 1593
       Name: net/http.http2WindowUpdateFrame
       ByteSize: 16
-      GoRuntimeType: 1641856
+      GoRuntimeType: 1641280
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41808,7 +41808,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 649
+      ID: 647
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1413920
@@ -41828,7 +41828,7 @@ Types:
       ID: 568
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 766464
+      GoRuntimeType: 766272
       GoKind: 24
       RawFields:
         - Name: str
@@ -41851,7 +41851,7 @@ Types:
       ID: 574
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 766656
+      GoRuntimeType: 766464
       GoKind: 24
       RawFields:
         - Name: str
@@ -41870,7 +41870,7 @@ Types:
       ID: 571
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 766560
+      GoRuntimeType: 766368
       GoKind: 24
       RawFields:
         - Name: str
@@ -41915,7 +41915,7 @@ Types:
       ID: 565
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 766368
+      GoRuntimeType: 766176
       GoKind: 24
       RawFields:
         - Name: str
@@ -41959,7 +41959,7 @@ Types:
     - __kind: ArrayType
       ID: 1094
       Name: net/http.incomparable
-      GoRuntimeType: 834432
+      GoRuntimeType: 833664
       GoKind: 17
       HasCount: true
       Element: 60 GoSubroutineType func()
@@ -41970,7 +41970,7 @@ Types:
     - __kind: StructureType
       ID: 2420
       Name: net/http.noBody
-      GoRuntimeType: 1300704
+      GoRuntimeType: 1299584
       GoKind: 25
       RawFields: []
     - __kind: StructureType
@@ -42009,7 +42009,7 @@ Types:
       ID: 1058
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1685408
+      GoRuntimeType: 1684960
       GoKind: 25
       RawFields:
         - Name: _
@@ -42022,10 +42022,10 @@ Types:
           Offset: 8
           Type: 1097 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 653
+      ID: 651
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1244576
+      GoRuntimeType: 1244416
       GoKind: 25
       RawFields:
         - Name: error
@@ -42042,7 +42042,7 @@ Types:
     - __kind: StructureType
       ID: 923
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1301824
+      GoRuntimeType: 1300704
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -42060,7 +42060,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 640
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -42228,7 +42228,7 @@ Types:
       ID: 577
       Name: net/url.EscapeError
       ByteSize: 16
-      GoRuntimeType: 767136
+      GoRuntimeType: 766944
       GoKind: 24
       RawFields:
         - Name: str
@@ -42247,7 +42247,7 @@ Types:
       ID: 580
       Name: net/url.InvalidHostError
       ByteSize: 16
-      GoRuntimeType: 767232
+      GoRuntimeType: 767040
       GoKind: 24
       RawFields:
         - Name: str
@@ -42428,16 +42428,16 @@ Types:
       GoRuntimeType: 772224
       GoKind: 2
     - __kind: BaseType
-      ID: 1222
+      ID: 1231
       Name: reflect.ChanDir
       ByteSize: 8
-      GoRuntimeType: 765504
+      GoRuntimeType: 768000
       GoKind: 2
     - __kind: BaseType
-      ID: 1223
+      ID: 1232
       Name: reflect.Kind
       ByteSize: 8
-      GoRuntimeType: 765600
+      GoRuntimeType: 768096
       GoKind: 7
     - __kind: StructureType
       ID: 2323
@@ -42456,14 +42456,14 @@ Types:
           Offset: 16
           Type: 2324 BaseType reflect.flag
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 691
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: BaseType
       ID: 2324
       Name: reflect.flag
       ByteSize: 8
-      GoRuntimeType: 1639744
+      GoRuntimeType: 1648384
       GoKind: 12
     - __kind: UnresolvedPointeeType
       ID: 2307
@@ -43374,7 +43374,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1300
+      ID: 1298
       Name: runtime/debug.BuildInfo
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -43430,7 +43430,7 @@ Types:
       ID: 2412
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
-      GoRuntimeType: 1541280
+      GoRuntimeType: 1539744
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -43443,7 +43443,7 @@ Types:
       ID: 2410
       Name: struct { io.Reader; io.WriterTo }
       ByteSize: 32
-      GoRuntimeType: 1538208
+      GoRuntimeType: 1536672
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -44146,10 +44146,10 @@ Issues:
       issue:
         Kind: 7
         Message: return value selector (e.g., @return.r0) must be used for multi-value returns
-GoModuledataInfo: {FirstModuledataAddr: "0x17777a0", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x17787a0", TypesOffset: 296}
 GoMapHashInfo:
-    UseAeshashAddr: "0x1850acb"
-    AeskeyschedAddr: "0x1851c60"
+    UseAeshashAddr: "0x1851acb"
+    AeskeyschedAddr: "0x1852c60"
 CommonTypes:
     G: 24 StructureType runtime.g
     M: 31 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -20,11 +20,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2989 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xce2c8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce384a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2990 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xce2cc5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3885", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -40,11 +40,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2824 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0xcdc80a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdce0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2825 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0xcdc845", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdce45", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -66,11 +66,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2827 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0xcdc8aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdceaa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2828 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0xcdc8dd", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdcedd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -91,11 +91,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2958 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xce128e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1d6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2959 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce1342", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1e22", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -183,7 +183,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2836 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xcdd140", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -248,11 +248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2860 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xcdf2e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdfbc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2861 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xcdf2f2", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdfbd2", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -274,11 +274,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2788 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0xcd7c60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7e60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2789 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0xcd7c7e", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7e7e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -344,7 +344,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2987 EventRootType Probe[main.testByteSliceInvalidUtf8]
-              InjectionPoints: [{PC: "0xce2540", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -366,7 +366,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2988 EventRootType Probe[main.testByteSliceMultibyteUtf8]
-              InjectionPoints: [{PC: "0xce2560", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -387,7 +387,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2803 EventRootType Probe[main.testCaptureContextImpl]
-              InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8d60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -414,11 +414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3011 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xce3140", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3f20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3012 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce3162", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3f42", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -426,7 +426,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: ""
       segments: []
@@ -438,15 +438,15 @@ Probes:
             - Kind: Line
               Type: 3075 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcdc02e"
+                - PC: "0xcdc52e"
                   Frameless: false
-                - PC: "0xcdc0b1"
+                - PC: "0xcdc5b1"
                   Frameless: false
-                - PC: "0xcdc1f2"
+                - PC: "0xcdc6f2"
                   Frameless: false
-                - PC: "0xcdc27c"
+                - PC: "0xcdc77c"
                   Frameless: false
-                - PC: "0xcdc34f"
+                - PC: "0xcdc84f"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -455,7 +455,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       when: {dsl: x == 3, json: {eq: [{ref: x}, 3]}}
       sampling: {snapshotsPerSecond: 100}
       template: ""
@@ -468,15 +468,15 @@ Probes:
             - Kind: Line
               Type: 3076 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcdc02e"
+                - PC: "0xcdc52e"
                   Frameless: false
-                - PC: "0xcdc0b1"
+                - PC: "0xcdc5b1"
                   Frameless: false
-                - PC: "0xcdc1f2"
+                - PC: "0xcdc6f2"
                   Frameless: false
-                - PC: "0xcdc27c"
+                - PC: "0xcdc77c"
                   Frameless: false
-                - PC: "0xcdc34f"
+                - PC: "0xcdc84f"
                   Frameless: false
               Condition:
                 Type: 6 BaseType bool
@@ -502,7 +502,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: x={x}
       segments: [x=, {json: {ref: x}, dsl: x}]
@@ -514,15 +514,15 @@ Probes:
             - Kind: Line
               Type: 3077 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcdc02e"
+                - PC: "0xcdc52e"
                   Frameless: false
-                - PC: "0xcdc0b1"
+                - PC: "0xcdc5b1"
                   Frameless: false
-                - PC: "0xcdc1f2"
+                - PC: "0xcdc6f2"
                   Frameless: false
-                - PC: "0xcdc27c"
+                - PC: "0xcdc77c"
                   Frameless: false
-                - PC: "0xcdc34f"
+                - PC: "0xcdc84f"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -550,7 +550,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2855 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xcdec80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf360", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -569,7 +569,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2856 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xcdec80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -595,7 +595,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3019 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xce3260", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4040", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -633,7 +633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2862 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xcdf300", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdfbe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -663,7 +663,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2854 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xcdec40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -692,11 +692,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2923 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xce04ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0fae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2924 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xce0591", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1071", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -718,7 +718,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2870 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xcdf6e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce00a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -740,7 +740,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2795 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0xcd8160", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -762,7 +762,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2796 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0xcd8180", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -784,7 +784,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2791 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0xcd7e40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -806,7 +806,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2792 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0xcd7e60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -828,7 +828,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2793 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0xcd7fe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd81e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -850,7 +850,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2794 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0xcd8000", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8200", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -872,7 +872,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2975 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xce2380", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2e60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -899,7 +899,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2978 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xce23e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2ec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -927,7 +927,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3003 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xce2dc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -949,7 +949,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3020 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xce32c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce40a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -970,7 +970,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3021 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xce32e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce40c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -992,7 +992,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2826 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0xcdc880", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdce80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1007,7 +1007,7 @@ Probes:
       where:
         methodName: main.testErrorAtLine
         sourceFile: complex.go
-        lines: ["108"]
+        lines: ["111"]
       tags:
         - config_diff:arch=amd64,toolchain=go1.26rc1
         - skip_integration:arch=arm64,toolchain=go1.25.0
@@ -1026,7 +1026,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2790 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0xcd7cfb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd7efb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -1054,11 +1054,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2808 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0xcdab0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb00a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2809 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0xcdab4c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdb04c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1080,11 +1080,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2806 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0xcda9ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdaeee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2807 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0xcdaa7b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdaf7b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1106,11 +1106,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2818 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0xcdc4e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc9e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2819 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0xcdc4e5", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc9e5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1132,11 +1132,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2820 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0xcdc504", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdca04", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2821 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0xcdc53d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdca3d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1151,7 +1151,7 @@ Probes:
       where:
         methodName: main.testFramelessArray
         sourceFile: inlined.go
-        lines: ["93"]
+        lines: ["96"]
       sampling: {snapshotsPerSecond: 100}
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
@@ -1161,7 +1161,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2822 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0xcdc508", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdca08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1183,11 +1183,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3061 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xce6060", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7060", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3062 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce6067", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7067", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1201,11 +1201,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3063 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xce6084", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7084", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3064 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xce60d1", Frameless: false}]
+              InjectionPoints: [{PC: "0xce70d1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1228,11 +1228,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3057 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xce5fca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6fca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3058 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xce5fd9", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6fd9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1246,11 +1246,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3059 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xce600a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce700a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3060 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xce6022", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7022", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1273,14 +1273,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 3065 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xce60e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce70e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3066 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xce6100"
+                - PC: "0xce7100"
                   Frameless: true
-                - PC: "0xce6103"
+                - PC: "0xce7103"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1295,14 +1295,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 3067 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xce612a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce712a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3068 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xce618b"
+                - PC: "0xce718b"
                   Frameless: false
-                - PC: "0xce6193"
+                - PC: "0xce7193"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1329,7 +1329,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3069 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xce60e5", Frameless: true}]
+              InjectionPoints: [{PC: "0xce70e5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1341,7 +1341,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3070 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xce613f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce713f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1362,11 +1362,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3045 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xce5c80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6c80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3046 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xce5c90", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6c90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1380,11 +1380,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3047 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xce5d20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6d20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3048 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xce5d28", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6d28", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1408,11 +1408,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3033 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xce580e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce680e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3034 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce58f4", Frameless: false}]
+              InjectionPoints: [{PC: "0xce68f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1454,11 +1454,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3037 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce594a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce694a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3038 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce5959", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6959", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1481,11 +1481,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3071 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xce61e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce71e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3072 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xce61e6", Frameless: true}]
+              InjectionPoints: [{PC: "0xce71e6", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1499,11 +1499,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3073 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xce626a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce726a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3074 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xce628d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce728d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1526,11 +1526,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3029 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xce5760", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6760", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3030 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce5763", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6763", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1544,11 +1544,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3031 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xce5780", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6780", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3032 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce578b", Frameless: true}]
+              InjectionPoints: [{PC: "0xce678b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1571,11 +1571,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3049 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xce5de0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6de0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3050 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xce5de7", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6de7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1589,11 +1589,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3051 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xce5e8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6e8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3052 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xce5eb6", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6eb6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1616,11 +1616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3039 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xce5c20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6c20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3040 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce5c23", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6c23", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1634,11 +1634,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3041 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xce5c40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6c40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3042 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xce5c43", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6c43", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1652,11 +1652,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3043 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xce5c60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6c60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3044 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xce5c63", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6c63", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1679,11 +1679,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3053 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xce5f80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6f80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3054 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xce5f87", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6f87", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1697,11 +1697,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3055 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce5fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6fa0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3056 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce5fae", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6fae", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1724,11 +1724,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3025 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xce5720", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6720", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3026 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce5723", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6723", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1742,11 +1742,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3027 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xce5740", Frameless: true}]
+              InjectionPoints: [{PC: "0xce6740", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3028 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce574b", Frameless: true}]
+              InjectionPoints: [{PC: "0xce674b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1769,14 +1769,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2858 EventRootType Probe[main.(*Server).handleOrder]
-              InjectionPoints: [{PC: "0xcdf033", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf7f3", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2859 EventRootType Probe[main.(*Server).handleOrder]Return
               InjectionPoints:
-                - PC: "0xcdf11c"
+                - PC: "0xcdf8dc"
                   Frameless: false
-                - PC: "0xcdf1f7"
+                - PC: "0xcdf9b7"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1799,11 +1799,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2810 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0xcdc1ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc6ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2811 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0xcdc22e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc72e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1830,11 +1830,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2812 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0xcdc26e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc76e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2813 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0xcdc2fe", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc7fe", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1861,11 +1861,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2814 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0xcdc34a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc84a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2815 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0xcdc38b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc88b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1887,7 +1887,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3081 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0xcdc2c6", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc7c6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1905,11 +1905,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2816 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0xcdc3ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc8ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2817 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0xcdc4be", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc9be", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1927,7 +1927,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3082 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0xcdc3d3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc8d3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1938,7 +1938,7 @@ Probes:
       where:
         methodName: main.testInlinedBCA
         sourceFile: inlined.go
-        lines: ["63"]
+        lines: ["66"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCA
       segments: [testInlinedBCA]
@@ -1948,7 +1948,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3083 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0xcdc3d3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc8d3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1966,7 +1966,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3084 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0xcdc486", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc986", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1977,7 +1977,7 @@ Probes:
       where:
         methodName: main.testInlinedBCB
         sourceFile: inlined.go
-        lines: ["67"]
+        lines: ["70"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCB
       segments: [testInlinedBCB]
@@ -1987,7 +1987,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3085 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0xcdc486", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc986", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -2008,7 +2008,7 @@ Probes:
               InjectionPoints:
                 - PC: "0xcd5fe1"
                   Frameless: true
-                - PC: "0xcdd006"
+                - PC: "0xcdd6c6"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2029,20 +2029,20 @@ Probes:
             - Kind: Entry
               Type: 3078 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0xcdc02a"
+                - PC: "0xcdc52a"
                   Frameless: false
-                - PC: "0xcdc0b1"
+                - PC: "0xcdc5b1"
                   Frameless: false
-                - PC: "0xcdc1f2"
+                - PC: "0xcdc6f2"
                   Frameless: false
-                - PC: "0xcdc27c"
+                - PC: "0xcdc77c"
                   Frameless: false
-                - PC: "0xcdc34f"
+                - PC: "0xcdc84f"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 3079 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0xcdc06a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc56a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2057,7 +2057,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2068,15 +2068,15 @@ Probes:
             - Kind: Line
               Type: 3080 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcdc02e"
+                - PC: "0xcdc52e"
                   Frameless: false
-                - PC: "0xcdc0b1"
+                - PC: "0xcdc5b1"
                   Frameless: false
-                - PC: "0xcdc1f2"
+                - PC: "0xcdc6f2"
                   Frameless: false
-                - PC: "0xcdc27c"
+                - PC: "0xcdc77c"
                   Frameless: false
-                - PC: "0xcdc34f"
+                - PC: "0xcdc84f"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2099,7 +2099,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3086 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0xcdc4e1", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc9e1", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2114,7 +2114,7 @@ Probes:
       where:
         methodName: main.testInlinedSq
         sourceFile: inlined.go
-        lines: ["75"]
+        lines: ["78"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2124,7 +2124,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3087 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0xcdc4e1", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc9e1", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2148,9 +2148,9 @@ Probes:
             - Kind: Entry
               Type: 3088 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0xcdc525"
+                - PC: "0xcdca25"
                   Frameless: false
-                - PC: "0xcdc5c5"
+                - PC: "0xcdcb35"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2283,7 +2283,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2823 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0xcdc7e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdcde0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2310,7 +2310,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3005 EventRootType Probe[main.testInvalidUtf8Strings]
-              InjectionPoints: [{PC: "0xce2e00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3ae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2956 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xce10ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1bce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2957 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce1253", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1d33", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2362,7 +2362,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2864 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xcdf500", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdfec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2377,7 +2377,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["230"]
+        lines: ["233"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
@@ -2387,7 +2387,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2799 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcd81fa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd83fa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2398,7 +2398,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["237"]
+        lines: ["240"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2409,7 +2409,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2800 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcd82ad", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd84ad", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2420,7 +2420,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["242"]
+        lines: ["245"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2431,7 +2431,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2801 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcd8374", Frameless: false}]
+              InjectionPoints: [{PC: "0xcd8574", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2474,11 +2474,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2962 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xce15b3", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2093", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2963 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xce17c2", Frameless: false}]
+              InjectionPoints: [{PC: "0xce22a2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2541,7 +2541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2804 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0xcd8d40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd9040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2565,7 +2565,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2805 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0xcda720", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdab20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2587,7 +2587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2834 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xcdd100", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd7e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2609,7 +2609,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2841 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xcdd1c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd8a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2631,7 +2631,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2851 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xcdd300", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd9e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2653,7 +2653,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2853 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xcdd340", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdda20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2675,7 +2675,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2852 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xcdd320", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdda00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2697,7 +2697,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2838 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xcdd180", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd860", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2719,7 +2719,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2850 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xcdd2e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd9c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2741,7 +2741,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2849 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xcdd2c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd9a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2765,7 +2765,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2839 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcdd1a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2789,7 +2789,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2840 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcdd1a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2811,7 +2811,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2848 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xcdd2a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2833,7 +2833,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2847 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xcdd280", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2855,7 +2855,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2832 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xcdd0c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd7a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2877,7 +2877,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2833 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xcdd0e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd7c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2899,7 +2899,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2831 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xcdd0a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2921,7 +2921,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2842 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xcdd1e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd8c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2943,7 +2943,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2845 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xcdd240", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2965,7 +2965,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2846 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xcdd260", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2987,7 +2987,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2843 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xcdd200", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd8e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3011,7 +3011,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2844 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xcdd220", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -3033,7 +3033,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3000 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xce2d80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3056,7 +3056,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3001 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xce2d80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3103,11 +3103,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2964 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xce1853", Frameless: false}]
+              InjectionPoints: [{PC: "0xce2333", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2965 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xce1a8b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce256b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3169,7 +3169,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3006 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0xce2e20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3192,7 +3192,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3007 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0xce2e20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3218,11 +3218,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2968 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xce1bce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce26ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2969 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xce1c9e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce277e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3253,11 +3253,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2960 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xce136e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1e4e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2961 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xce158a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce206a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3283,11 +3283,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2901 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce030e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0dee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2902 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce03af", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0e8f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3323,7 +3323,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2857 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xcdee00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3364,11 +3364,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2895 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xce026a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0d4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2896 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xce02d5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0db5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3392,11 +3392,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2897 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xce026a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0d4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2898 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xce02d5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0db5", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3415,11 +3415,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2903 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce030e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0dee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2904 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce03af", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0e8f", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3439,11 +3439,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2905 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce030e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0dee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2906 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce03af", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0e8f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3476,11 +3476,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2899 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xce026a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0d4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2900 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xce02d5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0db5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3508,7 +3508,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3015 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce3240", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3533,7 +3533,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3016 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce3240", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3564,7 +3564,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3017 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce3240", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3589,7 +3589,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3018 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce3240", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3616,7 +3616,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2869 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xcdf6a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3643,7 +3643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2982 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xce2460", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3670,7 +3670,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2979 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xce2400", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2ee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3705,7 +3705,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2981 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xce2440", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3737,7 +3737,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2999 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xce2d60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3759,7 +3759,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2865 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xcdf520", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdfee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3781,7 +3781,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2837 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xcdd160", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3803,7 +3803,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2863 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xcdf4e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdfea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3827,11 +3827,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2871 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdfb4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce062a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2872 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdfb9b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce067b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3851,11 +3851,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2915 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce03ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0ece", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2916 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce048b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0f6b", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3900,11 +3900,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2881 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcdfc6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce074e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2882 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcdfd24", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0804", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3946,11 +3946,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2873 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdfb4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce062a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2874 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdfb9b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce067b", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3995,11 +3995,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2883 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcdfc6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce074e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2884 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcdfd24", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0804", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -4043,11 +4043,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2917 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce03ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0ece", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2918 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce048b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0f6b", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -4064,11 +4064,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2919 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce03ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0ece", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2920 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce048b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0f6b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -4090,11 +4090,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2875 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdfb4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce062a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2876 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdfb9b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce067b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -4117,18 +4117,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2891 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xcdff0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce09ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2892 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xcdffc4"
+                - PC: "0xce0aa4"
                   Frameless: false
-                - PC: "0xcdffff"
+                - PC: "0xce0adf"
                   Frameless: false
-                - PC: "0xce00c2"
+                - PC: "0xce0ba2"
                   Frameless: false
-                - PC: "0xce00cc"
+                - PC: "0xce0bac"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4156,18 +4156,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2889 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xcdfdae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce088e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2890 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xcdfe04"
+                - PC: "0xce08e4"
                   Frameless: false
-                - PC: "0xcdfe53"
+                - PC: "0xce0933"
                   Frameless: false
-                - PC: "0xcdfe87"
+                - PC: "0xce0967"
                   Frameless: false
-                - PC: "0xcdfeb9"
+                - PC: "0xce0999"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4194,11 +4194,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2934 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xce0b8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce166a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2935 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xce0bed", Frameless: false}]
+              InjectionPoints: [{PC: "0xce16cd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4215,11 +4215,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2936 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xce0c0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce16ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2937 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xce0c4b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce172b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4236,11 +4236,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2938 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xce0c6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce174a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2939 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xce0ca6", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1786", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4257,11 +4257,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2942 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xce0d4e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce182e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2943 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xce0dca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce18aa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4278,11 +4278,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2954 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xce108a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1b6a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2955 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xce10d0", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1bb0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4299,11 +4299,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2930 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xce0a4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce152a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2931 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xce0aa6", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1586", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4321,14 +4321,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2887 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xcdfd4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce082a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2888 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xcdfd7a"
+                - PC: "0xce085a"
                   Frameless: false
-                - PC: "0xcdfd85"
+                - PC: "0xce0865"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4350,11 +4350,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2877 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcdfb4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce062a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2878 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcdfb9b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce067b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4375,11 +4375,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2885 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcdfc6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce074e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2886 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcdfd24", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0804", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4400,11 +4400,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2879 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xcdfbca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce06aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2880 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xcdfc34", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0714", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4426,14 +4426,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2893 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xce010e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0bee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2894 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xce01ef"
+                - PC: "0xce0ccf"
                   Frameless: false
-                - PC: "0xce01f9"
+                - PC: "0xce0cd9"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4455,11 +4455,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2932 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xce0ace", Frameless: false}]
+              InjectionPoints: [{PC: "0xce15ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2933 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xce0b53", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1633", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4476,11 +4476,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2928 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xce094e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce142e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2929 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xce0a27", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1507", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4497,11 +4497,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2946 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xce0eaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xce198a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2947 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xce0f0c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce19ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4518,11 +4518,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2940 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xce0cca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce17aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2941 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xce0d18", Frameless: false}]
+              InjectionPoints: [{PC: "0xce17f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4539,11 +4539,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2952 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xce100a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1aea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2953 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xce1056", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1b36", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4563,7 +4563,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2925 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xce06cf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce11af", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4584,11 +4584,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2950 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xce0faa", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1a8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2951 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xce0fee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1ace", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4605,11 +4605,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2926 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xce08ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce13aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2927 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xce0931", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1411", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4626,11 +4626,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2948 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xce0f2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1a0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2949 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xce0f8d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1a6d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4647,11 +4647,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2944 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xce0dee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce18ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2945 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xce0e74", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1954", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4704,11 +4704,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2907 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce030e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0dee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2908 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce03af", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0e8f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4754,7 +4754,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2774 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0xcd7960", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4776,7 +4776,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2772 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0xcd7920", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4798,7 +4798,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2785 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0xcd7ac0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7be0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4816,7 +4816,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2786 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0xcd7ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7c00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4834,7 +4834,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2775 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0xcd7980", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4856,7 +4856,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2777 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0xcd79c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7ae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4879,7 +4879,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2778 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0xcd79e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4901,7 +4901,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2779 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0xcd7a00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7b20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4930,7 +4930,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2776 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0xcd79a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4961,7 +4961,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2773 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0xcd7940", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4983,7 +4983,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2991 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xce2ce0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce39c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5005,7 +5005,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2780 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0xcd7a20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7b40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5027,7 +5027,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2782 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0xcd7a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7b80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5049,7 +5049,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2783 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0xcd7a80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7ba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5071,7 +5071,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2784 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0xcd7aa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7bc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5093,7 +5093,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2781 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0xcd7a40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7b60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5115,7 +5115,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2985 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xce24a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5137,7 +5137,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2976 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xce23a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5159,7 +5159,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2835 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xcdd120", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -5180,11 +5180,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2921 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce03ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0ece", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2922 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce048b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0f6b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5205,11 +5205,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2966 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xce1b2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce260a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2967 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xce1b9c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce267c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5253,7 +5253,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2868 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xcdf660", Frameless: true}]
+              InjectionPoints: [{PC: "0xce0020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5275,7 +5275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2980 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xce2420", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5297,7 +5297,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2797 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0xcd81a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd83a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5319,7 +5319,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2798 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0xcd81c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd83c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5341,11 +5341,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3013 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xce3140", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3f20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3014 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce3162", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3f42", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5372,7 +5372,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2977 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xce23c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2ea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5399,7 +5399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2829 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0xcdc900", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdcf00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5420,11 +5420,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2970 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xce1cce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce27ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2971 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xce1d7a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce285a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5446,11 +5446,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3009 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xce3000", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3de0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3010 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0xce301e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3dfe", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5471,7 +5471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3008 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xce2fe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3dc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5498,7 +5498,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2830 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xcdd080", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5531,7 +5531,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2986 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xce24c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2fa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5571,7 +5571,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3004 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xce2de0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2802 EventRootType Probe[main.testTakeContext]
-              InjectionPoints: [{PC: "0xcd8860", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
       version: 0
@@ -5619,11 +5619,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2909 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce030e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0dee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2910 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce03af", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0e8f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5644,11 +5644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2911 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce030e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0dee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2912 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce03af", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0e8f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5671,11 +5671,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2913 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce030e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0dee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2914 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce03af", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0e8f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5707,7 +5707,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2992 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xce2d00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce39e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5739,11 +5739,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2993 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xce2d20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3a00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2994 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xce2d3e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3a1e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5773,11 +5773,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2995 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xce2d20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3a00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2996 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xce2d3e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3a1e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5809,7 +5809,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2997 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xce2d40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5839,7 +5839,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2998 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xce2d40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5871,7 +5871,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3023 EventRootType Probe[main.testTimeFixedZone]
-              InjectionPoints: [{PC: "0xce4660", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5893,7 +5893,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3024 EventRootType Probe[main.testTimeMonotonic]
-              InjectionPoints: [{PC: "0xce4680", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -5915,7 +5915,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3022 EventRootType Probe[main.testTimeUTC]
-              InjectionPoints: [{PC: "0xce4640", Frameless: true}]
+              InjectionPoints: [{PC: "0xce5520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5937,7 +5937,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2787 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0xcd7b00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcd7c20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6069,7 +6069,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2867 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xcdf580", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdff40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6091,7 +6091,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2974 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xce2360", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2e40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -6113,7 +6113,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3002 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xce2da0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6135,7 +6135,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2866 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xcdf540", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdff00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6179,7 +6179,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2983 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xce2480", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6201,7 +6201,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2984 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xce2480", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2f60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6224,14 +6224,14 @@ Probes:
             - Kind: Entry
               Type: 3089 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0xcdc70a"
+                - PC: "0xcdcd0a"
                   Frameless: false
-                - PC: "0xce64a3"
+                - PC: "0xce74a3"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 3090 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0xcdc750", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdcd50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -6253,11 +6253,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2972 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xce1dae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce288e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2973 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce1e2c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce290c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -6554,132 +6554,6 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xcd7920..0xcd7921]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 5 BaseType uint8
-          Locations:
-            - Range: 0xcd7920..0xcd7921
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 22
-      Name: main.testSingleRune
-      OutOfLinePCRanges: [0xcd7940..0xcd7941]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 12 BaseType int32
-          Locations:
-            - Range: 0xcd7940..0xcd7941
-              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 23
-      Name: main.testSingleBool
-      OutOfLinePCRanges: [0xcd7960..0xcd7961]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 6 BaseType bool
-          Locations:
-            - Range: 0xcd7960..0xcd7961
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 24
-      Name: main.testSingleInt
-      OutOfLinePCRanges: [0xcd7980..0xcd7981]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xcd7980..0xcd7981
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 25
-      Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xcd79a0..0xcd79a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 17 BaseType int8
-          Locations:
-            - Range: 0xcd79a0..0xcd79a1
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 26
-      Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xcd79c0..0xcd79c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 105 BaseType int16
-          Locations:
-            - Range: 0xcd79c0..0xcd79c1
-              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 27
-      Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xcd79e0..0xcd79e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 12 BaseType int32
-          Locations:
-            - Range: 0xcd79e0..0xcd79e1
-              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 28
-      Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xcd7a00..0xcd7a01]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 14 BaseType int64
-          Locations:
-            - Range: 0xcd7a00..0xcd7a01
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 29
-      Name: main.testSingleUint
-      OutOfLinePCRanges: [0xcd7a20..0xcd7a21]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 18 BaseType uint
-          Locations:
-            - Range: 0xcd7a20..0xcd7a21
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 30
-      Name: main.testSingleUint8
       OutOfLinePCRanges: [0xcd7a40..0xcd7a41]
       InlinePCRanges: []
       Variables:
@@ -6692,41 +6566,41 @@ Subprograms:
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
-    - ID: 31
-      Name: main.testSingleUint16
+    - ID: 22
+      Name: main.testSingleRune
       OutOfLinePCRanges: [0xcd7a60..0xcd7a61]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 BaseType uint16
+          Type: 12 BaseType int32
           Locations:
             - Range: 0xcd7a60..0xcd7a61
-              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 32
-      Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xcd7a80..0xcd7a81]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 4 BaseType uint32
-          Locations:
-            - Range: 0xcd7a80..0xcd7a81
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
-    - ID: 33
-      Name: main.testSingleUint64
+    - ID: 23
+      Name: main.testSingleBool
+      OutOfLinePCRanges: [0xcd7a80..0xcd7a81]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 6 BaseType bool
+          Locations:
+            - Range: 0xcd7a80..0xcd7a81
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 24
+      Name: main.testSingleInt
       OutOfLinePCRanges: [0xcd7aa0..0xcd7aa1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 10 BaseType uint64
+          Type: 9 BaseType int
           Locations:
             - Range: 0xcd7aa0..0xcd7aa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -6734,15 +6608,141 @@ Subprograms:
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
+    - ID: 25
+      Name: main.testSingleInt8
+      OutOfLinePCRanges: [0xcd7ac0..0xcd7ac1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 17 BaseType int8
+          Locations:
+            - Range: 0xcd7ac0..0xcd7ac1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 26
+      Name: main.testSingleInt16
+      OutOfLinePCRanges: [0xcd7ae0..0xcd7ae1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 105 BaseType int16
+          Locations:
+            - Range: 0xcd7ae0..0xcd7ae1
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 27
+      Name: main.testSingleInt32
+      OutOfLinePCRanges: [0xcd7b00..0xcd7b01]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 12 BaseType int32
+          Locations:
+            - Range: 0xcd7b00..0xcd7b01
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 28
+      Name: main.testSingleInt64
+      OutOfLinePCRanges: [0xcd7b20..0xcd7b21]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 14 BaseType int64
+          Locations:
+            - Range: 0xcd7b20..0xcd7b21
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 29
+      Name: main.testSingleUint
+      OutOfLinePCRanges: [0xcd7b40..0xcd7b41]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 18 BaseType uint
+          Locations:
+            - Range: 0xcd7b40..0xcd7b41
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 30
+      Name: main.testSingleUint8
+      OutOfLinePCRanges: [0xcd7b60..0xcd7b61]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 5 BaseType uint8
+          Locations:
+            - Range: 0xcd7b60..0xcd7b61
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 31
+      Name: main.testSingleUint16
+      OutOfLinePCRanges: [0xcd7b80..0xcd7b81]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 BaseType uint16
+          Locations:
+            - Range: 0xcd7b80..0xcd7b81
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 32
+      Name: main.testSingleUint32
+      OutOfLinePCRanges: [0xcd7ba0..0xcd7ba1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 4 BaseType uint32
+          Locations:
+            - Range: 0xcd7ba0..0xcd7ba1
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 33
+      Name: main.testSingleUint64
+      OutOfLinePCRanges: [0xcd7bc0..0xcd7bc1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 BaseType uint64
+          Locations:
+            - Range: 0xcd7bc0..0xcd7bc1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xcd7ac0..0xcd7ac1]
+      OutOfLinePCRanges: [0xcd7be0..0xcd7be1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 BaseType float32
           Locations:
-            - Range: 0xcd7ac0..0xcd7ac1
+            - Range: 0xcd7be0..0xcd7be1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6750,13 +6750,13 @@ Subprograms:
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xcd7ae0..0xcd7ae1]
+      OutOfLinePCRanges: [0xcd7c00..0xcd7c01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 20 BaseType float64
           Locations:
-            - Range: 0xcd7ae0..0xcd7ae1
+            - Range: 0xcd7c00..0xcd7c01
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6764,13 +6764,13 @@ Subprograms:
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xcd7b00..0xcd7b01]
+      OutOfLinePCRanges: [0xcd7c20..0xcd7c21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 128 BaseType main.typeAlias
           Locations:
-            - Range: 0xcd7b00..0xcd7b01
+            - Range: 0xcd7c20..0xcd7c21
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6778,13 +6778,13 @@ Subprograms:
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xcd7c60..0xcd7c7f]
+      OutOfLinePCRanges: [0xcd7e60..0xcd7e7f]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 129 StructureType main.bigStruct
           Locations:
-            - Range: 0xcd7c60..0xcd7c7f
+            - Range: 0xcd7e60..0xcd7e7f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6804,51 +6804,51 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0xcd7cc0..0xcd7dd2]
+      OutOfLinePCRanges: [0xcd7ec0..0xcd7fd2]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcd7cc0..0xcd7cd8
+            - Range: 0xcd7ec0..0xcd7ed8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xcd7cc0..0xcd7dd2, Pieces: []}]
+          Locations: [{Range: 0xcd7ec0..0xcd7fd2, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: x
           Type: 9 BaseType int
-          Locations: [{Range: 0xcd7cc0..0xcd7dd2, Pieces: []}]
+          Locations: [{Range: 0xcd7ec0..0xcd7fd2, Pieces: []}]
           Role: Local
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: err
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xcd7ce9..0xcd7d05
+            - Range: 0xcd7ee9..0xcd7f05
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0xcd7d05..0xcd7d28
+            - Range: 0xcd7f05..0xcd7f28
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcd7d28..0xcd7d3e
+            - Range: 0xcd7f28..0xcd7f3e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0xcd7d3e..0xcd7dd2
+            - Range: 0xcd7f3e..0xcd7fd2
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -80}
@@ -6860,13 +6860,13 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xcd7e40..0xcd7e41]
+      OutOfLinePCRanges: [0xcd8040..0xcd8041]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 133 StructureType main.deepPtr1
           Locations:
-            - Range: 0xcd7e40..0xcd7e41
+            - Range: 0xcd8040..0xcd8041
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6874,13 +6874,13 @@ Subprograms:
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xcd7e60..0xcd7e61]
+      OutOfLinePCRanges: [0xcd8060..0xcd8061]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 136 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xcd7e60..0xcd7e61
+            - Range: 0xcd8060..0xcd8061
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6888,13 +6888,13 @@ Subprograms:
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xcd7fe0..0xcd7fe1]
+      OutOfLinePCRanges: [0xcd81e0..0xcd81e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 138 StructureType main.deepSlice1
           Locations:
-            - Range: 0xcd7fe0..0xcd7fe1
+            - Range: 0xcd81e0..0xcd81e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6908,13 +6908,13 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xcd8000..0xcd8001]
+      OutOfLinePCRanges: [0xcd8200..0xcd8201]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 142 PointerType *main.deepSlice7
           Locations:
-            - Range: 0xcd8000..0xcd8001
+            - Range: 0xcd8200..0xcd8201
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6922,13 +6922,13 @@ Subprograms:
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xcd8160..0xcd8161]
+      OutOfLinePCRanges: [0xcd8360..0xcd8361]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 144 StructureType main.deepMap1
           Locations:
-            - Range: 0xcd8160..0xcd8161
+            - Range: 0xcd8360..0xcd8361
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6936,13 +6936,13 @@ Subprograms:
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xcd8180..0xcd8181]
+      OutOfLinePCRanges: [0xcd8380..0xcd8381]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 150 PointerType *main.deepMap7
           Locations:
-            - Range: 0xcd8180..0xcd8181
+            - Range: 0xcd8380..0xcd8381
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6950,13 +6950,13 @@ Subprograms:
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0xcd81a0..0xcd81a1]
+      OutOfLinePCRanges: [0xcd83a0..0xcd83a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 152 PointerType *main.stringType1
           Locations:
-            - Range: 0xcd81a0..0xcd81a1
+            - Range: 0xcd83a0..0xcd83a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6964,13 +6964,13 @@ Subprograms:
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xcd81c0..0xcd81c1]
+      OutOfLinePCRanges: [0xcd83c0..0xcd83c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 154 PointerType **main.stringType2
           Locations:
-            - Range: 0xcd81c0..0xcd81c1
+            - Range: 0xcd83c0..0xcd83c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6978,15 +6978,15 @@ Subprograms:
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xcd81e0..0xcd842a]
+      OutOfLinePCRanges: [0xcd83e0..0xcd862a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcd82c4..0xcd82e5
+            - Range: 0xcd84c4..0xcd84e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd8398..0xcd83af
+            - Range: 0xcd8598..0xcd85af
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -6994,15 +6994,15 @@ Subprograms:
         - Name: aPerArch
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcd82ad..0xcd82b0
+            - Range: 0xcd84ad..0xcd84b0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd82b0..0xcd82e5
+            - Range: 0xcd84b0..0xcd84e5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd82e5..0xcd838b
+            - Range: 0xcd84e5..0xcd858b
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xcd838b..0xcd8398
+            - Range: 0xcd858b..0xcd8598
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcd8398..0xcd842a
+            - Range: 0xcd8598..0xcd862a
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
           DictIndex: -1
@@ -7010,21 +7010,21 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcd82aa..0xcd82b0
+            - Range: 0xcd84aa..0xcd84b0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd82b0..0xcd82b0
+            - Range: 0xcd84b0..0xcd84b0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd82b0..0xcd82e5
+            - Range: 0xcd84b0..0xcd84e5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd82e5..0xcd838b
+            - Range: 0xcd84e5..0xcd858b
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xcd838b..0xcd8390
+            - Range: 0xcd858b..0xcd8590
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcd8390..0xcd8398
+            - Range: 0xcd8590..0xcd8598
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcd8398..0xcd83af
+            - Range: 0xcd8598..0xcd85af
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcd83af..0xcd842a
+            - Range: 0xcd85af..0xcd862a
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
           DictIndex: -1
@@ -7032,13 +7032,13 @@ Subprograms:
       DictRegister: null
     - ID: 48
       Name: main.testTakeContext
-      OutOfLinePCRanges: [0xcd8860..0xcd8861]
+      OutOfLinePCRanges: [0xcd8b60..0xcd8b61]
       InlinePCRanges: []
       Variables:
         - Name: ctx
           Type: 156 GoInterfaceType context.Context
           Locations:
-            - Range: 0xcd8860..0xcd8861
+            - Range: 0xcd8b60..0xcd8b61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7050,13 +7050,13 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testCaptureContextImpl
-      OutOfLinePCRanges: [0xcd8a60..0xcd8a61]
+      OutOfLinePCRanges: [0xcd8d60..0xcd8d61]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 157 PointerType *main.contextImpl
           Locations:
-            - Range: 0xcd8a60..0xcd8a61
+            - Range: 0xcd8d60..0xcd8d61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7064,13 +7064,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0xcd8d40..0xcd8d41]
+      OutOfLinePCRanges: [0xcd9040..0xcd9041]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 159 StructureType main.manyPointers
           Locations:
-            - Range: 0xcd8d40..0xcd8d41
+            - Range: 0xcd9040..0xcd9041
               Pieces: [{Size: 560, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7078,13 +7078,13 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0xcda720..0xcda721]
+      OutOfLinePCRanges: [0xcdab20..0xcdab21]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 162 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcda720..0xcda721
+            - Range: 0xcdab20..0xcdab21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7098,13 +7098,13 @@ Subprograms:
       DictRegister: null
     - ID: 52
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xcda9e0..0xcdaae5]
+      OutOfLinePCRanges: [0xcdaee0..0xcdafe5]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 163 StructureType main.esotericStack
           Locations:
-            - Range: 0xcda9e0..0xcdaa33
+            - Range: 0xcdaee0..0xcdaf33
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -7124,7 +7124,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcdaa33..0xcdaa38
+            - Range: 0xcdaf33..0xcdaf38
               Pieces:
                 - Size: 4
                   Op: null
@@ -7144,7 +7144,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcdaa38..0xcdaa3d
+            - Range: 0xcdaf38..0xcdaf3d
               Pieces:
                 - Size: 4
                   Op: null
@@ -7170,13 +7170,13 @@ Subprograms:
       DictRegister: null
     - ID: 53
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xcdab00..0xcdab63]
+      OutOfLinePCRanges: [0xcdb000..0xcdb063]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 166 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xcdab00..0xcdab2d
+            - Range: 0xcdb000..0xcdb02d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7184,13 +7184,13 @@ Subprograms:
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xcdc1c0..0xcdc248]
+      OutOfLinePCRanges: [0xcdc6c0..0xcdc748]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdc1c0..0xcdc1d5
+            - Range: 0xcdc6c0..0xcdc6d5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7198,13 +7198,13 @@ Subprograms:
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xcdc260..0xcdc325]
+      OutOfLinePCRanges: [0xcdc760..0xcdc825]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdc260..0xcdc276
+            - Range: 0xcdc760..0xcdc776
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7212,7 +7212,7 @@ Subprograms:
         - Name: "y"
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdc260..0xcdc287
+            - Range: 0xcdc760..0xcdc787
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7220,9 +7220,9 @@ Subprograms:
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdc276..0xcdc287
+            - Range: 0xcdc776..0xcdc787
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc287..0xcdc325
+            - Range: 0xcdc787..0xcdc825
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
@@ -7230,13 +7230,13 @@ Subprograms:
       DictRegister: null
     - ID: 56
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xcdc340..0xcdc3a2]
+      OutOfLinePCRanges: [0xcdc840..0xcdc8a2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdc340..0xcdc35a
+            - Range: 0xcdc840..0xcdc85a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7244,17 +7244,17 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xcdc3c0..0xcdc4ce]
+      OutOfLinePCRanges: [0xcdc8c0..0xcdc9ce]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdc41b..0xcdc425
+            - Range: 0xcdc91b..0xcdc925
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcdc425..0xcdc440
+            - Range: 0xcdc925..0xcdc940
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcdc440..0xcdc454
+            - Range: 0xcdc940..0xcdc954
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7262,11 +7262,11 @@ Subprograms:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdc416..0xcdc420
+            - Range: 0xcdc916..0xcdc920
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcdc420..0xcdc440
+            - Range: 0xcdc920..0xcdc940
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcdc440..0xcdc44f
+            - Range: 0xcdc940..0xcdc94f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7274,13 +7274,13 @@ Subprograms:
       DictRegister: null
     - ID: 58
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xcdc4e0..0xcdc4e6]
+      OutOfLinePCRanges: [0xcdc9e0..0xcdc9e6]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdc4e0..0xcdc4e5
+            - Range: 0xcdc9e0..0xcdc9e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7288,9 +7288,9 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdc4e0..0xcdc4e5
+            - Range: 0xcdc9e0..0xcdc9e5
               Pieces: []
-            - Range: 0xcdc4e5..0xcdc4e6
+            - Range: 0xcdc9e5..0xcdc9e6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -7298,13 +7298,13 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xcdc500..0xcdc543]
+      OutOfLinePCRanges: [0xcdca00..0xcdca43]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 168 ArrayType [5]int
           Locations:
-            - Range: 0xcdc500..0xcdc543
+            - Range: 0xcdca00..0xcdca43
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7312,11 +7312,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdc500..0xcdc53d
+            - Range: 0xcdca00..0xcdca3d
               Pieces: []
-            - Range: 0xcdc53d..0xcdc53e
+            - Range: 0xcdca3d..0xcdca3e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc53e..0xcdc543
+            - Range: 0xcdca3e..0xcdca43
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7324,13 +7324,13 @@ Subprograms:
       DictRegister: null
     - ID: 60
       Name: main.testInterface
-      OutOfLinePCRanges: [0xcdc7e0..0xcdc7e1]
+      OutOfLinePCRanges: [0xcdcde0..0xcdcde1]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 169 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcdc7e0..0xcdc7e1
+            - Range: 0xcdcde0..0xcdcde1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7342,19 +7342,19 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testAny
-      OutOfLinePCRanges: [0xcdc800..0xcdc866]
+      OutOfLinePCRanges: [0xcdce00..0xcdce66]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdc800..0xcdc829
+            - Range: 0xcdce00..0xcdce29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdc829..0xcdc82e
+            - Range: 0xcdce29..0xcdce2e
               Pieces:
                 - Size: 8
                   Op: null
@@ -7366,15 +7366,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcdc800..0xcdc845
+            - Range: 0xcdce00..0xcdce45
               Pieces: []
-            - Range: 0xcdc845..0xcdc846
+            - Range: 0xcdce45..0xcdce46
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdc846..0xcdc866
+            - Range: 0xcdce46..0xcdce66
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7382,13 +7382,13 @@ Subprograms:
       DictRegister: null
     - ID: 62
       Name: main.testError
-      OutOfLinePCRanges: [0xcdc880..0xcdc881]
+      OutOfLinePCRanges: [0xcdce80..0xcdce81]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xcdc880..0xcdc881
+            - Range: 0xcdce80..0xcdce81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7400,13 +7400,13 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xcdc8a0..0xcdc8f4]
+      OutOfLinePCRanges: [0xcdcea0..0xcdcef4]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 170 PointerType *interface {}
           Locations:
-            - Range: 0xcdc8a0..0xcdc8c6
+            - Range: 0xcdcea0..0xcdcec6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7414,15 +7414,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcdc8a0..0xcdc8dd
+            - Range: 0xcdcea0..0xcdcedd
               Pieces: []
-            - Range: 0xcdc8dd..0xcdc8de
+            - Range: 0xcdcedd..0xcdcede
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdc8de..0xcdc8f4
+            - Range: 0xcdcede..0xcdcef4
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7430,13 +7430,13 @@ Subprograms:
       DictRegister: null
     - ID: 64
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xcdc900..0xcdc901]
+      OutOfLinePCRanges: [0xcdcf00..0xcdcf01]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 171 StructureType main.structWithAny
           Locations:
-            - Range: 0xcdc900..0xcdc901
+            - Range: 0xcdcf00..0xcdcf01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7448,13 +7448,13 @@ Subprograms:
       DictRegister: null
     - ID: 65
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcdd080..0xcdd081]
+      OutOfLinePCRanges: [0xcdd760..0xcdd761]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 172 StructureType main.structWithMap
           Locations:
-            - Range: 0xcdd080..0xcdd081
+            - Range: 0xcdd760..0xcdd761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7462,13 +7462,13 @@ Subprograms:
       DictRegister: null
     - ID: 66
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcdd0a0..0xcdd0a1]
+      OutOfLinePCRanges: [0xcdd780..0xcdd781]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 178 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xcdd0a0..0xcdd0a1
+            - Range: 0xcdd780..0xcdd781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7476,13 +7476,13 @@ Subprograms:
       DictRegister: null
     - ID: 67
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcdd0c0..0xcdd0c1]
+      OutOfLinePCRanges: [0xcdd7a0..0xcdd7a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 183 GoMapType map[string]int
           Locations:
-            - Range: 0xcdd0c0..0xcdd0c1
+            - Range: 0xcdd7a0..0xcdd7a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7490,13 +7490,13 @@ Subprograms:
       DictRegister: null
     - ID: 68
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcdd0e0..0xcdd0e1]
+      OutOfLinePCRanges: [0xcdd7c0..0xcdd7c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 188 GoMapType map[string][]string
           Locations:
-            - Range: 0xcdd0e0..0xcdd0e1
+            - Range: 0xcdd7c0..0xcdd7c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7504,13 +7504,13 @@ Subprograms:
       DictRegister: null
     - ID: 69
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcdd100..0xcdd101]
+      OutOfLinePCRanges: [0xcdd7e0..0xcdd7e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 193 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0xcdd100..0xcdd101
+            - Range: 0xcdd7e0..0xcdd7e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7518,13 +7518,13 @@ Subprograms:
       DictRegister: null
     - ID: 70
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcdd120..0xcdd121]
+      OutOfLinePCRanges: [0xcdd800..0xcdd801]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 183 GoMapType map[string]int
           Locations:
-            - Range: 0xcdd120..0xcdd121
+            - Range: 0xcdd800..0xcdd801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7532,13 +7532,13 @@ Subprograms:
       DictRegister: null
     - ID: 71
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcdd140..0xcdd141]
+      OutOfLinePCRanges: [0xcdd820..0xcdd821]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 198 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xcdd140..0xcdd141
+            - Range: 0xcdd820..0xcdd821
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7546,13 +7546,13 @@ Subprograms:
       DictRegister: null
     - ID: 72
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcdd160..0xcdd161]
+      OutOfLinePCRanges: [0xcdd840..0xcdd841]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 199 PointerType *map[string]int
           Locations:
-            - Range: 0xcdd160..0xcdd161
+            - Range: 0xcdd840..0xcdd841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7560,13 +7560,13 @@ Subprograms:
       DictRegister: null
     - ID: 73
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xcdd180..0xcdd181]
+      OutOfLinePCRanges: [0xcdd860..0xcdd861]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 173 GoMapType map[int]int
           Locations:
-            - Range: 0xcdd180..0xcdd181
+            - Range: 0xcdd860..0xcdd861
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7574,13 +7574,13 @@ Subprograms:
       DictRegister: null
     - ID: 74
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0xcdd1a0..0xcdd1a1]
+      OutOfLinePCRanges: [0xcdd880..0xcdd881]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 200 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcdd1a0..0xcdd1a1
+            - Range: 0xcdd880..0xcdd881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7588,13 +7588,13 @@ Subprograms:
       DictRegister: null
     - ID: 75
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xcdd1c0..0xcdd1c1]
+      OutOfLinePCRanges: [0xcdd8a0..0xcdd8a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 200 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcdd1c0..0xcdd1c1
+            - Range: 0xcdd8a0..0xcdd8a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7602,13 +7602,13 @@ Subprograms:
       DictRegister: null
     - ID: 76
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xcdd1e0..0xcdd1e1]
+      OutOfLinePCRanges: [0xcdd8c0..0xcdd8c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 205 GoMapType map[bool]main.node
           Locations:
-            - Range: 0xcdd1e0..0xcdd1e1
+            - Range: 0xcdd8c0..0xcdd8c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7616,13 +7616,13 @@ Subprograms:
       DictRegister: null
     - ID: 77
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xcdd200..0xcdd201]
+      OutOfLinePCRanges: [0xcdd8e0..0xcdd8e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 210 GoMapType map[int]uint8
           Locations:
-            - Range: 0xcdd200..0xcdd201
+            - Range: 0xcdd8e0..0xcdd8e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7630,13 +7630,13 @@ Subprograms:
       DictRegister: null
     - ID: 78
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xcdd220..0xcdd221]
+      OutOfLinePCRanges: [0xcdd900..0xcdd901]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 210 GoMapType map[int]uint8
           Locations:
-            - Range: 0xcdd220..0xcdd221
+            - Range: 0xcdd900..0xcdd901
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7644,13 +7644,13 @@ Subprograms:
       DictRegister: null
     - ID: 79
       Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xcdd240..0xcdd241]
+      OutOfLinePCRanges: [0xcdd920..0xcdd921]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 215 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcdd240..0xcdd241
+            - Range: 0xcdd920..0xcdd921
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7658,13 +7658,13 @@ Subprograms:
       DictRegister: null
     - ID: 80
       Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0xcdd260..0xcdd261]
+      OutOfLinePCRanges: [0xcdd940..0xcdd941]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 215 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcdd260..0xcdd261
+            - Range: 0xcdd940..0xcdd941
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7672,13 +7672,13 @@ Subprograms:
       DictRegister: null
     - ID: 81
       Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0xcdd280..0xcdd281]
+      OutOfLinePCRanges: [0xcdd960..0xcdd961]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 215 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcdd280..0xcdd281
+            - Range: 0xcdd960..0xcdd961
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7686,13 +7686,13 @@ Subprograms:
       DictRegister: null
     - ID: 82
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0xcdd2a0..0xcdd2a1]
+      OutOfLinePCRanges: [0xcdd980..0xcdd981]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 220 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0xcdd2a0..0xcdd2a1
+            - Range: 0xcdd980..0xcdd981
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7700,13 +7700,13 @@ Subprograms:
       DictRegister: null
     - ID: 83
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0xcdd2c0..0xcdd2c1]
+      OutOfLinePCRanges: [0xcdd9a0..0xcdd9a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 225 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0xcdd2c0..0xcdd2c1
+            - Range: 0xcdd9a0..0xcdd9a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7714,13 +7714,13 @@ Subprograms:
       DictRegister: null
     - ID: 84
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0xcdd2e0..0xcdd2e1]
+      OutOfLinePCRanges: [0xcdd9c0..0xcdd9c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 230 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0xcdd2e0..0xcdd2e1
+            - Range: 0xcdd9c0..0xcdd9c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7728,13 +7728,13 @@ Subprograms:
       DictRegister: null
     - ID: 85
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0xcdd300..0xcdd301]
+      OutOfLinePCRanges: [0xcdd9e0..0xcdd9e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 235 GoMapType map[struct {}]int
           Locations:
-            - Range: 0xcdd300..0xcdd301
+            - Range: 0xcdd9e0..0xcdd9e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7742,13 +7742,13 @@ Subprograms:
       DictRegister: null
     - ID: 86
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0xcdd320..0xcdd321]
+      OutOfLinePCRanges: [0xcdda00..0xcdda01]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 240 GoMapType map[int]struct {}
           Locations:
-            - Range: 0xcdd320..0xcdd321
+            - Range: 0xcdda00..0xcdda01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7756,13 +7756,13 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0xcdd340..0xcdd341]
+      OutOfLinePCRanges: [0xcdda20..0xcdda21]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 245 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0xcdd340..0xcdd341
+            - Range: 0xcdda20..0xcdda21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7770,13 +7770,13 @@ Subprograms:
       DictRegister: null
     - ID: 88
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcdec40..0xcdec41]
+      OutOfLinePCRanges: [0xcdf320..0xcdf321]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xcdec40..0xcdec41
+            - Range: 0xcdf320..0xcdf321
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7784,7 +7784,7 @@ Subprograms:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xcdec40..0xcdec41
+            - Range: 0xcdf320..0xcdf321
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7792,7 +7792,7 @@ Subprograms:
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0xcdec40..0xcdec41
+            - Range: 0xcdf320..0xcdf321
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7800,13 +7800,13 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xcdec80..0xcdec81]
+      OutOfLinePCRanges: [0xcdf360..0xcdf361]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xcdec80..0xcdec81
+            - Range: 0xcdf360..0xcdf361
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7814,7 +7814,7 @@ Subprograms:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcdec80..0xcdec81
+            - Range: 0xcdf360..0xcdf361
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7826,7 +7826,7 @@ Subprograms:
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0xcdec80..0xcdec81
+            - Range: 0xcdf360..0xcdf361
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7834,13 +7834,13 @@ Subprograms:
       DictRegister: null
     - ID: 90
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcdee00..0xcdee01]
+      OutOfLinePCRanges: [0xcdf4e0..0xcdf4e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcdee00..0xcdee01
+            - Range: 0xcdf4e0..0xcdf4e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7848,7 +7848,7 @@ Subprograms:
         - Name: b
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xcdee00..0xcdee01
+            - Range: 0xcdf4e0..0xcdf4e1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7856,7 +7856,7 @@ Subprograms:
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xcdee00..0xcdee01
+            - Range: 0xcdf4e0..0xcdf4e1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7864,7 +7864,7 @@ Subprograms:
         - Name: d
           Type: 18 BaseType uint
           Locations:
-            - Range: 0xcdee00..0xcdee01
+            - Range: 0xcdf4e0..0xcdf4e1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7872,7 +7872,7 @@ Subprograms:
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcdee00..0xcdee01
+            - Range: 0xcdf4e0..0xcdf4e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7884,13 +7884,13 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.(*Server).handleOrder
-      OutOfLinePCRanges: [0xcdf020..0xcdf21f]
+      OutOfLinePCRanges: [0xcdf7e0..0xcdf9df]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 250 PointerType *main.Server
           Locations:
-            - Range: 0xcdf020..0xcdf076
+            - Range: 0xcdf7e0..0xcdf836
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7898,9 +7898,9 @@ Subprograms:
         - Name: req
           Type: 252 PointerType *main.Request
           Locations:
-            - Range: 0xcdf020..0xcdf073
+            - Range: 0xcdf7e0..0xcdf833
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdf073..0xcdf21f
+            - Range: 0xcdf833..0xcdf9df
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7908,23 +7908,23 @@ Subprograms:
         - Name: ~r0
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xcdf020..0xcdf11c
+            - Range: 0xcdf7e0..0xcdf8dc
               Pieces: []
-            - Range: 0xcdf11c..0xcdf11d
+            - Range: 0xcdf8dc..0xcdf8dd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdf11d..0xcdf1f7
+            - Range: 0xcdf8dd..0xcdf9b7
               Pieces: []
-            - Range: 0xcdf1f7..0xcdf1f8
+            - Range: 0xcdf9b7..0xcdf9b8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdf1f8..0xcdf21f
+            - Range: 0xcdf9b8..0xcdf9df
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7932,13 +7932,13 @@ Subprograms:
       DictRegister: null
     - ID: 92
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xcdf2e0..0xcdf2f3]
+      OutOfLinePCRanges: [0xcdfbc0..0xcdfbd3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xcdf2e0..0xcdf2f2
+            - Range: 0xcdfbc0..0xcdfbd2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7946,9 +7946,9 @@ Subprograms:
         - Name: ~r0
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xcdf2e0..0xcdf2f2
+            - Range: 0xcdfbc0..0xcdfbd2
               Pieces: []
-            - Range: 0xcdf2f2..0xcdf2f3
+            - Range: 0xcdfbd2..0xcdfbd3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -7956,13 +7956,13 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcdf300..0xcdf301]
+      OutOfLinePCRanges: [0xcdfbe0..0xcdfbe1]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 254 GoChannelType chan bool
           Locations:
-            - Range: 0xcdf300..0xcdf301
+            - Range: 0xcdfbe0..0xcdfbe1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7970,13 +7970,13 @@ Subprograms:
       DictRegister: null
     - ID: 94
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcdf4e0..0xcdf4e1]
+      OutOfLinePCRanges: [0xcdfea0..0xcdfea1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 255 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcdf4e0..0xcdf4e1
+            - Range: 0xcdfea0..0xcdfea1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7984,13 +7984,13 @@ Subprograms:
       DictRegister: null
     - ID: 95
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcdf500..0xcdf501]
+      OutOfLinePCRanges: [0xcdfec0..0xcdfec1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 257 StructureType main.node
           Locations:
-            - Range: 0xcdf500..0xcdf501
+            - Range: 0xcdfec0..0xcdfec1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8002,13 +8002,13 @@ Subprograms:
       DictRegister: null
     - ID: 96
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcdf520..0xcdf521]
+      OutOfLinePCRanges: [0xcdfee0..0xcdfee1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 258 PointerType *main.node
           Locations:
-            - Range: 0xcdf520..0xcdf521
+            - Range: 0xcdfee0..0xcdfee1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8016,13 +8016,13 @@ Subprograms:
       DictRegister: null
     - ID: 97
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcdf540..0xcdf541]
+      OutOfLinePCRanges: [0xcdff00..0xcdff01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcdf540..0xcdf541
+            - Range: 0xcdff00..0xcdff01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8030,13 +8030,13 @@ Subprograms:
       DictRegister: null
     - ID: 98
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcdf580..0xcdf581]
+      OutOfLinePCRanges: [0xcdff40..0xcdff41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 PointerType *uint
           Locations:
-            - Range: 0xcdf580..0xcdf581
+            - Range: 0xcdff40..0xcdff41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8044,13 +8044,13 @@ Subprograms:
       DictRegister: null
     - ID: 99
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcdf660..0xcdf661]
+      OutOfLinePCRanges: [0xce0020..0xce0021]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 96 PointerType *string
           Locations:
-            - Range: 0xcdf660..0xcdf661
+            - Range: 0xce0020..0xce0021
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8058,13 +8058,13 @@ Subprograms:
       DictRegister: null
     - ID: 100
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcdf6a0..0xcdf6a1]
+      OutOfLinePCRanges: [0xce0060..0xce0061]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 13 PointerType *bool
           Locations:
-            - Range: 0xcdf6a0..0xcdf6a1
+            - Range: 0xce0060..0xce0061
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8072,7 +8072,7 @@ Subprograms:
         - Name: a
           Type: 18 BaseType uint
           Locations:
-            - Range: 0xcdf6a0..0xcdf6a1
+            - Range: 0xce0060..0xce0061
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8080,13 +8080,13 @@ Subprograms:
       DictRegister: null
     - ID: 101
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcdf6e0..0xcdf6e1]
+      OutOfLinePCRanges: [0xce00a0..0xce00a1]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 259 PointerType *main.t
           Locations:
-            - Range: 0xcdf6e0..0xcdf6e1
+            - Range: 0xce00a0..0xce00a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8094,13 +8094,13 @@ Subprograms:
       DictRegister: null
     - ID: 102
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcdfb40..0xcdfbb2]
+      OutOfLinePCRanges: [0xce0620..0xce0692]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdfb40..0xcdfb52
+            - Range: 0xce0620..0xce0632
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8108,11 +8108,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdfb40..0xcdfb9b
+            - Range: 0xce0620..0xce067b
               Pieces: []
-            - Range: 0xcdfb9b..0xcdfb9c
+            - Range: 0xce067b..0xce067c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdfb9c..0xcdfbb2
+            - Range: 0xce067c..0xce0692
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8120,9 +8120,9 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdfb52..0xcdfb65
+            - Range: 0xce0632..0xce0645
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdfb65..0xcdfbb2
+            - Range: 0xce0645..0xce0692
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
@@ -8130,15 +8130,15 @@ Subprograms:
       DictRegister: null
     - ID: 103
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xcdfbc0..0xcdfc4f]
+      OutOfLinePCRanges: [0xce06a0..0xce072f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdfbc0..0xcdfbda
+            - Range: 0xce06a0..0xce06ba
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdfbda..0xcdfc4f
+            - Range: 0xce06ba..0xce072f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8146,11 +8146,11 @@ Subprograms:
         - Name: ~r0
           Type: 101 PointerType *int
           Locations:
-            - Range: 0xcdfbc0..0xcdfc34
+            - Range: 0xce06a0..0xce0714
               Pieces: []
-            - Range: 0xcdfc34..0xcdfc35
+            - Range: 0xce0714..0xce0715
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdfc35..0xcdfc4f
+            - Range: 0xce0715..0xce072f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8158,9 +8158,9 @@ Subprograms:
         - Name: '&result'
           Type: 101 PointerType *int
           Locations:
-            - Range: 0xcdfbdf..0xcdfbf9
+            - Range: 0xce06bf..0xce06d9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdfbf9..0xcdfc4f
+            - Range: 0xce06d9..0xce072f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
@@ -8168,13 +8168,13 @@ Subprograms:
       DictRegister: null
     - ID: 104
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcdfc60..0xcdfd3e]
+      OutOfLinePCRanges: [0xce0740..0xce081e]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdfc60..0xcdfcc2
+            - Range: 0xce0740..0xce07a2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8182,27 +8182,27 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdfc60..0xcdfd24
+            - Range: 0xce0740..0xce0804
               Pieces: []
-            - Range: 0xcdfd24..0xcdfd25
+            - Range: 0xce0804..0xce0805
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdfd25..0xcdfd3e
+            - Range: 0xce0805..0xce081e
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 20 BaseType float64
-          Locations: [{Range: 0xcdfc60..0xcdfd3e, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce081e, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdfc76..0xcdfcc7
+            - Range: 0xce0756..0xce07a7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdfcc7..0xcdfd3e
+            - Range: 0xce07a7..0xce081e
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
@@ -8210,9 +8210,9 @@ Subprograms:
         - Name: resultFloat
           Type: 20 BaseType float64
           Locations:
-            - Range: 0xcdfc8f..0xcdfcc7
+            - Range: 0xce076f..0xce07a7
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcdfcc7..0xcdfd3e
+            - Range: 0xce07a7..0xce081e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
@@ -8220,13 +8220,13 @@ Subprograms:
       DictRegister: null
     - ID: 105
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xcdfd40..0xcdfd9b]
+      OutOfLinePCRanges: [0xce0820..0xce087b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcdfd40..0xcdfd59
+            - Range: 0xce0820..0xce0839
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8234,23 +8234,23 @@ Subprograms:
         - Name: ~r0
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xcdfd40..0xcdfd7a
+            - Range: 0xce0820..0xce085a
               Pieces: []
-            - Range: 0xcdfd7a..0xcdfd7b
+            - Range: 0xce085a..0xce085b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfd7b..0xcdfd85
+            - Range: 0xce085b..0xce0865
               Pieces: []
-            - Range: 0xcdfd85..0xcdfd86
+            - Range: 0xce0865..0xce0866
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfd86..0xcdfd9b
+            - Range: 0xce0866..0xce087b
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8258,37 +8258,37 @@ Subprograms:
       DictRegister: null
     - ID: 106
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcdfda0..0xcdfee6]
+      OutOfLinePCRanges: [0xce0880..0xce09c6]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdfda0..0xcdfdeb
+            - Range: 0xce0880..0xce08cb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfdeb..0xcdfdf6
+            - Range: 0xce08cb..0xce08d6
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfe27..0xcdfe2a
+            - Range: 0xce0907..0xce090a
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfe60..0xcdfe65
+            - Range: 0xce0940..0xce0945
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfe94..0xcdfe99
+            - Range: 0xce0974..0xce0979
               Pieces:
                 - Size: 8
                   Op: null
@@ -8300,7 +8300,7 @@ Subprograms:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcdfda0..0xcdfde3
+            - Range: 0xce0880..0xce08c3
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8308,39 +8308,39 @@ Subprograms:
         - Name: ~r0
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdfda0..0xcdfe04
+            - Range: 0xce0880..0xce08e4
               Pieces: []
-            - Range: 0xcdfe04..0xcdfe05
+            - Range: 0xce08e4..0xce08e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfe05..0xcdfe53
+            - Range: 0xce08e5..0xce0933
               Pieces: []
-            - Range: 0xcdfe53..0xcdfe54
+            - Range: 0xce0933..0xce0934
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfe54..0xcdfe87
+            - Range: 0xce0934..0xce0967
               Pieces: []
-            - Range: 0xcdfe87..0xcdfe88
+            - Range: 0xce0967..0xce0968
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfe88..0xcdfeb9
+            - Range: 0xce0968..0xce0999
               Pieces: []
-            - Range: 0xcdfeb9..0xcdfeba
+            - Range: 0xce0999..0xce099a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdfeba..0xcdfee6
+            - Range: 0xce099a..0xce09c6
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8348,39 +8348,39 @@ Subprograms:
         - Name: ~r1
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xcdfda0..0xcdfe04
+            - Range: 0xce0880..0xce08e4
               Pieces: []
-            - Range: 0xcdfe04..0xcdfe05
+            - Range: 0xce08e4..0xce08e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdfe05..0xcdfe53
+            - Range: 0xce08e5..0xce0933
               Pieces: []
-            - Range: 0xcdfe53..0xcdfe54
+            - Range: 0xce0933..0xce0934
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdfe54..0xcdfe87
+            - Range: 0xce0934..0xce0967
               Pieces: []
-            - Range: 0xcdfe87..0xcdfe88
+            - Range: 0xce0967..0xce0968
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdfe88..0xcdfeb9
+            - Range: 0xce0968..0xce0999
               Pieces: []
-            - Range: 0xcdfeb9..0xcdfeba
+            - Range: 0xce0999..0xce099a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdfeba..0xcdfee6
+            - Range: 0xce099a..0xce09c6
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8388,7 +8388,7 @@ Subprograms:
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdfdeb..0xcdfdf1
+            - Range: 0xce08cb..0xce08d1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8396,25 +8396,25 @@ Subprograms:
       DictRegister: null
     - ID: 107
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcdff00..0xce00f4]
+      OutOfLinePCRanges: [0xce09e0..0xce0bd4]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdff00..0xcdff4b
+            - Range: 0xce09e0..0xce0a2b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdff4b..0xcdff52
+            - Range: 0xce0a2b..0xce0a32
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdff52..0xce00f4
+            - Range: 0xce0a32..0xce0bd4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -8426,39 +8426,39 @@ Subprograms:
         - Name: ~r0
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdff00..0xcdffc4
+            - Range: 0xce09e0..0xce0aa4
               Pieces: []
-            - Range: 0xcdffc4..0xcdffc5
+            - Range: 0xce0aa4..0xce0aa5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdffc5..0xcdffff
+            - Range: 0xce0aa5..0xce0adf
               Pieces: []
-            - Range: 0xcdffff..0xce0000
+            - Range: 0xce0adf..0xce0ae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce0000..0xce00c2
+            - Range: 0xce0ae0..0xce0ba2
               Pieces: []
-            - Range: 0xce00c2..0xce00c3
+            - Range: 0xce0ba2..0xce0ba3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce00c3..0xce00cc
+            - Range: 0xce0ba3..0xce0bac
               Pieces: []
-            - Range: 0xce00cc..0xce00cd
+            - Range: 0xce0bac..0xce0bad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce00cd..0xce00f4
+            - Range: 0xce0bad..0xce0bd4
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8466,7 +8466,7 @@ Subprograms:
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdffea..0xcdfff0
+            - Range: 0xce0aca..0xce0ad0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8474,7 +8474,7 @@ Subprograms:
         - Name: '&result'
           Type: 101 PointerType *int
           Locations:
-            - Range: 0xcdffa5..0xcdffc4
+            - Range: 0xce0a85..0xce0aa4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8482,35 +8482,35 @@ Subprograms:
       DictRegister: null
     - ID: 108
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xce0100..0xce025d]
+      OutOfLinePCRanges: [0xce0be0..0xce0d3d]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce0100..0xce0140
+            - Range: 0xce0be0..0xce0c20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce0140..0xce018e
+            - Range: 0xce0c20..0xce0c6e
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce018e..0xce01ff
+            - Range: 0xce0c6e..0xce0cdf
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce01ff..0xce021f
+            - Range: 0xce0cdf..0xce0cff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce021f..0xce0226
+            - Range: 0xce0cff..0xce0d06
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce0226..0xce025d
+            - Range: 0xce0d06..0xce0d3d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8518,23 +8518,23 @@ Subprograms:
         - Name: ~r0
           Type: 169 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xce0100..0xce01ef
+            - Range: 0xce0be0..0xce0ccf
               Pieces: []
-            - Range: 0xce01ef..0xce01f0
+            - Range: 0xce0ccf..0xce0cd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce01f0..0xce01f9
+            - Range: 0xce0cd0..0xce0cd9
               Pieces: []
-            - Range: 0xce01f9..0xce01fa
+            - Range: 0xce0cd9..0xce0cda
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce01fa..0xce025d
+            - Range: 0xce0cda..0xce0d3d
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8542,39 +8542,39 @@ Subprograms:
         - Name: b
           Type: 169 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xce0100..0xce0140
+            - Range: 0xce0be0..0xce0c20
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce0140..0xce018e
+            - Range: 0xce0c20..0xce0c6e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce018e..0xce0195
+            - Range: 0xce0c6e..0xce0c75
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce0195..0xce01f5
+            - Range: 0xce0c75..0xce0cd5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce01f5..0xce01f7
+            - Range: 0xce0cd5..0xce0cd7
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce01f7..0xce01f9
+            - Range: 0xce0cd7..0xce0cd9
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce01f9..0xce025d
+            - Range: 0xce0cd9..0xce0d3d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
@@ -8582,13 +8582,13 @@ Subprograms:
       DictRegister: null
     - ID: 109
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xce0260..0xce02ef]
+      OutOfLinePCRanges: [0xce0d40..0xce0dcf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0260..0xce0271
+            - Range: 0xce0d40..0xce0d51
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8596,11 +8596,11 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0260..0xce02d5
+            - Range: 0xce0d40..0xce0db5
               Pieces: []
-            - Range: 0xce02d5..0xce02d6
+            - Range: 0xce0db5..0xce0db6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce02d6..0xce02ef
+            - Range: 0xce0db6..0xce0dcf
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8608,13 +8608,13 @@ Subprograms:
       DictRegister: null
     - ID: 110
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xce0300..0xce03c9]
+      OutOfLinePCRanges: [0xce0de0..0xce0ea9]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0300..0xce0353
+            - Range: 0xce0de0..0xce0e33
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8622,11 +8622,11 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0300..0xce03af
+            - Range: 0xce0de0..0xce0e8f
               Pieces: []
-            - Range: 0xce03af..0xce03b0
+            - Range: 0xce0e8f..0xce0e90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce03b0..0xce03c9
+            - Range: 0xce0e90..0xce0ea9
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8634,11 +8634,11 @@ Subprograms:
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0300..0xce03af
+            - Range: 0xce0de0..0xce0e8f
               Pieces: []
-            - Range: 0xce03af..0xce03b0
+            - Range: 0xce0e8f..0xce0e90
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce03b0..0xce03c9
+            - Range: 0xce0e90..0xce0ea9
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8646,15 +8646,15 @@ Subprograms:
       DictRegister: null
     - ID: 111
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xce03e0..0xce04a5]
+      OutOfLinePCRanges: [0xce0ec0..0xce0f85]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce03e0..0xce0425
+            - Range: 0xce0ec0..0xce0f05
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0425..0xce04a5
+            - Range: 0xce0f05..0xce0f85
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8662,11 +8662,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce03e0..0xce048b
+            - Range: 0xce0ec0..0xce0f6b
               Pieces: []
-            - Range: 0xce048b..0xce048c
+            - Range: 0xce0f6b..0xce0f6c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce048c..0xce04a5
+            - Range: 0xce0f6c..0xce0f85
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8674,11 +8674,11 @@ Subprograms:
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce03e0..0xce048b
+            - Range: 0xce0ec0..0xce0f6b
               Pieces: []
-            - Range: 0xce048b..0xce048c
+            - Range: 0xce0f6b..0xce0f6c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce048c..0xce04a5
+            - Range: 0xce0f6c..0xce0f85
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8686,11 +8686,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce03e0..0xce048b
+            - Range: 0xce0ec0..0xce0f6b
               Pieces: []
-            - Range: 0xce048b..0xce048c
+            - Range: 0xce0f6b..0xce0f6c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce048c..0xce04a5
+            - Range: 0xce0f6c..0xce0f85
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8698,15 +8698,15 @@ Subprograms:
       DictRegister: null
     - ID: 112
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xce04c0..0xce05af]
+      OutOfLinePCRanges: [0xce0fa0..0xce108f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce04c0..0xce0505
+            - Range: 0xce0fa0..0xce0fe5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0505..0xce05af
+            - Range: 0xce0fe5..0xce108f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8714,11 +8714,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce04c0..0xce0591
+            - Range: 0xce0fa0..0xce1071
               Pieces: []
-            - Range: 0xce0591..0xce0592
+            - Range: 0xce1071..0xce1072
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0592..0xce05af
+            - Range: 0xce1072..0xce108f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8726,15 +8726,15 @@ Subprograms:
         - Name: r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce04c0..0xce0591
+            - Range: 0xce0fa0..0xce1071
               Pieces: []
-            - Range: 0xce0591..0xce0592
+            - Range: 0xce1071..0xce1072
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce0592..0xce05af
+            - Range: 0xce1072..0xce108f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8742,15 +8742,15 @@ Subprograms:
       DictRegister: null
     - ID: 113
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xce05c0..0xce07cf]
+      OutOfLinePCRanges: [0xce10a0..0xce12af]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce05c0..0xce0646
+            - Range: 0xce10a0..0xce1126
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0646..0xce07cf
+            - Range: 0xce1126..0xce12af
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8758,7 +8758,7 @@ Subprograms:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce05f7..0xce07cf
+            - Range: 0xce10d7..0xce12af
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
@@ -8766,7 +8766,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce05fd..0xce07cf
+            - Range: 0xce10dd..0xce12af
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
@@ -8774,17 +8774,17 @@ Subprograms:
       DictRegister: null
     - ID: 114
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xce08c0..0xce093e]
+      OutOfLinePCRanges: [0xce13a0..0xce141e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType int8
           Locations:
-            - Range: 0xce08c0..0xce0931
+            - Range: 0xce13a0..0xce1411
               Pieces: []
-            - Range: 0xce0931..0xce0932
+            - Range: 0xce1411..0xce1412
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0932..0xce093e
+            - Range: 0xce1412..0xce141e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8792,11 +8792,11 @@ Subprograms:
         - Name: ~r1
           Type: 105 BaseType int16
           Locations:
-            - Range: 0xce08c0..0xce0931
+            - Range: 0xce13a0..0xce1411
               Pieces: []
-            - Range: 0xce0931..0xce0932
+            - Range: 0xce1411..0xce1412
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce0932..0xce093e
+            - Range: 0xce1412..0xce141e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8804,11 +8804,11 @@ Subprograms:
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xce08c0..0xce0931
+            - Range: 0xce13a0..0xce1411
               Pieces: []
-            - Range: 0xce0931..0xce0932
+            - Range: 0xce1411..0xce1412
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce0932..0xce093e
+            - Range: 0xce1412..0xce141e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8816,11 +8816,11 @@ Subprograms:
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0xce08c0..0xce0931
+            - Range: 0xce13a0..0xce1411
               Pieces: []
-            - Range: 0xce0931..0xce0932
+            - Range: 0xce1411..0xce1412
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce0932..0xce093e
+            - Range: 0xce1412..0xce141e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8828,11 +8828,11 @@ Subprograms:
         - Name: ~r4
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xce08c0..0xce0931
+            - Range: 0xce13a0..0xce1411
               Pieces: []
-            - Range: 0xce0931..0xce0932
+            - Range: 0xce1411..0xce1412
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce0932..0xce093e
+            - Range: 0xce1412..0xce141e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8840,11 +8840,11 @@ Subprograms:
         - Name: ~r5
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0xce08c0..0xce0931
+            - Range: 0xce13a0..0xce1411
               Pieces: []
-            - Range: 0xce0931..0xce0932
+            - Range: 0xce1411..0xce1412
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce0932..0xce093e
+            - Range: 0xce1412..0xce141e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8852,11 +8852,11 @@ Subprograms:
         - Name: ~r6
           Type: 4 BaseType uint32
           Locations:
-            - Range: 0xce08c0..0xce0931
+            - Range: 0xce13a0..0xce1411
               Pieces: []
-            - Range: 0xce0931..0xce0932
+            - Range: 0xce1411..0xce1412
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce0932..0xce093e
+            - Range: 0xce1412..0xce141e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8864,11 +8864,11 @@ Subprograms:
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xce08c0..0xce0931
+            - Range: 0xce13a0..0xce1411
               Pieces: []
-            - Range: 0xce0931..0xce0932
+            - Range: 0xce1411..0xce1412
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce0932..0xce093e
+            - Range: 0xce1412..0xce141e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8876,107 +8876,107 @@ Subprograms:
       DictRegister: null
     - ID: 115
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xce0940..0xce0a37]
+      OutOfLinePCRanges: [0xce1420..0xce1517]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0940..0xce0a37, Pieces: []}]
+          Locations: [{Range: 0xce1420..0xce1517, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0940..0xce0a37, Pieces: []}]
+          Locations: [{Range: 0xce1420..0xce1517, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0940..0xce0a37, Pieces: []}]
+          Locations: [{Range: 0xce1420..0xce1517, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0940..0xce0a37, Pieces: []}]
+          Locations: [{Range: 0xce1420..0xce1517, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0940..0xce0a37, Pieces: []}]
+          Locations: [{Range: 0xce1420..0xce1517, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r5
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0940..0xce0a37, Pieces: []}]
+          Locations: [{Range: 0xce1420..0xce1517, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r6
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0940..0xce0a37, Pieces: []}]
+          Locations: [{Range: 0xce1420..0xce1517, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r7
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0940..0xce0a37, Pieces: []}]
+          Locations: [{Range: 0xce1420..0xce1517, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r8
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0940..0xce0a37, Pieces: []}]
+          Locations: [{Range: 0xce1420..0xce1517, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r9
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0940..0xce0a37, Pieces: []}]
+          Locations: [{Range: 0xce1420..0xce1517, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r10
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0940..0xce0a37, Pieces: []}]
+          Locations: [{Range: 0xce1420..0xce1517, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r11
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0940..0xce0a37, Pieces: []}]
+          Locations: [{Range: 0xce1420..0xce1517, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r12
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0940..0xce0a37, Pieces: []}]
+          Locations: [{Range: 0xce1420..0xce1517, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r13
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0940..0xce0a37, Pieces: []}]
+          Locations: [{Range: 0xce1420..0xce1517, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r14
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0940..0xce0a37, Pieces: []}]
+          Locations: [{Range: 0xce1420..0xce1517, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: onlyOnAmd64_16
           Type: 20 BaseType float64
           Locations:
-            - Range: 0xce0940..0xce0a27
+            - Range: 0xce1420..0xce1507
               Pieces: []
-            - Range: 0xce0a27..0xce0a28
+            - Range: 0xce1507..0xce1508
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xce0a28..0xce0a37
+            - Range: 0xce1508..0xce1517
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8984,11 +8984,11 @@ Subprograms:
         - Name: bothArmAndAmd64
           Type: 20 BaseType float64
           Locations:
-            - Range: 0xce0940..0xce0a27
+            - Range: 0xce1420..0xce1507
               Pieces: []
-            - Range: 0xce0a27..0xce0a28
+            - Range: 0xce1507..0xce1508
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce0a28..0xce0a37
+            - Range: 0xce1508..0xce1517
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8996,35 +8996,35 @@ Subprograms:
       DictRegister: null
     - ID: 116
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xce0a40..0xce0ab3]
+      OutOfLinePCRanges: [0xce1520..0xce1593]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 97 BaseType complex64
-          Locations: [{Range: 0xce0a40..0xce0ab3, Pieces: []}]
+          Locations: [{Range: 0xce1520..0xce1593, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 98 BaseType complex128
-          Locations: [{Range: 0xce0a40..0xce0ab3, Pieces: []}]
+          Locations: [{Range: 0xce1520..0xce1593, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 117
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xce0ac0..0xce0b65]
+      OutOfLinePCRanges: [0xce15a0..0xce1645]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xce0ac0..0xce0b53
+            - Range: 0xce15a0..0xce1633
               Pieces: []
-            - Range: 0xce0b53..0xce0b54
+            - Range: 0xce1633..0xce1634
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xce0b54..0xce0b65
+            - Range: 0xce1634..0xce1645
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9032,17 +9032,17 @@ Subprograms:
       DictRegister: null
     - ID: 118
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xce0b80..0xce0bfa]
+      OutOfLinePCRanges: [0xce1660..0xce16da]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0xce0b80..0xce0bed
+            - Range: 0xce1660..0xce16cd
               Pieces: []
-            - Range: 0xce0bed..0xce0bee
+            - Range: 0xce16cd..0xce16ce
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xce0bee..0xce0bfa
+            - Range: 0xce16ce..0xce16da
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9050,17 +9050,17 @@ Subprograms:
       DictRegister: null
     - ID: 119
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xce0c00..0xce0c58]
+      OutOfLinePCRanges: [0xce16e0..0xce1738]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 263 ArrayType [1]int
           Locations:
-            - Range: 0xce0c00..0xce0c4b
+            - Range: 0xce16e0..0xce172b
               Pieces: []
-            - Range: 0xce0c4b..0xce0c4c
+            - Range: 0xce172b..0xce172c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0c4c..0xce0c58
+            - Range: 0xce172c..0xce1738
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9068,17 +9068,17 @@ Subprograms:
       DictRegister: null
     - ID: 120
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xce0c60..0xce0cb3]
+      OutOfLinePCRanges: [0xce1740..0xce1793]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 264 ArrayType [0]int
           Locations:
-            - Range: 0xce0c60..0xce0ca6
+            - Range: 0xce1740..0xce1786
               Pieces: []
-            - Range: 0xce0ca6..0xce0ca7
+            - Range: 0xce1786..0xce1787
               Pieces: []
-            - Range: 0xce0ca7..0xce0cb3
+            - Range: 0xce1787..0xce1793
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9086,29 +9086,29 @@ Subprograms:
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xce0cc0..0xce0d27]
+      OutOfLinePCRanges: [0xce17a0..0xce1807]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 265 StructureType main.mixedStruct
-          Locations: [{Range: 0xce0cc0..0xce0d27, Pieces: []}]
+          Locations: [{Range: 0xce17a0..0xce1807, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 122
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xce0d40..0xce0dda]
+      OutOfLinePCRanges: [0xce1820..0xce18ba]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0d40..0xce0dca
+            - Range: 0xce1820..0xce18aa
               Pieces: []
-            - Range: 0xce0dca..0xce0dcb
+            - Range: 0xce18aa..0xce18ab
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0dcb..0xce0dda
+            - Range: 0xce18ab..0xce18ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9116,11 +9116,11 @@ Subprograms:
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0d40..0xce0dca
+            - Range: 0xce1820..0xce18aa
               Pieces: []
-            - Range: 0xce0dca..0xce0dcb
+            - Range: 0xce18aa..0xce18ab
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce0dcb..0xce0dda
+            - Range: 0xce18ab..0xce18ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9128,11 +9128,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0d40..0xce0dca
+            - Range: 0xce1820..0xce18aa
               Pieces: []
-            - Range: 0xce0dca..0xce0dcb
+            - Range: 0xce18aa..0xce18ab
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce0dcb..0xce0dda
+            - Range: 0xce18ab..0xce18ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9140,11 +9140,11 @@ Subprograms:
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0d40..0xce0dca
+            - Range: 0xce1820..0xce18aa
               Pieces: []
-            - Range: 0xce0dca..0xce0dcb
+            - Range: 0xce18aa..0xce18ab
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce0dcb..0xce0dda
+            - Range: 0xce18ab..0xce18ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9152,11 +9152,11 @@ Subprograms:
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0d40..0xce0dca
+            - Range: 0xce1820..0xce18aa
               Pieces: []
-            - Range: 0xce0dca..0xce0dcb
+            - Range: 0xce18aa..0xce18ab
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce0dcb..0xce0dda
+            - Range: 0xce18ab..0xce18ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9164,11 +9164,11 @@ Subprograms:
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0d40..0xce0dca
+            - Range: 0xce1820..0xce18aa
               Pieces: []
-            - Range: 0xce0dca..0xce0dcb
+            - Range: 0xce18aa..0xce18ab
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce0dcb..0xce0dda
+            - Range: 0xce18ab..0xce18ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9176,11 +9176,11 @@ Subprograms:
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0d40..0xce0dca
+            - Range: 0xce1820..0xce18aa
               Pieces: []
-            - Range: 0xce0dca..0xce0dcb
+            - Range: 0xce18aa..0xce18ab
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce0dcb..0xce0dda
+            - Range: 0xce18ab..0xce18ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9188,11 +9188,11 @@ Subprograms:
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0d40..0xce0dca
+            - Range: 0xce1820..0xce18aa
               Pieces: []
-            - Range: 0xce0dca..0xce0dcb
+            - Range: 0xce18aa..0xce18ab
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce0dcb..0xce0dda
+            - Range: 0xce18ab..0xce18ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9200,11 +9200,11 @@ Subprograms:
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce0d40..0xce0dca
+            - Range: 0xce1820..0xce18aa
               Pieces: []
-            - Range: 0xce0dca..0xce0dcb
+            - Range: 0xce18aa..0xce18ab
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xce0dcb..0xce0dda
+            - Range: 0xce18ab..0xce18ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9212,17 +9212,17 @@ Subprograms:
       DictRegister: null
     - ID: 123
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xce0de0..0xce0e85]
+      OutOfLinePCRanges: [0xce18c0..0xce1965]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 266 StructureType main.wideStruct
           Locations:
-            - Range: 0xce0de0..0xce0e74
+            - Range: 0xce18c0..0xce1954
               Pieces: []
-            - Range: 0xce0e74..0xce0e75
+            - Range: 0xce1954..0xce1955
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xce0e75..0xce0e85
+            - Range: 0xce1955..0xce1965
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9230,57 +9230,57 @@ Subprograms:
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xce0ea0..0xce0f19]
+      OutOfLinePCRanges: [0xce1980..0xce19f9]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0ea0..0xce0f0c
+            - Range: 0xce1980..0xce19ec
               Pieces: []
-            - Range: 0xce0f0c..0xce0f0d
+            - Range: 0xce19ec..0xce19ed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0f0d..0xce0f19
+            - Range: 0xce19ed..0xce19f9
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0ea0..0xce0f19, Pieces: []}]
+          Locations: [{Range: 0xce1980..0xce19f9, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0ea0..0xce0f0c
+            - Range: 0xce1980..0xce19ec
               Pieces: []
-            - Range: 0xce0f0c..0xce0f0d
+            - Range: 0xce19ec..0xce19ed
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce0f0d..0xce0f19
+            - Range: 0xce19ed..0xce19f9
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0ea0..0xce0f19, Pieces: []}]
+          Locations: [{Range: 0xce1980..0xce19f9, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce0ea0..0xce0f0c
+            - Range: 0xce1980..0xce19ec
               Pieces: []
-            - Range: 0xce0f0c..0xce0f0d
+            - Range: 0xce19ec..0xce19ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce0f0d..0xce0f19
+            - Range: 0xce19ed..0xce19f9
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9288,17 +9288,17 @@ Subprograms:
       DictRegister: null
     - ID: 125
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xce0f20..0xce0f9a]
+      OutOfLinePCRanges: [0xce1a00..0xce1a7a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0xce0f20..0xce0f8d
+            - Range: 0xce1a00..0xce1a6d
               Pieces: []
-            - Range: 0xce0f8d..0xce0f8e
+            - Range: 0xce1a6d..0xce1a6e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xce0f8e..0xce0f9a
+            - Range: 0xce1a6e..0xce1a7a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9306,47 +9306,47 @@ Subprograms:
       DictRegister: null
     - ID: 126
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xce0fa0..0xce0ffb]
+      OutOfLinePCRanges: [0xce1a80..0xce1adb]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce0fa0..0xce0ffb, Pieces: []}]
+          Locations: [{Range: 0xce1a80..0xce1adb, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 127
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xce1000..0xce1067]
+      OutOfLinePCRanges: [0xce1ae0..0xce1b47]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float32
-          Locations: [{Range: 0xce1000..0xce1067, Pieces: []}]
+          Locations: [{Range: 0xce1ae0..0xce1b47, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 20 BaseType float64
-          Locations: [{Range: 0xce1000..0xce1067, Pieces: []}]
+          Locations: [{Range: 0xce1ae0..0xce1b47, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 128
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xce1080..0xce10dd]
+      OutOfLinePCRanges: [0xce1b60..0xce1bbd]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce1080..0xce10d0
+            - Range: 0xce1b60..0xce1bb0
               Pieces: []
-            - Range: 0xce10d0..0xce10d1
+            - Range: 0xce1bb0..0xce1bb1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce10d1..0xce10dd
+            - Range: 0xce1bb1..0xce1bbd
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9354,11 +9354,11 @@ Subprograms:
         - Name: ~r1
           Type: 3 BaseType uintptr
           Locations:
-            - Range: 0xce1080..0xce10d0
+            - Range: 0xce1b60..0xce1bb0
               Pieces: []
-            - Range: 0xce10d0..0xce10d1
+            - Range: 0xce1bb0..0xce1bb1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce10d1..0xce10dd
+            - Range: 0xce1bb1..0xce1bbd
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9366,13 +9366,13 @@ Subprograms:
       DictRegister: null
     - ID: 129
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xce10e0..0xce1265]
+      OutOfLinePCRanges: [0xce1bc0..0xce1d45]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xce10e0..0xce1265
+            - Range: 0xce1bc0..0xce1d45
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9380,11 +9380,11 @@ Subprograms:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xce10e0..0xce1253
+            - Range: 0xce1bc0..0xce1d33
               Pieces: []
-            - Range: 0xce1253..0xce1254
+            - Range: 0xce1d33..0xce1d34
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xce1254..0xce1265
+            - Range: 0xce1d34..0xce1d45
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9392,13 +9392,13 @@ Subprograms:
       DictRegister: null
     - ID: 130
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xce1280..0xce1352]
+      OutOfLinePCRanges: [0xce1d60..0xce1e32]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0xce1280..0xce1352
+            - Range: 0xce1d60..0xce1e32
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9406,11 +9406,11 @@ Subprograms:
         - Name: ~r0
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0xce1280..0xce1342
+            - Range: 0xce1d60..0xce1e22
               Pieces: []
-            - Range: 0xce1342..0xce1343
+            - Range: 0xce1e22..0xce1e23
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xce1343..0xce1352
+            - Range: 0xce1e23..0xce1e32
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9418,13 +9418,13 @@ Subprograms:
       DictRegister: null
     - ID: 131
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xce1360..0xce159a]
+      OutOfLinePCRanges: [0xce1e40..0xce207a]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xce1360..0xce159a
+            - Range: 0xce1e40..0xce207a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9432,7 +9432,7 @@ Subprograms:
         - Name: s2
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xce1360..0xce159a
+            - Range: 0xce1e40..0xce207a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
@@ -9440,11 +9440,11 @@ Subprograms:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xce1360..0xce158a
+            - Range: 0xce1e40..0xce206a
               Pieces: []
-            - Range: 0xce158a..0xce158b
+            - Range: 0xce206a..0xce206b
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xce158b..0xce159a
+            - Range: 0xce206b..0xce207a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9452,15 +9452,15 @@ Subprograms:
       DictRegister: null
     - ID: 132
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xce15a0..0xce182f]
+      OutOfLinePCRanges: [0xce2080..0xce230f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce15a0..0xce1650
+            - Range: 0xce2080..0xce2130
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1650..0xce182f
+            - Range: 0xce2130..0xce230f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -9468,9 +9468,9 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce15a0..0xce1650
+            - Range: 0xce2080..0xce2130
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce1650..0xce182f
+            - Range: 0xce2130..0xce230f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -9478,9 +9478,9 @@ Subprograms:
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce15a0..0xce163a
+            - Range: 0xce2080..0xce211a
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce163a..0xce182f
+            - Range: 0xce211a..0xce230f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
@@ -9488,9 +9488,9 @@ Subprograms:
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce15a0..0xce1610
+            - Range: 0xce2080..0xce20f0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce1610..0xce182f
+            - Range: 0xce20f0..0xce230f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
@@ -9498,9 +9498,9 @@ Subprograms:
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce15a0..0xce1650
+            - Range: 0xce2080..0xce2130
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce1650..0xce182f
+            - Range: 0xce2130..0xce230f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
@@ -9508,9 +9508,9 @@ Subprograms:
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce15a0..0xce1650
+            - Range: 0xce2080..0xce2130
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce1650..0xce182f
+            - Range: 0xce2130..0xce230f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
@@ -9518,9 +9518,9 @@ Subprograms:
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce15a0..0xce1650
+            - Range: 0xce2080..0xce2130
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce1650..0xce182f
+            - Range: 0xce2130..0xce230f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
@@ -9528,9 +9528,9 @@ Subprograms:
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce15a0..0xce1650
+            - Range: 0xce2080..0xce2130
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce1650..0xce182f
+            - Range: 0xce2130..0xce230f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
@@ -9538,9 +9538,9 @@ Subprograms:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce15a0..0xce1650
+            - Range: 0xce2080..0xce2130
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xce1650..0xce182f
+            - Range: 0xce2130..0xce230f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
@@ -9548,11 +9548,11 @@ Subprograms:
         - Name: ~r0
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0xce15a0..0xce17c2
+            - Range: 0xce2080..0xce22a2
               Pieces: []
-            - Range: 0xce17c2..0xce17c3
+            - Range: 0xce22a2..0xce22a3
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xce17c3..0xce182f
+            - Range: 0xce22a3..0xce230f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9560,15 +9560,15 @@ Subprograms:
       DictRegister: null
     - ID: 133
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xce1840..0xce1b0c]
+      OutOfLinePCRanges: [0xce2320..0xce25ec]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1840..0xce18eb
+            - Range: 0xce2320..0xce23cb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce18eb..0xce1b0c
+            - Range: 0xce23cb..0xce25ec
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
@@ -9576,9 +9576,9 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1840..0xce18eb
+            - Range: 0xce2320..0xce23cb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce18eb..0xce1b0c
+            - Range: 0xce23cb..0xce25ec
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
@@ -9586,9 +9586,9 @@ Subprograms:
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1840..0xce18d5
+            - Range: 0xce2320..0xce23b5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce18d5..0xce1b0c
+            - Range: 0xce23b5..0xce25ec
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
@@ -9596,9 +9596,9 @@ Subprograms:
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1840..0xce18a2
+            - Range: 0xce2320..0xce2382
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce18a2..0xce1b0c
+            - Range: 0xce2382..0xce25ec
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
@@ -9606,9 +9606,9 @@ Subprograms:
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1840..0xce18eb
+            - Range: 0xce2320..0xce23cb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce18eb..0xce1b0c
+            - Range: 0xce23cb..0xce25ec
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
@@ -9616,9 +9616,9 @@ Subprograms:
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1840..0xce18eb
+            - Range: 0xce2320..0xce23cb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce18eb..0xce1b0c
+            - Range: 0xce23cb..0xce25ec
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
@@ -9626,9 +9626,9 @@ Subprograms:
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1840..0xce18eb
+            - Range: 0xce2320..0xce23cb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce18eb..0xce1b0c
+            - Range: 0xce23cb..0xce25ec
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
@@ -9636,9 +9636,9 @@ Subprograms:
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1840..0xce18eb
+            - Range: 0xce2320..0xce23cb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce18eb..0xce1b0c
+            - Range: 0xce23cb..0xce25ec
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
@@ -9646,7 +9646,7 @@ Subprograms:
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce1840..0xce1b0c
+            - Range: 0xce2320..0xce25ec
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -9658,11 +9658,11 @@ Subprograms:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0xce1840..0xce1a8b
+            - Range: 0xce2320..0xce256b
               Pieces: []
-            - Range: 0xce1a8b..0xce1a8c
+            - Range: 0xce256b..0xce256c
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xce1a8c..0xce1b0c
+            - Range: 0xce256c..0xce25ec
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9670,13 +9670,13 @@ Subprograms:
       DictRegister: null
     - ID: 134
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xce1b20..0xce1bac]
+      OutOfLinePCRanges: [0xce2600..0xce268c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 168 ArrayType [5]int
           Locations:
-            - Range: 0xce1b20..0xce1bac
+            - Range: 0xce2600..0xce268c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9684,11 +9684,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1b20..0xce1b9c
+            - Range: 0xce2600..0xce267c
               Pieces: []
-            - Range: 0xce1b9c..0xce1b9d
+            - Range: 0xce267c..0xce267d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1b9d..0xce1bac
+            - Range: 0xce267d..0xce268c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9696,11 +9696,11 @@ Subprograms:
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1b20..0xce1b9c
+            - Range: 0xce2600..0xce267c
               Pieces: []
-            - Range: 0xce1b9c..0xce1b9d
+            - Range: 0xce267c..0xce267d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce1b9d..0xce1bac
+            - Range: 0xce267d..0xce268c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9708,11 +9708,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1b20..0xce1b9c
+            - Range: 0xce2600..0xce267c
               Pieces: []
-            - Range: 0xce1b9c..0xce1b9d
+            - Range: 0xce267c..0xce267d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce1b9d..0xce1bac
+            - Range: 0xce267d..0xce268c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9720,13 +9720,13 @@ Subprograms:
       DictRegister: null
     - ID: 135
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xce1bc0..0xce1cae]
+      OutOfLinePCRanges: [0xce26a0..0xce278e]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0xce1bc0..0xce1cae
+            - Range: 0xce26a0..0xce278e
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9734,7 +9734,7 @@ Subprograms:
         - Name: b
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0xce1bc0..0xce1cae
+            - Range: 0xce26a0..0xce278e
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -9742,11 +9742,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1bc0..0xce1c9e
+            - Range: 0xce26a0..0xce277e
               Pieces: []
-            - Range: 0xce1c9e..0xce1c9f
+            - Range: 0xce277e..0xce277f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1c9f..0xce1cae
+            - Range: 0xce277f..0xce278e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9754,11 +9754,11 @@ Subprograms:
         - Name: ~r1
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0xce1bc0..0xce1c9e
+            - Range: 0xce26a0..0xce277e
               Pieces: []
-            - Range: 0xce1c9e..0xce1c9f
+            - Range: 0xce277e..0xce277f
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xce1c9f..0xce1cae
+            - Range: 0xce277f..0xce278e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9766,13 +9766,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xce1cc0..0xce1d8b]
+      OutOfLinePCRanges: [0xce27a0..0xce286b]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0xce1cc0..0xce1d8b
+            - Range: 0xce27a0..0xce286b
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9780,11 +9780,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1cc0..0xce1d7a
+            - Range: 0xce27a0..0xce285a
               Pieces: []
-            - Range: 0xce1d7a..0xce1d7b
+            - Range: 0xce285a..0xce285b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1d7b..0xce1d8b
+            - Range: 0xce285b..0xce286b
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9792,11 +9792,11 @@ Subprograms:
         - Name: ~r1
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0xce1cc0..0xce1d7a
+            - Range: 0xce27a0..0xce285a
               Pieces: []
-            - Range: 0xce1d7a..0xce1d7b
+            - Range: 0xce285a..0xce285b
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xce1d7b..0xce1d8b
+            - Range: 0xce285b..0xce286b
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9804,7 +9804,7 @@ Subprograms:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1d46..0xce1d8b
+            - Range: 0xce2826..0xce286b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -9812,25 +9812,25 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xce1da0..0xce1e46]
+      OutOfLinePCRanges: [0xce2880..0xce2926]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 264 ArrayType [0]int
-          Locations: [{Range: 0xce1da0..0xce1e46, Pieces: []}]
+          Locations: [{Range: 0xce2880..0xce2926, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1da0..0xce1de5
+            - Range: 0xce2880..0xce28c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1de5..0xce1e07
+            - Range: 0xce28c5..0xce28e7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xce1e07..0xce1e1a
+            - Range: 0xce28e7..0xce28fa
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xce1e1a..0xce1e46
+            - Range: 0xce28fa..0xce2926
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
@@ -9838,11 +9838,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce1da0..0xce1e2c
+            - Range: 0xce2880..0xce290c
               Pieces: []
-            - Range: 0xce1e2c..0xce1e2d
+            - Range: 0xce290c..0xce290d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1e2d..0xce1e46
+            - Range: 0xce290d..0xce2926
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9850,11 +9850,11 @@ Subprograms:
         - Name: ~r1
           Type: 264 ArrayType [0]int
           Locations:
-            - Range: 0xce1da0..0xce1e2c
+            - Range: 0xce2880..0xce290c
               Pieces: []
-            - Range: 0xce1e2c..0xce1e2d
+            - Range: 0xce290c..0xce290d
               Pieces: []
-            - Range: 0xce1e2d..0xce1e46
+            - Range: 0xce290d..0xce2926
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9862,13 +9862,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xce2360..0xce2361]
+      OutOfLinePCRanges: [0xce2e40..0xce2e41]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce2360..0xce2361
+            - Range: 0xce2e40..0xce2e41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9882,13 +9882,13 @@ Subprograms:
       DictRegister: null
     - ID: 139
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xce2380..0xce2381]
+      OutOfLinePCRanges: [0xce2e60..0xce2e61]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce2380..0xce2381
+            - Range: 0xce2e60..0xce2e61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9902,13 +9902,13 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xce23a0..0xce23a1]
+      OutOfLinePCRanges: [0xce2e80..0xce2e81]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 269 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xce23a0..0xce23a1
+            - Range: 0xce2e80..0xce2e81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9922,13 +9922,13 @@ Subprograms:
       DictRegister: null
     - ID: 141
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0xce23c0..0xce23c1]
+      OutOfLinePCRanges: [0xce2ea0..0xce2ea1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xce23c0..0xce23c1
+            - Range: 0xce2ea0..0xce2ea1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9942,7 +9942,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce23c0..0xce23c1
+            - Range: 0xce2ea0..0xce2ea1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9950,13 +9950,13 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xce23e0..0xce23e1]
+      OutOfLinePCRanges: [0xce2ec0..0xce2ec1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xce23e0..0xce23e1
+            - Range: 0xce2ec0..0xce2ec1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9970,7 +9970,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce23e0..0xce23e1
+            - Range: 0xce2ec0..0xce2ec1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9978,13 +9978,13 @@ Subprograms:
       DictRegister: null
     - ID: 143
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xce2400..0xce2401]
+      OutOfLinePCRanges: [0xce2ee0..0xce2ee1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xce2400..0xce2401
+            - Range: 0xce2ee0..0xce2ee1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9998,7 +9998,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce2400..0xce2401
+            - Range: 0xce2ee0..0xce2ee1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10006,13 +10006,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xce2420..0xce2421]
+      OutOfLinePCRanges: [0xce2f00..0xce2f01]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 162 GoSliceHeaderType []string
           Locations:
-            - Range: 0xce2420..0xce2421
+            - Range: 0xce2f00..0xce2f01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10026,13 +10026,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xce2440..0xce2441]
+      OutOfLinePCRanges: [0xce2f20..0xce2f21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 17 BaseType int8
           Locations:
-            - Range: 0xce2440..0xce2441
+            - Range: 0xce2f20..0xce2f21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10040,7 +10040,7 @@ Subprograms:
         - Name: s
           Type: 274 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xce2440..0xce2441
+            - Range: 0xce2f20..0xce2f21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10054,7 +10054,7 @@ Subprograms:
         - Name: x
           Type: 18 BaseType uint
           Locations:
-            - Range: 0xce2440..0xce2441
+            - Range: 0xce2f20..0xce2f21
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10062,13 +10062,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xce2460..0xce2461]
+      OutOfLinePCRanges: [0xce2f40..0xce2f41]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 275 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xce2460..0xce2461
+            - Range: 0xce2f40..0xce2f41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10082,13 +10082,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xce2480..0xce2481]
+      OutOfLinePCRanges: [0xce2f60..0xce2f61]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce2480..0xce2481
+            - Range: 0xce2f60..0xce2f61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10102,13 +10102,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xce24a0..0xce24a1]
+      OutOfLinePCRanges: [0xce2f80..0xce2f81]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 276 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0xce24a0..0xce24a1
+            - Range: 0xce2f80..0xce2f81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10122,13 +10122,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xce24c0..0xce24c1]
+      OutOfLinePCRanges: [0xce2fa0..0xce2fa1]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce24c0..0xce24c1
+            - Range: 0xce2fa0..0xce2fa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10142,7 +10142,7 @@ Subprograms:
         - Name: bs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce24c0..0xce24c1
+            - Range: 0xce2fa0..0xce2fa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10156,7 +10156,7 @@ Subprograms:
         - Name: cs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce24c0..0xce24c1
+            - Range: 0xce2fa0..0xce2fa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -10170,13 +10170,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testByteSliceInvalidUtf8
-      OutOfLinePCRanges: [0xce2540..0xce2541]
+      OutOfLinePCRanges: [0xce3020..0xce3021]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0xce2540..0xce2541
+            - Range: 0xce3020..0xce3021
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10190,13 +10190,13 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testByteSliceMultibyteUtf8
-      OutOfLinePCRanges: [0xce2560..0xce2561]
+      OutOfLinePCRanges: [0xce3040..0xce3041]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0xce2560..0xce2561
+            - Range: 0xce3040..0xce3041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10210,21 +10210,21 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.stackC
-      OutOfLinePCRanges: [0xce2c80..0xce2cd2]
+      OutOfLinePCRanges: [0xce3840..0xce3892]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce2c80..0xce2cc5
+            - Range: 0xce3840..0xce3885
               Pieces: []
-            - Range: 0xce2cc5..0xce2cc6
+            - Range: 0xce3885..0xce3886
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce2cc6..0xce2cd2
+            - Range: 0xce3886..0xce3892
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10232,13 +10232,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xce2ce0..0xce2ce1]
+      OutOfLinePCRanges: [0xce39c0..0xce39c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce2ce0..0xce2ce1
+            - Range: 0xce39c0..0xce39c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10250,13 +10250,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xce2d00..0xce2d01]
+      OutOfLinePCRanges: [0xce39e0..0xce39e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce2d00..0xce2d01
+            - Range: 0xce39e0..0xce39e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10268,7 +10268,7 @@ Subprograms:
         - Name: "y"
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce2d00..0xce2d01
+            - Range: 0xce39e0..0xce39e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10280,7 +10280,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce2d00..0xce2d01
+            - Range: 0xce39e0..0xce39e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10292,13 +10292,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xce2d20..0xce2d3f]
+      OutOfLinePCRanges: [0xce3a00..0xce3a1f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xce2d20..0xce2d3f
+            - Range: 0xce3a00..0xce3a1f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10318,13 +10318,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xce2d40..0xce2d41]
+      OutOfLinePCRanges: [0xce3a20..0xce3a21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 279 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xce2d40..0xce2d41
+            - Range: 0xce3a20..0xce3a21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10332,13 +10332,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xce2d60..0xce2d61]
+      OutOfLinePCRanges: [0xce3a40..0xce3a41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xce2d60..0xce2d61
+            - Range: 0xce3a40..0xce3a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10346,13 +10346,13 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xce2d80..0xce2d81]
+      OutOfLinePCRanges: [0xce3a60..0xce3a61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce2d80..0xce2d81
+            - Range: 0xce3a60..0xce3a61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10364,13 +10364,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xce2da0..0xce2da1]
+      OutOfLinePCRanges: [0xce3a80..0xce3a81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce2da0..0xce2da1
+            - Range: 0xce3a80..0xce3a81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10382,13 +10382,13 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xce2dc0..0xce2dc1]
+      OutOfLinePCRanges: [0xce3aa0..0xce3aa1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce2dc0..0xce2dc1
+            - Range: 0xce3aa0..0xce3aa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10400,13 +10400,13 @@ Subprograms:
       DictRegister: null
     - ID: 161
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xce2de0..0xce2de1]
+      OutOfLinePCRanges: [0xce3ac0..0xce3ac1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce2de0..0xce2de1
+            - Range: 0xce3ac0..0xce3ac1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10418,7 +10418,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce2de0..0xce2de1
+            - Range: 0xce3ac0..0xce3ac1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10430,7 +10430,7 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce2de0..0xce2de1
+            - Range: 0xce3ac0..0xce3ac1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10442,13 +10442,13 @@ Subprograms:
       DictRegister: null
     - ID: 162
       Name: main.testInvalidUtf8Strings
-      OutOfLinePCRanges: [0xce2e00..0xce2e01]
+      OutOfLinePCRanges: [0xce3ae0..0xce3ae1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce2e00..0xce2e01
+            - Range: 0xce3ae0..0xce3ae1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10460,7 +10460,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce2e00..0xce2e01
+            - Range: 0xce3ae0..0xce3ae1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10472,13 +10472,13 @@ Subprograms:
       DictRegister: null
     - ID: 163
       Name: main.testMultibyteUtf8String
-      OutOfLinePCRanges: [0xce2e20..0xce2e21]
+      OutOfLinePCRanges: [0xce3b00..0xce3b01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce2e20..0xce2e21
+            - Range: 0xce3b00..0xce3b01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10490,13 +10490,13 @@ Subprograms:
       DictRegister: null
     - ID: 164
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xce2fe0..0xce2fe1]
+      OutOfLinePCRanges: [0xce3dc0..0xce3dc1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 282 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xce2fe0..0xce2fe1
+            - Range: 0xce3dc0..0xce3dc1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10504,13 +10504,13 @@ Subprograms:
       DictRegister: null
     - ID: 165
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xce3000..0xce301f]
+      OutOfLinePCRanges: [0xce3de0..0xce3dff]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 295 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xce3000..0xce301f
+            - Range: 0xce3de0..0xce3dff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10530,13 +10530,13 @@ Subprograms:
       DictRegister: null
     - ID: 166
       Name: main.testStruct
-      OutOfLinePCRanges: [0xce3140..0xce3163]
+      OutOfLinePCRanges: [0xce3f20..0xce3f43]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 326 StructureType main.aStruct
           Locations:
-            - Range: 0xce3140..0xce3163
+            - Range: 0xce3f20..0xce3f43
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10558,13 +10558,13 @@ Subprograms:
       DictRegister: null
     - ID: 167
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xce3240..0xce3241]
+      OutOfLinePCRanges: [0xce4020..0xce4021]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 327 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xce3240..0xce3241
+            - Range: 0xce4020..0xce4021
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10572,13 +10572,13 @@ Subprograms:
       DictRegister: null
     - ID: 168
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xce3260..0xce3261]
+      OutOfLinePCRanges: [0xce4040..0xce4041]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 StructureType main.tenStrings
           Locations:
-            - Range: 0xce3260..0xce3261
+            - Range: 0xce4040..0xce4041
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10586,25 +10586,25 @@ Subprograms:
       DictRegister: null
     - ID: 169
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xce32c0..0xce32c1]
+      OutOfLinePCRanges: [0xce40a0..0xce40a1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 330 StructureType main.emptyStruct
-          Locations: [{Range: 0xce32c0..0xce32c1, Pieces: []}]
+          Locations: [{Range: 0xce40a0..0xce40a1, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 170
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xce32e0..0xce32e1]
+      OutOfLinePCRanges: [0xce40c0..0xce40c1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 331 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xce32e0..0xce32e1
+            - Range: 0xce40c0..0xce40c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10612,13 +10612,13 @@ Subprograms:
       DictRegister: null
     - ID: 171
       Name: main.testTimeUTC
-      OutOfLinePCRanges: [0xce4640..0xce4641]
+      OutOfLinePCRanges: [0xce5520..0xce5521]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 332 GoTimeType time.Time
           Locations:
-            - Range: 0xce4640..0xce4641
+            - Range: 0xce5520..0xce5521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10632,13 +10632,13 @@ Subprograms:
       DictRegister: null
     - ID: 172
       Name: main.testTimeFixedZone
-      OutOfLinePCRanges: [0xce4660..0xce4661]
+      OutOfLinePCRanges: [0xce5540..0xce5541]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 332 GoTimeType time.Time
           Locations:
-            - Range: 0xce4660..0xce4661
+            - Range: 0xce5540..0xce5541
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10652,13 +10652,13 @@ Subprograms:
       DictRegister: null
     - ID: 173
       Name: main.testTimeMonotonic
-      OutOfLinePCRanges: [0xce4680..0xce4681]
+      OutOfLinePCRanges: [0xce5560..0xce5561]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 335 StructureType main.timeCapture
           Locations:
-            - Range: 0xce4680..0xce4681
+            - Range: 0xce5560..0xce5561
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10672,13 +10672,13 @@ Subprograms:
       DictRegister: null
     - ID: 174
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xce5720..0xce5724]
+      OutOfLinePCRanges: [0xce6720..0xce6724]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0xce5720..0xce5724
+            - Range: 0xce6720..0xce6724
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10686,9 +10686,9 @@ Subprograms:
         - Name: ~r0
           Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce5720..0xce5723
+            - Range: 0xce6720..0xce6723
               Pieces: []
-            - Range: 0xce5723..0xce5724
+            - Range: 0xce6723..0xce6724
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -10696,19 +10696,19 @@ Subprograms:
       DictRegister: 0
     - ID: 175
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xce5740..0xce574c]
+      OutOfLinePCRanges: [0xce6740..0xce674c]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5740..0xce574b
+            - Range: 0xce6740..0xce674b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce574b..0xce574c
+            - Range: 0xce674b..0xce674c
               Pieces:
                 - Size: 8
                   Op: null
@@ -10720,9 +10720,9 @@ Subprograms:
         - Name: ~r0
           Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce5740..0xce574b
+            - Range: 0xce6740..0xce674b
               Pieces: []
-            - Range: 0xce574b..0xce574c
+            - Range: 0xce674b..0xce674c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10734,13 +10734,13 @@ Subprograms:
       DictRegister: 0
     - ID: 176
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xce5760..0xce5764]
+      OutOfLinePCRanges: [0xce6760..0xce6764]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce5760..0xce5764
+            - Range: 0xce6760..0xce6764
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10748,9 +10748,9 @@ Subprograms:
         - Name: ~r0
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0xce5760..0xce5763
+            - Range: 0xce6760..0xce6763
               Pieces: []
-            - Range: 0xce5763..0xce5764
+            - Range: 0xce6763..0xce6764
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -10758,19 +10758,19 @@ Subprograms:
       DictRegister: 0
     - ID: 177
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xce5780..0xce578c]
+      OutOfLinePCRanges: [0xce6780..0xce678c]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce5780..0xce578b
+            - Range: 0xce6780..0xce678b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce578b..0xce578c
+            - Range: 0xce678b..0xce678c
               Pieces:
                 - Size: 8
                   Op: null
@@ -10782,9 +10782,9 @@ Subprograms:
         - Name: ~r0
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5780..0xce578b
+            - Range: 0xce6780..0xce678b
               Pieces: []
-            - Range: 0xce578b..0xce578c
+            - Range: 0xce678b..0xce678c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10796,13 +10796,13 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xce5800..0xce5936]
+      OutOfLinePCRanges: [0xce6800..0xce6936]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 340 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce5800..0xce5833
+            - Range: 0xce6800..0xce6833
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10810,7 +10810,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce5833..0xce583b
+            - Range: 0xce6833..0xce683b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10818,7 +10818,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xce583b..0xce5936
+            - Range: 0xce683b..0xce6936
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10832,9 +10832,9 @@ Subprograms:
         - Name: pred
           Type: 342 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xce5800..0xce583b
+            - Range: 0xce6800..0xce683b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce583b..0xce5936
+            - Range: 0xce683b..0xce6936
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
@@ -10842,9 +10842,9 @@ Subprograms:
         - Name: ~r0
           Type: 340 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce5800..0xce58f4
+            - Range: 0xce6800..0xce68f4
               Pieces: []
-            - Range: 0xce58f4..0xce58f5
+            - Range: 0xce68f4..0xce68f5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10852,7 +10852,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce58f5..0xce5936
+            - Range: 0xce68f5..0xce6936
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -10860,7 +10860,7 @@ Subprograms:
         - Name: result
           Type: 340 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce583b..0xce5859
+            - Range: 0xce683b..0xce6859
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10868,7 +10868,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce5859..0xce5861
+            - Range: 0xce6859..0xce6861
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10876,7 +10876,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce5861..0xce5869
+            - Range: 0xce6861..0xce6869
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10884,7 +10884,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce5869..0xce5869
+            - Range: 0xce6869..0xce6869
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10892,7 +10892,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce5869..0xce5893
+            - Range: 0xce6869..0xce6893
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10900,7 +10900,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce5893..0xce58eb
+            - Range: 0xce6893..0xce68eb
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10908,7 +10908,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce58eb..0xce5936
+            - Range: 0xce68eb..0xce6936
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10922,9 +10922,9 @@ Subprograms:
         - Name: item
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0xce5886..0xce5893
+            - Range: 0xce6886..0xce6893
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce5893..0xce58eb
+            - Range: 0xce6893..0xce68eb
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
@@ -10932,13 +10932,13 @@ Subprograms:
       DictRegister: 0
     - ID: 179
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce5940..0xce5984]
+      OutOfLinePCRanges: [0xce6940..0xce6984]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce5940..0xce5959
+            - Range: 0xce6940..0xce6959
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10946,7 +10946,7 @@ Subprograms:
         - Name: f
           Type: 343 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xce5940..0xce5959
+            - Range: 0xce6940..0xce6959
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -10954,15 +10954,15 @@ Subprograms:
         - Name: ~r0
           Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce5940..0xce5959
+            - Range: 0xce6940..0xce6959
               Pieces: []
-            - Range: 0xce5959..0xce595a
+            - Range: 0xce6959..0xce695a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce595a..0xce5984
+            - Range: 0xce695a..0xce6984
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -10970,13 +10970,13 @@ Subprograms:
       DictRegister: 0
     - ID: 180
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xce5c20..0xce5c24]
+      OutOfLinePCRanges: [0xce6c20..0xce6c24]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 341 PointerType *go.shape.int
           Locations:
-            - Range: 0xce5c20..0xce5c24
+            - Range: 0xce6c20..0xce6c24
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10984,9 +10984,9 @@ Subprograms:
         - Name: ~r0
           Type: 341 PointerType *go.shape.int
           Locations:
-            - Range: 0xce5c20..0xce5c23
+            - Range: 0xce6c20..0xce6c23
               Pieces: []
-            - Range: 0xce5c23..0xce5c24
+            - Range: 0xce6c23..0xce6c24
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -10994,13 +10994,13 @@ Subprograms:
       DictRegister: 0
     - ID: 181
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xce5c40..0xce5c44]
+      OutOfLinePCRanges: [0xce6c40..0xce6c44]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 344 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xce5c40..0xce5c44
+            - Range: 0xce6c40..0xce6c44
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11008,9 +11008,9 @@ Subprograms:
         - Name: ~r0
           Type: 344 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xce5c40..0xce5c43
+            - Range: 0xce6c40..0xce6c43
               Pieces: []
-            - Range: 0xce5c43..0xce5c44
+            - Range: 0xce6c43..0xce6c44
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11018,13 +11018,13 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xce5c60..0xce5c64]
+      OutOfLinePCRanges: [0xce6c60..0xce6c64]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 346 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xce5c60..0xce5c64
+            - Range: 0xce6c60..0xce6c64
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11032,9 +11032,9 @@ Subprograms:
         - Name: ~r0
           Type: 346 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xce5c60..0xce5c63
+            - Range: 0xce6c60..0xce6c63
               Pieces: []
-            - Range: 0xce5c63..0xce5c64
+            - Range: 0xce6c63..0xce6c64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11042,13 +11042,13 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xce5c80..0xce5c91]
+      OutOfLinePCRanges: [0xce6c80..0xce6c91]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 348 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xce5c80..0xce5c91
+            - Range: 0xce6c80..0xce6c91
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11056,9 +11056,9 @@ Subprograms:
         - Name: ~r0
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5c80..0xce5c90
+            - Range: 0xce6c80..0xce6c90
               Pieces: []
-            - Range: 0xce5c90..0xce5c91
+            - Range: 0xce6c90..0xce6c91
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11070,13 +11070,13 @@ Subprograms:
       DictRegister: 0
     - ID: 184
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xce5d20..0xce5d29]
+      OutOfLinePCRanges: [0xce6d20..0xce6d29]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 350 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xce5d20..0xce5d29
+            - Range: 0xce6d20..0xce6d29
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11084,9 +11084,9 @@ Subprograms:
         - Name: ~r0
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0xce5d20..0xce5d28
+            - Range: 0xce6d20..0xce6d28
               Pieces: []
-            - Range: 0xce5d28..0xce5d29
+            - Range: 0xce6d28..0xce6d29
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11094,13 +11094,13 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xce5de0..0xce5de8]
+      OutOfLinePCRanges: [0xce6de0..0xce6de8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 351 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xce5de0..0xce5de8
+            - Range: 0xce6de0..0xce6de8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11108,7 +11108,7 @@ Subprograms:
         - Name: k
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0xce5de0..0xce5de8
+            - Range: 0xce6de0..0xce6de8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11116,7 +11116,7 @@ Subprograms:
         - Name: v
           Type: 353 BaseType go.shape.bool
           Locations:
-            - Range: 0xce5de0..0xce5de8
+            - Range: 0xce6de0..0xce6de8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11124,13 +11124,13 @@ Subprograms:
       DictRegister: 3
     - ID: 186
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xce5e80..0xce5ef1]
+      OutOfLinePCRanges: [0xce6e80..0xce6ef1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 354 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xce5e80..0xce5ef1
+            - Range: 0xce6e80..0xce6ef1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11138,7 +11138,7 @@ Subprograms:
         - Name: k
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5e80..0xce5ef1
+            - Range: 0xce6e80..0xce6ef1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -11150,7 +11150,7 @@ Subprograms:
         - Name: v
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0xce5e80..0xce5ef1
+            - Range: 0xce6e80..0xce6ef1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11158,13 +11158,13 @@ Subprograms:
       DictRegister: 3
     - ID: 187
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xce5f80..0xce5f88]
+      OutOfLinePCRanges: [0xce6f80..0xce6f88]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5f80..0xce5f88
+            - Range: 0xce6f80..0xce6f88
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11176,7 +11176,7 @@ Subprograms:
         - Name: b
           Type: 353 BaseType go.shape.bool
           Locations:
-            - Range: 0xce5f80..0xce5f88
+            - Range: 0xce6f80..0xce6f88
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11184,9 +11184,9 @@ Subprograms:
         - Name: ~r0
           Type: 353 BaseType go.shape.bool
           Locations:
-            - Range: 0xce5f80..0xce5f87
+            - Range: 0xce6f80..0xce6f87
               Pieces: []
-            - Range: 0xce5f87..0xce5f88
+            - Range: 0xce6f87..0xce6f88
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11194,9 +11194,9 @@ Subprograms:
         - Name: ~r1
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5f80..0xce5f87
+            - Range: 0xce6f80..0xce6f87
               Pieces: []
-            - Range: 0xce5f87..0xce5f88
+            - Range: 0xce6f87..0xce6f88
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11208,13 +11208,13 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce5fa0..0xce5faf]
+      OutOfLinePCRanges: [0xce6fa0..0xce6faf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0xce5fa0..0xce5fae
+            - Range: 0xce6fa0..0xce6fae
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11222,13 +11222,13 @@ Subprograms:
         - Name: b
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5fa0..0xce5fab
+            - Range: 0xce6fa0..0xce6fab
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce5fab..0xce5faf
+            - Range: 0xce6fab..0xce6faf
               Pieces:
                 - Size: 8
                   Op: null
@@ -11240,9 +11240,9 @@ Subprograms:
         - Name: ~r0
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5fa0..0xce5fae
+            - Range: 0xce6fa0..0xce6fae
               Pieces: []
-            - Range: 0xce5fae..0xce5faf
+            - Range: 0xce6fae..0xce6faf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11254,9 +11254,9 @@ Subprograms:
         - Name: ~r1
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0xce5fa0..0xce5fae
+            - Range: 0xce6fa0..0xce6fae
               Pieces: []
-            - Range: 0xce5fae..0xce5faf
+            - Range: 0xce6fae..0xce6faf
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
@@ -11264,13 +11264,13 @@ Subprograms:
       DictRegister: 0
     - ID: 189
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xce5fc0..0xce5ffa]
+      OutOfLinePCRanges: [0xce6fc0..0xce6ffa]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 356 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xce5fc0..0xce5fd9
+            - Range: 0xce6fc0..0xce6fd9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11278,15 +11278,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce5fc0..0xce5fd9
+            - Range: 0xce6fc0..0xce6fd9
               Pieces: []
-            - Range: 0xce5fd9..0xce5fda
+            - Range: 0xce6fd9..0xce6fda
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce5fda..0xce5ffa
+            - Range: 0xce6fda..0xce6ffa
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11294,19 +11294,19 @@ Subprograms:
       DictRegister: 0
     - ID: 190
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xce6000..0xce604d]
+      OutOfLinePCRanges: [0xce7000..0xce704d]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 357 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xce6000..0xce601f
+            - Range: 0xce7000..0xce701f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce601f..0xce6022
+            - Range: 0xce701f..0xce7022
               Pieces:
                 - Size: 8
                   Op: null
@@ -11318,15 +11318,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce6000..0xce6022
+            - Range: 0xce7000..0xce7022
               Pieces: []
-            - Range: 0xce6022..0xce6023
+            - Range: 0xce7022..0xce7023
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce6023..0xce604d
+            - Range: 0xce7023..0xce704d
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11334,13 +11334,13 @@ Subprograms:
       DictRegister: 0
     - ID: 191
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xce6060..0xce6068]
+      OutOfLinePCRanges: [0xce7060..0xce7068]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 358 PointerType *go.shape.string
           Locations:
-            - Range: 0xce6060..0xce6067
+            - Range: 0xce7060..0xce7067
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11348,9 +11348,9 @@ Subprograms:
         - Name: ~r0
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce6060..0xce6067
+            - Range: 0xce7060..0xce7067
               Pieces: []
-            - Range: 0xce6067..0xce6068
+            - Range: 0xce7067..0xce7068
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11362,13 +11362,13 @@ Subprograms:
       DictRegister: 0
     - ID: 192
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xce6080..0xce60d7]
+      OutOfLinePCRanges: [0xce7080..0xce70d7]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 359 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce6080..0xce60bd
+            - Range: 0xce7080..0xce70bd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11376,9 +11376,9 @@ Subprograms:
         - Name: ~r0
           Type: 360 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce6080..0xce60d1
+            - Range: 0xce7080..0xce70d1
               Pieces: []
-            - Range: 0xce60d1..0xce60d2
+            - Range: 0xce70d1..0xce70d2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11392,7 +11392,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce60d2..0xce60d7
+            - Range: 0xce70d2..0xce70d7
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11400,13 +11400,13 @@ Subprograms:
       DictRegister: 0
     - ID: 193
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xce60e0..0xce6104]
+      OutOfLinePCRanges: [0xce70e0..0xce7104]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 340 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce60e0..0xce6104
+            - Range: 0xce70e0..0xce7104
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11420,7 +11420,7 @@ Subprograms:
         - Name: needle
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0xce60e0..0xce6104
+            - Range: 0xce70e0..0xce7104
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11428,13 +11428,13 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce60e0..0xce6100
+            - Range: 0xce70e0..0xce7100
               Pieces: []
-            - Range: 0xce6100..0xce6101
+            - Range: 0xce7100..0xce7101
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce6101..0xce6103
+            - Range: 0xce7101..0xce7103
               Pieces: []
-            - Range: 0xce6103..0xce6104
+            - Range: 0xce7103..0xce7104
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -11442,13 +11442,13 @@ Subprograms:
       DictRegister: 0
     - ID: 194
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xce6120..0xce61df]
+      OutOfLinePCRanges: [0xce7120..0xce71df]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 361 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xce6120..0xce613d
+            - Range: 0xce7120..0xce713d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11456,7 +11456,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce613d..0xce613f
+            - Range: 0xce713d..0xce713f
               Pieces:
                 - Size: 8
                   Op: null
@@ -11470,13 +11470,13 @@ Subprograms:
         - Name: needle
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce6120..0xce616c
+            - Range: 0xce7120..0xce716c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce616c..0xce61df
+            - Range: 0xce716c..0xce71df
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -11488,15 +11488,15 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce6120..0xce618b
+            - Range: 0xce7120..0xce718b
               Pieces: []
-            - Range: 0xce618b..0xce618c
+            - Range: 0xce718b..0xce718c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce618c..0xce6193
+            - Range: 0xce718c..0xce7193
               Pieces: []
-            - Range: 0xce6193..0xce6194
+            - Range: 0xce7193..0xce7194
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce6194..0xce61df
+            - Range: 0xce7194..0xce71df
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11504,13 +11504,13 @@ Subprograms:
         - Name: v
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce614f..0xce6161
+            - Range: 0xce714f..0xce7161
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xce6161..0xce616c
+            - Range: 0xce7161..0xce716c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11522,13 +11522,13 @@ Subprograms:
       DictRegister: 0
     - ID: 195
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xce61e0..0xce61e7]
+      OutOfLinePCRanges: [0xce71e0..0xce71e7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 362 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xce61e0..0xce61e6
+            - Range: 0xce71e0..0xce71e6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11536,7 +11536,7 @@ Subprograms:
         - Name: value
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0xce61e0..0xce61e7
+            - Range: 0xce71e0..0xce71e7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11544,9 +11544,9 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce61e0..0xce61e6
+            - Range: 0xce71e0..0xce71e6
               Pieces: []
-            - Range: 0xce61e6..0xce61e7
+            - Range: 0xce71e6..0xce71e7
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -11554,25 +11554,25 @@ Subprograms:
       DictRegister: 3
     - ID: 196
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xce6260..0xce62cc]
+      OutOfLinePCRanges: [0xce7260..0xce72cc]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 363 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xce6260..0xce6280
+            - Range: 0xce7260..0xce7280
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce6280..0xce6288
+            - Range: 0xce7280..0xce7288
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce6288..0xce628d
+            - Range: 0xce7288..0xce728d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11584,7 +11584,7 @@ Subprograms:
         - Name: value
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce6260..0xce628d
+            - Range: 0xce7260..0xce728d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -11596,11 +11596,11 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce6260..0xce628d
+            - Range: 0xce7260..0xce728d
               Pieces: []
-            - Range: 0xce628d..0xce628e
+            - Range: 0xce728d..0xce728e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce628e..0xce62cc
+            - Range: 0xce728e..0xce72cc
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11832,31 +11832,31 @@ Subprograms:
       DictRegister: null
     - ID: 199
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xcdc020..0xcdc082]
+      OutOfLinePCRanges: [0xcdc520..0xcdc582]
       InlinePCRanges:
-        - Ranges: [0xcdc0b1..0xcdc0ed]
-          RootRanges: [0xcdc0a0..0xcdc111]
-        - Ranges: [0xcdc1f2..0xcdc22e]
-          RootRanges: [0xcdc1c0..0xcdc248]
-        - Ranges: [0xcdc27c..0xcdc2b8]
-          RootRanges: [0xcdc260..0xcdc325]
-        - Ranges: [0xcdc34f..0xcdc38b]
-          RootRanges: [0xcdc340..0xcdc3a2]
+        - Ranges: [0xcdc5b1..0xcdc5ed]
+          RootRanges: [0xcdc5a0..0xcdc611]
+        - Ranges: [0xcdc6f2..0xcdc72e]
+          RootRanges: [0xcdc6c0..0xcdc748]
+        - Ranges: [0xcdc77c..0xcdc7b8]
+          RootRanges: [0xcdc760..0xcdc825]
+        - Ranges: [0xcdc84f..0xcdc88b]
+          RootRanges: [0xcdc840..0xcdc8a2]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdc020..0xcdc039
+            - Range: 0xcdc520..0xcdc539
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc0b1..0xcdc0bc
+            - Range: 0xcdc5b1..0xcdc5bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc1f2..0xcdc1fd
+            - Range: 0xcdc6f2..0xcdc6fd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc276..0xcdc287
+            - Range: 0xcdc776..0xcdc787
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc287..0xcdc325
+            - Range: 0xcdc787..0xcdc825
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcdc340..0xcdc35a
+            - Range: 0xcdc840..0xcdc85a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11866,37 +11866,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdc2c6..0xcdc2fe]
-          RootRanges: [0xcdc260..0xcdc325]
+        - Ranges: [0xcdc7c6..0xcdc7fe]
+          RootRanges: [0xcdc760..0xcdc825]
       Variables: []
       DictRegister: null
     - ID: 201
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdc3d3..0xcdc411]
-          RootRanges: [0xcdc3c0..0xcdc4ce]
+        - Ranges: [0xcdc8d3..0xcdc911]
+          RootRanges: [0xcdc8c0..0xcdc9ce]
       Variables: []
       DictRegister: null
     - ID: 202
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdc486..0xcdc4be]
-          RootRanges: [0xcdc3c0..0xcdc4ce]
+        - Ranges: [0xcdc986..0xcdc9be]
+          RootRanges: [0xcdc8c0..0xcdc9ce]
       Variables: []
       DictRegister: null
     - ID: 203
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdc4e1..0xcdc4e5]
-          RootRanges: [0xcdc4e0..0xcdc4e6]
+        - Ranges: [0xcdc9e1..0xcdc9e5]
+          RootRanges: [0xcdc9e0..0xcdc9e6]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdc4e0..0xcdc4e5
+            - Range: 0xcdc9e0..0xcdc9e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11906,39 +11906,39 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdc525..0xcdc53d]
-          RootRanges: [0xcdc500..0xcdc543]
-        - Ranges: [0xcdc5c5..0xcdc5e3]
-          RootRanges: [0xcdc560..0xcdc6e5]
+        - Ranges: [0xcdca25..0xcdca3d]
+          RootRanges: [0xcdca00..0xcdca43]
+        - Ranges: [0xcdcb35..0xcdcb53]
+          RootRanges: [0xcdca60..0xcdcc8c]
       Variables:
         - Name: a
           Type: 168 ArrayType [5]int
           Locations:
-            - Range: 0xcdc50d..0xcdc543
+            - Range: 0xcdca0d..0xcdca43
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xcdc5ac..0xcdc6e5
-              Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
+            - Range: 0xcdcb19..0xcdcc8c
+              Pieces: [{Size: 40, Op: {CfaOffset: -152}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 205
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xcdc700..0xcdc771]
+      OutOfLinePCRanges: [0xcdcd00..0xcdcd71]
       InlinePCRanges:
-        - Ranges: [0xce64a3..0xce64e5]
-          RootRanges: [0xce6480..0xce6516]
+        - Ranges: [0xce74a3..0xce74e5]
+          RootRanges: [0xce7480..0xce7516]
       Variables:
         - Name: b
           Type: 368 StructureType main.firstBehavior
           Locations:
-            - Range: 0xcdc700..0xcdc728
+            - Range: 0xcdcd00..0xcdcd28
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdc728..0xcdc72d
+            - Range: 0xcdcd28..0xcdcd2d
               Pieces:
                 - Size: 8
                   Op: null
@@ -11950,15 +11950,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcdc700..0xcdc750
+            - Range: 0xcdcd00..0xcdcd50
               Pieces: []
-            - Range: 0xcdc750..0xcdc751
+            - Range: 0xcdcd50..0xcdcd51
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdc751..0xcdc771
+            - Range: 0xcdcd51..0xcdcd71
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11968,8 +11968,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcdd006..0xcdd00d]
-          RootRanges: [0xcdcf60..0xcdd06a]
+        - Ranges: [0xcdd6c6..0xcdd6cd]
+          RootRanges: [0xcdd5a0..0xcdd75a]
         - Ranges: [0xcd5fe1..0xcd5fe9]
           RootRanges: [0xcd5fe0..0xcd5fea]
       Variables: []
@@ -12639,7 +12639,7 @@ Types:
       ID: 2622
       Name: '*compress/gzip.Reader'
       ByteSize: 8
-      GoRuntimeType: 1630048
+      GoRuntimeType: 1629280
       GoKind: 22
       Pointee: 2623 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
@@ -12653,7 +12653,7 @@ Types:
       ID: 418
       Name: '*context.backgroundCtx'
       ByteSize: 8
-      GoRuntimeType: 1556160
+      GoRuntimeType: 1555680
       GoKind: 22
       Pointee: 419 GoContextImplementationType context.backgroundCtx
     - __kind: PointerType
@@ -12667,21 +12667,21 @@ Types:
       ID: 1067
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1194624
+      GoRuntimeType: 1192960
       GoKind: 22
       Pointee: 1068 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 405
       Name: '*context.emptyCtx'
       ByteSize: 8
-      GoRuntimeType: 1418720
+      GoRuntimeType: 1418560
       GoKind: 22
       Pointee: 406 GoContextImplementationType context.emptyCtx
     - __kind: PointerType
       ID: 407
       Name: '*context.stopCtx'
       ByteSize: 8
-      GoRuntimeType: 1418880
+      GoRuntimeType: 1418720
       GoKind: 22
       Pointee: 408 GoContextImplementationType context.stopCtx
     - __kind: PointerType
@@ -12695,21 +12695,21 @@ Types:
       ID: 420
       Name: '*context.todoCtx'
       ByteSize: 8
-      GoRuntimeType: 1556320
+      GoRuntimeType: 1555840
       GoKind: 22
       Pointee: 421 GoContextImplementationType context.todoCtx
     - __kind: PointerType
       ID: 414
       Name: '*context.valueCtx'
       ByteSize: 8
-      GoRuntimeType: 1555840
+      GoRuntimeType: 1555360
       GoKind: 22
       Pointee: 415 GoContextImplementationType context.valueCtx
     - __kind: PointerType
       ID: 416
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
-      GoRuntimeType: 1556000
+      GoRuntimeType: 1555520
       GoKind: 22
       Pointee: 417 GoContextImplementationType context.withoutCancelCtx
     - __kind: PointerType
@@ -13071,17 +13071,17 @@ Types:
       GoKind: 22
       Pointee: 962 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 857
+      ID: 855
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 911744
+      GoRuntimeType: 911072
       GoKind: 22
       Pointee: 757 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
       ID: 1212
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1042816
+      GoRuntimeType: 1042688
       GoKind: 22
       Pointee: 1213 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -13092,31 +13092,31 @@ Types:
       GoKind: 22
       Pointee: 758 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 1479
+      ID: 1477
       Name: '*encoding/json.Delim'
       ByteSize: 8
-      GoRuntimeType: 906560
+      GoRuntimeType: 905888
       GoKind: 22
-      Pointee: 1409 BaseType encoding/json.Delim
+      Pointee: 1407 BaseType encoding/json.Delim
     - __kind: PointerType
-      ID: 828
+      ID: 826
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 906464
+      GoRuntimeType: 905792
       GoKind: 22
-      Pointee: 829 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 827 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
       ID: 1030
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1039104
+      GoRuntimeType: 1038976
       GoKind: 22
       Pointee: 1031 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
       ID: 1649
       Name: '*encoding/json.Number'
       ByteSize: 8
-      GoRuntimeType: 1208832
+      GoRuntimeType: 1208320
       GoKind: 22
       Pointee: 1631 GoStringHeaderType encoding/json.Number
     - __kind: PointerType
@@ -13125,33 +13125,33 @@ Types:
       ByteSize: 8
       Pointee: 1632 GoStringDataType encoding/json.Number.str
     - __kind: PointerType
-      ID: 820
+      ID: 818
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 906080
+      GoRuntimeType: 905408
       GoKind: 22
-      Pointee: 821 UnresolvedPointeeType encoding/json.SyntaxError
-    - __kind: PointerType
-      ID: 826
-      Name: '*encoding/json.UnmarshalTypeError'
-      ByteSize: 8
-      GoRuntimeType: 906368
-      GoKind: 22
-      Pointee: 827 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 819 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
       ID: 824
-      Name: '*encoding/json.UnsupportedTypeError'
+      Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
-      GoRuntimeType: 906272
+      GoRuntimeType: 905696
       GoKind: 22
-      Pointee: 825 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 825 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
       ID: 822
+      Name: '*encoding/json.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 905600
+      GoKind: 22
+      Pointee: 823 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 820
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
-      GoRuntimeType: 906176
+      GoRuntimeType: 905504
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 821 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
       ID: 1354
       Name: '*encoding/json.encodeState'
@@ -13160,12 +13160,12 @@ Types:
       GoKind: 22
       Pointee: 1355 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 830
+      ID: 828
       Name: '*encoding/json.jsonError'
       ByteSize: 8
-      GoRuntimeType: 906848
+      GoRuntimeType: 906176
       GoKind: 22
-      Pointee: 831 StructureType encoding/json.jsonError
+      Pointee: 829 StructureType encoding/json.jsonError
     - __kind: PointerType
       ID: 1220
       Name: '*encoding/pem.lineBreaker'
@@ -13224,14 +13224,14 @@ Types:
       ID: 798
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 897440
+      GoRuntimeType: 898304
       GoKind: 22
       Pointee: 799 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 997
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1024896
+      GoRuntimeType: 1025920
       GoKind: 22
       Pointee: 998 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -13266,21 +13266,21 @@ Types:
       ID: 2528
       Name: '*fmt.stringReader'
       ByteSize: 8
-      GoRuntimeType: 897536
+      GoRuntimeType: 898400
       GoKind: 22
       Pointee: 2529 UnresolvedPointeeType fmt.stringReader
     - __kind: PointerType
       ID: 999
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1025024
+      GoRuntimeType: 1026048
       GoKind: 22
       Pointee: 1000 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 1001
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1025152
+      GoRuntimeType: 1026176
       GoKind: 22
       Pointee: 1002 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -13308,7 +13308,7 @@ Types:
       ID: 2370
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AgentPayload'
       ByteSize: 8
-      GoRuntimeType: 2201696
+      GoRuntimeType: 2200864
       GoKind: 22
       Pointee: 2371 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AgentPayload
     - __kind: PointerType
@@ -13322,7 +13322,7 @@ Types:
       ID: 2051
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType'
       ByteSize: 8
-      GoRuntimeType: 1849568
+      GoRuntimeType: 1849344
       GoKind: 22
       Pointee: 1998 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
     - __kind: PointerType
@@ -13343,7 +13343,7 @@ Types:
       ID: 2052
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType'
       ByteSize: 8
-      GoRuntimeType: 1849792
+      GoRuntimeType: 1849568
       GoKind: 22
       Pointee: 1999 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
     - __kind: PointerType
@@ -13392,7 +13392,7 @@ Types:
       ID: 2368
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.StatsPayload'
       ByteSize: 8
-      GoRuntimeType: 2200864
+      GoRuntimeType: 2200032
       GoKind: 22
       Pointee: 2369 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.StatsPayload
     - __kind: PointerType
@@ -13413,7 +13413,7 @@ Types:
       ID: 2434
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.TracerPayload'
       ByteSize: 8
-      GoRuntimeType: 2255808
+      GoRuntimeType: 2254848
       GoKind: 22
       Pointee: 2435 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.TracerPayload
     - __kind: PointerType
@@ -13431,45 +13431,45 @@ Types:
       GoKind: 22
       Pointee: 1707 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/version.Version
     - __kind: PointerType
-      ID: 839
+      ID: 837
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
-      GoRuntimeType: 909248
+      GoRuntimeType: 908576
       GoKind: 22
-      Pointee: 840 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 838 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 841
+      ID: 839
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
-      GoRuntimeType: 909344
+      GoRuntimeType: 908672
       GoKind: 22
-      Pointee: 842 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 840 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
       ID: 1158
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
-      GoRuntimeType: 909056
+      GoRuntimeType: 908384
       GoKind: 22
       Pointee: 1159 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 845
+      ID: 843
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
-      GoRuntimeType: 909632
+      GoRuntimeType: 908960
       GoKind: 22
-      Pointee: 846 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 844 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
       ID: 1160
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
-      GoRuntimeType: 909152
+      GoRuntimeType: 908480
       GoKind: 22
       Pointee: 1161 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 843
+      ID: 841
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
-      GoRuntimeType: 909440
+      GoRuntimeType: 908768
       GoKind: 22
       Pointee: 751 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
@@ -13478,10 +13478,10 @@ Types:
       ByteSize: 8
       Pointee: 752 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 838
+      ID: 836
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
-      GoRuntimeType: 908960
+      GoRuntimeType: 908288
       GoKind: 22
       Pointee: 748 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
@@ -13490,10 +13490,10 @@ Types:
       ByteSize: 8
       Pointee: 749 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 844
+      ID: 842
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
-      GoRuntimeType: 909536
+      GoRuntimeType: 908864
       GoKind: 22
       Pointee: 754 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
@@ -13505,7 +13505,7 @@ Types:
       ID: 1234
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1212160
+      GoRuntimeType: 1211648
       GoKind: 22
       Pointee: 1235 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
@@ -13526,14 +13526,14 @@ Types:
       ID: 1764
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule'
       ByteSize: 8
-      GoRuntimeType: 1556480
+      GoRuntimeType: 1556000
       GoKind: 22
       Pointee: 1765 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule
     - __kind: PointerType
       ID: 1462
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType'
       ByteSize: 8
-      GoRuntimeType: 898016
+      GoRuntimeType: 897536
       GoKind: 22
       Pointee: 1400 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType
     - __kind: PointerType
@@ -13554,14 +13554,14 @@ Types:
       ID: 392
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
-      GoRuntimeType: 1194880
+      GoRuntimeType: 1193216
       GoKind: 22
       Pointee: 393 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
       ID: 1465
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate'
       ByteSize: 8
-      GoRuntimeType: 898304
+      GoRuntimeType: 897824
       GoKind: 22
       Pointee: 1466 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate
     - __kind: PointerType
@@ -13575,7 +13575,7 @@ Types:
       ID: 1463
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule'
       ByteSize: 8
-      GoRuntimeType: 898208
+      GoRuntimeType: 897728
       GoKind: 22
       Pointee: 1464 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule
     - __kind: PointerType
@@ -13589,35 +13589,35 @@ Types:
       ID: 1648
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance'
       ByteSize: 8
-      GoRuntimeType: 1196288
+      GoRuntimeType: 1194624
       GoKind: 22
       Pointee: 1556 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance
     - __kind: PointerType
       ID: 2325
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter'
       ByteSize: 8
-      GoRuntimeType: 898112
+      GoRuntimeType: 897632
       GoKind: 22
       Pointee: 2326 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter
     - __kind: PointerType
       ID: 395
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
-      GoRuntimeType: 1195008
+      GoRuntimeType: 1193344
       GoKind: 22
       Pointee: 396 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
       ID: 2685
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
-      GoRuntimeType: 1195648
+      GoRuntimeType: 1193984
       GoKind: 22
       Pointee: 2686 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
       ID: 722
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      GoRuntimeType: 1195776
+      GoRuntimeType: 1194112
       GoKind: 22
       Pointee: 723 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
@@ -13645,7 +13645,7 @@ Types:
       ID: 1726
       Name: '*github.com/DataDog/dd-trace-go/v2/internal.TraceSource'
       ByteSize: 8
-      GoRuntimeType: 1424000
+      GoRuntimeType: 1423840
       GoKind: 22
       Pointee: 1557 BaseType github.com/DataDog/dd-trace-go/v2/internal.TraceSource
     - __kind: PointerType
@@ -13729,7 +13729,7 @@ Types:
       ID: 410
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
-      GoRuntimeType: 1424320
+      GoRuntimeType: 1424160
       GoKind: 22
       Pointee: 411 GoContextImplementationType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
@@ -13743,21 +13743,21 @@ Types:
       ID: 1588
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource'
       ByteSize: 8
-      GoRuntimeType: 1041152
+      GoRuntimeType: 1041024
       GoKind: 22
       Pointee: 1589 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource
     - __kind: PointerType
       ID: 1590
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource'
       ByteSize: 8
-      GoRuntimeType: 1041280
+      GoRuntimeType: 1041152
       GoKind: 22
       Pointee: 1591 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource
     - __kind: PointerType
       ID: 1582
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey'
       ByteSize: 8
-      GoRuntimeType: 1038720
+      GoRuntimeType: 1038592
       GoKind: 22
       Pointee: 1583 StructureType github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey
     - __kind: PointerType
@@ -13972,47 +13972,47 @@ Types:
       GoKind: 22
       Pointee: 2437 StructureType github.com/Masterminds/semver/v3.Version
     - __kind: PointerType
-      ID: 1491
+      ID: 1489
       Name: '*github.com/cihub/seelog.CfgParseParams'
       ByteSize: 8
-      GoRuntimeType: 911456
+      GoRuntimeType: 910784
       GoKind: 22
-      Pointee: 1492 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
+      Pointee: 1490 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
     - __kind: PointerType
-      ID: 1490
+      ID: 1488
       Name: '*github.com/cihub/seelog.LogLevel'
       ByteSize: 8
-      GoRuntimeType: 910592
+      GoRuntimeType: 909920
       GoKind: 22
-      Pointee: 1412 BaseType github.com/cihub/seelog.LogLevel
+      Pointee: 1410 BaseType github.com/cihub/seelog.LogLevel
     - __kind: PointerType
       ID: 2008
       Name: '*github.com/cihub/seelog.LogLevelException'
       ByteSize: 8
-      GoRuntimeType: 1807360
+      GoRuntimeType: 1806912
       GoKind: 22
       Pointee: 2009 UnresolvedPointeeType github.com/cihub/seelog.LogLevelException
     - __kind: PointerType
-      ID: 847
+      ID: 845
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
-      GoRuntimeType: 910784
+      GoRuntimeType: 910112
       GoKind: 22
-      Pointee: 848 StructureType github.com/cihub/seelog.baseError
+      Pointee: 846 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 1272
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1807808
+      GoRuntimeType: 1807360
       GoKind: 22
       Pointee: 1273 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 849
+      ID: 847
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
-      GoRuntimeType: 910880
+      GoRuntimeType: 910208
       GoKind: 22
-      Pointee: 850 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 848 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 1252
       Name: '*github.com/cihub/seelog.connWriter'
@@ -14024,42 +14024,42 @@ Types:
       ID: 1208
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1041792
+      GoRuntimeType: 1041664
       GoKind: 22
       Pointee: 1209 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1731
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1428480
+      GoRuntimeType: 1428320
       GoKind: 22
       Pointee: 1732 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
       ID: 1840
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
-      GoRuntimeType: 1641568
+      GoRuntimeType: 1640800
       GoKind: 22
       Pointee: 1841 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
       ID: 1242
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1428000
+      GoRuntimeType: 1427840
       GoKind: 22
       Pointee: 1243 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
       ID: 1844
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1642336
+      GoRuntimeType: 1641568
       GoKind: 22
       Pointee: 1845 UnresolvedPointeeType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
       ID: 1727
       Name: '*github.com/cihub/seelog.formattedWriter'
       ByteSize: 8
-      GoRuntimeType: 1428160
+      GoRuntimeType: 1428000
       GoKind: 22
       Pointee: 1728 UnresolvedPointeeType github.com/cihub/seelog.formattedWriter
     - __kind: PointerType
@@ -14073,42 +14073,42 @@ Types:
       ID: 1654
       Name: '*github.com/cihub/seelog.listConstraints'
       ByteSize: 8
-      GoRuntimeType: 1214464
+      GoRuntimeType: 1213952
       GoKind: 22
       Pointee: 1655 UnresolvedPointeeType github.com/cihub/seelog.listConstraints
     - __kind: PointerType
-      ID: 1488
+      ID: 1486
       Name: '*github.com/cihub/seelog.logFormattedMessage'
       ByteSize: 8
-      GoRuntimeType: 910496
+      GoRuntimeType: 909824
       GoKind: 22
-      Pointee: 1489 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
+      Pointee: 1487 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
     - __kind: PointerType
-      ID: 1486
+      ID: 1484
       Name: '*github.com/cihub/seelog.logMessage'
       ByteSize: 8
-      GoRuntimeType: 910400
+      GoRuntimeType: 909728
       GoKind: 22
-      Pointee: 1487 UnresolvedPointeeType github.com/cihub/seelog.logMessage
+      Pointee: 1485 UnresolvedPointeeType github.com/cihub/seelog.logMessage
     - __kind: PointerType
       ID: 1594
       Name: '*github.com/cihub/seelog.minMaxConstraints'
       ByteSize: 8
-      GoRuntimeType: 1042304
+      GoRuntimeType: 1042176
       GoKind: 22
       Pointee: 1595 UnresolvedPointeeType github.com/cihub/seelog.minMaxConstraints
     - __kind: PointerType
-      ID: 853
+      ID: 851
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
-      GoRuntimeType: 911072
+      GoRuntimeType: 910400
       GoKind: 22
-      Pointee: 854 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 852 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 1592
       Name: '*github.com/cihub/seelog.offConstraints'
       ByteSize: 8
-      GoRuntimeType: 1042176
+      GoRuntimeType: 1042048
       GoKind: 22
       Pointee: 1593 UnresolvedPointeeType github.com/cihub/seelog.offConstraints
     - __kind: PointerType
@@ -14136,35 +14136,35 @@ Types:
       ID: 1210
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1041920
+      GoRuntimeType: 1041792
       GoKind: 22
       Pointee: 1211 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
       ID: 1842
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1641760
+      GoRuntimeType: 1640992
       GoKind: 22
       Pointee: 1843 UnresolvedPointeeType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 851
+      ID: 849
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
-      GoRuntimeType: 910976
+      GoRuntimeType: 910304
       GoKind: 22
-      Pointee: 852 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 850 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 855
+      ID: 853
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
-      GoRuntimeType: 911168
+      GoRuntimeType: 910496
       GoKind: 22
-      Pointee: 856 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 854 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 1729
       Name: '*github.com/cihub/seelog.xmlNode'
       ByteSize: 8
-      GoRuntimeType: 1428320
+      GoRuntimeType: 1428160
       GoKind: 22
       Pointee: 1730 UnresolvedPointeeType github.com/cihub/seelog.xmlNode
     - __kind: PointerType
@@ -15016,42 +15016,42 @@ Types:
       ID: 1079
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1203072
+      GoRuntimeType: 1202560
       GoKind: 22
       Pointee: 1080 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 1073
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1202688
+      GoRuntimeType: 1202176
       GoKind: 22
       Pointee: 1074 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 1016
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1033344
+      GoRuntimeType: 1033216
       GoKind: 22
       Pointee: 1017 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 1085
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1203456
+      GoRuntimeType: 1202944
       GoKind: 22
       Pointee: 1086 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 1015
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1033216
+      GoRuntimeType: 1033088
       GoKind: 22
       Pointee: 994 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 1077
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1202944
+      GoRuntimeType: 1202432
       GoKind: 22
       Pointee: 1078 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
@@ -15062,31 +15062,31 @@ Types:
       GoKind: 22
       Pointee: 2661 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Reader
     - __kind: PointerType
-      ID: 1472
+      ID: 1470
       Name: '*github.com/tinylib/msgp/msgp.Type'
       ByteSize: 8
-      GoRuntimeType: 902528
+      GoRuntimeType: 901856
       GoKind: 22
       Pointee: 1166 BaseType github.com/tinylib/msgp/msgp.Type
     - __kind: PointerType
       ID: 1075
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1202816
+      GoRuntimeType: 1202304
       GoKind: 22
       Pointee: 1076 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 1083
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1203328
+      GoRuntimeType: 1202816
       GoKind: 22
       Pointee: 1084 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 1081
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1203200
+      GoRuntimeType: 1202688
       GoKind: 22
       Pointee: 1082 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
@@ -15100,28 +15100,28 @@ Types:
       ID: 1089
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1203840
+      GoRuntimeType: 1203328
       GoKind: 22
       Pointee: 1090 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 1020
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1033600
+      GoRuntimeType: 1033472
       GoKind: 22
       Pointee: 1021 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 1018
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1033472
+      GoRuntimeType: 1033344
       GoKind: 22
       Pointee: 1019 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 1087
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1203712
+      GoRuntimeType: 1203200
       GoKind: 22
       Pointee: 1088 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -17158,77 +17158,77 @@ Types:
       ID: 2532
       Name: '*io.LimitedReader'
       ByteSize: 8
-      GoRuntimeType: 897728
+      GoRuntimeType: 898592
       GoKind: 22
       Pointee: 2533 UnresolvedPointeeType io.LimitedReader
     - __kind: PointerType
       ID: 2637
       Name: '*io.PipeReader'
       ByteSize: 8
-      GoRuntimeType: 1840384
+      GoRuntimeType: 1842624
       GoKind: 22
       Pointee: 2638 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
       ID: 1230
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1194368
+      GoRuntimeType: 1197568
       GoKind: 22
       Pointee: 1231 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 2616
       Name: '*io.SectionReader'
       ByteSize: 8
-      GoRuntimeType: 1555520
+      GoRuntimeType: 1557120
       GoKind: 22
       Pointee: 2617 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
       ID: 1228
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1193984
+      GoRuntimeType: 1197184
       GoKind: 22
       Pointee: 1229 StructureType io.discard
     - __kind: PointerType
       ID: 2534
       Name: '*io.eofReader'
       ByteSize: 8
-      GoRuntimeType: 897824
+      GoRuntimeType: 898688
       GoKind: 22
       Pointee: 2535 StructureType io.eofReader
     - __kind: PointerType
       ID: 2590
       Name: '*io.multiReader'
       ByteSize: 8
-      GoRuntimeType: 1193728
+      GoRuntimeType: 1196928
       GoKind: 22
       Pointee: 2591 UnresolvedPointeeType io.multiReader
     - __kind: PointerType
       ID: 1202
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1025920
+      GoRuntimeType: 1026944
       GoKind: 22
       Pointee: 1203 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 2558
       Name: '*io.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1026176
+      GoRuntimeType: 1027200
       GoKind: 22
       Pointee: 2559 StructureType io.nopCloser
     - __kind: PointerType
       ID: 2592
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
-      GoRuntimeType: 1193856
+      GoRuntimeType: 1197056
       GoKind: 22
       Pointee: 2593 StructureType io.nopCloserWriterTo
     - __kind: PointerType
       ID: 2530
       Name: '*io.teeReader'
       ByteSize: 8
-      GoRuntimeType: 897632
+      GoRuntimeType: 898496
       GoKind: 22
       Pointee: 2531 UnresolvedPointeeType io.teeReader
     - __kind: PointerType
@@ -17256,28 +17256,28 @@ Types:
       ID: 1656
       Name: '*log/slog.Attr'
       ByteSize: 8
-      GoRuntimeType: 1215104
+      GoRuntimeType: 1214592
       GoKind: 22
       Pointee: 1657 StructureType log/slog.Attr
     - __kind: PointerType
-      ID: 1493
+      ID: 1491
       Name: '*log/slog.Kind'
       ByteSize: 8
-      GoRuntimeType: 911552
+      GoRuntimeType: 910880
       GoKind: 22
-      Pointee: 1413 BaseType log/slog.Kind
+      Pointee: 1411 BaseType log/slog.Kind
     - __kind: PointerType
       ID: 2010
       Name: '*log/slog.Level'
       ByteSize: 8
-      GoRuntimeType: 1808256
+      GoRuntimeType: 1807808
       GoKind: 22
       Pointee: 1760 BaseType log/slog.Level
     - __kind: PointerType
       ID: 2372
       Name: '*log/slog.Value'
       ByteSize: 8
-      GoRuntimeType: 2202112
+      GoRuntimeType: 2201280
       GoKind: 22
       Pointee: 2000 StructureType log/slog.Value
     - __kind: PointerType
@@ -17801,7 +17801,7 @@ Types:
       ID: 2624
       Name: '*math/rand/v2.ChaCha8'
       ByteSize: 8
-      GoRuntimeType: 1638688
+      GoRuntimeType: 1637920
       GoKind: 22
       Pointee: 2625 UnresolvedPointeeType math/rand/v2.ChaCha8
     - __kind: PointerType
@@ -17850,21 +17850,21 @@ Types:
       ID: 1096
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1209984
+      GoRuntimeType: 1209472
       GoKind: 22
       Pointee: 1097 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 1127
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1426240
+      GoRuntimeType: 1426080
       GoKind: 22
       Pointee: 1128 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1484
+      ID: 1482
       Name: '*net.HardwareAddr.array'
       ByteSize: 8
-      Pointee: 1483 GoSliceDataType net.HardwareAddr.array
+      Pointee: 1481 GoSliceDataType net.HardwareAddr.array
     - __kind: PointerType
       ID: 2335
       Name: '*net.IP'
@@ -17895,7 +17895,7 @@ Types:
       ID: 1584
       Name: '*net.IPMask'
       ByteSize: 8
-      GoRuntimeType: 1039744
+      GoRuntimeType: 1039616
       GoKind: 22
       Pointee: 1585 GoSliceHeaderType net.IPMask
     - __kind: PointerType
@@ -17907,28 +17907,28 @@ Types:
       ID: 1650
       Name: '*net.IPNet'
       ByteSize: 8
-      GoRuntimeType: 1209728
+      GoRuntimeType: 1209216
       GoKind: 22
       Pointee: 1651 UnresolvedPointeeType net.IPNet
     - __kind: PointerType
       ID: 1125
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1425920
+      GoRuntimeType: 1425760
       GoKind: 22
       Pointee: 1126 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 1098
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1210112
+      GoRuntimeType: 1209600
       GoKind: 22
       Pointee: 1099 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 2006
       Name: '*net.TCPAddr'
       ByteSize: 8
-      GoRuntimeType: 1806464
+      GoRuntimeType: 1806016
       GoKind: 22
       Pointee: 2007 UnresolvedPointeeType net.TCPAddr
     - __kind: PointerType
@@ -17942,7 +17942,7 @@ Types:
       ID: 2004
       Name: '*net.UDPAddr'
       ByteSize: 8
-      GoRuntimeType: 1806240
+      GoRuntimeType: 1805792
       GoKind: 22
       Pointee: 2005 UnresolvedPointeeType net.UDPAddr
     - __kind: PointerType
@@ -17970,7 +17970,7 @@ Types:
       ID: 1095
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1209216
+      GoRuntimeType: 1208704
       GoKind: 22
       Pointee: 1064 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -17982,37 +17982,37 @@ Types:
       ID: 2149
       Name: '*net.addrPortUDPAddr'
       ByteSize: 8
-      GoRuntimeType: 2014976
+      GoRuntimeType: 2014688
       GoKind: 22
       Pointee: 2150 StructureType net.addrPortUDPAddr
     - __kind: PointerType
       ID: 1032
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1040000
+      GoRuntimeType: 1039872
       GoKind: 22
       Pointee: 1033 StructureType net.canceledError
     - __kind: PointerType
       ID: 1312
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2014688
+      GoRuntimeType: 2014400
       GoKind: 22
       Pointee: 1313 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1167
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1851360
+      GoRuntimeType: 1851136
       GoKind: 22
       Pointee: 1168 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1485
+      ID: 1483
       Name: '*net.hostLookupOrder'
       ByteSize: 8
-      GoRuntimeType: 908192
+      GoRuntimeType: 907520
       GoKind: 22
-      Pointee: 1411 BaseType net.hostLookupOrder
+      Pointee: 1409 BaseType net.hostLookupOrder
     - __kind: PointerType
       ID: 1358
       Name: '*net.netFD'
@@ -18021,157 +18021,157 @@ Types:
       GoKind: 22
       Pointee: 1359 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 832
+      ID: 830
       Name: '*net.notFoundError'
       ByteSize: 8
-      GoRuntimeType: 907808
+      GoRuntimeType: 907136
       GoKind: 22
-      Pointee: 833 UnresolvedPointeeType net.notFoundError
+      Pointee: 831 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 412
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
-      GoRuntimeType: 1426080
+      GoRuntimeType: 1425920
       GoKind: 22
       Pointee: 413 GoContextImplementationType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 834
+      ID: 832
       Name: '*net.result·2'
       ByteSize: 8
-      GoRuntimeType: 908480
+      GoRuntimeType: 907808
       GoKind: 22
-      Pointee: 835 StructureType net.result·2
+      Pointee: 833 StructureType net.result·2
     - __kind: PointerType
       ID: 1340
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2256768
+      GoRuntimeType: 2255808
       GoKind: 22
       Pointee: 1341 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1338
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2256288
+      GoRuntimeType: 2255328
       GoKind: 22
       Pointee: 1339 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 1100
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1210752
+      GoRuntimeType: 1210240
       GoKind: 22
       Pointee: 1101 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 1129
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1426400
+      GoRuntimeType: 1426240
       GoKind: 22
       Pointee: 1130 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 1578
       Name: '*net/http.Cookie'
       ByteSize: 8
-      GoRuntimeType: 1034368
+      GoRuntimeType: 1034240
       GoKind: 22
       Pointee: 1579 UnresolvedPointeeType net/http.Cookie
     - __kind: PointerType
       ID: 1022
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1036032
+      GoRuntimeType: 1035904
       GoKind: 22
       Pointee: 1023 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 2003
       Name: '*net/http.Protocols'
       ByteSize: 8
-      GoRuntimeType: 1805568
+      GoRuntimeType: 1805120
       GoKind: 22
       Pointee: 1918 StructureType net/http.Protocols
     - __kind: PointerType
       ID: 2604
       Name: '*net/http.body'
       ByteSize: 8
-      GoRuntimeType: 1806016
+      GoRuntimeType: 1805568
       GoKind: 22
       Pointee: 2605 UnresolvedPointeeType net/http.body
     - __kind: PointerType
       ID: 2594
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
-      GoRuntimeType: 1204864
+      GoRuntimeType: 1204352
       GoKind: 22
       Pointee: 2595 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
       ID: 2536
       Name: '*net/http.bodyLocked'
       ByteSize: 8
-      GoRuntimeType: 903392
+      GoRuntimeType: 902720
       GoKind: 22
       Pointee: 2537 StructureType net/http.bodyLocked
     - __kind: PointerType
       ID: 1184
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
-      GoRuntimeType: 903584
+      GoRuntimeType: 902912
       GoKind: 22
       Pointee: 1185 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
       ID: 2538
       Name: '*net/http.byteReader'
       ByteSize: 8
-      GoRuntimeType: 903680
+      GoRuntimeType: 903008
       GoKind: 22
       Pointee: 2539 UnresolvedPointeeType net/http.byteReader
     - __kind: PointerType
       ID: 2570
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
-      GoRuntimeType: 1035904
+      GoRuntimeType: 1035776
       GoKind: 22
       Pointee: 2571 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 1475
+      ID: 1473
       Name: '*net/http.connectMethodKey'
       ByteSize: 8
-      GoRuntimeType: 904160
+      GoRuntimeType: 903488
       GoKind: 22
-      Pointee: 1476 StructureType net/http.connectMethodKey
+      Pointee: 1474 StructureType net/http.connectMethodKey
     - __kind: PointerType
-      ID: 1477
+      ID: 1475
       Name: '*net/http.contextKey'
       ByteSize: 8
-      GoRuntimeType: 905504
+      GoRuntimeType: 904832
       GoKind: 22
-      Pointee: 1478 UnresolvedPointeeType net/http.contextKey
+      Pointee: 1476 UnresolvedPointeeType net/http.contextKey
     - __kind: PointerType
       ID: 2540
       Name: '*net/http.errorReader'
       ByteSize: 8
-      GoRuntimeType: 903776
+      GoRuntimeType: 903104
       GoKind: 22
       Pointee: 2541 StructureType net/http.errorReader
     - __kind: PointerType
       ID: 2542
       Name: '*net/http.finishAsyncByteRead'
       ByteSize: 8
-      GoRuntimeType: 903872
+      GoRuntimeType: 903200
       GoKind: 22
       Pointee: 2543 StructureType net/http.finishAsyncByteRead
     - __kind: PointerType
       ID: 2572
       Name: '*net/http.gzipReader'
       ByteSize: 8
-      GoRuntimeType: 1036544
+      GoRuntimeType: 1036416
       GoKind: 22
       Pointee: 2573 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 809
+      ID: 807
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 904256
+      GoRuntimeType: 903584
       GoKind: 22
       Pointee: 729 BaseType net/http.http2ConnectionError
     - __kind: PointerType
@@ -18192,7 +18192,7 @@ Types:
       ID: 1575
       Name: '*net/http.http2ErrCode'
       ByteSize: 8
-      GoRuntimeType: 1034112
+      GoRuntimeType: 1033984
       GoKind: 22
       Pointee: 1140 BaseType net/http.http2ErrCode
     - __kind: PointerType
@@ -18203,52 +18203,52 @@ Types:
       GoKind: 22
       Pointee: 1769 StructureType net/http.http2FrameHeader
     - __kind: PointerType
-      ID: 1473
+      ID: 1471
       Name: '*net/http.http2FrameType'
       ByteSize: 8
-      GoRuntimeType: 902720
+      GoRuntimeType: 902048
       GoKind: 22
-      Pointee: 1406 BaseType net/http.http2FrameType
+      Pointee: 1404 BaseType net/http.http2FrameType
     - __kind: PointerType
-      ID: 810
+      ID: 808
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
-      GoRuntimeType: 904352
+      GoRuntimeType: 903680
       GoKind: 22
-      Pointee: 811 StructureType net/http.http2GoAwayError
+      Pointee: 809 StructureType net/http.http2GoAwayError
     - __kind: PointerType
       ID: 1832
       Name: '*net/http.http2GoAwayFrame'
       ByteSize: 8
-      GoRuntimeType: 1630816
+      GoRuntimeType: 1630048
       GoKind: 22
       Pointee: 1833 StructureType net/http.http2GoAwayFrame
     - __kind: PointerType
       ID: 2050
       Name: '*net/http.http2HeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 1847776
+      GoRuntimeType: 1847552
       GoKind: 22
       Pointee: 2049 StructureType net/http.http2HeadersFrame
     - __kind: PointerType
       ID: 2147
       Name: '*net/http.http2MetaHeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 2013824
+      GoRuntimeType: 2013536
       GoKind: 22
       Pointee: 2148 StructureType net/http.http2MetaHeadersFrame
     - __kind: PointerType
       ID: 1834
       Name: '*net/http.http2PingFrame'
       ByteSize: 8
-      GoRuntimeType: 1631008
+      GoRuntimeType: 1630240
       GoKind: 22
       Pointee: 1835 StructureType net/http.http2PingFrame
     - __kind: PointerType
       ID: 1836
       Name: '*net/http.http2PriorityFrame'
       ByteSize: 8
-      GoRuntimeType: 1631200
+      GoRuntimeType: 1630432
       GoKind: 22
       Pointee: 1837 StructureType net/http.http2PriorityFrame
     - __kind: PointerType
@@ -18269,16 +18269,16 @@ Types:
       ID: 1576
       Name: '*net/http.http2Setting'
       ByteSize: 8
-      GoRuntimeType: 1034240
+      GoRuntimeType: 1034112
       GoKind: 22
       Pointee: 1577 StructureType net/http.http2Setting
     - __kind: PointerType
-      ID: 1474
+      ID: 1472
       Name: '*net/http.http2SettingID'
       ByteSize: 8
-      GoRuntimeType: 903008
+      GoRuntimeType: 902336
       GoKind: 22
-      Pointee: 1407 BaseType net/http.http2SettingID
+      Pointee: 1405 BaseType net/http.http2SettingID
     - __kind: PointerType
       ID: 2107
       Name: '*net/http.http2SettingsFrame'
@@ -18290,14 +18290,14 @@ Types:
       ID: 1121
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1422400
+      GoRuntimeType: 1422240
       GoKind: 22
       Pointee: 1122 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 1838
       Name: '*net/http.http2UnknownFrame'
       ByteSize: 8
-      GoRuntimeType: 1632544
+      GoRuntimeType: 1631776
       GoKind: 22
       Pointee: 1839 StructureType net/http.http2UnknownFrame
     - __kind: PointerType
@@ -18311,16 +18311,16 @@ Types:
       ID: 2618
       Name: '*net/http.http2clientStream'
       ByteSize: 8
-      GoRuntimeType: 2014112
+      GoRuntimeType: 2013824
       GoKind: 22
       Pointee: 2619 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 814
+      ID: 812
       Name: '*net/http.http2connError'
       ByteSize: 8
-      GoRuntimeType: 904928
+      GoRuntimeType: 904256
       GoKind: 22
-      Pointee: 815 StructureType net/http.http2connError
+      Pointee: 813 StructureType net/http.http2connError
     - __kind: PointerType
       ID: 1248
       Name: '*net/http.http2dataBuffer'
@@ -18329,10 +18329,10 @@ Types:
       GoKind: 22
       Pointee: 1249 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 813
+      ID: 811
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 904832
+      GoRuntimeType: 904160
       GoKind: 22
       Pointee: 733 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
@@ -18344,14 +18344,14 @@ Types:
       ID: 2568
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
-      GoRuntimeType: 1035648
+      GoRuntimeType: 1035520
       GoKind: 22
       Pointee: 2569 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 817
+      ID: 815
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 905120
+      GoRuntimeType: 904448
       GoKind: 22
       Pointee: 739 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
@@ -18360,10 +18360,10 @@ Types:
       ByteSize: 8
       Pointee: 740 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 816
+      ID: 814
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 905024
+      GoRuntimeType: 904352
       GoKind: 22
       Pointee: 736 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
@@ -18375,28 +18375,28 @@ Types:
       ID: 1093
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1205888
+      GoRuntimeType: 1205376
       GoKind: 22
       Pointee: 1094 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 2564
       Name: '*net/http.http2missingBody'
       ByteSize: 8
-      GoRuntimeType: 1035392
+      GoRuntimeType: 1035264
       GoKind: 22
       Pointee: 2565 StructureType net/http.http2missingBody
     - __kind: PointerType
       ID: 2574
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
-      GoRuntimeType: 1036800
+      GoRuntimeType: 1036672
       GoKind: 22
       Pointee: 2575 StructureType net/http.http2noBodyReader
     - __kind: PointerType
       ID: 1028
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1036672
+      GoRuntimeType: 1036544
       GoKind: 22
       Pointee: 1029 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
@@ -18407,10 +18407,10 @@ Types:
       GoKind: 22
       Pointee: 1303 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 812
+      ID: 810
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 904736
+      GoRuntimeType: 904064
       GoKind: 22
       Pointee: 730 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
@@ -18422,98 +18422,98 @@ Types:
       ID: 1186
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
-      GoRuntimeType: 905216
+      GoRuntimeType: 904544
       GoKind: 22
       Pointee: 1187 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
       ID: 2566
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
-      GoRuntimeType: 1035520
+      GoRuntimeType: 1035392
       GoKind: 22
       Pointee: 2567 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
       ID: 2562
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
-      GoRuntimeType: 1035008
+      GoRuntimeType: 1034880
       GoKind: 22
       Pointee: 2563 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
       ID: 2596
       Name: '*net/http.noBody'
       ByteSize: 8
-      GoRuntimeType: 1205120
+      GoRuntimeType: 1204608
       GoKind: 22
       Pointee: 2597 StructureType net/http.noBody
     - __kind: PointerType
       ID: 1024
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1036288
+      GoRuntimeType: 1036160
       GoKind: 22
       Pointee: 1025 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1830
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1630432
+      GoRuntimeType: 1629664
       GoKind: 22
       Pointee: 1831 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 1250
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2181344
+      GoRuntimeType: 2180928
       GoKind: 22
       Pointee: 1251 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1206
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1036160
+      GoRuntimeType: 1036032
       GoKind: 22
       Pointee: 1207 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 2560
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
-      GoRuntimeType: 1034624
+      GoRuntimeType: 1034496
       GoKind: 22
       Pointee: 2561 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
       ID: 1232
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1204992
+      GoRuntimeType: 1204480
       GoKind: 22
       Pointee: 1233 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 818
+      ID: 816
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
-      GoRuntimeType: 905312
+      GoRuntimeType: 904640
       GoKind: 22
-      Pointee: 819 StructureType net/http.requestBodyReadError
+      Pointee: 817 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 1580
       Name: '*net/http.socksAddr'
       ByteSize: 8
-      GoRuntimeType: 1034752
+      GoRuntimeType: 1034624
       GoKind: 22
       Pointee: 1581 UnresolvedPointeeType net/http.socksAddr
     - __kind: PointerType
       ID: 1123
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1423520
+      GoRuntimeType: 1423360
       GoKind: 22
       Pointee: 1124 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 1091
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1205760
+      GoRuntimeType: 1205248
       GoKind: 22
       Pointee: 1092 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
@@ -18527,23 +18527,23 @@ Types:
       ID: 1026
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1036416
+      GoRuntimeType: 1036288
       GoKind: 22
       Pointee: 1027 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1284
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1848224
+      GoRuntimeType: 1848000
       GoKind: 22
       Pointee: 1285 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 807
+      ID: 805
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
-      GoRuntimeType: 903488
+      GoRuntimeType: 902816
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 806 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 2584
       Name: '*net/http/httputil.failureToReadBody'
@@ -18665,14 +18665,14 @@ Types:
       ID: 1131
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1426720
+      GoRuntimeType: 1426560
       GoKind: 22
       Pointee: 1132 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 836
+      ID: 834
       Name: '*net/url.EscapeError'
       ByteSize: 8
-      GoRuntimeType: 908576
+      GoRuntimeType: 907904
       GoKind: 22
       Pointee: 742 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
@@ -18681,10 +18681,10 @@ Types:
       ByteSize: 8
       Pointee: 743 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 837
+      ID: 835
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
-      GoRuntimeType: 908672
+      GoRuntimeType: 908000
       GoKind: 22
       Pointee: 745 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
@@ -18703,7 +18703,7 @@ Types:
       ID: 1652
       Name: '*net/url.Userinfo'
       ByteSize: 8
-      GoRuntimeType: 1211520
+      GoRuntimeType: 1211008
       GoKind: 22
       Pointee: 1653 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
@@ -18975,19 +18975,19 @@ Types:
       GoKind: 22
       Pointee: 777 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 1470
+      ID: 1492
       Name: '*reflect.ChanDir'
       ByteSize: 8
-      GoRuntimeType: 901664
+      GoRuntimeType: 911168
       GoKind: 22
-      Pointee: 1403 BaseType reflect.ChanDir
+      Pointee: 1412 BaseType reflect.ChanDir
     - __kind: PointerType
-      ID: 1471
+      ID: 1493
       Name: '*reflect.Kind'
       ByteSize: 8
-      GoRuntimeType: 901856
+      GoRuntimeType: 911360
       GoKind: 22
-      Pointee: 1404 BaseType reflect.Kind
+      Pointee: 1413 BaseType reflect.Kind
     - __kind: PointerType
       ID: 2501
       Name: '*reflect.Value'
@@ -18996,12 +18996,12 @@ Types:
       GoKind: 22
       Pointee: 2502 StructureType reflect.Value
     - __kind: PointerType
-      ID: 805
+      ID: 856
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 902240
+      GoRuntimeType: 911744
       GoKind: 22
-      Pointee: 806 UnresolvedPointeeType reflect.ValueError
+      Pointee: 857 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 2485
       Name: '*reflect.rtype'
@@ -19207,12 +19207,12 @@ Types:
       GoKind: 22
       Pointee: 36 BaseType runtime.waitReason
     - __kind: PointerType
-      ID: 1480
+      ID: 1478
       Name: '*runtime/debug.BuildInfo'
       ByteSize: 8
-      GoRuntimeType: 907520
+      GoRuntimeType: 906848
       GoKind: 22
-      Pointee: 1481 UnresolvedPointeeType runtime/debug.BuildInfo
+      Pointee: 1479 UnresolvedPointeeType runtime/debug.BuildInfo
     - __kind: PointerType
       ID: 1494
       Name: '*runtime/pprof.labelMap'
@@ -31295,7 +31295,7 @@ Types:
     - __kind: ArrayType
       ID: 1915
       Name: '[0]func()'
-      GoRuntimeType: 732928
+      GoRuntimeType: 730912
       GoKind: 17
       HasCount: true
       Element: 62 GoSubroutineType func()
@@ -31624,7 +31624,7 @@ Types:
       ID: 1996
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 695328
+      GoRuntimeType: 694464
       GoKind: 17
       Count: 8
       HasCount: true
@@ -31633,7 +31633,7 @@ Types:
       ID: 1395
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
-      GoRuntimeType: 481760
+      GoRuntimeType: 481568
       GoKind: 23
       RawFields:
         - Name: array
@@ -32170,7 +32170,7 @@ Types:
       ID: 391
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
-      GoRuntimeType: 481312
+      GoRuntimeType: 481120
       GoKind: 23
       RawFields:
         - Name: array
@@ -32193,7 +32193,7 @@ Types:
       ID: 394
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
-      GoRuntimeType: 481504
+      GoRuntimeType: 481312
       GoKind: 23
       RawFields:
         - Name: array
@@ -32239,7 +32239,7 @@ Types:
       ID: 364
       Name: '[]go.shape.float64'
       ByteSize: 24
-      GoRuntimeType: 483872
+      GoRuntimeType: 483680
       GoKind: 23
       RawFields:
         - Name: array
@@ -32826,7 +32826,7 @@ Types:
       ID: 2180
       Name: '[]vendor/golang.org/x/net/http2/hpack.HeaderField'
       ByteSize: 24
-      GoRuntimeType: 492736
+      GoRuntimeType: 491904
       GoKind: 23
       RawFields:
         - Name: array
@@ -33069,7 +33069,7 @@ Types:
       ID: 156
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1286336
+      GoRuntimeType: 1286208
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33121,7 +33121,7 @@ Types:
       ID: 707
       Name: context.canceler
       ByteSize: 16
-      GoRuntimeType: 1113376
+      GoRuntimeType: 1112480
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33133,7 +33133,7 @@ Types:
     - __kind: StructureType
       ID: 1068
       Name: context.deadlineExceededError
-      GoRuntimeType: 1469600
+      GoRuntimeType: 1468480
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
@@ -33164,7 +33164,7 @@ Types:
       ID: 431
       Name: context.timerCtx
       ByteSize: 112
-      GoRuntimeType: 1619872
+      GoRuntimeType: 1619488
       GoKind: 25
       RawFields:
         - Name: cancelCtx
@@ -33194,7 +33194,7 @@ Types:
       ID: 415
       Name: context.valueCtx
       ByteSize: 48
-      GoRuntimeType: 1840608
+      GoRuntimeType: 1839488
       GoKind: 25
       RawFields:
         - Name: Context
@@ -33629,7 +33629,7 @@ Types:
       ID: 757
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 835648
+      GoRuntimeType: 835456
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1213
@@ -33642,13 +33642,13 @@ Types:
       GoRuntimeType: 835840
       GoKind: 8
     - __kind: BaseType
-      ID: 1409
+      ID: 1407
       Name: encoding/json.Delim
       ByteSize: 4
-      GoRuntimeType: 834304
+      GoRuntimeType: 834112
       GoKind: 5
     - __kind: UnresolvedPointeeType
-      ID: 829
+      ID: 827
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -33675,19 +33675,19 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 821
+      ID: 819
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 827
+      ID: 825
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 825
+      ID: 823
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 821
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -33695,10 +33695,10 @@ Types:
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 831
+      ID: 829
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1424960
+      GoRuntimeType: 1424800
       GoKind: 25
       RawFields:
         - Name: error
@@ -33780,7 +33780,7 @@ Types:
       ID: 2651
       Name: fmt.ScanState
       ByteSize: 16
-      GoRuntimeType: 1468800
+      GoRuntimeType: 1470880
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33793,7 +33793,7 @@ Types:
       ID: 403
       Name: fmt.Stringer
       ByteSize: 16
-      GoRuntimeType: 1025664
+      GoRuntimeType: 1026688
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33901,7 +33901,7 @@ Types:
       ID: 1998
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
       ByteSize: 4
-      GoRuntimeType: 1762432
+      GoRuntimeType: 1761856
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 2163
@@ -33915,7 +33915,7 @@ Types:
       ID: 1999
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
       ByteSize: 4
-      GoRuntimeType: 1762624
+      GoRuntimeType: 1762048
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 2465
@@ -33976,7 +33976,7 @@ Types:
       Name: github.com/DataDog/datadog-agent/pkg/version.Version
       ByteSize: 8
     - __kind: StructureType
-      ID: 840
+      ID: 838
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1734816
@@ -33992,7 +33992,7 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 842
+      ID: 840
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34000,7 +34000,7 @@ Types:
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 846
+      ID: 844
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1116064
       GoKind: 25
@@ -34013,7 +34013,7 @@ Types:
       ID: 751
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
-      GoRuntimeType: 835072
+      GoRuntimeType: 834880
       GoKind: 24
       RawFields:
         - Name: str
@@ -34081,13 +34081,13 @@ Types:
       ID: 1156
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
-      GoRuntimeType: 586496
+      GoRuntimeType: 586432
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 748
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
-      GoRuntimeType: 834976
+      GoRuntimeType: 834784
       GoKind: 24
       RawFields:
         - Name: str
@@ -34106,7 +34106,7 @@ Types:
       ID: 754
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
-      GoRuntimeType: 835168
+      GoRuntimeType: 834976
       GoKind: 24
       RawFields:
         - Name: str
@@ -34317,7 +34317,7 @@ Types:
       ID: 393
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
-      GoRuntimeType: 1916960
+      GoRuntimeType: 1916704
       GoKind: 25
       RawFields:
         - Name: TraceID
@@ -34390,7 +34390,7 @@ Types:
       ID: 381
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 1286464
+      GoRuntimeType: 1286336
       GoKind: 21
       HeaderType: 383 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
@@ -34411,7 +34411,7 @@ Types:
       ID: 1397
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
-      GoRuntimeType: 583616
+      GoRuntimeType: 583552
       GoKind: 10
     - __kind: StructureType
       ID: 396
@@ -34440,7 +34440,7 @@ Types:
       ID: 723
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
-      GoRuntimeType: 1917216
+      GoRuntimeType: 1916960
       GoKind: 25
       RawFields:
         - Name: Type
@@ -34471,7 +34471,7 @@ Types:
       ID: 401
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
-      GoRuntimeType: 2111968
+      GoRuntimeType: 2111616
       GoKind: 25
       RawFields:
         - Name: mu
@@ -34508,7 +34508,7 @@ Types:
       ID: 402
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
-      GoRuntimeType: 898400
+      GoRuntimeType: 897920
       GoKind: 17
       Count: 16
       HasCount: true
@@ -34527,7 +34527,7 @@ Types:
       ID: 1557
       Name: github.com/DataDog/dd-trace-go/v2/internal.TraceSource
       ByteSize: 1
-      GoRuntimeType: 992608
+      GoRuntimeType: 992512
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1351
@@ -34574,16 +34574,16 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/waf.Feature
       ByteSize: 8
     - __kind: BaseType
-      ID: 1405
+      ID: 1403
       Name: github.com/DataDog/dd-trace-go/v2/internal/log.Level
       ByteSize: 8
-      GoRuntimeType: 833248
+      GoRuntimeType: 833056
       GoKind: 2
     - __kind: GoContextImplementationType
       ID: 411
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
-      GoRuntimeType: 1633696
+      GoRuntimeType: 1632928
       GoKind: 25
       RawFields:
         - Name: Context
@@ -34975,24 +34975,24 @@ Types:
           Offset: 56
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1492
+      ID: 1490
       Name: github.com/cihub/seelog.CfgParseParams
       ByteSize: 8
     - __kind: BaseType
-      ID: 1412
+      ID: 1410
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
-      GoRuntimeType: 835456
+      GoRuntimeType: 835264
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 2009
       Name: github.com/cihub/seelog.LogLevelException
       ByteSize: 8
     - __kind: StructureType
-      ID: 848
+      ID: 846
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1427200
+      GoRuntimeType: 1427040
       GoKind: 25
       RawFields:
         - Name: message
@@ -35003,15 +35003,15 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 850
+      ID: 848
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1427360
+      GoRuntimeType: 1427200
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 848 StructureType github.com/cihub/seelog.baseError
+          Type: 846 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1253
       Name: github.com/cihub/seelog.connWriter
@@ -35049,11 +35049,11 @@ Types:
       Name: github.com/cihub/seelog.listConstraints
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1489
+      ID: 1487
       Name: github.com/cihub/seelog.logFormattedMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1487
+      ID: 1485
       Name: github.com/cihub/seelog.logMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -35061,15 +35061,15 @@ Types:
       Name: github.com/cihub/seelog.minMaxConstraints
       ByteSize: 8
     - __kind: StructureType
-      ID: 854
+      ID: 852
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1427680
+      GoRuntimeType: 1427520
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 848 StructureType github.com/cihub/seelog.baseError
+          Type: 846 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1593
       Name: github.com/cihub/seelog.offConstraints
@@ -35116,25 +35116,25 @@ Types:
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 852
+      ID: 850
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1427520
+      GoRuntimeType: 1427360
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 848 StructureType github.com/cihub/seelog.baseError
+          Type: 846 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 856
+      ID: 854
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1427840
+      GoRuntimeType: 1427680
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 848 StructureType github.com/cihub/seelog.baseError
+          Type: 846 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1730
       Name: github.com/cihub/seelog.xmlNode
@@ -35759,7 +35759,7 @@ Types:
       ID: 1080
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1846432
+      GoRuntimeType: 1846208
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -35792,7 +35792,7 @@ Types:
       ID: 1086
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1846880
+      GoRuntimeType: 1846656
       GoKind: 25
       RawFields:
         - Name: Value
@@ -35808,13 +35808,13 @@ Types:
       ID: 994
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 992032
+      GoRuntimeType: 991936
       GoKind: 8
     - __kind: StructureType
       ID: 1078
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1846208
+      GoRuntimeType: 1845984
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -35834,13 +35834,13 @@ Types:
       ID: 1166
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
-      GoRuntimeType: 833344
+      GoRuntimeType: 833152
       GoKind: 8
     - __kind: StructureType
       ID: 1076
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1845984
+      GoRuntimeType: 1845760
       GoKind: 25
       RawFields:
         - Name: Method
@@ -35856,7 +35856,7 @@ Types:
       ID: 1084
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1759744
+      GoRuntimeType: 1759168
       GoKind: 25
       RawFields:
         - Name: Value
@@ -35869,7 +35869,7 @@ Types:
       ID: 1082
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1846656
+      GoRuntimeType: 1846432
       GoKind: 25
       RawFields:
         - Name: Value
@@ -35889,7 +35889,7 @@ Types:
       ID: 1090
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1629472
+      GoRuntimeType: 1628704
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -35911,7 +35911,7 @@ Types:
       ID: 1088
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1759936
+      GoRuntimeType: 1759360
       GoKind: 25
       RawFields:
         - Name: cause
@@ -38548,7 +38548,7 @@ Types:
       ID: 2630
       Name: io.Closer
       ByteSize: 16
-      GoRuntimeType: 1026688
+      GoRuntimeType: 1027712
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38573,7 +38573,7 @@ Types:
       ID: 1271
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1194112
+      GoRuntimeType: 1197312
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38586,7 +38586,7 @@ Types:
       ID: 404
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1026048
+      GoRuntimeType: 1027072
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38603,7 +38603,7 @@ Types:
       ID: 1260
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1112864
+      GoRuntimeType: 1113120
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38616,7 +38616,7 @@ Types:
       ID: 132
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1025792
+      GoRuntimeType: 1026816
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38629,7 +38629,7 @@ Types:
       ID: 2629
       Name: io.WriterTo
       ByteSize: 16
-      GoRuntimeType: 1026560
+      GoRuntimeType: 1027584
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38641,13 +38641,13 @@ Types:
     - __kind: StructureType
       ID: 1229
       Name: io.discard
-      GoRuntimeType: 1469280
+      GoRuntimeType: 1471360
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 2535
       Name: io.eofReader
-      GoRuntimeType: 1112608
+      GoRuntimeType: 1112864
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -38662,7 +38662,7 @@ Types:
       ID: 2559
       Name: io.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1555360
+      GoRuntimeType: 1556960
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -38672,7 +38672,7 @@ Types:
       ID: 2593
       Name: io.nopCloserWriterTo
       ByteSize: 16
-      GoRuntimeType: 1619488
+      GoRuntimeType: 1620640
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -38719,7 +38719,7 @@ Types:
       ID: 1657
       Name: log/slog.Attr
       ByteSize: 40
-      GoRuntimeType: 1767808
+      GoRuntimeType: 1767232
       GoKind: 25
       RawFields:
         - Name: Key
@@ -38729,16 +38729,16 @@ Types:
           Offset: 16
           Type: 2000 StructureType log/slog.Value
     - __kind: BaseType
-      ID: 1413
+      ID: 1411
       Name: log/slog.Kind
       ByteSize: 8
-      GoRuntimeType: 835552
+      GoRuntimeType: 835360
       GoKind: 2
     - __kind: BaseType
       ID: 1760
       Name: log/slog.Level
       ByteSize: 8
-      GoRuntimeType: 1489920
+      GoRuntimeType: 1488800
       GoKind: 2
     - __kind: StructureType
       ID: 2000
@@ -41226,16 +41226,16 @@ Types:
       Name: net.DNSError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1410
+      ID: 1408
       Name: net.Flags
       ByteSize: 8
-      GoRuntimeType: 834496
+      GoRuntimeType: 834304
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 1482
+      ID: 1480
       Name: net.HardwareAddr
       ByteSize: 24
-      GoRuntimeType: 908000
+      GoRuntimeType: 907328
       GoKind: 23
       RawFields:
         - Name: array
@@ -41247,9 +41247,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1483 GoSliceDataType net.HardwareAddr.array
+      Data: 1481 GoSliceDataType net.HardwareAddr.array
     - __kind: GoSliceDataType
-      ID: 1483
+      ID: 1481
       Name: net.HardwareAddr.array
       DynamicSizeClass: slice
       ByteSize: 1
@@ -41289,7 +41289,7 @@ Types:
       ID: 1585
       Name: net.IPMask
       ByteSize: 24
-      GoRuntimeType: 1039872
+      GoRuntimeType: 1039744
       GoKind: 23
       RawFields:
         - Name: array
@@ -41403,10 +41403,10 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: BaseType
-      ID: 1411
+      ID: 1409
       Name: net.hostLookupOrder
       ByteSize: 8
-      GoRuntimeType: 834592
+      GoRuntimeType: 834400
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1359
@@ -41425,14 +41425,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 833
+      ID: 831
       Name: net.notFoundError
       ByteSize: 8
     - __kind: GoContextImplementationType
       ID: 413
       Name: net.onlyValuesCtx
       ByteSize: 32
-      GoRuntimeType: 1764736
+      GoRuntimeType: 1764160
       GoKind: 25
       RawFields:
         - Name: Context
@@ -41444,7 +41444,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: StructureType
-      ID: 835
+      ID: 833
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1734624
@@ -41494,10 +41494,10 @@ Types:
       Name: net.timeoutError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1408
+      ID: 1406
       Name: net/http.ConnState
       ByteSize: 8
-      GoRuntimeType: 833728
+      GoRuntimeType: 833536
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1579
@@ -41526,7 +41526,7 @@ Types:
       ID: 2537
       Name: net/http.bodyLocked
       ByteSize: 8
-      GoRuntimeType: 1422560
+      GoRuntimeType: 1422400
       GoKind: 25
       RawFields:
         - Name: b
@@ -41536,7 +41536,7 @@ Types:
       ID: 1185
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1422720
+      GoRuntimeType: 1422560
       GoKind: 25
       RawFields:
         - Name: w
@@ -41551,7 +41551,7 @@ Types:
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 1476
+      ID: 1474
       Name: net/http.connectMethodKey
       ByteSize: 56
       GoRuntimeType: 1829344
@@ -41570,14 +41570,14 @@ Types:
           Offset: 48
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1478
+      ID: 1476
       Name: net/http.contextKey
       ByteSize: 8
     - __kind: StructureType
       ID: 2541
       Name: net/http.errorReader
       ByteSize: 16
-      GoRuntimeType: 1422880
+      GoRuntimeType: 1422720
       GoKind: 25
       RawFields:
         - Name: err
@@ -41587,7 +41587,7 @@ Types:
       ID: 2543
       Name: net/http.finishAsyncByteRead
       ByteSize: 8
-      GoRuntimeType: 1423040
+      GoRuntimeType: 1422880
       GoKind: 25
       RawFields:
         - Name: tw
@@ -41601,13 +41601,13 @@ Types:
       ID: 729
       Name: net/http.http2ConnectionError
       ByteSize: 4
-      GoRuntimeType: 833824
+      GoRuntimeType: 833632
       GoKind: 10
     - __kind: StructureType
       ID: 1922
       Name: net/http.http2ContinuationFrame
       ByteSize: 40
-      GoRuntimeType: 1761856
+      GoRuntimeType: 1761280
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41620,7 +41620,7 @@ Types:
       ID: 1917
       Name: net/http.http2DataFrame
       ByteSize: 40
-      GoRuntimeType: 1760128
+      GoRuntimeType: 1759552
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41633,13 +41633,13 @@ Types:
       ID: 1140
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 992128
+      GoRuntimeType: 992032
       GoKind: 10
     - __kind: BaseType
       ID: 1995
       Name: net/http.http2Flags
       ByteSize: 1
-      GoRuntimeType: 833536
+      GoRuntimeType: 833344
       GoKind: 8
     - __kind: StructureType
       ID: 1769
@@ -41653,7 +41653,7 @@ Types:
           Type: 6 BaseType bool
         - Name: Type
           Offset: 1
-          Type: 1406 BaseType net/http.http2FrameType
+          Type: 1404 BaseType net/http.http2FrameType
         - Name: Flags
           Offset: 2
           Type: 1995 BaseType net/http.http2Flags
@@ -41664,13 +41664,13 @@ Types:
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1406
+      ID: 1404
       Name: net/http.http2FrameType
       ByteSize: 1
-      GoRuntimeType: 833440
+      GoRuntimeType: 833248
       GoKind: 8
     - __kind: StructureType
-      ID: 811
+      ID: 809
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1733280
@@ -41689,7 +41689,7 @@ Types:
       ID: 1833
       Name: net/http.http2GoAwayFrame
       ByteSize: 48
-      GoRuntimeType: 1920544
+      GoRuntimeType: 1920288
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41708,7 +41708,7 @@ Types:
       ID: 2049
       Name: net/http.http2HeadersFrame
       ByteSize: 48
-      GoRuntimeType: 1847552
+      GoRuntimeType: 1847328
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41740,7 +41740,7 @@ Types:
       ID: 1835
       Name: net/http.http2PingFrame
       ByteSize: 20
-      GoRuntimeType: 1760320
+      GoRuntimeType: 1759744
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41782,7 +41782,7 @@ Types:
       ID: 1920
       Name: net/http.http2PushPromiseFrame
       ByteSize: 40
-      GoRuntimeType: 1849344
+      GoRuntimeType: 1849120
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41798,7 +41798,7 @@ Types:
       ID: 1771
       Name: net/http.http2RSTStreamFrame
       ByteSize: 16
-      GoRuntimeType: 1760512
+      GoRuntimeType: 1759936
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41816,21 +41816,21 @@ Types:
       RawFields:
         - Name: ID
           Offset: 0
-          Type: 1407 BaseType net/http.http2SettingID
+          Type: 1405 BaseType net/http.http2SettingID
         - Name: Val
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1407
+      ID: 1405
       Name: net/http.http2SettingID
       ByteSize: 2
-      GoRuntimeType: 833632
+      GoRuntimeType: 833440
       GoKind: 9
     - __kind: StructureType
       ID: 1997
       Name: net/http.http2SettingsFrame
       ByteSize: 40
-      GoRuntimeType: 1760704
+      GoRuntimeType: 1760128
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41843,7 +41843,7 @@ Types:
       ID: 1122
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1905728
+      GoRuntimeType: 1905472
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -41859,7 +41859,7 @@ Types:
       ID: 1839
       Name: net/http.http2UnknownFrame
       ByteSize: 40
-      GoRuntimeType: 1761664
+      GoRuntimeType: 1761088
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41872,7 +41872,7 @@ Types:
       ID: 1773
       Name: net/http.http2WindowUpdateFrame
       ByteSize: 16
-      GoRuntimeType: 1760896
+      GoRuntimeType: 1760320
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41886,7 +41886,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 815
+      ID: 813
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1601760
@@ -41906,7 +41906,7 @@ Types:
       ID: 733
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 834016
+      GoRuntimeType: 833824
       GoKind: 24
       RawFields:
         - Name: str
@@ -41929,7 +41929,7 @@ Types:
       ID: 739
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 834208
+      GoRuntimeType: 834016
       GoKind: 24
       RawFields:
         - Name: str
@@ -41948,7 +41948,7 @@ Types:
       ID: 736
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 834112
+      GoRuntimeType: 833920
       GoKind: 24
       RawFields:
         - Name: str
@@ -41993,7 +41993,7 @@ Types:
       ID: 730
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 833920
+      GoRuntimeType: 833728
       GoKind: 24
       RawFields:
         - Name: str
@@ -42031,7 +42031,7 @@ Types:
       ID: 1282
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
-      GoRuntimeType: 1422080
+      GoRuntimeType: 1421920
       GoKind: 20
       RawFields:
         - Name: tab
@@ -42053,7 +42053,7 @@ Types:
     - __kind: ArrayType
       ID: 1268
       Name: net/http.incomparable
-      GoRuntimeType: 903296
+      GoRuntimeType: 902624
       GoKind: 17
       HasCount: true
       Element: 62 GoSubroutineType func()
@@ -42064,7 +42064,7 @@ Types:
     - __kind: StructureType
       ID: 2597
       Name: net/http.noBody
-      GoRuntimeType: 1480320
+      GoRuntimeType: 1479200
       GoKind: 25
       RawFields: []
     - __kind: StructureType
@@ -42103,7 +42103,7 @@ Types:
       ID: 1233
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1805792
+      GoRuntimeType: 1805344
       GoKind: 25
       RawFields:
         - Name: _
@@ -42116,10 +42116,10 @@ Types:
           Offset: 8
           Type: 1271 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 819
+      ID: 817
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1423680
+      GoRuntimeType: 1423520
       GoKind: 25
       RawFields:
         - Name: error
@@ -42136,7 +42136,7 @@ Types:
     - __kind: StructureType
       ID: 1092
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1481600
+      GoRuntimeType: 1480480
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -42157,7 +42157,7 @@ Types:
       ID: 1285
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2031936
+      GoRuntimeType: 2031648
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -42167,7 +42167,7 @@ Types:
           Offset: 16
           Type: 1163 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 806
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -42335,7 +42335,7 @@ Types:
       ID: 742
       Name: net/url.EscapeError
       ByteSize: 16
-      GoRuntimeType: 834688
+      GoRuntimeType: 834496
       GoKind: 24
       RawFields:
         - Name: str
@@ -42354,7 +42354,7 @@ Types:
       ID: 745
       Name: net/url.InvalidHostError
       ByteSize: 16
-      GoRuntimeType: 834784
+      GoRuntimeType: 834592
       GoKind: 24
       RawFields:
         - Name: str
@@ -42453,7 +42453,7 @@ Types:
       ID: 705
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
-      GoRuntimeType: 689984
+      GoRuntimeType: 688448
       GoKind: 17
       Count: 8
       HasCount: true
@@ -42534,7 +42534,7 @@ Types:
       ID: 720
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
-      GoRuntimeType: 690624
+      GoRuntimeType: 689184
       GoKind: 17
       Count: 8
       HasCount: true
@@ -42543,7 +42543,7 @@ Types:
       ID: 2522
       Name: noalg.[8]struct { key string; elem *regexp.Regexp }
       ByteSize: 192
-      GoRuntimeType: 691776
+      GoRuntimeType: 690624
       GoKind: 17
       Count: 8
       HasCount: true
@@ -42570,7 +42570,7 @@ Types:
       ID: 687
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
-      GoRuntimeType: 690528
+      GoRuntimeType: 689088
       GoKind: 17
       Count: 8
       HasCount: true
@@ -42759,7 +42759,7 @@ Types:
       ID: 704
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
-      GoRuntimeType: 1304384
+      GoRuntimeType: 1304256
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -42876,7 +42876,7 @@ Types:
       ID: 719
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
-      GoRuntimeType: 1305280
+      GoRuntimeType: 1305152
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -42889,7 +42889,7 @@ Types:
       ID: 2521
       Name: noalg.map.group[string]*regexp.Regexp
       ByteSize: 200
-      GoRuntimeType: 1306048
+      GoRuntimeType: 1305920
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -42928,7 +42928,7 @@ Types:
       ID: 686
       Name: noalg.map.group[string]float64
       ByteSize: 200
-      GoRuntimeType: 1305024
+      GoRuntimeType: 1304896
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43182,7 +43182,7 @@ Types:
       ID: 706
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
-      GoRuntimeType: 1304256
+      GoRuntimeType: 1304128
       GoKind: 25
       RawFields:
         - Name: key
@@ -43299,7 +43299,7 @@ Types:
       ID: 721
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
-      GoRuntimeType: 1305152
+      GoRuntimeType: 1305024
       GoKind: 25
       RawFields:
         - Name: key
@@ -43312,7 +43312,7 @@ Types:
       ID: 2523
       Name: noalg.struct { key string; elem *regexp.Regexp }
       ByteSize: 24
-      GoRuntimeType: 1305920
+      GoRuntimeType: 1305792
       GoKind: 25
       RawFields:
         - Name: key
@@ -43351,7 +43351,7 @@ Types:
       ID: 688
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
-      GoRuntimeType: 1304896
+      GoRuntimeType: 1304768
       GoKind: 25
       RawFields:
         - Name: key
@@ -43670,16 +43670,16 @@ Types:
       GoRuntimeType: 839872
       GoKind: 2
     - __kind: BaseType
-      ID: 1403
+      ID: 1412
       Name: reflect.ChanDir
       ByteSize: 8
-      GoRuntimeType: 833056
+      GoRuntimeType: 835552
       GoKind: 2
     - __kind: BaseType
-      ID: 1404
+      ID: 1413
       Name: reflect.Kind
       ByteSize: 8
-      GoRuntimeType: 833152
+      GoRuntimeType: 835648
       GoKind: 7
     - __kind: StructureType
       ID: 2502
@@ -43698,14 +43698,14 @@ Types:
           Offset: 16
           Type: 2503 BaseType reflect.flag
     - __kind: UnresolvedPointeeType
-      ID: 806
+      ID: 857
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: BaseType
       ID: 2503
       Name: reflect.flag
       ByteSize: 8
-      GoRuntimeType: 1758784
+      GoRuntimeType: 1767424
       GoKind: 12
     - __kind: UnresolvedPointeeType
       ID: 2486
@@ -44650,7 +44650,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1481
+      ID: 1479
       Name: runtime/debug.BuildInfo
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -44706,7 +44706,7 @@ Types:
       ID: 2589
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
-      GoRuntimeType: 1715392
+      GoRuntimeType: 1714816
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -44719,7 +44719,7 @@ Types:
       ID: 2587
       Name: struct { io.Reader; io.WriterTo }
       ByteSize: 32
-      GoRuntimeType: 1715200
+      GoRuntimeType: 1714624
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -46209,10 +46209,10 @@ Issues:
       issue:
         Kind: 7
         Message: return value selector (e.g., @return.r0) must be used for multi-value returns
-GoModuledataInfo: {FirstModuledataAddr: "0x181b3a0", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x181d3a0", TypesOffset: 296}
 GoMapHashInfo:
-    UseAeshashAddr: "0x190aa6b"
-    AeskeyschedAddr: "0x190bbc0"
+    UseAeshashAddr: "0x190ca6b"
+    AeskeyschedAddr: "0x190dbc0"
 CommonTypes:
     G: 24 StructureType runtime.g
     M: 31 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -20,11 +20,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3006 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xce736a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7f0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3007 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xce73a5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce7f45", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -40,11 +40,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2841 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0xce0faa", Frameless: false}]
+              InjectionPoints: [{PC: "0xce158a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2842 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0xce0fe5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce15c5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -66,11 +66,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2844 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0xce104a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce162a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2845 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0xce107d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce165d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -91,11 +91,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2975 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xce598e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce644e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2976 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce5a42", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6502", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -183,7 +183,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2853 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xce1880", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1f40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -248,11 +248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2877 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xce3a20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce42e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2878 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xce3a32", Frameless: true}]
+              InjectionPoints: [{PC: "0xce42f2", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -274,11 +274,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2805 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0xcdc4c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc6c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2806 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0xcdc4de", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc6de", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -344,7 +344,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3004 EventRootType Probe[main.testByteSliceInvalidUtf8]
-              InjectionPoints: [{PC: "0xce6c20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce76e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -366,7 +366,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3005 EventRootType Probe[main.testByteSliceMultibyteUtf8]
-              InjectionPoints: [{PC: "0xce6c40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -387,7 +387,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2820 EventRootType Probe[main.testCaptureContextImpl]
-              InjectionPoints: [{PC: "0xcdd2a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -414,11 +414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3028 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xce7820", Frameless: true}]
+              InjectionPoints: [{PC: "0xce85e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3029 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce7842", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8602", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -426,7 +426,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: ""
       segments: []
@@ -438,15 +438,15 @@ Probes:
             - Kind: Line
               Type: 3092 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xce07ce"
+                - PC: "0xce0cae"
                   Frameless: false
-                - PC: "0xce0851"
+                - PC: "0xce0d31"
                   Frameless: false
-                - PC: "0xce0992"
+                - PC: "0xce0e72"
                   Frameless: false
-                - PC: "0xce0a1c"
+                - PC: "0xce0efc"
                   Frameless: false
-                - PC: "0xce0aef"
+                - PC: "0xce0fcf"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -455,7 +455,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       when: {dsl: x == 3, json: {eq: [{ref: x}, 3]}}
       sampling: {snapshotsPerSecond: 100}
       template: ""
@@ -468,15 +468,15 @@ Probes:
             - Kind: Line
               Type: 3093 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xce07ce"
+                - PC: "0xce0cae"
                   Frameless: false
-                - PC: "0xce0851"
+                - PC: "0xce0d31"
                   Frameless: false
-                - PC: "0xce0992"
+                - PC: "0xce0e72"
                   Frameless: false
-                - PC: "0xce0a1c"
+                - PC: "0xce0efc"
                   Frameless: false
-                - PC: "0xce0aef"
+                - PC: "0xce0fcf"
                   Frameless: false
               Condition:
                 Type: 6 BaseType bool
@@ -502,7 +502,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: x={x}
       segments: [x=, {json: {ref: x}, dsl: x}]
@@ -514,15 +514,15 @@ Probes:
             - Kind: Line
               Type: 3094 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xce07ce"
+                - PC: "0xce0cae"
                   Frameless: false
-                - PC: "0xce0851"
+                - PC: "0xce0d31"
                   Frameless: false
-                - PC: "0xce0992"
+                - PC: "0xce0e72"
                   Frameless: false
-                - PC: "0xce0a1c"
+                - PC: "0xce0efc"
                   Frameless: false
-                - PC: "0xce0aef"
+                - PC: "0xce0fcf"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -550,7 +550,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2872 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xce33c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3a80", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -569,7 +569,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2873 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xce33c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -595,7 +595,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3036 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xce7940", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8700", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -633,7 +633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2879 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xce3a40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -663,7 +663,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2871 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xce3380", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -692,11 +692,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2940 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xce4bce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce568e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2941 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xce4c91", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5751", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -718,7 +718,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2887 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xce3e00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce47a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -740,7 +740,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2812 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0xcdc9a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdcba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -762,7 +762,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2813 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0xcdc9c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdcbc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -784,7 +784,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2808 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0xcdc680", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -806,7 +806,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2809 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0xcdc6a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc8a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -828,7 +828,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2810 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0xcdc820", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdca20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -850,7 +850,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2811 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0xcdc840", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdca40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -872,7 +872,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2992 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xce6a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -899,7 +899,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2995 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xce6ac0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -927,7 +927,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3020 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xce74a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -949,7 +949,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3037 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xce79a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -970,7 +970,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3038 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xce79c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -992,7 +992,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2843 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0xce1020", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1007,7 +1007,7 @@ Probes:
       where:
         methodName: main.testErrorAtLine
         sourceFile: complex.go
-        lines: ["108"]
+        lines: ["111"]
       tags:
         - config_diff:arch=amd64,toolchain=go1.26rc1
         - skip_integration:arch=arm64,toolchain=go1.25.0
@@ -1026,7 +1026,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2807 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0xcdc55b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdc75b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -1054,11 +1054,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2825 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0xcdf3aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf88a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2826 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0xcdf3ec", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf8cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1080,11 +1080,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2823 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0xcdf28e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf76e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2824 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0xcdf31b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdf7fb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1106,11 +1106,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2835 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0xce0c80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1160", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2836 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0xce0c85", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1165", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1132,11 +1132,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2837 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0xce0ca4", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1184", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2838 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0xce0cdd", Frameless: false}]
+              InjectionPoints: [{PC: "0xce11bd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1151,7 +1151,7 @@ Probes:
       where:
         methodName: main.testFramelessArray
         sourceFile: inlined.go
-        lines: ["93"]
+        lines: ["96"]
       sampling: {snapshotsPerSecond: 100}
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
@@ -1161,7 +1161,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2839 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0xce0ca8", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1188", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1183,11 +1183,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3078 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xcea640", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb620", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3079 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcea647", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb627", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1201,11 +1201,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3080 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xcea664", Frameless: false}]
+              InjectionPoints: [{PC: "0xceb644", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3081 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xcea6b1", Frameless: false}]
+              InjectionPoints: [{PC: "0xceb691", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1228,11 +1228,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3074 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xcea5aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xceb58a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3075 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xcea5b9", Frameless: false}]
+              InjectionPoints: [{PC: "0xceb599", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1246,11 +1246,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3076 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xcea5ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xceb5ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3077 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xcea602", Frameless: false}]
+              InjectionPoints: [{PC: "0xceb5e2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1273,14 +1273,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 3082 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xcea6c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb6a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3083 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xcea6e0"
+                - PC: "0xceb6c0"
                   Frameless: true
-                - PC: "0xcea6e3"
+                - PC: "0xceb6c3"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1295,14 +1295,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 3084 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xcea70a", Frameless: false}]
+              InjectionPoints: [{PC: "0xceb6ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3085 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xcea76b"
+                - PC: "0xceb74b"
                   Frameless: false
-                - PC: "0xcea773"
+                - PC: "0xceb753"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1329,7 +1329,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3086 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xcea6c5", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb6a5", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1341,7 +1341,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3087 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xcea71f", Frameless: false}]
+              InjectionPoints: [{PC: "0xceb6ff", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1362,11 +1362,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3062 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xcea260", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb240", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3063 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xcea270", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb250", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1380,11 +1380,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3064 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xcea300", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb2e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3065 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xcea308", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb2e8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1408,11 +1408,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3050 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xce9dee", Frameless: false}]
+              InjectionPoints: [{PC: "0xceadce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3051 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce9ed4", Frameless: false}]
+              InjectionPoints: [{PC: "0xceaeb4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1454,11 +1454,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3054 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce9f2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xceaf0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3055 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce9f39", Frameless: false}]
+              InjectionPoints: [{PC: "0xceaf19", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1481,11 +1481,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3088 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xcea7c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb7a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3089 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xcea7c6", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb7a6", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1499,11 +1499,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3090 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xcea84a", Frameless: false}]
+              InjectionPoints: [{PC: "0xceb82a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3091 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xcea86d", Frameless: false}]
+              InjectionPoints: [{PC: "0xceb84d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1526,11 +1526,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3046 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xce9d40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcead20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3047 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce9d43", Frameless: true}]
+              InjectionPoints: [{PC: "0xcead23", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1544,11 +1544,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3048 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xce9d60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcead40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3049 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce9d6b", Frameless: true}]
+              InjectionPoints: [{PC: "0xcead4b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1571,11 +1571,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3066 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xcea3c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb3a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3067 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xcea3c7", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb3a7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1589,11 +1589,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3068 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xcea46a", Frameless: false}]
+              InjectionPoints: [{PC: "0xceb44a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3069 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xcea493", Frameless: false}]
+              InjectionPoints: [{PC: "0xceb473", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1616,11 +1616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3056 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xcea200", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb1e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3057 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcea203", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb1e3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1634,11 +1634,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3058 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xcea220", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb200", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3059 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xcea223", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb203", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1652,11 +1652,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3060 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xcea240", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb220", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3061 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xcea243", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb223", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1679,11 +1679,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3070 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xcea560", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb540", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3071 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xcea567", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb547", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1697,11 +1697,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3072 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xcea580", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb560", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3073 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcea58e", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb56e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1724,11 +1724,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3042 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xce9d00", Frameless: true}]
+              InjectionPoints: [{PC: "0xceace0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3043 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce9d03", Frameless: true}]
+              InjectionPoints: [{PC: "0xceace3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1742,11 +1742,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3044 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xce9d20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcead00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3045 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce9d2b", Frameless: true}]
+              InjectionPoints: [{PC: "0xcead0b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1769,14 +1769,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2875 EventRootType Probe[main.(*Server).handleOrder]
-              InjectionPoints: [{PC: "0xce3773", Frameless: false}]
+              InjectionPoints: [{PC: "0xce3f13", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2876 EventRootType Probe[main.(*Server).handleOrder]Return
               InjectionPoints:
-                - PC: "0xce385c"
+                - PC: "0xce3ffc"
                   Frameless: false
-                - PC: "0xce3937"
+                - PC: "0xce40d7"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1799,11 +1799,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2827 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0xce096a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0e4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2828 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0xce09ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0eae", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1830,11 +1830,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2829 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0xce0a0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0eee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2830 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0xce0a9e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0f7e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1861,11 +1861,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2831 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0xce0aea", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0fca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2832 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0xce0b2b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce100b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1887,7 +1887,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3098 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0xce0a66", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0f46", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1905,11 +1905,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2833 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0xce0b6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce104e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2834 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0xce0c53", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1133", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1927,7 +1927,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3099 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0xce0b73", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1053", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1938,7 +1938,7 @@ Probes:
       where:
         methodName: main.testInlinedBCA
         sourceFile: inlined.go
-        lines: ["63"]
+        lines: ["66"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCA
       segments: [testInlinedBCA]
@@ -1948,7 +1948,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3100 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0xce0b73", Frameless: false}]
+              InjectionPoints: [{PC: "0xce1053", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1966,7 +1966,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3101 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0xce0c1b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce10fb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1977,7 +1977,7 @@ Probes:
       where:
         methodName: main.testInlinedBCB
         sourceFile: inlined.go
-        lines: ["67"]
+        lines: ["70"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCB
       segments: [testInlinedBCB]
@@ -1987,7 +1987,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3102 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0xce0c1b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce10fb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -2008,7 +2008,7 @@ Probes:
               InjectionPoints:
                 - PC: "0xcda821"
                   Frameless: true
-                - PC: "0xce1746"
+                - PC: "0xce1de6"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2029,20 +2029,20 @@ Probes:
             - Kind: Entry
               Type: 3095 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0xce07ca"
+                - PC: "0xce0caa"
                   Frameless: false
-                - PC: "0xce0851"
+                - PC: "0xce0d31"
                   Frameless: false
-                - PC: "0xce0992"
+                - PC: "0xce0e72"
                   Frameless: false
-                - PC: "0xce0a1c"
+                - PC: "0xce0efc"
                   Frameless: false
-                - PC: "0xce0aef"
+                - PC: "0xce0fcf"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 3096 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0xce080a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce0cea", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2057,7 +2057,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2068,15 +2068,15 @@ Probes:
             - Kind: Line
               Type: 3097 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xce07ce"
+                - PC: "0xce0cae"
                   Frameless: false
-                - PC: "0xce0851"
+                - PC: "0xce0d31"
                   Frameless: false
-                - PC: "0xce0992"
+                - PC: "0xce0e72"
                   Frameless: false
-                - PC: "0xce0a1c"
+                - PC: "0xce0efc"
                   Frameless: false
-                - PC: "0xce0aef"
+                - PC: "0xce0fcf"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2099,7 +2099,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3103 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0xce0c81", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1161", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2114,7 +2114,7 @@ Probes:
       where:
         methodName: main.testInlinedSq
         sourceFile: inlined.go
-        lines: ["75"]
+        lines: ["78"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2124,7 +2124,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3104 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0xce0c81", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1161", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2148,9 +2148,9 @@ Probes:
             - Kind: Entry
               Type: 3105 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0xce0cc5"
+                - PC: "0xce11a5"
                   Frameless: false
-                - PC: "0xce0d65"
+                - PC: "0xce12b5"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2283,7 +2283,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2840 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0xce0f80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2310,7 +2310,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3022 EventRootType Probe[main.testInvalidUtf8Strings]
-              InjectionPoints: [{PC: "0xce74e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce81a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2973 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xce57ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce62ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2974 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce5953", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6413", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2362,7 +2362,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2881 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xce3c20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce45c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2377,7 +2377,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["230"]
+        lines: ["233"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
@@ -2387,7 +2387,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2816 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcdca3a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdcc3a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2398,7 +2398,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["237"]
+        lines: ["240"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2409,7 +2409,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2817 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcdcaed", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdcced", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2420,7 +2420,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["242"]
+        lines: ["245"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2431,7 +2431,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2818 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xcdcbb4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcdcdb4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2474,11 +2474,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2979 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xce5cb3", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6773", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2980 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xce5ec2", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6982", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2541,7 +2541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2821 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0xcdd580", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2565,7 +2565,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2822 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0xcdef60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdf360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2587,7 +2587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2851 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xce1840", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1f00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2609,7 +2609,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2858 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xce1900", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1fc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2631,7 +2631,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2868 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xce1a40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2653,7 +2653,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2870 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xce1a80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2675,7 +2675,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2869 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xce1a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2697,7 +2697,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2855 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xce18c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1f80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2719,7 +2719,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2867 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xce1a20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce20e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2741,7 +2741,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2866 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xce1a00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce20c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2765,7 +2765,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2856 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xce18e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1fa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2789,7 +2789,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2857 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xce18e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1fa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2811,7 +2811,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2865 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xce19e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce20a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2833,7 +2833,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2864 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xce19c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2855,7 +2855,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2849 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xce1800", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1ec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2877,7 +2877,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2850 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xce1820", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1ee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2899,7 +2899,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2848 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xce17e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1ea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2921,7 +2921,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2859 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xce1920", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1fe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2943,7 +2943,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2862 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xce1980", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2965,7 +2965,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2863 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xce19a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2987,7 +2987,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2860 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xce1940", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3011,7 +3011,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2861 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xce1960", Frameless: true}]
+              InjectionPoints: [{PC: "0xce2020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -3033,7 +3033,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3017 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xce7460", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3056,7 +3056,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3018 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xce7460", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3103,11 +3103,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2981 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xce5f53", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6a13", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2982 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xce618b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6c4b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3169,7 +3169,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3023 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0xce7500", Frameless: true}]
+              InjectionPoints: [{PC: "0xce81c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3192,7 +3192,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3024 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0xce7500", Frameless: true}]
+              InjectionPoints: [{PC: "0xce81c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3218,11 +3218,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2985 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xce62ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6d8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2986 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xce639f", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6e5f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3253,11 +3253,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2977 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xce5a6e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce652e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2978 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xce5c8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce674a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3283,11 +3283,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2918 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce4a0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce54ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2919 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce4aaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce556f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3323,7 +3323,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2874 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xce3540", Frameless: true}]
+              InjectionPoints: [{PC: "0xce3c00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3364,11 +3364,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2912 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xce496a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce542a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2913 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xce49d5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5495", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3392,11 +3392,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2914 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xce496a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce542a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2915 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xce49d5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5495", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3415,11 +3415,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2920 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce4a0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce54ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2921 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce4aaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce556f", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3439,11 +3439,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2922 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce4a0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce54ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2923 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce4aaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce556f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3476,11 +3476,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2916 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xce496a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce542a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2917 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xce49d5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5495", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3508,7 +3508,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3032 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce7920", Frameless: true}]
+              InjectionPoints: [{PC: "0xce86e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3533,7 +3533,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3033 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce7920", Frameless: true}]
+              InjectionPoints: [{PC: "0xce86e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3564,7 +3564,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3034 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce7920", Frameless: true}]
+              InjectionPoints: [{PC: "0xce86e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3589,7 +3589,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3035 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce7920", Frameless: true}]
+              InjectionPoints: [{PC: "0xce86e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3616,7 +3616,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2886 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xce3dc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3643,7 +3643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2999 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xce6b40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3670,7 +3670,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2996 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xce6ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce75a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3705,7 +3705,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2998 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xce6b20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce75e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3737,7 +3737,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3016 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xce7440", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3759,7 +3759,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2882 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xce3c40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce45e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3781,7 +3781,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2854 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xce18a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1f60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3803,7 +3803,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2880 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xce3c00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce45a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3827,11 +3827,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2888 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xce424a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4d0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2889 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xce429b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4d5b", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3851,11 +3851,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2932 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce4aee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce55ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2933 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce4b8d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce564d", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3900,11 +3900,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2898 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xce436e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4e2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2899 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xce4424", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4ee4", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3946,11 +3946,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2890 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xce424a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4d0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2891 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xce429b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4d5b", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3995,11 +3995,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2900 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xce436e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4e2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2901 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xce4424", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4ee4", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -4043,11 +4043,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2934 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce4aee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce55ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2935 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce4b8d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce564d", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -4064,11 +4064,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2936 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce4aee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce55ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2937 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce4b8d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce564d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -4090,11 +4090,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2892 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xce424a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4d0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2893 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xce429b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4d5b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -4117,18 +4117,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2908 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xce460e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce50ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2909 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xce46b5"
+                - PC: "0xce5175"
                   Frameless: false
-                - PC: "0xce4704"
+                - PC: "0xce51c4"
                   Frameless: false
-                - PC: "0xce47c0"
+                - PC: "0xce5280"
                   Frameless: false
-                - PC: "0xce47ca"
+                - PC: "0xce528a"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4156,18 +4156,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2906 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xce44ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4f6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2907 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xce4504"
+                - PC: "0xce4fc4"
                   Frameless: false
-                - PC: "0xce4553"
+                - PC: "0xce5013"
                   Frameless: false
-                - PC: "0xce4587"
+                - PC: "0xce5047"
                   Frameless: false
-                - PC: "0xce45b9"
+                - PC: "0xce5079"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4194,11 +4194,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2951 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xce528a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5d4a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2952 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xce52ed", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5dad", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4215,11 +4215,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2953 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xce530a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5dca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2954 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xce534b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5e0b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4236,11 +4236,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2955 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xce536a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5e2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2956 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xce53a6", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5e66", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4257,11 +4257,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2959 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xce544e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5f0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2960 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xce54ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5f8a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4278,11 +4278,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2971 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xce578a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce624a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2972 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xce57d0", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6290", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4299,11 +4299,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2947 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xce514a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5c0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2948 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xce51a6", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5c66", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4321,14 +4321,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2904 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xce444a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4f0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2905 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xce447a"
+                - PC: "0xce4f3a"
                   Frameless: false
-                - PC: "0xce4485"
+                - PC: "0xce4f45"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4350,11 +4350,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2894 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xce424a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4d0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2895 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xce429b", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4d5b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4375,11 +4375,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2902 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xce436e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4e2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2903 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xce4424", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4ee4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4400,11 +4400,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2896 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xce42ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4d8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2897 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xce4334", Frameless: false}]
+              InjectionPoints: [{PC: "0xce4df4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4426,14 +4426,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2910 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xce480e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce52ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2911 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xce48df"
+                - PC: "0xce539f"
                   Frameless: false
-                - PC: "0xce48e9"
+                - PC: "0xce53a9"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4455,11 +4455,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2949 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xce51ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5c8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2950 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xce5253", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5d13", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4476,11 +4476,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2945 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xce504e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5b0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2946 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xce5127", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5be7", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4497,11 +4497,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2963 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xce55aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xce606a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2964 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xce560c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce60cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4518,11 +4518,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2957 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xce53ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5e8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2958 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xce5418", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5ed8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4539,11 +4539,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2969 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xce570a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce61ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2970 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xce5756", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6216", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4563,7 +4563,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2942 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xce4dcf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce588f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4584,11 +4584,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2967 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xce56aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xce616a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2968 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xce56ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce61ae", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4605,11 +4605,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2943 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xce4fca", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5a8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2944 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xce5031", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5af1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4626,11 +4626,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2965 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xce562a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce60ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2966 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xce568d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce614d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4647,11 +4647,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2961 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xce54ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce5fae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2962 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xce5574", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6034", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4704,11 +4704,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2924 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce4a0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce54ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2925 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce4aaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce556f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4754,7 +4754,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2791 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0xcdc1c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc2e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4776,7 +4776,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2789 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0xcdc180", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc2a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4798,7 +4798,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2802 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0xcdc320", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4816,7 +4816,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2803 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0xcdc340", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4834,7 +4834,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2792 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0xcdc1e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4856,7 +4856,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2794 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0xcdc220", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4879,7 +4879,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2795 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0xcdc240", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4901,7 +4901,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2796 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0xcdc260", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4930,7 +4930,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2793 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0xcdc200", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4961,7 +4961,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2790 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0xcdc1a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc2c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4983,7 +4983,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3008 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xce73c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5005,7 +5005,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2797 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0xcdc280", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc3a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5027,7 +5027,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2799 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0xcdc2c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc3e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5049,7 +5049,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2800 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0xcdc2e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5071,7 +5071,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2801 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0xcdc300", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5093,7 +5093,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2798 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0xcdc2a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc3c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5115,7 +5115,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3002 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xce6b80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5137,7 +5137,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2993 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xce6a80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5159,7 +5159,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2852 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xce1860", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -5180,11 +5180,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2938 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xce4aee", Frameless: false}]
+              InjectionPoints: [{PC: "0xce55ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2939 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xce4b8d", Frameless: false}]
+              InjectionPoints: [{PC: "0xce564d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5205,11 +5205,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2983 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xce622a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6cea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2984 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xce629c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6d5c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5253,7 +5253,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2885 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xce3d80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5275,7 +5275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2997 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xce6b00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce75c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5297,7 +5297,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2814 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0xcdc9e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdcbe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5319,7 +5319,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2815 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0xcdca00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdcc00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5341,11 +5341,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3030 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xce7820", Frameless: true}]
+              InjectionPoints: [{PC: "0xce85e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3031 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce7842", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8602", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5372,7 +5372,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2994 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xce6aa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5399,7 +5399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2846 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0xce10a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5420,11 +5420,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2987 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xce63ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6e8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2988 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xce647c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6f3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5446,11 +5446,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3026 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xce76e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce84a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3027 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0xce76fe", Frameless: true}]
+              InjectionPoints: [{PC: "0xce84be", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5471,7 +5471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3025 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xce76c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5498,7 +5498,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2847 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xce17c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce1e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5531,7 +5531,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3003 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xce6ba0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5571,7 +5571,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3021 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xce74c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2819 EventRootType Probe[main.testTakeContext]
-              InjectionPoints: [{PC: "0xcdd0a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdd3a0", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
       version: 0
@@ -5619,11 +5619,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2926 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce4a0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce54ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2927 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce4aaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce556f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5644,11 +5644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2928 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce4a0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce54ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2929 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce4aaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce556f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5671,11 +5671,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2930 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xce4a0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xce54ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2931 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xce4aaf", Frameless: false}]
+              InjectionPoints: [{PC: "0xce556f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5707,7 +5707,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3009 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xce73e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce80a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5739,11 +5739,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3010 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xce7400", Frameless: true}]
+              InjectionPoints: [{PC: "0xce80c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3011 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xce741e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce80de", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5773,11 +5773,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3012 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xce7400", Frameless: true}]
+              InjectionPoints: [{PC: "0xce80c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3013 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xce741e", Frameless: true}]
+              InjectionPoints: [{PC: "0xce80de", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5809,7 +5809,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3014 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xce7420", Frameless: true}]
+              InjectionPoints: [{PC: "0xce80e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5839,7 +5839,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3015 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xce7420", Frameless: true}]
+              InjectionPoints: [{PC: "0xce80e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5871,7 +5871,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3040 EventRootType Probe[main.testTimeFixedZone]
-              InjectionPoints: [{PC: "0xce8ba0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5893,7 +5893,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3041 EventRootType Probe[main.testTimeMonotonic]
-              InjectionPoints: [{PC: "0xce8bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -5915,7 +5915,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3039 EventRootType Probe[main.testTimeUTC]
-              InjectionPoints: [{PC: "0xce8b80", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5937,7 +5937,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2804 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0xcdc360", Frameless: true}]
+              InjectionPoints: [{PC: "0xcdc480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6069,7 +6069,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2884 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xce3ca0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6091,7 +6091,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2991 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xce6a40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -6113,7 +6113,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3019 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xce7480", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6135,7 +6135,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2883 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xce3c60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce4600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6179,7 +6179,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3000 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xce6b60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6201,7 +6201,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3001 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xce6b60", Frameless: true}]
+              InjectionPoints: [{PC: "0xce7620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6224,14 +6224,14 @@ Probes:
             - Kind: Entry
               Type: 3106 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0xce0eaa"
+                - PC: "0xce148a"
                   Frameless: false
-                - PC: "0xceaa83"
+                - PC: "0xceba63"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 3107 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0xce0ee5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce14c5", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -6253,11 +6253,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2989 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xce64ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6f6e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2990 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce652c", Frameless: false}]
+              InjectionPoints: [{PC: "0xce6fec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -6554,132 +6554,6 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xcdc180..0xcdc181]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 5 BaseType uint8
-          Locations:
-            - Range: 0xcdc180..0xcdc181
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 22
-      Name: main.testSingleRune
-      OutOfLinePCRanges: [0xcdc1a0..0xcdc1a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 12 BaseType int32
-          Locations:
-            - Range: 0xcdc1a0..0xcdc1a1
-              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 23
-      Name: main.testSingleBool
-      OutOfLinePCRanges: [0xcdc1c0..0xcdc1c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 6 BaseType bool
-          Locations:
-            - Range: 0xcdc1c0..0xcdc1c1
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 24
-      Name: main.testSingleInt
-      OutOfLinePCRanges: [0xcdc1e0..0xcdc1e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xcdc1e0..0xcdc1e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 25
-      Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xcdc200..0xcdc201]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 18 BaseType int8
-          Locations:
-            - Range: 0xcdc200..0xcdc201
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 26
-      Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xcdc220..0xcdc221]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 107 BaseType int16
-          Locations:
-            - Range: 0xcdc220..0xcdc221
-              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 27
-      Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xcdc240..0xcdc241]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 12 BaseType int32
-          Locations:
-            - Range: 0xcdc240..0xcdc241
-              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 28
-      Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xcdc260..0xcdc261]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 14 BaseType int64
-          Locations:
-            - Range: 0xcdc260..0xcdc261
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 29
-      Name: main.testSingleUint
-      OutOfLinePCRanges: [0xcdc280..0xcdc281]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 19 BaseType uint
-          Locations:
-            - Range: 0xcdc280..0xcdc281
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 30
-      Name: main.testSingleUint8
       OutOfLinePCRanges: [0xcdc2a0..0xcdc2a1]
       InlinePCRanges: []
       Variables:
@@ -6692,41 +6566,41 @@ Subprograms:
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
-    - ID: 31
-      Name: main.testSingleUint16
+    - ID: 22
+      Name: main.testSingleRune
       OutOfLinePCRanges: [0xcdc2c0..0xcdc2c1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 BaseType uint16
+          Type: 12 BaseType int32
           Locations:
             - Range: 0xcdc2c0..0xcdc2c1
-              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 32
-      Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xcdc2e0..0xcdc2e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 4 BaseType uint32
-          Locations:
-            - Range: 0xcdc2e0..0xcdc2e1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
-    - ID: 33
-      Name: main.testSingleUint64
+    - ID: 23
+      Name: main.testSingleBool
+      OutOfLinePCRanges: [0xcdc2e0..0xcdc2e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 6 BaseType bool
+          Locations:
+            - Range: 0xcdc2e0..0xcdc2e1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 24
+      Name: main.testSingleInt
       OutOfLinePCRanges: [0xcdc300..0xcdc301]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 10 BaseType uint64
+          Type: 9 BaseType int
           Locations:
             - Range: 0xcdc300..0xcdc301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -6734,15 +6608,141 @@ Subprograms:
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
+    - ID: 25
+      Name: main.testSingleInt8
+      OutOfLinePCRanges: [0xcdc320..0xcdc321]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 18 BaseType int8
+          Locations:
+            - Range: 0xcdc320..0xcdc321
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 26
+      Name: main.testSingleInt16
+      OutOfLinePCRanges: [0xcdc340..0xcdc341]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 107 BaseType int16
+          Locations:
+            - Range: 0xcdc340..0xcdc341
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 27
+      Name: main.testSingleInt32
+      OutOfLinePCRanges: [0xcdc360..0xcdc361]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 12 BaseType int32
+          Locations:
+            - Range: 0xcdc360..0xcdc361
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 28
+      Name: main.testSingleInt64
+      OutOfLinePCRanges: [0xcdc380..0xcdc381]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 14 BaseType int64
+          Locations:
+            - Range: 0xcdc380..0xcdc381
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 29
+      Name: main.testSingleUint
+      OutOfLinePCRanges: [0xcdc3a0..0xcdc3a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 19 BaseType uint
+          Locations:
+            - Range: 0xcdc3a0..0xcdc3a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 30
+      Name: main.testSingleUint8
+      OutOfLinePCRanges: [0xcdc3c0..0xcdc3c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 5 BaseType uint8
+          Locations:
+            - Range: 0xcdc3c0..0xcdc3c1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 31
+      Name: main.testSingleUint16
+      OutOfLinePCRanges: [0xcdc3e0..0xcdc3e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 BaseType uint16
+          Locations:
+            - Range: 0xcdc3e0..0xcdc3e1
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 32
+      Name: main.testSingleUint32
+      OutOfLinePCRanges: [0xcdc400..0xcdc401]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 4 BaseType uint32
+          Locations:
+            - Range: 0xcdc400..0xcdc401
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 33
+      Name: main.testSingleUint64
+      OutOfLinePCRanges: [0xcdc420..0xcdc421]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 BaseType uint64
+          Locations:
+            - Range: 0xcdc420..0xcdc421
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xcdc320..0xcdc321]
+      OutOfLinePCRanges: [0xcdc440..0xcdc441]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 20 BaseType float32
           Locations:
-            - Range: 0xcdc320..0xcdc321
+            - Range: 0xcdc440..0xcdc441
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6750,13 +6750,13 @@ Subprograms:
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xcdc340..0xcdc341]
+      OutOfLinePCRanges: [0xcdc460..0xcdc461]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xcdc340..0xcdc341
+            - Range: 0xcdc460..0xcdc461
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6764,13 +6764,13 @@ Subprograms:
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xcdc360..0xcdc361]
+      OutOfLinePCRanges: [0xcdc480..0xcdc481]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 130 BaseType main.typeAlias
           Locations:
-            - Range: 0xcdc360..0xcdc361
+            - Range: 0xcdc480..0xcdc481
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6778,13 +6778,13 @@ Subprograms:
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xcdc4c0..0xcdc4df]
+      OutOfLinePCRanges: [0xcdc6c0..0xcdc6df]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 131 StructureType main.bigStruct
           Locations:
-            - Range: 0xcdc4c0..0xcdc4df
+            - Range: 0xcdc6c0..0xcdc6df
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6804,51 +6804,51 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0xcdc520..0xcdc61a]
+      OutOfLinePCRanges: [0xcdc720..0xcdc81a]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcdc520..0xcdc538
+            - Range: 0xcdc720..0xcdc738
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xcdc520..0xcdc61a, Pieces: []}]
+          Locations: [{Range: 0xcdc720..0xcdc81a, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: x
           Type: 9 BaseType int
-          Locations: [{Range: 0xcdc520..0xcdc61a, Pieces: []}]
+          Locations: [{Range: 0xcdc720..0xcdc81a, Pieces: []}]
           Role: Local
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: err
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xcdc549..0xcdc565
+            - Range: 0xcdc749..0xcdc765
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0xcdc565..0xcdc5d2
+            - Range: 0xcdc765..0xcdc7d2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcdc5d2..0xcdc5d7
+            - Range: 0xcdc7d2..0xcdc7d7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcdc5d7..0xcdc61a
+            - Range: 0xcdc7d7..0xcdc81a
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}, {Size: 8, Op: null}]
           Role: Local
           DictIndex: -1
@@ -6856,13 +6856,13 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xcdc680..0xcdc681]
+      OutOfLinePCRanges: [0xcdc880..0xcdc881]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 135 StructureType main.deepPtr1
           Locations:
-            - Range: 0xcdc680..0xcdc681
+            - Range: 0xcdc880..0xcdc881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6870,13 +6870,13 @@ Subprograms:
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xcdc6a0..0xcdc6a1]
+      OutOfLinePCRanges: [0xcdc8a0..0xcdc8a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 138 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xcdc6a0..0xcdc6a1
+            - Range: 0xcdc8a0..0xcdc8a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6884,13 +6884,13 @@ Subprograms:
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xcdc820..0xcdc821]
+      OutOfLinePCRanges: [0xcdca20..0xcdca21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 140 StructureType main.deepSlice1
           Locations:
-            - Range: 0xcdc820..0xcdc821
+            - Range: 0xcdca20..0xcdca21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6904,13 +6904,13 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xcdc840..0xcdc841]
+      OutOfLinePCRanges: [0xcdca40..0xcdca41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 144 PointerType *main.deepSlice7
           Locations:
-            - Range: 0xcdc840..0xcdc841
+            - Range: 0xcdca40..0xcdca41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6918,13 +6918,13 @@ Subprograms:
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xcdc9a0..0xcdc9a1]
+      OutOfLinePCRanges: [0xcdcba0..0xcdcba1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 146 StructureType main.deepMap1
           Locations:
-            - Range: 0xcdc9a0..0xcdc9a1
+            - Range: 0xcdcba0..0xcdcba1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6932,13 +6932,13 @@ Subprograms:
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xcdc9c0..0xcdc9c1]
+      OutOfLinePCRanges: [0xcdcbc0..0xcdcbc1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 152 PointerType *main.deepMap7
           Locations:
-            - Range: 0xcdc9c0..0xcdc9c1
+            - Range: 0xcdcbc0..0xcdcbc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6946,13 +6946,13 @@ Subprograms:
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0xcdc9e0..0xcdc9e1]
+      OutOfLinePCRanges: [0xcdcbe0..0xcdcbe1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 154 PointerType *main.stringType1
           Locations:
-            - Range: 0xcdc9e0..0xcdc9e1
+            - Range: 0xcdcbe0..0xcdcbe1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6960,13 +6960,13 @@ Subprograms:
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xcdca00..0xcdca01]
+      OutOfLinePCRanges: [0xcdcc00..0xcdcc01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 156 PointerType **main.stringType2
           Locations:
-            - Range: 0xcdca00..0xcdca01
+            - Range: 0xcdcc00..0xcdcc01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6974,15 +6974,15 @@ Subprograms:
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xcdca20..0xcdcc6a]
+      OutOfLinePCRanges: [0xcdcc20..0xcdce6a]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdcb04..0xcdcb25
+            - Range: 0xcdcd04..0xcdcd25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdcbd8..0xcdcbef
+            - Range: 0xcdcdd8..0xcdcdef
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -6990,15 +6990,15 @@ Subprograms:
         - Name: aPerArch
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdcaed..0xcdcaf0
+            - Range: 0xcdcced..0xcdccf0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdcaf0..0xcdcb25
+            - Range: 0xcdccf0..0xcdcd25
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdcb25..0xcdcbcb
+            - Range: 0xcdcd25..0xcdcdcb
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xcdcbcb..0xcdcbd8
+            - Range: 0xcdcdcb..0xcdcdd8
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcdcbd8..0xcdcc6a
+            - Range: 0xcdcdd8..0xcdce6a
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
           DictIndex: -1
@@ -7006,21 +7006,21 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcdcae7..0xcdcaf0
+            - Range: 0xcdcce7..0xcdccf0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdcaf0..0xcdcaf0
+            - Range: 0xcdccf0..0xcdccf0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdcaf0..0xcdcb25
+            - Range: 0xcdccf0..0xcdcd25
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdcb25..0xcdcbcb
+            - Range: 0xcdcd25..0xcdcdcb
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xcdcbcb..0xcdcbd0
+            - Range: 0xcdcdcb..0xcdcdd0
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xcdcbd0..0xcdcbd8
+            - Range: 0xcdcdd0..0xcdcdd8
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcdcbd8..0xcdcbef
+            - Range: 0xcdcdd8..0xcdcdef
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xcdcbef..0xcdcc6a
+            - Range: 0xcdcdef..0xcdce6a
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
           DictIndex: -1
@@ -7028,13 +7028,13 @@ Subprograms:
       DictRegister: null
     - ID: 48
       Name: main.testTakeContext
-      OutOfLinePCRanges: [0xcdd0a0..0xcdd0a1]
+      OutOfLinePCRanges: [0xcdd3a0..0xcdd3a1]
       InlinePCRanges: []
       Variables:
         - Name: ctx
           Type: 158 GoInterfaceType context.Context
           Locations:
-            - Range: 0xcdd0a0..0xcdd0a1
+            - Range: 0xcdd3a0..0xcdd3a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7046,13 +7046,13 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testCaptureContextImpl
-      OutOfLinePCRanges: [0xcdd2a0..0xcdd2a1]
+      OutOfLinePCRanges: [0xcdd5a0..0xcdd5a1]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 159 PointerType *main.contextImpl
           Locations:
-            - Range: 0xcdd2a0..0xcdd2a1
+            - Range: 0xcdd5a0..0xcdd5a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7060,13 +7060,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0xcdd580..0xcdd581]
+      OutOfLinePCRanges: [0xcdd880..0xcdd881]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 161 StructureType main.manyPointers
           Locations:
-            - Range: 0xcdd580..0xcdd581
+            - Range: 0xcdd880..0xcdd881
               Pieces: [{Size: 560, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7074,13 +7074,13 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0xcdef60..0xcdef61]
+      OutOfLinePCRanges: [0xcdf360..0xcdf361]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 164 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcdef60..0xcdef61
+            - Range: 0xcdf360..0xcdf361
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7094,13 +7094,13 @@ Subprograms:
       DictRegister: null
     - ID: 52
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xcdf280..0xcdf385]
+      OutOfLinePCRanges: [0xcdf760..0xcdf865]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 165 StructureType main.esotericStack
           Locations:
-            - Range: 0xcdf280..0xcdf2d3
+            - Range: 0xcdf760..0xcdf7b3
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -7120,7 +7120,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcdf2d3..0xcdf2d8
+            - Range: 0xcdf7b3..0xcdf7b8
               Pieces:
                 - Size: 4
                   Op: null
@@ -7140,7 +7140,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcdf2d8..0xcdf2dd
+            - Range: 0xcdf7b8..0xcdf7bd
               Pieces:
                 - Size: 4
                   Op: null
@@ -7166,13 +7166,13 @@ Subprograms:
       DictRegister: null
     - ID: 53
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xcdf3a0..0xcdf403]
+      OutOfLinePCRanges: [0xcdf880..0xcdf8e3]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 168 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xcdf3a0..0xcdf3cd
+            - Range: 0xcdf880..0xcdf8ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7180,13 +7180,13 @@ Subprograms:
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xce0960..0xce09e8]
+      OutOfLinePCRanges: [0xce0e40..0xce0ec8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0960..0xce0975
+            - Range: 0xce0e40..0xce0e55
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7194,13 +7194,13 @@ Subprograms:
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xce0a00..0xce0ac5]
+      OutOfLinePCRanges: [0xce0ee0..0xce0fa5]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0a00..0xce0a16
+            - Range: 0xce0ee0..0xce0ef6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7208,7 +7208,7 @@ Subprograms:
         - Name: "y"
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0a00..0xce0a27
+            - Range: 0xce0ee0..0xce0f07
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7216,9 +7216,9 @@ Subprograms:
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0a16..0xce0a27
+            - Range: 0xce0ef6..0xce0f07
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0a27..0xce0ac5
+            - Range: 0xce0f07..0xce0fa5
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
@@ -7226,13 +7226,13 @@ Subprograms:
       DictRegister: null
     - ID: 56
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xce0ae0..0xce0b42]
+      OutOfLinePCRanges: [0xce0fc0..0xce1022]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0ae0..0xce0afa
+            - Range: 0xce0fc0..0xce0fda
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7240,17 +7240,17 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xce0b60..0xce0c65]
+      OutOfLinePCRanges: [0xce1040..0xce1145]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0bbb..0xce0bc5
+            - Range: 0xce109b..0xce10a5
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xce0bc5..0xce0bd5
+            - Range: 0xce10a5..0xce10b5
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xce0bd5..0xce0be9
+            - Range: 0xce10b5..0xce10c9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7258,11 +7258,11 @@ Subprograms:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0bb6..0xce0bc0
+            - Range: 0xce1096..0xce10a0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xce0bc0..0xce0bd5
+            - Range: 0xce10a0..0xce10b5
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xce0bd5..0xce0be4
+            - Range: 0xce10b5..0xce10c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7270,13 +7270,13 @@ Subprograms:
       DictRegister: null
     - ID: 58
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xce0c80..0xce0c86]
+      OutOfLinePCRanges: [0xce1160..0xce1166]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0c80..0xce0c85
+            - Range: 0xce1160..0xce1165
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7284,9 +7284,9 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0c80..0xce0c85
+            - Range: 0xce1160..0xce1165
               Pieces: []
-            - Range: 0xce0c85..0xce0c86
+            - Range: 0xce1165..0xce1166
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -7294,13 +7294,13 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xce0ca0..0xce0ce3]
+      OutOfLinePCRanges: [0xce1180..0xce11c3]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 170 ArrayType [5]int
           Locations:
-            - Range: 0xce0ca0..0xce0ce3
+            - Range: 0xce1180..0xce11c3
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7308,11 +7308,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0ca0..0xce0cdd
+            - Range: 0xce1180..0xce11bd
               Pieces: []
-            - Range: 0xce0cdd..0xce0cde
+            - Range: 0xce11bd..0xce11be
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0cde..0xce0ce3
+            - Range: 0xce11be..0xce11c3
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7320,13 +7320,13 @@ Subprograms:
       DictRegister: null
     - ID: 60
       Name: main.testInterface
-      OutOfLinePCRanges: [0xce0f80..0xce0f81]
+      OutOfLinePCRanges: [0xce1560..0xce1561]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 171 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xce0f80..0xce0f81
+            - Range: 0xce1560..0xce1561
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7338,19 +7338,19 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testAny
-      OutOfLinePCRanges: [0xce0fa0..0xce1006]
+      OutOfLinePCRanges: [0xce1580..0xce15e6]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce0fa0..0xce0fc9
+            - Range: 0xce1580..0xce15a9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce0fc9..0xce0fce
+            - Range: 0xce15a9..0xce15ae
               Pieces:
                 - Size: 8
                   Op: null
@@ -7362,15 +7362,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce0fa0..0xce0fe5
+            - Range: 0xce1580..0xce15c5
               Pieces: []
-            - Range: 0xce0fe5..0xce0fe6
+            - Range: 0xce15c5..0xce15c6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce0fe6..0xce1006
+            - Range: 0xce15c6..0xce15e6
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7378,13 +7378,13 @@ Subprograms:
       DictRegister: null
     - ID: 62
       Name: main.testError
-      OutOfLinePCRanges: [0xce1020..0xce1021]
+      OutOfLinePCRanges: [0xce1600..0xce1601]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xce1020..0xce1021
+            - Range: 0xce1600..0xce1601
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7396,13 +7396,13 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xce1040..0xce1094]
+      OutOfLinePCRanges: [0xce1620..0xce1674]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 172 PointerType *interface {}
           Locations:
-            - Range: 0xce1040..0xce1066
+            - Range: 0xce1620..0xce1646
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7410,15 +7410,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce1040..0xce107d
+            - Range: 0xce1620..0xce165d
               Pieces: []
-            - Range: 0xce107d..0xce107e
+            - Range: 0xce165d..0xce165e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce107e..0xce1094
+            - Range: 0xce165e..0xce1674
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7426,13 +7426,13 @@ Subprograms:
       DictRegister: null
     - ID: 64
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xce10a0..0xce10a1]
+      OutOfLinePCRanges: [0xce1680..0xce1681]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 173 StructureType main.structWithAny
           Locations:
-            - Range: 0xce10a0..0xce10a1
+            - Range: 0xce1680..0xce1681
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7444,13 +7444,13 @@ Subprograms:
       DictRegister: null
     - ID: 65
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xce17c0..0xce17c1]
+      OutOfLinePCRanges: [0xce1e80..0xce1e81]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 174 StructureType main.structWithMap
           Locations:
-            - Range: 0xce17c0..0xce17c1
+            - Range: 0xce1e80..0xce1e81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7458,13 +7458,13 @@ Subprograms:
       DictRegister: null
     - ID: 66
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xce17e0..0xce17e1]
+      OutOfLinePCRanges: [0xce1ea0..0xce1ea1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 180 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xce17e0..0xce17e1
+            - Range: 0xce1ea0..0xce1ea1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7472,13 +7472,13 @@ Subprograms:
       DictRegister: null
     - ID: 67
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xce1800..0xce1801]
+      OutOfLinePCRanges: [0xce1ec0..0xce1ec1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 185 GoMapType map[string]int
           Locations:
-            - Range: 0xce1800..0xce1801
+            - Range: 0xce1ec0..0xce1ec1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7486,13 +7486,13 @@ Subprograms:
       DictRegister: null
     - ID: 68
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xce1820..0xce1821]
+      OutOfLinePCRanges: [0xce1ee0..0xce1ee1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 190 GoMapType map[string][]string
           Locations:
-            - Range: 0xce1820..0xce1821
+            - Range: 0xce1ee0..0xce1ee1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7500,13 +7500,13 @@ Subprograms:
       DictRegister: null
     - ID: 69
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xce1840..0xce1841]
+      OutOfLinePCRanges: [0xce1f00..0xce1f01]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 195 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0xce1840..0xce1841
+            - Range: 0xce1f00..0xce1f01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7514,13 +7514,13 @@ Subprograms:
       DictRegister: null
     - ID: 70
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0xce1860..0xce1861]
+      OutOfLinePCRanges: [0xce1f20..0xce1f21]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 185 GoMapType map[string]int
           Locations:
-            - Range: 0xce1860..0xce1861
+            - Range: 0xce1f20..0xce1f21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7528,13 +7528,13 @@ Subprograms:
       DictRegister: null
     - ID: 71
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xce1880..0xce1881]
+      OutOfLinePCRanges: [0xce1f40..0xce1f41]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 200 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xce1880..0xce1881
+            - Range: 0xce1f40..0xce1f41
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7542,13 +7542,13 @@ Subprograms:
       DictRegister: null
     - ID: 72
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xce18a0..0xce18a1]
+      OutOfLinePCRanges: [0xce1f60..0xce1f61]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 201 PointerType *map[string]int
           Locations:
-            - Range: 0xce18a0..0xce18a1
+            - Range: 0xce1f60..0xce1f61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7556,13 +7556,13 @@ Subprograms:
       DictRegister: null
     - ID: 73
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xce18c0..0xce18c1]
+      OutOfLinePCRanges: [0xce1f80..0xce1f81]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 175 GoMapType map[int]int
           Locations:
-            - Range: 0xce18c0..0xce18c1
+            - Range: 0xce1f80..0xce1f81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7570,13 +7570,13 @@ Subprograms:
       DictRegister: null
     - ID: 74
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0xce18e0..0xce18e1]
+      OutOfLinePCRanges: [0xce1fa0..0xce1fa1]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 202 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xce18e0..0xce18e1
+            - Range: 0xce1fa0..0xce1fa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7584,13 +7584,13 @@ Subprograms:
       DictRegister: null
     - ID: 75
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xce1900..0xce1901]
+      OutOfLinePCRanges: [0xce1fc0..0xce1fc1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 202 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xce1900..0xce1901
+            - Range: 0xce1fc0..0xce1fc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7598,13 +7598,13 @@ Subprograms:
       DictRegister: null
     - ID: 76
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xce1920..0xce1921]
+      OutOfLinePCRanges: [0xce1fe0..0xce1fe1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 207 GoMapType map[bool]main.node
           Locations:
-            - Range: 0xce1920..0xce1921
+            - Range: 0xce1fe0..0xce1fe1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7612,13 +7612,13 @@ Subprograms:
       DictRegister: null
     - ID: 77
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xce1940..0xce1941]
+      OutOfLinePCRanges: [0xce2000..0xce2001]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 212 GoMapType map[int]uint8
           Locations:
-            - Range: 0xce1940..0xce1941
+            - Range: 0xce2000..0xce2001
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7626,13 +7626,13 @@ Subprograms:
       DictRegister: null
     - ID: 78
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xce1960..0xce1961]
+      OutOfLinePCRanges: [0xce2020..0xce2021]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 212 GoMapType map[int]uint8
           Locations:
-            - Range: 0xce1960..0xce1961
+            - Range: 0xce2020..0xce2021
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7640,13 +7640,13 @@ Subprograms:
       DictRegister: null
     - ID: 79
       Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xce1980..0xce1981]
+      OutOfLinePCRanges: [0xce2040..0xce2041]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 217 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xce1980..0xce1981
+            - Range: 0xce2040..0xce2041
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7654,13 +7654,13 @@ Subprograms:
       DictRegister: null
     - ID: 80
       Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0xce19a0..0xce19a1]
+      OutOfLinePCRanges: [0xce2060..0xce2061]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 217 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xce19a0..0xce19a1
+            - Range: 0xce2060..0xce2061
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7668,13 +7668,13 @@ Subprograms:
       DictRegister: null
     - ID: 81
       Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0xce19c0..0xce19c1]
+      OutOfLinePCRanges: [0xce2080..0xce2081]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 217 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xce19c0..0xce19c1
+            - Range: 0xce2080..0xce2081
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7682,13 +7682,13 @@ Subprograms:
       DictRegister: null
     - ID: 82
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0xce19e0..0xce19e1]
+      OutOfLinePCRanges: [0xce20a0..0xce20a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 222 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0xce19e0..0xce19e1
+            - Range: 0xce20a0..0xce20a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7696,13 +7696,13 @@ Subprograms:
       DictRegister: null
     - ID: 83
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0xce1a00..0xce1a01]
+      OutOfLinePCRanges: [0xce20c0..0xce20c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 227 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0xce1a00..0xce1a01
+            - Range: 0xce20c0..0xce20c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7710,13 +7710,13 @@ Subprograms:
       DictRegister: null
     - ID: 84
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0xce1a20..0xce1a21]
+      OutOfLinePCRanges: [0xce20e0..0xce20e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 232 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0xce1a20..0xce1a21
+            - Range: 0xce20e0..0xce20e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7724,13 +7724,13 @@ Subprograms:
       DictRegister: null
     - ID: 85
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0xce1a40..0xce1a41]
+      OutOfLinePCRanges: [0xce2100..0xce2101]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 237 GoMapType map[struct {}]int
           Locations:
-            - Range: 0xce1a40..0xce1a41
+            - Range: 0xce2100..0xce2101
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7738,13 +7738,13 @@ Subprograms:
       DictRegister: null
     - ID: 86
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0xce1a60..0xce1a61]
+      OutOfLinePCRanges: [0xce2120..0xce2121]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 242 GoMapType map[int]struct {}
           Locations:
-            - Range: 0xce1a60..0xce1a61
+            - Range: 0xce2120..0xce2121
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7752,13 +7752,13 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0xce1a80..0xce1a81]
+      OutOfLinePCRanges: [0xce2140..0xce2141]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 247 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0xce1a80..0xce1a81
+            - Range: 0xce2140..0xce2141
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7766,13 +7766,13 @@ Subprograms:
       DictRegister: null
     - ID: 88
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xce3380..0xce3381]
+      OutOfLinePCRanges: [0xce3a40..0xce3a41]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xce3380..0xce3381
+            - Range: 0xce3a40..0xce3a41
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7780,7 +7780,7 @@ Subprograms:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xce3380..0xce3381
+            - Range: 0xce3a40..0xce3a41
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7788,7 +7788,7 @@ Subprograms:
         - Name: "y"
           Type: 20 BaseType float32
           Locations:
-            - Range: 0xce3380..0xce3381
+            - Range: 0xce3a40..0xce3a41
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7796,13 +7796,13 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xce33c0..0xce33c1]
+      OutOfLinePCRanges: [0xce3a80..0xce3a81]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xce33c0..0xce33c1
+            - Range: 0xce3a80..0xce3a81
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7810,7 +7810,7 @@ Subprograms:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce33c0..0xce33c1
+            - Range: 0xce3a80..0xce3a81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7822,7 +7822,7 @@ Subprograms:
         - Name: "y"
           Type: 20 BaseType float32
           Locations:
-            - Range: 0xce33c0..0xce33c1
+            - Range: 0xce3a80..0xce3a81
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7830,13 +7830,13 @@ Subprograms:
       DictRegister: null
     - ID: 90
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xce3540..0xce3541]
+      OutOfLinePCRanges: [0xce3c00..0xce3c01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce3540..0xce3541
+            - Range: 0xce3c00..0xce3c01
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7844,7 +7844,7 @@ Subprograms:
         - Name: b
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xce3540..0xce3541
+            - Range: 0xce3c00..0xce3c01
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7852,7 +7852,7 @@ Subprograms:
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xce3540..0xce3541
+            - Range: 0xce3c00..0xce3c01
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7860,7 +7860,7 @@ Subprograms:
         - Name: d
           Type: 19 BaseType uint
           Locations:
-            - Range: 0xce3540..0xce3541
+            - Range: 0xce3c00..0xce3c01
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7868,7 +7868,7 @@ Subprograms:
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce3540..0xce3541
+            - Range: 0xce3c00..0xce3c01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7880,13 +7880,13 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.(*Server).handleOrder
-      OutOfLinePCRanges: [0xce3760..0xce395f]
+      OutOfLinePCRanges: [0xce3f00..0xce40ff]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 252 PointerType *main.Server
           Locations:
-            - Range: 0xce3760..0xce37b6
+            - Range: 0xce3f00..0xce3f56
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7894,9 +7894,9 @@ Subprograms:
         - Name: req
           Type: 254 PointerType *main.Request
           Locations:
-            - Range: 0xce3760..0xce37b3
+            - Range: 0xce3f00..0xce3f53
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce37b3..0xce395f
+            - Range: 0xce3f53..0xce40ff
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7904,23 +7904,23 @@ Subprograms:
         - Name: ~r0
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xce3760..0xce385c
+            - Range: 0xce3f00..0xce3ffc
               Pieces: []
-            - Range: 0xce385c..0xce385d
+            - Range: 0xce3ffc..0xce3ffd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce385d..0xce3937
+            - Range: 0xce3ffd..0xce40d7
               Pieces: []
-            - Range: 0xce3937..0xce3938
+            - Range: 0xce40d7..0xce40d8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce3938..0xce395f
+            - Range: 0xce40d8..0xce40ff
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7928,13 +7928,13 @@ Subprograms:
       DictRegister: null
     - ID: 92
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xce3a20..0xce3a33]
+      OutOfLinePCRanges: [0xce42e0..0xce42f3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xce3a20..0xce3a32
+            - Range: 0xce42e0..0xce42f2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7942,9 +7942,9 @@ Subprograms:
         - Name: ~r0
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xce3a20..0xce3a32
+            - Range: 0xce42e0..0xce42f2
               Pieces: []
-            - Range: 0xce3a32..0xce3a33
+            - Range: 0xce42f2..0xce42f3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -7952,13 +7952,13 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testChannel
-      OutOfLinePCRanges: [0xce3a40..0xce3a41]
+      OutOfLinePCRanges: [0xce4300..0xce4301]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 256 GoChannelType chan bool
           Locations:
-            - Range: 0xce3a40..0xce3a41
+            - Range: 0xce4300..0xce4301
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7966,13 +7966,13 @@ Subprograms:
       DictRegister: null
     - ID: 94
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xce3c00..0xce3c01]
+      OutOfLinePCRanges: [0xce45a0..0xce45a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 257 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xce3c00..0xce3c01
+            - Range: 0xce45a0..0xce45a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7980,13 +7980,13 @@ Subprograms:
       DictRegister: null
     - ID: 95
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xce3c20..0xce3c21]
+      OutOfLinePCRanges: [0xce45c0..0xce45c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 259 StructureType main.node
           Locations:
-            - Range: 0xce3c20..0xce3c21
+            - Range: 0xce45c0..0xce45c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7998,13 +7998,13 @@ Subprograms:
       DictRegister: null
     - ID: 96
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xce3c40..0xce3c41]
+      OutOfLinePCRanges: [0xce45e0..0xce45e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 260 PointerType *main.node
           Locations:
-            - Range: 0xce3c40..0xce3c41
+            - Range: 0xce45e0..0xce45e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8012,13 +8012,13 @@ Subprograms:
       DictRegister: null
     - ID: 97
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xce3c60..0xce3c61]
+      OutOfLinePCRanges: [0xce4600..0xce4601]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xce3c60..0xce3c61
+            - Range: 0xce4600..0xce4601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8026,13 +8026,13 @@ Subprograms:
       DictRegister: null
     - ID: 98
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xce3ca0..0xce3ca1]
+      OutOfLinePCRanges: [0xce4640..0xce4641]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 PointerType *uint
           Locations:
-            - Range: 0xce3ca0..0xce3ca1
+            - Range: 0xce4640..0xce4641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8040,13 +8040,13 @@ Subprograms:
       DictRegister: null
     - ID: 99
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xce3d80..0xce3d81]
+      OutOfLinePCRanges: [0xce4720..0xce4721]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 98 PointerType *string
           Locations:
-            - Range: 0xce3d80..0xce3d81
+            - Range: 0xce4720..0xce4721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8054,13 +8054,13 @@ Subprograms:
       DictRegister: null
     - ID: 100
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xce3dc0..0xce3dc1]
+      OutOfLinePCRanges: [0xce4760..0xce4761]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 13 PointerType *bool
           Locations:
-            - Range: 0xce3dc0..0xce3dc1
+            - Range: 0xce4760..0xce4761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8068,7 +8068,7 @@ Subprograms:
         - Name: a
           Type: 19 BaseType uint
           Locations:
-            - Range: 0xce3dc0..0xce3dc1
+            - Range: 0xce4760..0xce4761
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8076,13 +8076,13 @@ Subprograms:
       DictRegister: null
     - ID: 101
       Name: main.testCycle
-      OutOfLinePCRanges: [0xce3e00..0xce3e01]
+      OutOfLinePCRanges: [0xce47a0..0xce47a1]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 261 PointerType *main.t
           Locations:
-            - Range: 0xce3e00..0xce3e01
+            - Range: 0xce47a0..0xce47a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8090,13 +8090,13 @@ Subprograms:
       DictRegister: null
     - ID: 102
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xce4240..0xce42b2]
+      OutOfLinePCRanges: [0xce4d00..0xce4d72]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4240..0xce4252
+            - Range: 0xce4d00..0xce4d12
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8104,11 +8104,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4240..0xce429b
+            - Range: 0xce4d00..0xce4d5b
               Pieces: []
-            - Range: 0xce429b..0xce429c
+            - Range: 0xce4d5b..0xce4d5c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce429c..0xce42b2
+            - Range: 0xce4d5c..0xce4d72
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8116,9 +8116,9 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4252..0xce4265
+            - Range: 0xce4d12..0xce4d25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce4265..0xce42b2
+            - Range: 0xce4d25..0xce4d72
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
@@ -8126,15 +8126,15 @@ Subprograms:
       DictRegister: null
     - ID: 103
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xce42c0..0xce434f]
+      OutOfLinePCRanges: [0xce4d80..0xce4e0f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce42c0..0xce42da
+            - Range: 0xce4d80..0xce4d9a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce42da..0xce434f
+            - Range: 0xce4d9a..0xce4e0f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8142,11 +8142,11 @@ Subprograms:
         - Name: ~r0
           Type: 102 PointerType *int
           Locations:
-            - Range: 0xce42c0..0xce4334
+            - Range: 0xce4d80..0xce4df4
               Pieces: []
-            - Range: 0xce4334..0xce4335
+            - Range: 0xce4df4..0xce4df5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce4335..0xce434f
+            - Range: 0xce4df5..0xce4e0f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8154,9 +8154,9 @@ Subprograms:
         - Name: '&result'
           Type: 102 PointerType *int
           Locations:
-            - Range: 0xce42df..0xce42f9
+            - Range: 0xce4d9f..0xce4db9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce42f9..0xce434f
+            - Range: 0xce4db9..0xce4e0f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
@@ -8164,13 +8164,13 @@ Subprograms:
       DictRegister: null
     - ID: 104
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xce4360..0xce443e]
+      OutOfLinePCRanges: [0xce4e20..0xce4efe]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4360..0xce43c2
+            - Range: 0xce4e20..0xce4e82
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8178,27 +8178,27 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4360..0xce4424
+            - Range: 0xce4e20..0xce4ee4
               Pieces: []
-            - Range: 0xce4424..0xce4425
+            - Range: 0xce4ee4..0xce4ee5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce4425..0xce443e
+            - Range: 0xce4ee5..0xce4efe
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce4360..0xce443e, Pieces: []}]
+          Locations: [{Range: 0xce4e20..0xce4efe, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4376..0xce43c7
+            - Range: 0xce4e36..0xce4e87
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce43c7..0xce443e
+            - Range: 0xce4e87..0xce4efe
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
@@ -8206,9 +8206,9 @@ Subprograms:
         - Name: resultFloat
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xce438f..0xce43c7
+            - Range: 0xce4e4f..0xce4e87
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xce43c7..0xce443e
+            - Range: 0xce4e87..0xce4efe
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
@@ -8216,13 +8216,13 @@ Subprograms:
       DictRegister: null
     - ID: 105
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xce4440..0xce449b]
+      OutOfLinePCRanges: [0xce4f00..0xce4f5b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce4440..0xce4459
+            - Range: 0xce4f00..0xce4f19
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8230,23 +8230,23 @@ Subprograms:
         - Name: ~r0
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xce4440..0xce447a
+            - Range: 0xce4f00..0xce4f3a
               Pieces: []
-            - Range: 0xce447a..0xce447b
+            - Range: 0xce4f3a..0xce4f3b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce447b..0xce4485
+            - Range: 0xce4f3b..0xce4f45
               Pieces: []
-            - Range: 0xce4485..0xce4486
+            - Range: 0xce4f45..0xce4f46
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4486..0xce449b
+            - Range: 0xce4f46..0xce4f5b
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8254,37 +8254,37 @@ Subprograms:
       DictRegister: null
     - ID: 106
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xce44a0..0xce45e6]
+      OutOfLinePCRanges: [0xce4f60..0xce50a6]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce44a0..0xce44eb
+            - Range: 0xce4f60..0xce4fab
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce44eb..0xce44f6
+            - Range: 0xce4fab..0xce4fb6
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4527..0xce452a
+            - Range: 0xce4fe7..0xce4fea
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4560..0xce4565
+            - Range: 0xce5020..0xce5025
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4594..0xce4599
+            - Range: 0xce5054..0xce5059
               Pieces:
                 - Size: 8
                   Op: null
@@ -8296,7 +8296,7 @@ Subprograms:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce44a0..0xce44e3
+            - Range: 0xce4f60..0xce4fa3
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8304,39 +8304,39 @@ Subprograms:
         - Name: ~r0
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce44a0..0xce4504
+            - Range: 0xce4f60..0xce4fc4
               Pieces: []
-            - Range: 0xce4504..0xce4505
+            - Range: 0xce4fc4..0xce4fc5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4505..0xce4553
+            - Range: 0xce4fc5..0xce5013
               Pieces: []
-            - Range: 0xce4553..0xce4554
+            - Range: 0xce5013..0xce5014
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4554..0xce4587
+            - Range: 0xce5014..0xce5047
               Pieces: []
-            - Range: 0xce4587..0xce4588
+            - Range: 0xce5047..0xce5048
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4588..0xce45b9
+            - Range: 0xce5048..0xce5079
               Pieces: []
-            - Range: 0xce45b9..0xce45ba
+            - Range: 0xce5079..0xce507a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce45ba..0xce45e6
+            - Range: 0xce507a..0xce50a6
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8344,39 +8344,39 @@ Subprograms:
         - Name: ~r1
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xce44a0..0xce4504
+            - Range: 0xce4f60..0xce4fc4
               Pieces: []
-            - Range: 0xce4504..0xce4505
+            - Range: 0xce4fc4..0xce4fc5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce4505..0xce4553
+            - Range: 0xce4fc5..0xce5013
               Pieces: []
-            - Range: 0xce4553..0xce4554
+            - Range: 0xce5013..0xce5014
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce4554..0xce4587
+            - Range: 0xce5014..0xce5047
               Pieces: []
-            - Range: 0xce4587..0xce4588
+            - Range: 0xce5047..0xce5048
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce4588..0xce45b9
+            - Range: 0xce5048..0xce5079
               Pieces: []
-            - Range: 0xce45b9..0xce45ba
+            - Range: 0xce5079..0xce507a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce45ba..0xce45e6
+            - Range: 0xce507a..0xce50a6
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8384,7 +8384,7 @@ Subprograms:
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce44eb..0xce44f1
+            - Range: 0xce4fab..0xce4fb1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8392,25 +8392,25 @@ Subprograms:
       DictRegister: null
     - ID: 107
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xce4600..0xce47ee]
+      OutOfLinePCRanges: [0xce50c0..0xce52ae]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce4600..0xce464b
+            - Range: 0xce50c0..0xce510b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce464b..0xce4652
+            - Range: 0xce510b..0xce5112
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce4652..0xce47ee
+            - Range: 0xce5112..0xce52ae
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -8422,39 +8422,39 @@ Subprograms:
         - Name: ~r0
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce4600..0xce46b5
+            - Range: 0xce50c0..0xce5175
               Pieces: []
-            - Range: 0xce46b5..0xce46b6
+            - Range: 0xce5175..0xce5176
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce46b6..0xce4704
+            - Range: 0xce5176..0xce51c4
               Pieces: []
-            - Range: 0xce4704..0xce4705
+            - Range: 0xce51c4..0xce51c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4705..0xce47c0
+            - Range: 0xce51c5..0xce5280
               Pieces: []
-            - Range: 0xce47c0..0xce47c1
+            - Range: 0xce5280..0xce5281
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce47c1..0xce47ca
+            - Range: 0xce5281..0xce528a
               Pieces: []
-            - Range: 0xce47ca..0xce47cb
+            - Range: 0xce528a..0xce528b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce47cb..0xce47ee
+            - Range: 0xce528b..0xce52ae
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8462,7 +8462,7 @@ Subprograms:
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce46a0..0xce46a6
+            - Range: 0xce5160..0xce5166
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8470,7 +8470,7 @@ Subprograms:
         - Name: '&result'
           Type: 102 PointerType *int
           Locations:
-            - Range: 0xce46e5..0xce4704
+            - Range: 0xce51a5..0xce51c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8478,35 +8478,35 @@ Subprograms:
       DictRegister: null
     - ID: 108
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xce4800..0xce4954]
+      OutOfLinePCRanges: [0xce52c0..0xce5414]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce4800..0xce4840
+            - Range: 0xce52c0..0xce5300
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4840..0xce488e
+            - Range: 0xce5300..0xce534e
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce488e..0xce48ef
+            - Range: 0xce534e..0xce53af
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce48ef..0xce4911
+            - Range: 0xce53af..0xce53d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce4911..0xce4918
+            - Range: 0xce53d1..0xce53d8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce4918..0xce4954
+            - Range: 0xce53d8..0xce5414
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8514,23 +8514,23 @@ Subprograms:
         - Name: ~r0
           Type: 171 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xce4800..0xce48df
+            - Range: 0xce52c0..0xce539f
               Pieces: []
-            - Range: 0xce48df..0xce48e0
+            - Range: 0xce539f..0xce53a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce48e0..0xce48e9
+            - Range: 0xce53a0..0xce53a9
               Pieces: []
-            - Range: 0xce48e9..0xce48ea
+            - Range: 0xce53a9..0xce53aa
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce48ea..0xce4954
+            - Range: 0xce53aa..0xce5414
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8538,39 +8538,39 @@ Subprograms:
         - Name: b
           Type: 171 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xce4800..0xce4840
+            - Range: 0xce52c0..0xce5300
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4840..0xce488e
+            - Range: 0xce5300..0xce534e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce488e..0xce4895
+            - Range: 0xce534e..0xce5355
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce4895..0xce48e5
+            - Range: 0xce5355..0xce53a5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce48e5..0xce48e7
+            - Range: 0xce53a5..0xce53a7
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xce48e7..0xce48e9
+            - Range: 0xce53a7..0xce53a9
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce48e9..0xce4954
+            - Range: 0xce53a9..0xce5414
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
@@ -8578,13 +8578,13 @@ Subprograms:
       DictRegister: null
     - ID: 109
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xce4960..0xce49ef]
+      OutOfLinePCRanges: [0xce5420..0xce54af]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4960..0xce4971
+            - Range: 0xce5420..0xce5431
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8592,11 +8592,11 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4960..0xce49d5
+            - Range: 0xce5420..0xce5495
               Pieces: []
-            - Range: 0xce49d5..0xce49d6
+            - Range: 0xce5495..0xce5496
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce49d6..0xce49ef
+            - Range: 0xce5496..0xce54af
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8604,13 +8604,13 @@ Subprograms:
       DictRegister: null
     - ID: 110
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xce4a00..0xce4ac9]
+      OutOfLinePCRanges: [0xce54c0..0xce5589]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4a00..0xce4a51
+            - Range: 0xce54c0..0xce5511
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8618,11 +8618,11 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4a00..0xce4aaf
+            - Range: 0xce54c0..0xce556f
               Pieces: []
-            - Range: 0xce4aaf..0xce4ab0
+            - Range: 0xce556f..0xce5570
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce4ab0..0xce4ac9
+            - Range: 0xce5570..0xce5589
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8630,11 +8630,11 @@ Subprograms:
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4a00..0xce4aaf
+            - Range: 0xce54c0..0xce556f
               Pieces: []
-            - Range: 0xce4aaf..0xce4ab0
+            - Range: 0xce556f..0xce5570
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce4ab0..0xce4ac9
+            - Range: 0xce5570..0xce5589
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8642,15 +8642,15 @@ Subprograms:
       DictRegister: null
     - ID: 111
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xce4ae0..0xce4ba7]
+      OutOfLinePCRanges: [0xce55a0..0xce5667]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4ae0..0xce4b25
+            - Range: 0xce55a0..0xce55e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce4b25..0xce4ba7
+            - Range: 0xce55e5..0xce5667
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8658,11 +8658,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4ae0..0xce4b8d
+            - Range: 0xce55a0..0xce564d
               Pieces: []
-            - Range: 0xce4b8d..0xce4b8e
+            - Range: 0xce564d..0xce564e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce4b8e..0xce4ba7
+            - Range: 0xce564e..0xce5667
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8670,11 +8670,11 @@ Subprograms:
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4ae0..0xce4b8d
+            - Range: 0xce55a0..0xce564d
               Pieces: []
-            - Range: 0xce4b8d..0xce4b8e
+            - Range: 0xce564d..0xce564e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce4b8e..0xce4ba7
+            - Range: 0xce564e..0xce5667
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8682,11 +8682,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4ae0..0xce4b8d
+            - Range: 0xce55a0..0xce564d
               Pieces: []
-            - Range: 0xce4b8d..0xce4b8e
+            - Range: 0xce564d..0xce564e
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce4b8e..0xce4ba7
+            - Range: 0xce564e..0xce5667
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8694,15 +8694,15 @@ Subprograms:
       DictRegister: null
     - ID: 112
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xce4bc0..0xce4caf]
+      OutOfLinePCRanges: [0xce5680..0xce576f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4bc0..0xce4c05
+            - Range: 0xce5680..0xce56c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce4c05..0xce4caf
+            - Range: 0xce56c5..0xce576f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8710,11 +8710,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4bc0..0xce4c91
+            - Range: 0xce5680..0xce5751
               Pieces: []
-            - Range: 0xce4c91..0xce4c92
+            - Range: 0xce5751..0xce5752
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce4c92..0xce4caf
+            - Range: 0xce5752..0xce576f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8722,15 +8722,15 @@ Subprograms:
         - Name: r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce4bc0..0xce4c91
+            - Range: 0xce5680..0xce5751
               Pieces: []
-            - Range: 0xce4c91..0xce4c92
+            - Range: 0xce5751..0xce5752
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce4c92..0xce4caf
+            - Range: 0xce5752..0xce576f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8738,15 +8738,15 @@ Subprograms:
       DictRegister: null
     - ID: 113
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xce4cc0..0xce4ecf]
+      OutOfLinePCRanges: [0xce5780..0xce598f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce4cc0..0xce4d46
+            - Range: 0xce5780..0xce5806
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce4d46..0xce4ecf
+            - Range: 0xce5806..0xce598f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8754,7 +8754,7 @@ Subprograms:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce4cf7..0xce4ecf
+            - Range: 0xce57b7..0xce598f
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
@@ -8762,7 +8762,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce4cfd..0xce4ecf
+            - Range: 0xce57bd..0xce598f
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
@@ -8770,17 +8770,17 @@ Subprograms:
       DictRegister: null
     - ID: 114
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xce4fc0..0xce503e]
+      OutOfLinePCRanges: [0xce5a80..0xce5afe]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType int8
           Locations:
-            - Range: 0xce4fc0..0xce5031
+            - Range: 0xce5a80..0xce5af1
               Pieces: []
-            - Range: 0xce5031..0xce5032
+            - Range: 0xce5af1..0xce5af2
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce5032..0xce503e
+            - Range: 0xce5af2..0xce5afe
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8788,11 +8788,11 @@ Subprograms:
         - Name: ~r1
           Type: 107 BaseType int16
           Locations:
-            - Range: 0xce4fc0..0xce5031
+            - Range: 0xce5a80..0xce5af1
               Pieces: []
-            - Range: 0xce5031..0xce5032
+            - Range: 0xce5af1..0xce5af2
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce5032..0xce503e
+            - Range: 0xce5af2..0xce5afe
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8800,11 +8800,11 @@ Subprograms:
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xce4fc0..0xce5031
+            - Range: 0xce5a80..0xce5af1
               Pieces: []
-            - Range: 0xce5031..0xce5032
+            - Range: 0xce5af1..0xce5af2
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce5032..0xce503e
+            - Range: 0xce5af2..0xce5afe
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8812,11 +8812,11 @@ Subprograms:
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0xce4fc0..0xce5031
+            - Range: 0xce5a80..0xce5af1
               Pieces: []
-            - Range: 0xce5031..0xce5032
+            - Range: 0xce5af1..0xce5af2
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce5032..0xce503e
+            - Range: 0xce5af2..0xce5afe
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8824,11 +8824,11 @@ Subprograms:
         - Name: ~r4
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xce4fc0..0xce5031
+            - Range: 0xce5a80..0xce5af1
               Pieces: []
-            - Range: 0xce5031..0xce5032
+            - Range: 0xce5af1..0xce5af2
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce5032..0xce503e
+            - Range: 0xce5af2..0xce5afe
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8836,11 +8836,11 @@ Subprograms:
         - Name: ~r5
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0xce4fc0..0xce5031
+            - Range: 0xce5a80..0xce5af1
               Pieces: []
-            - Range: 0xce5031..0xce5032
+            - Range: 0xce5af1..0xce5af2
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce5032..0xce503e
+            - Range: 0xce5af2..0xce5afe
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8848,11 +8848,11 @@ Subprograms:
         - Name: ~r6
           Type: 4 BaseType uint32
           Locations:
-            - Range: 0xce4fc0..0xce5031
+            - Range: 0xce5a80..0xce5af1
               Pieces: []
-            - Range: 0xce5031..0xce5032
+            - Range: 0xce5af1..0xce5af2
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce5032..0xce503e
+            - Range: 0xce5af2..0xce5afe
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8860,11 +8860,11 @@ Subprograms:
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xce4fc0..0xce5031
+            - Range: 0xce5a80..0xce5af1
               Pieces: []
-            - Range: 0xce5031..0xce5032
+            - Range: 0xce5af1..0xce5af2
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce5032..0xce503e
+            - Range: 0xce5af2..0xce5afe
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8872,107 +8872,107 @@ Subprograms:
       DictRegister: null
     - ID: 115
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xce5040..0xce5137]
+      OutOfLinePCRanges: [0xce5b00..0xce5bf7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5040..0xce5137, Pieces: []}]
+          Locations: [{Range: 0xce5b00..0xce5bf7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5040..0xce5137, Pieces: []}]
+          Locations: [{Range: 0xce5b00..0xce5bf7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5040..0xce5137, Pieces: []}]
+          Locations: [{Range: 0xce5b00..0xce5bf7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5040..0xce5137, Pieces: []}]
+          Locations: [{Range: 0xce5b00..0xce5bf7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5040..0xce5137, Pieces: []}]
+          Locations: [{Range: 0xce5b00..0xce5bf7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r5
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5040..0xce5137, Pieces: []}]
+          Locations: [{Range: 0xce5b00..0xce5bf7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r6
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5040..0xce5137, Pieces: []}]
+          Locations: [{Range: 0xce5b00..0xce5bf7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r7
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5040..0xce5137, Pieces: []}]
+          Locations: [{Range: 0xce5b00..0xce5bf7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r8
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5040..0xce5137, Pieces: []}]
+          Locations: [{Range: 0xce5b00..0xce5bf7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r9
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5040..0xce5137, Pieces: []}]
+          Locations: [{Range: 0xce5b00..0xce5bf7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r10
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5040..0xce5137, Pieces: []}]
+          Locations: [{Range: 0xce5b00..0xce5bf7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r11
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5040..0xce5137, Pieces: []}]
+          Locations: [{Range: 0xce5b00..0xce5bf7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r12
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5040..0xce5137, Pieces: []}]
+          Locations: [{Range: 0xce5b00..0xce5bf7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r13
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5040..0xce5137, Pieces: []}]
+          Locations: [{Range: 0xce5b00..0xce5bf7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r14
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5040..0xce5137, Pieces: []}]
+          Locations: [{Range: 0xce5b00..0xce5bf7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xce5040..0xce5127
+            - Range: 0xce5b00..0xce5be7
               Pieces: []
-            - Range: 0xce5127..0xce5128
+            - Range: 0xce5be7..0xce5be8
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xce5128..0xce5137
+            - Range: 0xce5be8..0xce5bf7
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8980,11 +8980,11 @@ Subprograms:
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xce5040..0xce5127
+            - Range: 0xce5b00..0xce5be7
               Pieces: []
-            - Range: 0xce5127..0xce5128
+            - Range: 0xce5be7..0xce5be8
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce5128..0xce5137
+            - Range: 0xce5be8..0xce5bf7
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8992,35 +8992,35 @@ Subprograms:
       DictRegister: null
     - ID: 116
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xce5140..0xce51b3]
+      OutOfLinePCRanges: [0xce5c00..0xce5c73]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 99 BaseType complex64
-          Locations: [{Range: 0xce5140..0xce51b3, Pieces: []}]
+          Locations: [{Range: 0xce5c00..0xce5c73, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 100 BaseType complex128
-          Locations: [{Range: 0xce5140..0xce51b3, Pieces: []}]
+          Locations: [{Range: 0xce5c00..0xce5c73, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 117
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xce51c0..0xce5265]
+      OutOfLinePCRanges: [0xce5c80..0xce5d25]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0xce51c0..0xce5253
+            - Range: 0xce5c80..0xce5d13
               Pieces: []
-            - Range: 0xce5253..0xce5254
+            - Range: 0xce5d13..0xce5d14
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xce5254..0xce5265
+            - Range: 0xce5d14..0xce5d25
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9028,17 +9028,17 @@ Subprograms:
       DictRegister: null
     - ID: 118
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xce5280..0xce52fa]
+      OutOfLinePCRanges: [0xce5d40..0xce5dba]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 264 ArrayType [3]int
           Locations:
-            - Range: 0xce5280..0xce52ed
+            - Range: 0xce5d40..0xce5dad
               Pieces: []
-            - Range: 0xce52ed..0xce52ee
+            - Range: 0xce5dad..0xce5dae
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xce52ee..0xce52fa
+            - Range: 0xce5dae..0xce5dba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9046,17 +9046,17 @@ Subprograms:
       DictRegister: null
     - ID: 119
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xce5300..0xce5358]
+      OutOfLinePCRanges: [0xce5dc0..0xce5e18]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 265 ArrayType [1]int
           Locations:
-            - Range: 0xce5300..0xce534b
+            - Range: 0xce5dc0..0xce5e0b
               Pieces: []
-            - Range: 0xce534b..0xce534c
+            - Range: 0xce5e0b..0xce5e0c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce534c..0xce5358
+            - Range: 0xce5e0c..0xce5e18
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9064,17 +9064,17 @@ Subprograms:
       DictRegister: null
     - ID: 120
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xce5360..0xce53b3]
+      OutOfLinePCRanges: [0xce5e20..0xce5e73]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 266 ArrayType [0]int
           Locations:
-            - Range: 0xce5360..0xce53a6
+            - Range: 0xce5e20..0xce5e66
               Pieces: []
-            - Range: 0xce53a6..0xce53a7
+            - Range: 0xce5e66..0xce5e67
               Pieces: []
-            - Range: 0xce53a7..0xce53b3
+            - Range: 0xce5e67..0xce5e73
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9082,29 +9082,29 @@ Subprograms:
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xce53c0..0xce5427]
+      OutOfLinePCRanges: [0xce5e80..0xce5ee7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 267 StructureType main.mixedStruct
-          Locations: [{Range: 0xce53c0..0xce5427, Pieces: []}]
+          Locations: [{Range: 0xce5e80..0xce5ee7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 122
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xce5440..0xce54da]
+      OutOfLinePCRanges: [0xce5f00..0xce5f9a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5440..0xce54ca
+            - Range: 0xce5f00..0xce5f8a
               Pieces: []
-            - Range: 0xce54ca..0xce54cb
+            - Range: 0xce5f8a..0xce5f8b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce54cb..0xce54da
+            - Range: 0xce5f8b..0xce5f9a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9112,11 +9112,11 @@ Subprograms:
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5440..0xce54ca
+            - Range: 0xce5f00..0xce5f8a
               Pieces: []
-            - Range: 0xce54ca..0xce54cb
+            - Range: 0xce5f8a..0xce5f8b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce54cb..0xce54da
+            - Range: 0xce5f8b..0xce5f9a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9124,11 +9124,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5440..0xce54ca
+            - Range: 0xce5f00..0xce5f8a
               Pieces: []
-            - Range: 0xce54ca..0xce54cb
+            - Range: 0xce5f8a..0xce5f8b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce54cb..0xce54da
+            - Range: 0xce5f8b..0xce5f9a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9136,11 +9136,11 @@ Subprograms:
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5440..0xce54ca
+            - Range: 0xce5f00..0xce5f8a
               Pieces: []
-            - Range: 0xce54ca..0xce54cb
+            - Range: 0xce5f8a..0xce5f8b
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce54cb..0xce54da
+            - Range: 0xce5f8b..0xce5f9a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9148,11 +9148,11 @@ Subprograms:
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5440..0xce54ca
+            - Range: 0xce5f00..0xce5f8a
               Pieces: []
-            - Range: 0xce54ca..0xce54cb
+            - Range: 0xce5f8a..0xce5f8b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce54cb..0xce54da
+            - Range: 0xce5f8b..0xce5f9a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9160,11 +9160,11 @@ Subprograms:
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5440..0xce54ca
+            - Range: 0xce5f00..0xce5f8a
               Pieces: []
-            - Range: 0xce54ca..0xce54cb
+            - Range: 0xce5f8a..0xce5f8b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce54cb..0xce54da
+            - Range: 0xce5f8b..0xce5f9a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9172,11 +9172,11 @@ Subprograms:
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5440..0xce54ca
+            - Range: 0xce5f00..0xce5f8a
               Pieces: []
-            - Range: 0xce54ca..0xce54cb
+            - Range: 0xce5f8a..0xce5f8b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce54cb..0xce54da
+            - Range: 0xce5f8b..0xce5f9a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9184,11 +9184,11 @@ Subprograms:
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5440..0xce54ca
+            - Range: 0xce5f00..0xce5f8a
               Pieces: []
-            - Range: 0xce54ca..0xce54cb
+            - Range: 0xce5f8a..0xce5f8b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce54cb..0xce54da
+            - Range: 0xce5f8b..0xce5f9a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9196,11 +9196,11 @@ Subprograms:
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce5440..0xce54ca
+            - Range: 0xce5f00..0xce5f8a
               Pieces: []
-            - Range: 0xce54ca..0xce54cb
+            - Range: 0xce5f8a..0xce5f8b
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xce54cb..0xce54da
+            - Range: 0xce5f8b..0xce5f9a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9208,17 +9208,17 @@ Subprograms:
       DictRegister: null
     - ID: 123
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xce54e0..0xce5585]
+      OutOfLinePCRanges: [0xce5fa0..0xce6045]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 268 StructureType main.wideStruct
           Locations:
-            - Range: 0xce54e0..0xce5574
+            - Range: 0xce5fa0..0xce6034
               Pieces: []
-            - Range: 0xce5574..0xce5575
+            - Range: 0xce6034..0xce6035
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xce5575..0xce5585
+            - Range: 0xce6035..0xce6045
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9226,57 +9226,57 @@ Subprograms:
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xce55a0..0xce5619]
+      OutOfLinePCRanges: [0xce6060..0xce60d9]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce55a0..0xce560c
+            - Range: 0xce6060..0xce60cc
               Pieces: []
-            - Range: 0xce560c..0xce560d
+            - Range: 0xce60cc..0xce60cd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce560d..0xce5619
+            - Range: 0xce60cd..0xce60d9
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce55a0..0xce5619, Pieces: []}]
+          Locations: [{Range: 0xce6060..0xce60d9, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce55a0..0xce560c
+            - Range: 0xce6060..0xce60cc
               Pieces: []
-            - Range: 0xce560c..0xce560d
+            - Range: 0xce60cc..0xce60cd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce560d..0xce5619
+            - Range: 0xce60cd..0xce60d9
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce55a0..0xce5619, Pieces: []}]
+          Locations: [{Range: 0xce6060..0xce60d9, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce55a0..0xce560c
+            - Range: 0xce6060..0xce60cc
               Pieces: []
-            - Range: 0xce560c..0xce560d
+            - Range: 0xce60cc..0xce60cd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce560d..0xce5619
+            - Range: 0xce60cd..0xce60d9
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9284,17 +9284,17 @@ Subprograms:
       DictRegister: null
     - ID: 125
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xce5620..0xce569a]
+      OutOfLinePCRanges: [0xce60e0..0xce615a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 269 StructureType main.structWithArray
           Locations:
-            - Range: 0xce5620..0xce568d
+            - Range: 0xce60e0..0xce614d
               Pieces: []
-            - Range: 0xce568d..0xce568e
+            - Range: 0xce614d..0xce614e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xce568e..0xce569a
+            - Range: 0xce614e..0xce615a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9302,47 +9302,47 @@ Subprograms:
       DictRegister: null
     - ID: 126
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xce56a0..0xce56fb]
+      OutOfLinePCRanges: [0xce6160..0xce61bb]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce56a0..0xce56fb, Pieces: []}]
+          Locations: [{Range: 0xce6160..0xce61bb, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 127
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xce5700..0xce5767]
+      OutOfLinePCRanges: [0xce61c0..0xce6227]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 20 BaseType float32
-          Locations: [{Range: 0xce5700..0xce5767, Pieces: []}]
+          Locations: [{Range: 0xce61c0..0xce6227, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xce5700..0xce5767, Pieces: []}]
+          Locations: [{Range: 0xce61c0..0xce6227, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 128
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xce5780..0xce57dd]
+      OutOfLinePCRanges: [0xce6240..0xce629d]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce5780..0xce57d0
+            - Range: 0xce6240..0xce6290
               Pieces: []
-            - Range: 0xce57d0..0xce57d1
+            - Range: 0xce6290..0xce6291
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce57d1..0xce57dd
+            - Range: 0xce6291..0xce629d
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9350,11 +9350,11 @@ Subprograms:
         - Name: ~r1
           Type: 3 BaseType uintptr
           Locations:
-            - Range: 0xce5780..0xce57d0
+            - Range: 0xce6240..0xce6290
               Pieces: []
-            - Range: 0xce57d0..0xce57d1
+            - Range: 0xce6290..0xce6291
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce57d1..0xce57dd
+            - Range: 0xce6291..0xce629d
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9362,13 +9362,13 @@ Subprograms:
       DictRegister: null
     - ID: 129
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xce57e0..0xce5965]
+      OutOfLinePCRanges: [0xce62a0..0xce6425]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0xce57e0..0xce5965
+            - Range: 0xce62a0..0xce6425
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9376,11 +9376,11 @@ Subprograms:
         - Name: ~r0
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0xce57e0..0xce5953
+            - Range: 0xce62a0..0xce6413
               Pieces: []
-            - Range: 0xce5953..0xce5954
+            - Range: 0xce6413..0xce6414
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xce5954..0xce5965
+            - Range: 0xce6414..0xce6425
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9388,13 +9388,13 @@ Subprograms:
       DictRegister: null
     - ID: 130
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xce5980..0xce5a52]
+      OutOfLinePCRanges: [0xce6440..0xce6512]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 264 ArrayType [3]int
           Locations:
-            - Range: 0xce5980..0xce5a52
+            - Range: 0xce6440..0xce6512
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9402,11 +9402,11 @@ Subprograms:
         - Name: ~r0
           Type: 264 ArrayType [3]int
           Locations:
-            - Range: 0xce5980..0xce5a42
+            - Range: 0xce6440..0xce6502
               Pieces: []
-            - Range: 0xce5a42..0xce5a43
+            - Range: 0xce6502..0xce6503
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xce5a43..0xce5a52
+            - Range: 0xce6503..0xce6512
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9414,13 +9414,13 @@ Subprograms:
       DictRegister: null
     - ID: 131
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xce5a60..0xce5c9a]
+      OutOfLinePCRanges: [0xce6520..0xce675a]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0xce5a60..0xce5c9a
+            - Range: 0xce6520..0xce675a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9428,7 +9428,7 @@ Subprograms:
         - Name: s2
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0xce5a60..0xce5c9a
+            - Range: 0xce6520..0xce675a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
@@ -9436,11 +9436,11 @@ Subprograms:
         - Name: ~r0
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0xce5a60..0xce5c8a
+            - Range: 0xce6520..0xce674a
               Pieces: []
-            - Range: 0xce5c8a..0xce5c8b
+            - Range: 0xce674a..0xce674b
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xce5c8b..0xce5c9a
+            - Range: 0xce674b..0xce675a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9448,15 +9448,15 @@ Subprograms:
       DictRegister: null
     - ID: 132
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xce5ca0..0xce5f2f]
+      OutOfLinePCRanges: [0xce6760..0xce69ef]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5ca0..0xce5d50
+            - Range: 0xce6760..0xce6810
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce5d50..0xce5f2f
+            - Range: 0xce6810..0xce69ef
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -9464,9 +9464,9 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5ca0..0xce5d50
+            - Range: 0xce6760..0xce6810
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce5d50..0xce5f2f
+            - Range: 0xce6810..0xce69ef
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -9474,9 +9474,9 @@ Subprograms:
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5ca0..0xce5d3a
+            - Range: 0xce6760..0xce67fa
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce5d3a..0xce5f2f
+            - Range: 0xce67fa..0xce69ef
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
@@ -9484,9 +9484,9 @@ Subprograms:
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5ca0..0xce5d10
+            - Range: 0xce6760..0xce67d0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce5d10..0xce5f2f
+            - Range: 0xce67d0..0xce69ef
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
@@ -9494,9 +9494,9 @@ Subprograms:
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5ca0..0xce5d50
+            - Range: 0xce6760..0xce6810
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce5d50..0xce5f2f
+            - Range: 0xce6810..0xce69ef
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
@@ -9504,9 +9504,9 @@ Subprograms:
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5ca0..0xce5d50
+            - Range: 0xce6760..0xce6810
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce5d50..0xce5f2f
+            - Range: 0xce6810..0xce69ef
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
@@ -9514,9 +9514,9 @@ Subprograms:
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5ca0..0xce5d50
+            - Range: 0xce6760..0xce6810
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce5d50..0xce5f2f
+            - Range: 0xce6810..0xce69ef
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
@@ -9524,9 +9524,9 @@ Subprograms:
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5ca0..0xce5d50
+            - Range: 0xce6760..0xce6810
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce5d50..0xce5f2f
+            - Range: 0xce6810..0xce69ef
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
@@ -9534,9 +9534,9 @@ Subprograms:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5ca0..0xce5d50
+            - Range: 0xce6760..0xce6810
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xce5d50..0xce5f2f
+            - Range: 0xce6810..0xce69ef
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
@@ -9544,11 +9544,11 @@ Subprograms:
         - Name: ~r0
           Type: 116 ArrayType [2]int
           Locations:
-            - Range: 0xce5ca0..0xce5ec2
+            - Range: 0xce6760..0xce6982
               Pieces: []
-            - Range: 0xce5ec2..0xce5ec3
+            - Range: 0xce6982..0xce6983
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xce5ec3..0xce5f2f
+            - Range: 0xce6983..0xce69ef
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9556,15 +9556,15 @@ Subprograms:
       DictRegister: null
     - ID: 133
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xce5f40..0xce620c]
+      OutOfLinePCRanges: [0xce6a00..0xce6ccc]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5f40..0xce5feb
+            - Range: 0xce6a00..0xce6aab
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce5feb..0xce620c
+            - Range: 0xce6aab..0xce6ccc
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
@@ -9572,9 +9572,9 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5f40..0xce5feb
+            - Range: 0xce6a00..0xce6aab
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce5feb..0xce620c
+            - Range: 0xce6aab..0xce6ccc
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
@@ -9582,9 +9582,9 @@ Subprograms:
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5f40..0xce5fd5
+            - Range: 0xce6a00..0xce6a95
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce5fd5..0xce620c
+            - Range: 0xce6a95..0xce6ccc
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
@@ -9592,9 +9592,9 @@ Subprograms:
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5f40..0xce5fa2
+            - Range: 0xce6a00..0xce6a62
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce5fa2..0xce620c
+            - Range: 0xce6a62..0xce6ccc
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
@@ -9602,9 +9602,9 @@ Subprograms:
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5f40..0xce5feb
+            - Range: 0xce6a00..0xce6aab
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce5feb..0xce620c
+            - Range: 0xce6aab..0xce6ccc
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
@@ -9612,9 +9612,9 @@ Subprograms:
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5f40..0xce5feb
+            - Range: 0xce6a00..0xce6aab
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce5feb..0xce620c
+            - Range: 0xce6aab..0xce6ccc
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
@@ -9622,9 +9622,9 @@ Subprograms:
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5f40..0xce5feb
+            - Range: 0xce6a00..0xce6aab
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce5feb..0xce620c
+            - Range: 0xce6aab..0xce6ccc
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
@@ -9632,9 +9632,9 @@ Subprograms:
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce5f40..0xce5feb
+            - Range: 0xce6a00..0xce6aab
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce5feb..0xce620c
+            - Range: 0xce6aab..0xce6ccc
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
@@ -9642,7 +9642,7 @@ Subprograms:
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce5f40..0xce620c
+            - Range: 0xce6a00..0xce6ccc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -9654,11 +9654,11 @@ Subprograms:
         - Name: ~r0
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0xce5f40..0xce618b
+            - Range: 0xce6a00..0xce6c4b
               Pieces: []
-            - Range: 0xce618b..0xce618c
+            - Range: 0xce6c4b..0xce6c4c
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xce618c..0xce620c
+            - Range: 0xce6c4c..0xce6ccc
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9666,13 +9666,13 @@ Subprograms:
       DictRegister: null
     - ID: 134
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xce6220..0xce62ac]
+      OutOfLinePCRanges: [0xce6ce0..0xce6d6c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 170 ArrayType [5]int
           Locations:
-            - Range: 0xce6220..0xce62ac
+            - Range: 0xce6ce0..0xce6d6c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9680,11 +9680,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce6220..0xce629c
+            - Range: 0xce6ce0..0xce6d5c
               Pieces: []
-            - Range: 0xce629c..0xce629d
+            - Range: 0xce6d5c..0xce6d5d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce629d..0xce62ac
+            - Range: 0xce6d5d..0xce6d6c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9692,11 +9692,11 @@ Subprograms:
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce6220..0xce629c
+            - Range: 0xce6ce0..0xce6d5c
               Pieces: []
-            - Range: 0xce629c..0xce629d
+            - Range: 0xce6d5c..0xce6d5d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce629d..0xce62ac
+            - Range: 0xce6d5d..0xce6d6c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9704,11 +9704,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce6220..0xce629c
+            - Range: 0xce6ce0..0xce6d5c
               Pieces: []
-            - Range: 0xce629c..0xce629d
+            - Range: 0xce6d5c..0xce6d5d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce629d..0xce62ac
+            - Range: 0xce6d5d..0xce6d6c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9716,13 +9716,13 @@ Subprograms:
       DictRegister: null
     - ID: 135
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xce62c0..0xce63af]
+      OutOfLinePCRanges: [0xce6d80..0xce6e6f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 116 ArrayType [2]int
           Locations:
-            - Range: 0xce62c0..0xce63af
+            - Range: 0xce6d80..0xce6e6f
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9730,7 +9730,7 @@ Subprograms:
         - Name: b
           Type: 264 ArrayType [3]int
           Locations:
-            - Range: 0xce62c0..0xce63af
+            - Range: 0xce6d80..0xce6e6f
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -9738,11 +9738,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce62c0..0xce639f
+            - Range: 0xce6d80..0xce6e5f
               Pieces: []
-            - Range: 0xce639f..0xce63a0
+            - Range: 0xce6e5f..0xce6e60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce63a0..0xce63af
+            - Range: 0xce6e60..0xce6e6f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9750,11 +9750,11 @@ Subprograms:
         - Name: ~r1
           Type: 116 ArrayType [2]int
           Locations:
-            - Range: 0xce62c0..0xce639f
+            - Range: 0xce6d80..0xce6e5f
               Pieces: []
-            - Range: 0xce639f..0xce63a0
+            - Range: 0xce6e5f..0xce6e60
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xce63a0..0xce63af
+            - Range: 0xce6e60..0xce6e6f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9762,13 +9762,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xce63c0..0xce648c]
+      OutOfLinePCRanges: [0xce6e80..0xce6f4c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 269 StructureType main.structWithArray
           Locations:
-            - Range: 0xce63c0..0xce648c
+            - Range: 0xce6e80..0xce6f4c
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9776,11 +9776,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce63c0..0xce647c
+            - Range: 0xce6e80..0xce6f3c
               Pieces: []
-            - Range: 0xce647c..0xce647d
+            - Range: 0xce6f3c..0xce6f3d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce647d..0xce648c
+            - Range: 0xce6f3d..0xce6f4c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9788,11 +9788,11 @@ Subprograms:
         - Name: ~r1
           Type: 269 StructureType main.structWithArray
           Locations:
-            - Range: 0xce63c0..0xce647c
+            - Range: 0xce6e80..0xce6f3c
               Pieces: []
-            - Range: 0xce647c..0xce647d
+            - Range: 0xce6f3c..0xce6f3d
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xce647d..0xce648c
+            - Range: 0xce6f3d..0xce6f4c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9800,7 +9800,7 @@ Subprograms:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce6446..0xce648c
+            - Range: 0xce6f06..0xce6f4c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -9808,25 +9808,25 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xce64a0..0xce6546]
+      OutOfLinePCRanges: [0xce6f60..0xce7006]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 266 ArrayType [0]int
-          Locations: [{Range: 0xce64a0..0xce6546, Pieces: []}]
+          Locations: [{Range: 0xce6f60..0xce7006, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce64a0..0xce64e5
+            - Range: 0xce6f60..0xce6fa5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce64e5..0xce6507
+            - Range: 0xce6fa5..0xce6fc7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xce6507..0xce651a
+            - Range: 0xce6fc7..0xce6fda
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xce651a..0xce6546
+            - Range: 0xce6fda..0xce7006
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
@@ -9834,11 +9834,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce64a0..0xce652c
+            - Range: 0xce6f60..0xce6fec
               Pieces: []
-            - Range: 0xce652c..0xce652d
+            - Range: 0xce6fec..0xce6fed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce652d..0xce6546
+            - Range: 0xce6fed..0xce7006
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9846,11 +9846,11 @@ Subprograms:
         - Name: ~r1
           Type: 266 ArrayType [0]int
           Locations:
-            - Range: 0xce64a0..0xce652c
+            - Range: 0xce6f60..0xce6fec
               Pieces: []
-            - Range: 0xce652c..0xce652d
+            - Range: 0xce6fec..0xce6fed
               Pieces: []
-            - Range: 0xce652d..0xce6546
+            - Range: 0xce6fed..0xce7006
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9858,13 +9858,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xce6a40..0xce6a41]
+      OutOfLinePCRanges: [0xce7500..0xce7501]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 270 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce6a40..0xce6a41
+            - Range: 0xce7500..0xce7501
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9878,13 +9878,13 @@ Subprograms:
       DictRegister: null
     - ID: 139
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xce6a60..0xce6a61]
+      OutOfLinePCRanges: [0xce7520..0xce7521]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 270 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce6a60..0xce6a61
+            - Range: 0xce7520..0xce7521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9898,13 +9898,13 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xce6a80..0xce6a81]
+      OutOfLinePCRanges: [0xce7540..0xce7541]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 271 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xce6a80..0xce6a81
+            - Range: 0xce7540..0xce7541
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9918,13 +9918,13 @@ Subprograms:
       DictRegister: null
     - ID: 141
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0xce6aa0..0xce6aa1]
+      OutOfLinePCRanges: [0xce7560..0xce7561]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 273 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xce6aa0..0xce6aa1
+            - Range: 0xce7560..0xce7561
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9938,7 +9938,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce6aa0..0xce6aa1
+            - Range: 0xce7560..0xce7561
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9946,13 +9946,13 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xce6ac0..0xce6ac1]
+      OutOfLinePCRanges: [0xce7580..0xce7581]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 273 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xce6ac0..0xce6ac1
+            - Range: 0xce7580..0xce7581
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9966,7 +9966,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce6ac0..0xce6ac1
+            - Range: 0xce7580..0xce7581
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9974,13 +9974,13 @@ Subprograms:
       DictRegister: null
     - ID: 143
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xce6ae0..0xce6ae1]
+      OutOfLinePCRanges: [0xce75a0..0xce75a1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 273 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xce6ae0..0xce6ae1
+            - Range: 0xce75a0..0xce75a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9994,7 +9994,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce6ae0..0xce6ae1
+            - Range: 0xce75a0..0xce75a1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10002,13 +10002,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xce6b00..0xce6b01]
+      OutOfLinePCRanges: [0xce75c0..0xce75c1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 164 GoSliceHeaderType []string
           Locations:
-            - Range: 0xce6b00..0xce6b01
+            - Range: 0xce75c0..0xce75c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10022,13 +10022,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xce6b20..0xce6b21]
+      OutOfLinePCRanges: [0xce75e0..0xce75e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 18 BaseType int8
           Locations:
-            - Range: 0xce6b20..0xce6b21
+            - Range: 0xce75e0..0xce75e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10036,7 +10036,7 @@ Subprograms:
         - Name: s
           Type: 276 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xce6b20..0xce6b21
+            - Range: 0xce75e0..0xce75e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10050,7 +10050,7 @@ Subprograms:
         - Name: x
           Type: 19 BaseType uint
           Locations:
-            - Range: 0xce6b20..0xce6b21
+            - Range: 0xce75e0..0xce75e1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10058,13 +10058,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xce6b40..0xce6b41]
+      OutOfLinePCRanges: [0xce7600..0xce7601]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 277 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xce6b40..0xce6b41
+            - Range: 0xce7600..0xce7601
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10078,13 +10078,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xce6b60..0xce6b61]
+      OutOfLinePCRanges: [0xce7620..0xce7621]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 270 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce6b60..0xce6b61
+            - Range: 0xce7620..0xce7621
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10098,13 +10098,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xce6b80..0xce6b81]
+      OutOfLinePCRanges: [0xce7640..0xce7641]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 278 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0xce6b80..0xce6b81
+            - Range: 0xce7640..0xce7641
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10118,13 +10118,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xce6ba0..0xce6ba1]
+      OutOfLinePCRanges: [0xce7660..0xce7661]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 270 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce6ba0..0xce6ba1
+            - Range: 0xce7660..0xce7661
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10138,7 +10138,7 @@ Subprograms:
         - Name: bs
           Type: 270 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce6ba0..0xce6ba1
+            - Range: 0xce7660..0xce7661
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10152,7 +10152,7 @@ Subprograms:
         - Name: cs
           Type: 270 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce6ba0..0xce6ba1
+            - Range: 0xce7660..0xce7661
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -10166,13 +10166,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testByteSliceInvalidUtf8
-      OutOfLinePCRanges: [0xce6c20..0xce6c21]
+      OutOfLinePCRanges: [0xce76e0..0xce76e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0xce6c20..0xce6c21
+            - Range: 0xce76e0..0xce76e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10186,13 +10186,13 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testByteSliceMultibyteUtf8
-      OutOfLinePCRanges: [0xce6c40..0xce6c41]
+      OutOfLinePCRanges: [0xce7700..0xce7701]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0xce6c40..0xce6c41
+            - Range: 0xce7700..0xce7701
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10206,21 +10206,21 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.stackC
-      OutOfLinePCRanges: [0xce7360..0xce73b2]
+      OutOfLinePCRanges: [0xce7f00..0xce7f52]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce7360..0xce73a5
+            - Range: 0xce7f00..0xce7f45
               Pieces: []
-            - Range: 0xce73a5..0xce73a6
+            - Range: 0xce7f45..0xce7f46
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce73a6..0xce73b2
+            - Range: 0xce7f46..0xce7f52
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10228,13 +10228,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xce73c0..0xce73c1]
+      OutOfLinePCRanges: [0xce8080..0xce8081]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce73c0..0xce73c1
+            - Range: 0xce8080..0xce8081
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10246,13 +10246,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xce73e0..0xce73e1]
+      OutOfLinePCRanges: [0xce80a0..0xce80a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce73e0..0xce73e1
+            - Range: 0xce80a0..0xce80a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10264,7 +10264,7 @@ Subprograms:
         - Name: "y"
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce73e0..0xce73e1
+            - Range: 0xce80a0..0xce80a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10276,7 +10276,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce73e0..0xce73e1
+            - Range: 0xce80a0..0xce80a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10288,13 +10288,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xce7400..0xce741f]
+      OutOfLinePCRanges: [0xce80c0..0xce80df]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xce7400..0xce741f
+            - Range: 0xce80c0..0xce80df
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10314,13 +10314,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xce7420..0xce7421]
+      OutOfLinePCRanges: [0xce80e0..0xce80e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 281 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xce7420..0xce7421
+            - Range: 0xce80e0..0xce80e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10328,13 +10328,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xce7440..0xce7441]
+      OutOfLinePCRanges: [0xce8100..0xce8101]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 282 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xce7440..0xce7441
+            - Range: 0xce8100..0xce8101
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10342,13 +10342,13 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xce7460..0xce7461]
+      OutOfLinePCRanges: [0xce8120..0xce8121]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce7460..0xce7461
+            - Range: 0xce8120..0xce8121
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10360,13 +10360,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xce7480..0xce7481]
+      OutOfLinePCRanges: [0xce8140..0xce8141]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce7480..0xce7481
+            - Range: 0xce8140..0xce8141
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10378,13 +10378,13 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xce74a0..0xce74a1]
+      OutOfLinePCRanges: [0xce8160..0xce8161]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce74a0..0xce74a1
+            - Range: 0xce8160..0xce8161
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10396,13 +10396,13 @@ Subprograms:
       DictRegister: null
     - ID: 161
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xce74c0..0xce74c1]
+      OutOfLinePCRanges: [0xce8180..0xce8181]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce74c0..0xce74c1
+            - Range: 0xce8180..0xce8181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10414,7 +10414,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce74c0..0xce74c1
+            - Range: 0xce8180..0xce8181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10426,7 +10426,7 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce74c0..0xce74c1
+            - Range: 0xce8180..0xce8181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10438,13 +10438,13 @@ Subprograms:
       DictRegister: null
     - ID: 162
       Name: main.testInvalidUtf8Strings
-      OutOfLinePCRanges: [0xce74e0..0xce74e1]
+      OutOfLinePCRanges: [0xce81a0..0xce81a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce74e0..0xce74e1
+            - Range: 0xce81a0..0xce81a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10456,7 +10456,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce74e0..0xce74e1
+            - Range: 0xce81a0..0xce81a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10468,13 +10468,13 @@ Subprograms:
       DictRegister: null
     - ID: 163
       Name: main.testMultibyteUtf8String
-      OutOfLinePCRanges: [0xce7500..0xce7501]
+      OutOfLinePCRanges: [0xce81c0..0xce81c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce7500..0xce7501
+            - Range: 0xce81c0..0xce81c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10486,13 +10486,13 @@ Subprograms:
       DictRegister: null
     - ID: 164
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xce76c0..0xce76c1]
+      OutOfLinePCRanges: [0xce8480..0xce8481]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 284 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xce76c0..0xce76c1
+            - Range: 0xce8480..0xce8481
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10500,13 +10500,13 @@ Subprograms:
       DictRegister: null
     - ID: 165
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xce76e0..0xce76ff]
+      OutOfLinePCRanges: [0xce84a0..0xce84bf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 297 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xce76e0..0xce76ff
+            - Range: 0xce84a0..0xce84bf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10526,13 +10526,13 @@ Subprograms:
       DictRegister: null
     - ID: 166
       Name: main.testStruct
-      OutOfLinePCRanges: [0xce7820..0xce7843]
+      OutOfLinePCRanges: [0xce85e0..0xce8603]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 328 StructureType main.aStruct
           Locations:
-            - Range: 0xce7820..0xce7843
+            - Range: 0xce85e0..0xce8603
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10554,13 +10554,13 @@ Subprograms:
       DictRegister: null
     - ID: 167
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xce7920..0xce7921]
+      OutOfLinePCRanges: [0xce86e0..0xce86e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xce7920..0xce7921
+            - Range: 0xce86e0..0xce86e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10568,13 +10568,13 @@ Subprograms:
       DictRegister: null
     - ID: 168
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xce7940..0xce7941]
+      OutOfLinePCRanges: [0xce8700..0xce8701]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 331 StructureType main.tenStrings
           Locations:
-            - Range: 0xce7940..0xce7941
+            - Range: 0xce8700..0xce8701
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10582,25 +10582,25 @@ Subprograms:
       DictRegister: null
     - ID: 169
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xce79a0..0xce79a1]
+      OutOfLinePCRanges: [0xce8760..0xce8761]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 332 StructureType main.emptyStruct
-          Locations: [{Range: 0xce79a0..0xce79a1, Pieces: []}]
+          Locations: [{Range: 0xce8760..0xce8761, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 170
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xce79c0..0xce79c1]
+      OutOfLinePCRanges: [0xce8780..0xce8781]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 333 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xce79c0..0xce79c1
+            - Range: 0xce8780..0xce8781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10608,13 +10608,13 @@ Subprograms:
       DictRegister: null
     - ID: 171
       Name: main.testTimeUTC
-      OutOfLinePCRanges: [0xce8b80..0xce8b81]
+      OutOfLinePCRanges: [0xce9a40..0xce9a41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 GoTimeType time.Time
           Locations:
-            - Range: 0xce8b80..0xce8b81
+            - Range: 0xce9a40..0xce9a41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10628,13 +10628,13 @@ Subprograms:
       DictRegister: null
     - ID: 172
       Name: main.testTimeFixedZone
-      OutOfLinePCRanges: [0xce8ba0..0xce8ba1]
+      OutOfLinePCRanges: [0xce9a60..0xce9a61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 GoTimeType time.Time
           Locations:
-            - Range: 0xce8ba0..0xce8ba1
+            - Range: 0xce9a60..0xce9a61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10648,13 +10648,13 @@ Subprograms:
       DictRegister: null
     - ID: 173
       Name: main.testTimeMonotonic
-      OutOfLinePCRanges: [0xce8bc0..0xce8bc1]
+      OutOfLinePCRanges: [0xce9a80..0xce9a81]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 337 StructureType main.timeCapture
           Locations:
-            - Range: 0xce8bc0..0xce8bc1
+            - Range: 0xce9a80..0xce9a81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10668,13 +10668,13 @@ Subprograms:
       DictRegister: null
     - ID: 174
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xce9d00..0xce9d04]
+      OutOfLinePCRanges: [0xceace0..0xceace4]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xce9d00..0xce9d04
+            - Range: 0xceace0..0xceace4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10682,9 +10682,9 @@ Subprograms:
         - Name: ~r0
           Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce9d00..0xce9d03
+            - Range: 0xceace0..0xceace3
               Pieces: []
-            - Range: 0xce9d03..0xce9d04
+            - Range: 0xceace3..0xceace4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -10692,19 +10692,19 @@ Subprograms:
       DictRegister: 0
     - ID: 175
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xce9d20..0xce9d2c]
+      OutOfLinePCRanges: [0xcead00..0xcead0c]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce9d20..0xce9d2b
+            - Range: 0xcead00..0xcead0b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce9d2b..0xce9d2c
+            - Range: 0xcead0b..0xcead0c
               Pieces:
                 - Size: 8
                   Op: null
@@ -10716,9 +10716,9 @@ Subprograms:
         - Name: ~r0
           Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce9d20..0xce9d2b
+            - Range: 0xcead00..0xcead0b
               Pieces: []
-            - Range: 0xce9d2b..0xce9d2c
+            - Range: 0xcead0b..0xcead0c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10730,13 +10730,13 @@ Subprograms:
       DictRegister: 0
     - ID: 176
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xce9d40..0xce9d44]
+      OutOfLinePCRanges: [0xcead20..0xcead24]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce9d40..0xce9d44
+            - Range: 0xcead20..0xcead24
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10744,9 +10744,9 @@ Subprograms:
         - Name: ~r0
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xce9d40..0xce9d43
+            - Range: 0xcead20..0xcead23
               Pieces: []
-            - Range: 0xce9d43..0xce9d44
+            - Range: 0xcead23..0xcead24
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -10754,19 +10754,19 @@ Subprograms:
       DictRegister: 0
     - ID: 177
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xce9d60..0xce9d6c]
+      OutOfLinePCRanges: [0xcead40..0xcead4c]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce9d60..0xce9d6b
+            - Range: 0xcead40..0xcead4b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce9d6b..0xce9d6c
+            - Range: 0xcead4b..0xcead4c
               Pieces:
                 - Size: 8
                   Op: null
@@ -10778,9 +10778,9 @@ Subprograms:
         - Name: ~r0
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce9d60..0xce9d6b
+            - Range: 0xcead40..0xcead4b
               Pieces: []
-            - Range: 0xce9d6b..0xce9d6c
+            - Range: 0xcead4b..0xcead4c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10792,13 +10792,13 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xce9de0..0xce9f16]
+      OutOfLinePCRanges: [0xceadc0..0xceaef6]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce9de0..0xce9e13
+            - Range: 0xceadc0..0xceadf3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10806,7 +10806,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce9e13..0xce9e1b
+            - Range: 0xceadf3..0xceadfb
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10814,7 +10814,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xce9e1b..0xce9f16
+            - Range: 0xceadfb..0xceaef6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10828,9 +10828,9 @@ Subprograms:
         - Name: pred
           Type: 344 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xce9de0..0xce9e1b
+            - Range: 0xceadc0..0xceadfb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce9e1b..0xce9f16
+            - Range: 0xceadfb..0xceaef6
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
@@ -10838,9 +10838,9 @@ Subprograms:
         - Name: ~r0
           Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce9de0..0xce9ed4
+            - Range: 0xceadc0..0xceaeb4
               Pieces: []
-            - Range: 0xce9ed4..0xce9ed5
+            - Range: 0xceaeb4..0xceaeb5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10848,7 +10848,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce9ed5..0xce9f16
+            - Range: 0xceaeb5..0xceaef6
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -10856,7 +10856,7 @@ Subprograms:
         - Name: result
           Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce9e1b..0xce9e39
+            - Range: 0xceadfb..0xceae19
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10864,7 +10864,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce9e39..0xce9e41
+            - Range: 0xceae19..0xceae21
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10872,7 +10872,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce9e41..0xce9e49
+            - Range: 0xceae21..0xceae29
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10880,7 +10880,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce9e49..0xce9e49
+            - Range: 0xceae29..0xceae29
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10888,7 +10888,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce9e49..0xce9e73
+            - Range: 0xceae29..0xceae53
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10896,7 +10896,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce9e73..0xce9ecb
+            - Range: 0xceae53..0xceaeab
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10904,7 +10904,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce9ecb..0xce9f16
+            - Range: 0xceaeab..0xceaef6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -10918,9 +10918,9 @@ Subprograms:
         - Name: item
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xce9e66..0xce9e73
+            - Range: 0xceae46..0xceae53
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce9e73..0xce9ecb
+            - Range: 0xceae53..0xceaeab
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
@@ -10928,13 +10928,13 @@ Subprograms:
       DictRegister: 0
     - ID: 179
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce9f20..0xce9f64]
+      OutOfLinePCRanges: [0xceaf00..0xceaf44]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce9f20..0xce9f39
+            - Range: 0xceaf00..0xceaf19
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10942,7 +10942,7 @@ Subprograms:
         - Name: f
           Type: 345 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xce9f20..0xce9f39
+            - Range: 0xceaf00..0xceaf19
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -10950,15 +10950,15 @@ Subprograms:
         - Name: ~r0
           Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce9f20..0xce9f39
+            - Range: 0xceaf00..0xceaf19
               Pieces: []
-            - Range: 0xce9f39..0xce9f3a
+            - Range: 0xceaf19..0xceaf1a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9f3a..0xce9f64
+            - Range: 0xceaf1a..0xceaf44
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -10966,13 +10966,13 @@ Subprograms:
       DictRegister: 0
     - ID: 180
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xcea200..0xcea204]
+      OutOfLinePCRanges: [0xceb1e0..0xceb1e4]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 343 PointerType *go.shape.int
           Locations:
-            - Range: 0xcea200..0xcea204
+            - Range: 0xceb1e0..0xceb1e4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10980,9 +10980,9 @@ Subprograms:
         - Name: ~r0
           Type: 343 PointerType *go.shape.int
           Locations:
-            - Range: 0xcea200..0xcea203
+            - Range: 0xceb1e0..0xceb1e3
               Pieces: []
-            - Range: 0xcea203..0xcea204
+            - Range: 0xceb1e3..0xceb1e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -10990,13 +10990,13 @@ Subprograms:
       DictRegister: 0
     - ID: 181
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xcea220..0xcea224]
+      OutOfLinePCRanges: [0xceb200..0xceb204]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 346 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xcea220..0xcea224
+            - Range: 0xceb200..0xceb204
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11004,9 +11004,9 @@ Subprograms:
         - Name: ~r0
           Type: 346 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xcea220..0xcea223
+            - Range: 0xceb200..0xceb203
               Pieces: []
-            - Range: 0xcea223..0xcea224
+            - Range: 0xceb203..0xceb204
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11014,13 +11014,13 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xcea240..0xcea244]
+      OutOfLinePCRanges: [0xceb220..0xceb224]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 348 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xcea240..0xcea244
+            - Range: 0xceb220..0xceb224
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11028,9 +11028,9 @@ Subprograms:
         - Name: ~r0
           Type: 348 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xcea240..0xcea243
+            - Range: 0xceb220..0xceb223
               Pieces: []
-            - Range: 0xcea243..0xcea244
+            - Range: 0xceb223..0xceb224
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11038,13 +11038,13 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xcea260..0xcea271]
+      OutOfLinePCRanges: [0xceb240..0xceb251]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 350 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xcea260..0xcea271
+            - Range: 0xceb240..0xceb251
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11052,9 +11052,9 @@ Subprograms:
         - Name: ~r0
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcea260..0xcea270
+            - Range: 0xceb240..0xceb250
               Pieces: []
-            - Range: 0xcea270..0xcea271
+            - Range: 0xceb250..0xceb251
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11066,13 +11066,13 @@ Subprograms:
       DictRegister: 0
     - ID: 184
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xcea300..0xcea309]
+      OutOfLinePCRanges: [0xceb2e0..0xceb2e9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 352 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xcea300..0xcea309
+            - Range: 0xceb2e0..0xceb2e9
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11080,9 +11080,9 @@ Subprograms:
         - Name: ~r0
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xcea300..0xcea308
+            - Range: 0xceb2e0..0xceb2e8
               Pieces: []
-            - Range: 0xcea308..0xcea309
+            - Range: 0xceb2e8..0xceb2e9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11090,13 +11090,13 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xcea3c0..0xcea3c8]
+      OutOfLinePCRanges: [0xceb3a0..0xceb3a8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 353 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xcea3c0..0xcea3c8
+            - Range: 0xceb3a0..0xceb3a8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11104,7 +11104,7 @@ Subprograms:
         - Name: k
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xcea3c0..0xcea3c8
+            - Range: 0xceb3a0..0xceb3a8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11112,7 +11112,7 @@ Subprograms:
         - Name: v
           Type: 355 BaseType go.shape.bool
           Locations:
-            - Range: 0xcea3c0..0xcea3c8
+            - Range: 0xceb3a0..0xceb3a8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11120,13 +11120,13 @@ Subprograms:
       DictRegister: 3
     - ID: 186
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xcea460..0xcea4ce]
+      OutOfLinePCRanges: [0xceb440..0xceb4ae]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 356 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xcea460..0xcea4ce
+            - Range: 0xceb440..0xceb4ae
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11134,7 +11134,7 @@ Subprograms:
         - Name: k
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcea460..0xcea4ce
+            - Range: 0xceb440..0xceb4ae
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -11146,7 +11146,7 @@ Subprograms:
         - Name: v
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xcea460..0xcea4ce
+            - Range: 0xceb440..0xceb4ae
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11154,13 +11154,13 @@ Subprograms:
       DictRegister: 3
     - ID: 187
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xcea560..0xcea568]
+      OutOfLinePCRanges: [0xceb540..0xceb548]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcea560..0xcea568
+            - Range: 0xceb540..0xceb548
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11172,7 +11172,7 @@ Subprograms:
         - Name: b
           Type: 355 BaseType go.shape.bool
           Locations:
-            - Range: 0xcea560..0xcea568
+            - Range: 0xceb540..0xceb548
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11180,9 +11180,9 @@ Subprograms:
         - Name: ~r0
           Type: 355 BaseType go.shape.bool
           Locations:
-            - Range: 0xcea560..0xcea567
+            - Range: 0xceb540..0xceb547
               Pieces: []
-            - Range: 0xcea567..0xcea568
+            - Range: 0xceb547..0xceb548
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11190,9 +11190,9 @@ Subprograms:
         - Name: ~r1
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcea560..0xcea567
+            - Range: 0xceb540..0xceb547
               Pieces: []
-            - Range: 0xcea567..0xcea568
+            - Range: 0xceb547..0xceb548
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11204,13 +11204,13 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xcea580..0xcea58f]
+      OutOfLinePCRanges: [0xceb560..0xceb56f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xcea580..0xcea58e
+            - Range: 0xceb560..0xceb56e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11218,13 +11218,13 @@ Subprograms:
         - Name: b
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcea580..0xcea58b
+            - Range: 0xceb560..0xceb56b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcea58b..0xcea58f
+            - Range: 0xceb56b..0xceb56f
               Pieces:
                 - Size: 8
                   Op: null
@@ -11236,9 +11236,9 @@ Subprograms:
         - Name: ~r0
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcea580..0xcea58e
+            - Range: 0xceb560..0xceb56e
               Pieces: []
-            - Range: 0xcea58e..0xcea58f
+            - Range: 0xceb56e..0xceb56f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11250,9 +11250,9 @@ Subprograms:
         - Name: ~r1
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xcea580..0xcea58e
+            - Range: 0xceb560..0xceb56e
               Pieces: []
-            - Range: 0xcea58e..0xcea58f
+            - Range: 0xceb56e..0xceb56f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
@@ -11260,13 +11260,13 @@ Subprograms:
       DictRegister: 0
     - ID: 189
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xcea5a0..0xcea5da]
+      OutOfLinePCRanges: [0xceb580..0xceb5ba]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 358 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xcea5a0..0xcea5b9
+            - Range: 0xceb580..0xceb599
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11274,15 +11274,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcea5a0..0xcea5b9
+            - Range: 0xceb580..0xceb599
               Pieces: []
-            - Range: 0xcea5b9..0xcea5ba
+            - Range: 0xceb599..0xceb59a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea5ba..0xcea5da
+            - Range: 0xceb59a..0xceb5ba
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11290,19 +11290,19 @@ Subprograms:
       DictRegister: 0
     - ID: 190
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xcea5e0..0xcea62d]
+      OutOfLinePCRanges: [0xceb5c0..0xceb60d]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 359 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xcea5e0..0xcea5ff
+            - Range: 0xceb5c0..0xceb5df
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcea5ff..0xcea602
+            - Range: 0xceb5df..0xceb5e2
               Pieces:
                 - Size: 8
                   Op: null
@@ -11314,15 +11314,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcea5e0..0xcea602
+            - Range: 0xceb5c0..0xceb5e2
               Pieces: []
-            - Range: 0xcea602..0xcea603
+            - Range: 0xceb5e2..0xceb5e3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea603..0xcea62d
+            - Range: 0xceb5e3..0xceb60d
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11330,13 +11330,13 @@ Subprograms:
       DictRegister: 0
     - ID: 191
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xcea640..0xcea648]
+      OutOfLinePCRanges: [0xceb620..0xceb628]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 360 PointerType *go.shape.string
           Locations:
-            - Range: 0xcea640..0xcea647
+            - Range: 0xceb620..0xceb627
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11344,9 +11344,9 @@ Subprograms:
         - Name: ~r0
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcea640..0xcea647
+            - Range: 0xceb620..0xceb627
               Pieces: []
-            - Range: 0xcea647..0xcea648
+            - Range: 0xceb627..0xceb628
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11358,13 +11358,13 @@ Subprograms:
       DictRegister: 0
     - ID: 192
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xcea660..0xcea6b7]
+      OutOfLinePCRanges: [0xceb640..0xceb697]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 361 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xcea660..0xcea69d
+            - Range: 0xceb640..0xceb67d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11372,9 +11372,9 @@ Subprograms:
         - Name: ~r0
           Type: 362 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xcea660..0xcea6b1
+            - Range: 0xceb640..0xceb691
               Pieces: []
-            - Range: 0xcea6b1..0xcea6b2
+            - Range: 0xceb691..0xceb692
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11388,7 +11388,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xcea6b2..0xcea6b7
+            - Range: 0xceb692..0xceb697
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11396,13 +11396,13 @@ Subprograms:
       DictRegister: 0
     - ID: 193
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xcea6c0..0xcea6e4]
+      OutOfLinePCRanges: [0xceb6a0..0xceb6c4]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcea6c0..0xcea6e4
+            - Range: 0xceb6a0..0xceb6c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11416,7 +11416,7 @@ Subprograms:
         - Name: needle
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xcea6c0..0xcea6e4
+            - Range: 0xceb6a0..0xceb6c4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11424,13 +11424,13 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcea6c0..0xcea6e0
+            - Range: 0xceb6a0..0xceb6c0
               Pieces: []
-            - Range: 0xcea6e0..0xcea6e1
+            - Range: 0xceb6c0..0xceb6c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea6e1..0xcea6e3
+            - Range: 0xceb6c1..0xceb6c3
               Pieces: []
-            - Range: 0xcea6e3..0xcea6e4
+            - Range: 0xceb6c3..0xceb6c4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -11438,13 +11438,13 @@ Subprograms:
       DictRegister: 0
     - ID: 194
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xcea700..0xcea7bf]
+      OutOfLinePCRanges: [0xceb6e0..0xceb79f]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 363 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xcea700..0xcea71d
+            - Range: 0xceb6e0..0xceb6fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11452,7 +11452,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcea71d..0xcea71f
+            - Range: 0xceb6fd..0xceb6ff
               Pieces:
                 - Size: 8
                   Op: null
@@ -11466,13 +11466,13 @@ Subprograms:
         - Name: needle
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcea700..0xcea74c
+            - Range: 0xceb6e0..0xceb72c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xcea74c..0xcea7bf
+            - Range: 0xceb72c..0xceb79f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -11484,15 +11484,15 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcea700..0xcea76b
+            - Range: 0xceb6e0..0xceb74b
               Pieces: []
-            - Range: 0xcea76b..0xcea76c
+            - Range: 0xceb74b..0xceb74c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea76c..0xcea773
+            - Range: 0xceb74c..0xceb753
               Pieces: []
-            - Range: 0xcea773..0xcea774
+            - Range: 0xceb753..0xceb754
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea774..0xcea7bf
+            - Range: 0xceb754..0xceb79f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11500,13 +11500,13 @@ Subprograms:
         - Name: v
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcea72f..0xcea741
+            - Range: 0xceb70f..0xceb721
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcea741..0xcea74c
+            - Range: 0xceb721..0xceb72c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11518,13 +11518,13 @@ Subprograms:
       DictRegister: 0
     - ID: 195
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xcea7c0..0xcea7c7]
+      OutOfLinePCRanges: [0xceb7a0..0xceb7a7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 364 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xcea7c0..0xcea7c6
+            - Range: 0xceb7a0..0xceb7a6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11532,7 +11532,7 @@ Subprograms:
         - Name: value
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0xcea7c0..0xcea7c7
+            - Range: 0xceb7a0..0xceb7a7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11540,9 +11540,9 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcea7c0..0xcea7c6
+            - Range: 0xceb7a0..0xceb7a6
               Pieces: []
-            - Range: 0xcea7c6..0xcea7c7
+            - Range: 0xceb7a6..0xceb7a7
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -11550,25 +11550,25 @@ Subprograms:
       DictRegister: 3
     - ID: 196
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xcea840..0xcea8ac]
+      OutOfLinePCRanges: [0xceb820..0xceb88c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 365 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xcea840..0xcea860
+            - Range: 0xceb820..0xceb840
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea860..0xcea868
+            - Range: 0xceb840..0xceb848
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea868..0xcea86d
+            - Range: 0xceb848..0xceb84d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11580,7 +11580,7 @@ Subprograms:
         - Name: value
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcea840..0xcea86d
+            - Range: 0xceb820..0xceb84d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -11592,11 +11592,11 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcea840..0xcea86d
+            - Range: 0xceb820..0xceb84d
               Pieces: []
-            - Range: 0xcea86d..0xcea86e
+            - Range: 0xceb84d..0xceb84e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea86e..0xcea8ac
+            - Range: 0xceb84e..0xceb88c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11834,31 +11834,31 @@ Subprograms:
       DictRegister: null
     - ID: 199
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xce07c0..0xce0822]
+      OutOfLinePCRanges: [0xce0ca0..0xce0d02]
       InlinePCRanges:
-        - Ranges: [0xce0851..0xce088d]
-          RootRanges: [0xce0840..0xce08b1]
-        - Ranges: [0xce0992..0xce09ce]
-          RootRanges: [0xce0960..0xce09e8]
-        - Ranges: [0xce0a1c..0xce0a58]
-          RootRanges: [0xce0a00..0xce0ac5]
-        - Ranges: [0xce0aef..0xce0b2b]
-          RootRanges: [0xce0ae0..0xce0b42]
+        - Ranges: [0xce0d31..0xce0d6d]
+          RootRanges: [0xce0d20..0xce0d91]
+        - Ranges: [0xce0e72..0xce0eae]
+          RootRanges: [0xce0e40..0xce0ec8]
+        - Ranges: [0xce0efc..0xce0f38]
+          RootRanges: [0xce0ee0..0xce0fa5]
+        - Ranges: [0xce0fcf..0xce100b]
+          RootRanges: [0xce0fc0..0xce1022]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce07c0..0xce07d9
+            - Range: 0xce0ca0..0xce0cb9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0851..0xce085c
+            - Range: 0xce0d31..0xce0d3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0992..0xce099d
+            - Range: 0xce0e72..0xce0e7d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0a16..0xce0a27
+            - Range: 0xce0ef6..0xce0f07
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0a27..0xce0ac5
+            - Range: 0xce0f07..0xce0fa5
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xce0ae0..0xce0afa
+            - Range: 0xce0fc0..0xce0fda
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11868,37 +11868,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xce0a66..0xce0a9e]
-          RootRanges: [0xce0a00..0xce0ac5]
+        - Ranges: [0xce0f46..0xce0f7e]
+          RootRanges: [0xce0ee0..0xce0fa5]
       Variables: []
       DictRegister: null
     - ID: 201
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xce0b73..0xce0bb1]
-          RootRanges: [0xce0b60..0xce0c65]
+        - Ranges: [0xce1053..0xce1091]
+          RootRanges: [0xce1040..0xce1145]
       Variables: []
       DictRegister: null
     - ID: 202
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xce0c1b..0xce0c53]
-          RootRanges: [0xce0b60..0xce0c65]
+        - Ranges: [0xce10fb..0xce1133]
+          RootRanges: [0xce1040..0xce1145]
       Variables: []
       DictRegister: null
     - ID: 203
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xce0c81..0xce0c85]
-          RootRanges: [0xce0c80..0xce0c86]
+        - Ranges: [0xce1161..0xce1165]
+          RootRanges: [0xce1160..0xce1166]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce0c80..0xce0c85
+            - Range: 0xce1160..0xce1165
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11908,33 +11908,33 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xce0cc5..0xce0cdd]
-          RootRanges: [0xce0ca0..0xce0ce3]
-        - Ranges: [0xce0d65..0xce0d83]
-          RootRanges: [0xce0d00..0xce0e85]
+        - Ranges: [0xce11a5..0xce11bd]
+          RootRanges: [0xce1180..0xce11c3]
+        - Ranges: [0xce12b5..0xce12d3]
+          RootRanges: [0xce11e0..0xce140c]
       Variables:
         - Name: a
           Type: 170 ArrayType [5]int
           Locations:
-            - Range: 0xce0cad..0xce0ce3
+            - Range: 0xce118d..0xce11c3
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xce0d4c..0xce0e85
-              Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
+            - Range: 0xce1299..0xce140c
+              Pieces: [{Size: 40, Op: {CfaOffset: -152}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 205
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xce0ea0..0xce0f06]
+      OutOfLinePCRanges: [0xce1480..0xce14e6]
       InlinePCRanges:
-        - Ranges: [0xceaa83..0xceaab1]
-          RootRanges: [0xceaa60..0xceaadf]
+        - Ranges: [0xceba63..0xceba91]
+          RootRanges: [0xceba40..0xcebabf]
       Variables:
         - Name: b
           Type: 370 StructureType main.firstBehavior
           Locations:
-            - Range: 0xce0ea0..0xce0ebe
+            - Range: 0xce1480..0xce149e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11946,15 +11946,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xce0ea0..0xce0ee5
+            - Range: 0xce1480..0xce14c5
               Pieces: []
-            - Range: 0xce0ee5..0xce0ee6
+            - Range: 0xce14c5..0xce14c6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce0ee6..0xce0f06
+            - Range: 0xce14c6..0xce14e6
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11964,8 +11964,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xce1746..0xce174d]
-          RootRanges: [0xce16a0..0xce17aa]
+        - Ranges: [0xce1de6..0xce1ded]
+          RootRanges: [0xce1cc0..0xce1e7a]
         - Ranges: [0xcda821..0xcda829]
           RootRanges: [0xcda820..0xcda82a]
       Variables: []
@@ -12646,7 +12646,7 @@ Types:
       ID: 2639
       Name: '*compress/gzip.Reader'
       ByteSize: 8
-      GoRuntimeType: 1635136
+      GoRuntimeType: 1634368
       GoKind: 22
       Pointee: 2640 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
@@ -12660,7 +12660,7 @@ Types:
       ID: 420
       Name: '*context.backgroundCtx'
       ByteSize: 8
-      GoRuntimeType: 1561344
+      GoRuntimeType: 1560864
       GoKind: 22
       Pointee: 421 GoContextImplementationType context.backgroundCtx
     - __kind: PointerType
@@ -12674,21 +12674,21 @@ Types:
       ID: 1084
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1198592
+      GoRuntimeType: 1196928
       GoKind: 22
       Pointee: 1085 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 407
       Name: '*context.emptyCtx'
       ByteSize: 8
-      GoRuntimeType: 1422560
+      GoRuntimeType: 1422400
       GoKind: 22
       Pointee: 408 GoContextImplementationType context.emptyCtx
     - __kind: PointerType
       ID: 409
       Name: '*context.stopCtx'
       ByteSize: 8
-      GoRuntimeType: 1422720
+      GoRuntimeType: 1422560
       GoKind: 22
       Pointee: 410 GoContextImplementationType context.stopCtx
     - __kind: PointerType
@@ -12702,21 +12702,21 @@ Types:
       ID: 422
       Name: '*context.todoCtx'
       ByteSize: 8
-      GoRuntimeType: 1561504
+      GoRuntimeType: 1561024
       GoKind: 22
       Pointee: 423 GoContextImplementationType context.todoCtx
     - __kind: PointerType
       ID: 416
       Name: '*context.valueCtx'
       ByteSize: 8
-      GoRuntimeType: 1561024
+      GoRuntimeType: 1560544
       GoKind: 22
       Pointee: 417 GoContextImplementationType context.valueCtx
     - __kind: PointerType
       ID: 418
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
-      GoRuntimeType: 1561184
+      GoRuntimeType: 1560704
       GoKind: 22
       Pointee: 419 GoContextImplementationType context.withoutCancelCtx
     - __kind: PointerType
@@ -13092,17 +13092,17 @@ Types:
       GoKind: 22
       Pointee: 975 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 867
+      ID: 865
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 916288
+      GoRuntimeType: 915616
       GoKind: 22
       Pointee: 762 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
       ID: 1231
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1047200
+      GoRuntimeType: 1047072
       GoKind: 22
       Pointee: 1232 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -13113,31 +13113,31 @@ Types:
       GoKind: 22
       Pointee: 763 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 1498
+      ID: 1496
       Name: '*encoding/json.Delim'
       ByteSize: 8
-      GoRuntimeType: 911200
+      GoRuntimeType: 910528
       GoKind: 22
-      Pointee: 1428 BaseType encoding/json.Delim
+      Pointee: 1426 BaseType encoding/json.Delim
     - __kind: PointerType
-      ID: 838
+      ID: 836
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 911104
+      GoRuntimeType: 910432
       GoKind: 22
-      Pointee: 839 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 837 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
       ID: 1043
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1043360
+      GoRuntimeType: 1043232
       GoKind: 22
       Pointee: 1044 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
       ID: 1668
       Name: '*encoding/json.Number'
       ByteSize: 8
-      GoRuntimeType: 1212544
+      GoRuntimeType: 1212032
       GoKind: 22
       Pointee: 1650 GoStringHeaderType encoding/json.Number
     - __kind: PointerType
@@ -13146,33 +13146,33 @@ Types:
       ByteSize: 8
       Pointee: 1651 GoStringDataType encoding/json.Number.str
     - __kind: PointerType
-      ID: 830
+      ID: 828
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 910720
+      GoRuntimeType: 910048
       GoKind: 22
-      Pointee: 831 UnresolvedPointeeType encoding/json.SyntaxError
-    - __kind: PointerType
-      ID: 836
-      Name: '*encoding/json.UnmarshalTypeError'
-      ByteSize: 8
-      GoRuntimeType: 911008
-      GoKind: 22
-      Pointee: 837 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 829 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
       ID: 834
-      Name: '*encoding/json.UnsupportedTypeError'
+      Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
-      GoRuntimeType: 910912
+      GoRuntimeType: 910336
       GoKind: 22
-      Pointee: 835 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 835 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
       ID: 832
+      Name: '*encoding/json.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 910240
+      GoKind: 22
+      Pointee: 833 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 830
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
-      GoRuntimeType: 910816
+      GoRuntimeType: 910144
       GoKind: 22
-      Pointee: 833 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 831 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
       ID: 1373
       Name: '*encoding/json.encodeState'
@@ -13181,12 +13181,12 @@ Types:
       GoKind: 22
       Pointee: 1374 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 840
+      ID: 838
       Name: '*encoding/json.jsonError'
       ByteSize: 8
-      GoRuntimeType: 911488
+      GoRuntimeType: 910816
       GoKind: 22
-      Pointee: 841 StructureType encoding/json.jsonError
+      Pointee: 839 StructureType encoding/json.jsonError
     - __kind: PointerType
       ID: 1239
       Name: '*encoding/pem.lineBreaker'
@@ -13245,14 +13245,14 @@ Types:
       ID: 806
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 901792
+      GoRuntimeType: 902656
       GoKind: 22
       Pointee: 807 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 1010
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1029152
+      GoRuntimeType: 1030176
       GoKind: 22
       Pointee: 1011 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -13287,21 +13287,21 @@ Types:
       ID: 2545
       Name: '*fmt.stringReader'
       ByteSize: 8
-      GoRuntimeType: 901888
+      GoRuntimeType: 902752
       GoKind: 22
       Pointee: 2546 UnresolvedPointeeType fmt.stringReader
     - __kind: PointerType
       ID: 1012
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1029280
+      GoRuntimeType: 1030304
       GoKind: 22
       Pointee: 1013 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 1014
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1029408
+      GoRuntimeType: 1030432
       GoKind: 22
       Pointee: 1015 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -13329,7 +13329,7 @@ Types:
       ID: 2389
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AgentPayload'
       ByteSize: 8
-      GoRuntimeType: 2209856
+      GoRuntimeType: 2209024
       GoKind: 22
       Pointee: 2390 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AgentPayload
     - __kind: PointerType
@@ -13343,7 +13343,7 @@ Types:
       ID: 2070
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType'
       ByteSize: 8
-      GoRuntimeType: 1858368
+      GoRuntimeType: 1858144
       GoKind: 22
       Pointee: 2017 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
     - __kind: PointerType
@@ -13364,7 +13364,7 @@ Types:
       ID: 2071
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType'
       ByteSize: 8
-      GoRuntimeType: 1858592
+      GoRuntimeType: 1858368
       GoKind: 22
       Pointee: 2018 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
     - __kind: PointerType
@@ -13413,7 +13413,7 @@ Types:
       ID: 2387
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.StatsPayload'
       ByteSize: 8
-      GoRuntimeType: 2209024
+      GoRuntimeType: 2208192
       GoKind: 22
       Pointee: 2388 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.StatsPayload
     - __kind: PointerType
@@ -13434,7 +13434,7 @@ Types:
       ID: 2453
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.TracerPayload'
       ByteSize: 8
-      GoRuntimeType: 2260384
+      GoRuntimeType: 2259424
       GoKind: 22
       Pointee: 2454 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.TracerPayload
     - __kind: PointerType
@@ -13452,45 +13452,45 @@ Types:
       GoKind: 22
       Pointee: 1726 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/version.Version
     - __kind: PointerType
-      ID: 849
+      ID: 847
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
-      GoRuntimeType: 913888
+      GoRuntimeType: 913216
       GoKind: 22
-      Pointee: 850 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 848 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 851
+      ID: 849
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
-      GoRuntimeType: 913984
+      GoRuntimeType: 913312
       GoKind: 22
-      Pointee: 852 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 850 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
       ID: 1177
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
-      GoRuntimeType: 913696
+      GoRuntimeType: 913024
       GoKind: 22
       Pointee: 1178 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 855
+      ID: 853
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
-      GoRuntimeType: 914272
+      GoRuntimeType: 913600
       GoKind: 22
-      Pointee: 856 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 854 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
       ID: 1179
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
-      GoRuntimeType: 913792
+      GoRuntimeType: 913120
       GoKind: 22
       Pointee: 1180 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 853
+      ID: 851
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
-      GoRuntimeType: 914080
+      GoRuntimeType: 913408
       GoKind: 22
       Pointee: 756 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
@@ -13499,10 +13499,10 @@ Types:
       ByteSize: 8
       Pointee: 757 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 848
+      ID: 846
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
-      GoRuntimeType: 913600
+      GoRuntimeType: 912928
       GoKind: 22
       Pointee: 753 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
@@ -13511,10 +13511,10 @@ Types:
       ByteSize: 8
       Pointee: 754 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 854
+      ID: 852
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
-      GoRuntimeType: 914176
+      GoRuntimeType: 913504
       GoKind: 22
       Pointee: 759 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
@@ -13526,7 +13526,7 @@ Types:
       ID: 1251
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1215872
+      GoRuntimeType: 1215360
       GoKind: 22
       Pointee: 1252 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
@@ -13547,14 +13547,14 @@ Types:
       ID: 1783
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule'
       ByteSize: 8
-      GoRuntimeType: 1561664
+      GoRuntimeType: 1561184
       GoKind: 22
       Pointee: 1784 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule
     - __kind: PointerType
       ID: 1481
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType'
       ByteSize: 8
-      GoRuntimeType: 902368
+      GoRuntimeType: 901888
       GoKind: 22
       Pointee: 1419 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType
     - __kind: PointerType
@@ -13575,14 +13575,14 @@ Types:
       ID: 394
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
-      GoRuntimeType: 1198848
+      GoRuntimeType: 1197184
       GoKind: 22
       Pointee: 395 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
       ID: 1484
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate'
       ByteSize: 8
-      GoRuntimeType: 902656
+      GoRuntimeType: 902176
       GoKind: 22
       Pointee: 1485 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate
     - __kind: PointerType
@@ -13596,7 +13596,7 @@ Types:
       ID: 1482
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule'
       ByteSize: 8
-      GoRuntimeType: 902560
+      GoRuntimeType: 902080
       GoKind: 22
       Pointee: 1483 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule
     - __kind: PointerType
@@ -13610,35 +13610,35 @@ Types:
       ID: 1667
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance'
       ByteSize: 8
-      GoRuntimeType: 1200256
+      GoRuntimeType: 1198592
       GoKind: 22
       Pointee: 1575 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance
     - __kind: PointerType
       ID: 2344
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter'
       ByteSize: 8
-      GoRuntimeType: 902464
+      GoRuntimeType: 901984
       GoKind: 22
       Pointee: 2345 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter
     - __kind: PointerType
       ID: 397
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
-      GoRuntimeType: 1198976
+      GoRuntimeType: 1197312
       GoKind: 22
       Pointee: 398 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
       ID: 2702
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
-      GoRuntimeType: 1199616
+      GoRuntimeType: 1197952
       GoKind: 22
       Pointee: 2703 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
       ID: 727
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      GoRuntimeType: 1199744
+      GoRuntimeType: 1198080
       GoKind: 22
       Pointee: 728 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
@@ -13666,7 +13666,7 @@ Types:
       ID: 1745
       Name: '*github.com/DataDog/dd-trace-go/v2/internal.TraceSource'
       ByteSize: 8
-      GoRuntimeType: 1428480
+      GoRuntimeType: 1428320
       GoKind: 22
       Pointee: 1576 BaseType github.com/DataDog/dd-trace-go/v2/internal.TraceSource
     - __kind: PointerType
@@ -13750,7 +13750,7 @@ Types:
       ID: 412
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
-      GoRuntimeType: 1428800
+      GoRuntimeType: 1428640
       GoKind: 22
       Pointee: 413 GoContextImplementationType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
@@ -13764,21 +13764,21 @@ Types:
       ID: 1607
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource'
       ByteSize: 8
-      GoRuntimeType: 1045408
+      GoRuntimeType: 1045280
       GoKind: 22
       Pointee: 1608 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource
     - __kind: PointerType
       ID: 1609
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource'
       ByteSize: 8
-      GoRuntimeType: 1045536
+      GoRuntimeType: 1045408
       GoKind: 22
       Pointee: 1610 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource
     - __kind: PointerType
       ID: 1601
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey'
       ByteSize: 8
-      GoRuntimeType: 1042976
+      GoRuntimeType: 1042848
       GoKind: 22
       Pointee: 1602 StructureType github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey
     - __kind: PointerType
@@ -13993,47 +13993,47 @@ Types:
       GoKind: 22
       Pointee: 2456 StructureType github.com/Masterminds/semver/v3.Version
     - __kind: PointerType
-      ID: 1510
+      ID: 1508
       Name: '*github.com/cihub/seelog.CfgParseParams'
       ByteSize: 8
-      GoRuntimeType: 916096
+      GoRuntimeType: 915424
       GoKind: 22
-      Pointee: 1511 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
+      Pointee: 1509 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
     - __kind: PointerType
-      ID: 1509
+      ID: 1507
       Name: '*github.com/cihub/seelog.LogLevel'
       ByteSize: 8
-      GoRuntimeType: 915232
+      GoRuntimeType: 914560
       GoKind: 22
-      Pointee: 1431 BaseType github.com/cihub/seelog.LogLevel
+      Pointee: 1429 BaseType github.com/cihub/seelog.LogLevel
     - __kind: PointerType
       ID: 2027
       Name: '*github.com/cihub/seelog.LogLevelException'
       ByteSize: 8
-      GoRuntimeType: 1815136
+      GoRuntimeType: 1814688
       GoKind: 22
       Pointee: 2028 UnresolvedPointeeType github.com/cihub/seelog.LogLevelException
     - __kind: PointerType
-      ID: 857
+      ID: 855
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
-      GoRuntimeType: 915424
+      GoRuntimeType: 914752
       GoKind: 22
-      Pointee: 858 StructureType github.com/cihub/seelog.baseError
+      Pointee: 856 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 1291
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1815584
+      GoRuntimeType: 1815136
       GoKind: 22
       Pointee: 1292 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 859
+      ID: 857
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
-      GoRuntimeType: 915520
+      GoRuntimeType: 914848
       GoKind: 22
-      Pointee: 860 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 858 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 1271
       Name: '*github.com/cihub/seelog.connWriter'
@@ -14045,42 +14045,42 @@ Types:
       ID: 1227
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1046048
+      GoRuntimeType: 1045920
       GoKind: 22
       Pointee: 1228 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1750
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1432960
+      GoRuntimeType: 1432800
       GoKind: 22
       Pointee: 1751 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
       ID: 1859
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
-      GoRuntimeType: 1646656
+      GoRuntimeType: 1645888
       GoKind: 22
       Pointee: 1860 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
       ID: 1261
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1432480
+      GoRuntimeType: 1432320
       GoKind: 22
       Pointee: 1262 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
       ID: 1863
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1647424
+      GoRuntimeType: 1646656
       GoKind: 22
       Pointee: 1864 UnresolvedPointeeType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
       ID: 1746
       Name: '*github.com/cihub/seelog.formattedWriter'
       ByteSize: 8
-      GoRuntimeType: 1432640
+      GoRuntimeType: 1432480
       GoKind: 22
       Pointee: 1747 UnresolvedPointeeType github.com/cihub/seelog.formattedWriter
     - __kind: PointerType
@@ -14094,42 +14094,42 @@ Types:
       ID: 1673
       Name: '*github.com/cihub/seelog.listConstraints'
       ByteSize: 8
-      GoRuntimeType: 1218176
+      GoRuntimeType: 1217664
       GoKind: 22
       Pointee: 1674 UnresolvedPointeeType github.com/cihub/seelog.listConstraints
     - __kind: PointerType
-      ID: 1507
+      ID: 1505
       Name: '*github.com/cihub/seelog.logFormattedMessage'
       ByteSize: 8
-      GoRuntimeType: 915136
+      GoRuntimeType: 914464
       GoKind: 22
-      Pointee: 1508 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
+      Pointee: 1506 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
     - __kind: PointerType
-      ID: 1505
+      ID: 1503
       Name: '*github.com/cihub/seelog.logMessage'
       ByteSize: 8
-      GoRuntimeType: 915040
+      GoRuntimeType: 914368
       GoKind: 22
-      Pointee: 1506 UnresolvedPointeeType github.com/cihub/seelog.logMessage
+      Pointee: 1504 UnresolvedPointeeType github.com/cihub/seelog.logMessage
     - __kind: PointerType
       ID: 1613
       Name: '*github.com/cihub/seelog.minMaxConstraints'
       ByteSize: 8
-      GoRuntimeType: 1046560
+      GoRuntimeType: 1046432
       GoKind: 22
       Pointee: 1614 UnresolvedPointeeType github.com/cihub/seelog.minMaxConstraints
     - __kind: PointerType
-      ID: 863
+      ID: 861
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
-      GoRuntimeType: 915712
+      GoRuntimeType: 915040
       GoKind: 22
-      Pointee: 864 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 862 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 1611
       Name: '*github.com/cihub/seelog.offConstraints'
       ByteSize: 8
-      GoRuntimeType: 1046432
+      GoRuntimeType: 1046304
       GoKind: 22
       Pointee: 1612 UnresolvedPointeeType github.com/cihub/seelog.offConstraints
     - __kind: PointerType
@@ -14157,35 +14157,35 @@ Types:
       ID: 1229
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1046176
+      GoRuntimeType: 1046048
       GoKind: 22
       Pointee: 1230 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
       ID: 1861
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1646848
+      GoRuntimeType: 1646080
       GoKind: 22
       Pointee: 1862 UnresolvedPointeeType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 861
+      ID: 859
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
-      GoRuntimeType: 915616
+      GoRuntimeType: 914944
       GoKind: 22
-      Pointee: 862 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 860 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 865
+      ID: 863
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
-      GoRuntimeType: 915808
+      GoRuntimeType: 915136
       GoKind: 22
-      Pointee: 866 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 864 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 1748
       Name: '*github.com/cihub/seelog.xmlNode'
       ByteSize: 8
-      GoRuntimeType: 1432800
+      GoRuntimeType: 1432640
       GoKind: 22
       Pointee: 1749 UnresolvedPointeeType github.com/cihub/seelog.xmlNode
     - __kind: PointerType
@@ -15037,42 +15037,42 @@ Types:
       ID: 1096
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1207040
+      GoRuntimeType: 1206528
       GoKind: 22
       Pointee: 1097 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 1090
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1206656
+      GoRuntimeType: 1206144
       GoKind: 22
       Pointee: 1091 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 1029
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1037600
+      GoRuntimeType: 1037472
       GoKind: 22
       Pointee: 1030 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 1102
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1207424
+      GoRuntimeType: 1206912
       GoKind: 22
       Pointee: 1103 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 1028
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1037472
+      GoRuntimeType: 1037344
       GoKind: 22
       Pointee: 1007 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 1094
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1206912
+      GoRuntimeType: 1206400
       GoKind: 22
       Pointee: 1095 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
@@ -15083,31 +15083,31 @@ Types:
       GoKind: 22
       Pointee: 2678 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Reader
     - __kind: PointerType
-      ID: 1491
+      ID: 1489
       Name: '*github.com/tinylib/msgp/msgp.Type'
       ByteSize: 8
-      GoRuntimeType: 907168
+      GoRuntimeType: 906496
       GoKind: 22
       Pointee: 1185 BaseType github.com/tinylib/msgp/msgp.Type
     - __kind: PointerType
       ID: 1092
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1206784
+      GoRuntimeType: 1206272
       GoKind: 22
       Pointee: 1093 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 1100
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1207296
+      GoRuntimeType: 1206784
       GoKind: 22
       Pointee: 1101 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 1098
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1207168
+      GoRuntimeType: 1206656
       GoKind: 22
       Pointee: 1099 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
@@ -15121,28 +15121,28 @@ Types:
       ID: 1106
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1207808
+      GoRuntimeType: 1207296
       GoKind: 22
       Pointee: 1107 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 1033
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1037856
+      GoRuntimeType: 1037728
       GoKind: 22
       Pointee: 1034 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 1031
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1037728
+      GoRuntimeType: 1037600
       GoKind: 22
       Pointee: 1032 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 1104
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1207680
+      GoRuntimeType: 1207168
       GoKind: 22
       Pointee: 1105 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -17198,77 +17198,77 @@ Types:
       ID: 2549
       Name: '*io.LimitedReader'
       ByteSize: 8
-      GoRuntimeType: 902080
+      GoRuntimeType: 902944
       GoKind: 22
       Pointee: 2550 UnresolvedPointeeType io.LimitedReader
     - __kind: PointerType
       ID: 2654
       Name: '*io.PipeReader'
       ByteSize: 8
-      GoRuntimeType: 1849632
+      GoRuntimeType: 1851872
       GoKind: 22
       Pointee: 2655 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
       ID: 1249
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1198336
+      GoRuntimeType: 1201536
       GoKind: 22
       Pointee: 1250 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 2633
       Name: '*io.SectionReader'
       ByteSize: 8
-      GoRuntimeType: 1560704
+      GoRuntimeType: 1562304
       GoKind: 22
       Pointee: 2634 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
       ID: 1247
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1197952
+      GoRuntimeType: 1201152
       GoKind: 22
       Pointee: 1248 StructureType io.discard
     - __kind: PointerType
       ID: 2551
       Name: '*io.eofReader'
       ByteSize: 8
-      GoRuntimeType: 902176
+      GoRuntimeType: 903040
       GoKind: 22
       Pointee: 2552 StructureType io.eofReader
     - __kind: PointerType
       ID: 2607
       Name: '*io.multiReader'
       ByteSize: 8
-      GoRuntimeType: 1197696
+      GoRuntimeType: 1200896
       GoKind: 22
       Pointee: 2608 UnresolvedPointeeType io.multiReader
     - __kind: PointerType
       ID: 1221
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1030176
+      GoRuntimeType: 1031200
       GoKind: 22
       Pointee: 1222 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 2575
       Name: '*io.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1030432
+      GoRuntimeType: 1031456
       GoKind: 22
       Pointee: 2576 StructureType io.nopCloser
     - __kind: PointerType
       ID: 2609
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
-      GoRuntimeType: 1197824
+      GoRuntimeType: 1201024
       GoKind: 22
       Pointee: 2610 StructureType io.nopCloserWriterTo
     - __kind: PointerType
       ID: 2547
       Name: '*io.teeReader'
       ByteSize: 8
-      GoRuntimeType: 901984
+      GoRuntimeType: 902848
       GoKind: 22
       Pointee: 2548 UnresolvedPointeeType io.teeReader
     - __kind: PointerType
@@ -17296,28 +17296,28 @@ Types:
       ID: 1675
       Name: '*log/slog.Attr'
       ByteSize: 8
-      GoRuntimeType: 1218816
+      GoRuntimeType: 1218304
       GoKind: 22
       Pointee: 1676 StructureType log/slog.Attr
     - __kind: PointerType
-      ID: 1512
+      ID: 1510
       Name: '*log/slog.Kind'
       ByteSize: 8
-      GoRuntimeType: 916192
+      GoRuntimeType: 915520
       GoKind: 22
-      Pointee: 1432 BaseType log/slog.Kind
+      Pointee: 1430 BaseType log/slog.Kind
     - __kind: PointerType
       ID: 2029
       Name: '*log/slog.Level'
       ByteSize: 8
-      GoRuntimeType: 1816032
+      GoRuntimeType: 1815584
       GoKind: 22
       Pointee: 1779 BaseType log/slog.Level
     - __kind: PointerType
       ID: 2391
       Name: '*log/slog.Value'
       ByteSize: 8
-      GoRuntimeType: 2210272
+      GoRuntimeType: 2209440
       GoKind: 22
       Pointee: 2019 StructureType log/slog.Value
     - __kind: PointerType
@@ -17841,7 +17841,7 @@ Types:
       ID: 2641
       Name: '*math/rand/v2.ChaCha8'
       ByteSize: 8
-      GoRuntimeType: 1643776
+      GoRuntimeType: 1643008
       GoKind: 22
       Pointee: 2642 UnresolvedPointeeType math/rand/v2.ChaCha8
     - __kind: PointerType
@@ -17890,21 +17890,21 @@ Types:
       ID: 1113
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1213696
+      GoRuntimeType: 1213184
       GoKind: 22
       Pointee: 1114 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 1144
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1430720
+      GoRuntimeType: 1430560
       GoKind: 22
       Pointee: 1145 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1503
+      ID: 1501
       Name: '*net.HardwareAddr.array'
       ByteSize: 8
-      Pointee: 1502 GoSliceDataType net.HardwareAddr.array
+      Pointee: 1500 GoSliceDataType net.HardwareAddr.array
     - __kind: PointerType
       ID: 2354
       Name: '*net.IP'
@@ -17935,7 +17935,7 @@ Types:
       ID: 1603
       Name: '*net.IPMask'
       ByteSize: 8
-      GoRuntimeType: 1044000
+      GoRuntimeType: 1043872
       GoKind: 22
       Pointee: 1604 GoSliceHeaderType net.IPMask
     - __kind: PointerType
@@ -17947,28 +17947,28 @@ Types:
       ID: 1669
       Name: '*net.IPNet'
       ByteSize: 8
-      GoRuntimeType: 1213440
+      GoRuntimeType: 1212928
       GoKind: 22
       Pointee: 1670 UnresolvedPointeeType net.IPNet
     - __kind: PointerType
       ID: 1142
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1430400
+      GoRuntimeType: 1430240
       GoKind: 22
       Pointee: 1143 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 1115
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1213824
+      GoRuntimeType: 1213312
       GoKind: 22
       Pointee: 1116 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 2025
       Name: '*net.TCPAddr'
       ByteSize: 8
-      GoRuntimeType: 1814240
+      GoRuntimeType: 1813792
       GoKind: 22
       Pointee: 2026 UnresolvedPointeeType net.TCPAddr
     - __kind: PointerType
@@ -17982,7 +17982,7 @@ Types:
       ID: 2023
       Name: '*net.UDPAddr'
       ByteSize: 8
-      GoRuntimeType: 1814016
+      GoRuntimeType: 1813568
       GoKind: 22
       Pointee: 2024 UnresolvedPointeeType net.UDPAddr
     - __kind: PointerType
@@ -18010,7 +18010,7 @@ Types:
       ID: 1112
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1212928
+      GoRuntimeType: 1212416
       GoKind: 22
       Pointee: 1081 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -18022,37 +18022,37 @@ Types:
       ID: 2168
       Name: '*net.addrPortUDPAddr'
       ByteSize: 8
-      GoRuntimeType: 2023104
+      GoRuntimeType: 2022816
       GoKind: 22
       Pointee: 2169 StructureType net.addrPortUDPAddr
     - __kind: PointerType
       ID: 1045
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1044256
+      GoRuntimeType: 1044128
       GoKind: 22
       Pointee: 1046 StructureType net.canceledError
     - __kind: PointerType
       ID: 1331
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2022816
+      GoRuntimeType: 2022528
       GoKind: 22
       Pointee: 1332 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1186
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1860160
+      GoRuntimeType: 1859936
       GoKind: 22
       Pointee: 1187 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1504
+      ID: 1502
       Name: '*net.hostLookupOrder'
       ByteSize: 8
-      GoRuntimeType: 912832
+      GoRuntimeType: 912160
       GoKind: 22
-      Pointee: 1430 BaseType net.hostLookupOrder
+      Pointee: 1428 BaseType net.hostLookupOrder
     - __kind: PointerType
       ID: 1377
       Name: '*net.netFD'
@@ -18061,157 +18061,157 @@ Types:
       GoKind: 22
       Pointee: 1378 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 842
+      ID: 840
       Name: '*net.notFoundError'
       ByteSize: 8
-      GoRuntimeType: 912448
+      GoRuntimeType: 911776
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType net.notFoundError
+      Pointee: 841 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 414
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
-      GoRuntimeType: 1430560
+      GoRuntimeType: 1430400
       GoKind: 22
       Pointee: 415 GoContextImplementationType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 844
+      ID: 842
       Name: '*net.result·2'
       ByteSize: 8
-      GoRuntimeType: 913120
+      GoRuntimeType: 912448
       GoKind: 22
-      Pointee: 845 StructureType net.result·2
+      Pointee: 843 StructureType net.result·2
     - __kind: PointerType
       ID: 1359
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2261344
+      GoRuntimeType: 2260384
       GoKind: 22
       Pointee: 1360 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1357
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2260864
+      GoRuntimeType: 2259904
       GoKind: 22
       Pointee: 1358 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 1117
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1214464
+      GoRuntimeType: 1213952
       GoKind: 22
       Pointee: 1118 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 1146
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1430880
+      GoRuntimeType: 1430720
       GoKind: 22
       Pointee: 1147 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 1597
       Name: '*net/http.Cookie'
       ByteSize: 8
-      GoRuntimeType: 1038624
+      GoRuntimeType: 1038496
       GoKind: 22
       Pointee: 1598 UnresolvedPointeeType net/http.Cookie
     - __kind: PointerType
       ID: 1035
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1040288
+      GoRuntimeType: 1040160
       GoKind: 22
       Pointee: 1036 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 2022
       Name: '*net/http.Protocols'
       ByteSize: 8
-      GoRuntimeType: 1813344
+      GoRuntimeType: 1812896
       GoKind: 22
       Pointee: 1937 StructureType net/http.Protocols
     - __kind: PointerType
       ID: 2621
       Name: '*net/http.body'
       ByteSize: 8
-      GoRuntimeType: 1813792
+      GoRuntimeType: 1813344
       GoKind: 22
       Pointee: 2622 UnresolvedPointeeType net/http.body
     - __kind: PointerType
       ID: 2611
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
-      GoRuntimeType: 1208832
+      GoRuntimeType: 1208320
       GoKind: 22
       Pointee: 2612 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
       ID: 2553
       Name: '*net/http.bodyLocked'
       ByteSize: 8
-      GoRuntimeType: 908032
+      GoRuntimeType: 907360
       GoKind: 22
       Pointee: 2554 StructureType net/http.bodyLocked
     - __kind: PointerType
       ID: 1203
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
-      GoRuntimeType: 908224
+      GoRuntimeType: 907552
       GoKind: 22
       Pointee: 1204 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
       ID: 2555
       Name: '*net/http.byteReader'
       ByteSize: 8
-      GoRuntimeType: 908320
+      GoRuntimeType: 907648
       GoKind: 22
       Pointee: 2556 UnresolvedPointeeType net/http.byteReader
     - __kind: PointerType
       ID: 2587
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
-      GoRuntimeType: 1040160
+      GoRuntimeType: 1040032
       GoKind: 22
       Pointee: 2588 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 1494
+      ID: 1492
       Name: '*net/http.connectMethodKey'
       ByteSize: 8
-      GoRuntimeType: 908800
+      GoRuntimeType: 908128
       GoKind: 22
-      Pointee: 1495 StructureType net/http.connectMethodKey
+      Pointee: 1493 StructureType net/http.connectMethodKey
     - __kind: PointerType
-      ID: 1496
+      ID: 1494
       Name: '*net/http.contextKey'
       ByteSize: 8
-      GoRuntimeType: 910144
+      GoRuntimeType: 909472
       GoKind: 22
-      Pointee: 1497 UnresolvedPointeeType net/http.contextKey
+      Pointee: 1495 UnresolvedPointeeType net/http.contextKey
     - __kind: PointerType
       ID: 2557
       Name: '*net/http.errorReader'
       ByteSize: 8
-      GoRuntimeType: 908416
+      GoRuntimeType: 907744
       GoKind: 22
       Pointee: 2558 StructureType net/http.errorReader
     - __kind: PointerType
       ID: 2559
       Name: '*net/http.finishAsyncByteRead'
       ByteSize: 8
-      GoRuntimeType: 908512
+      GoRuntimeType: 907840
       GoKind: 22
       Pointee: 2560 StructureType net/http.finishAsyncByteRead
     - __kind: PointerType
       ID: 2589
       Name: '*net/http.gzipReader'
       ByteSize: 8
-      GoRuntimeType: 1040800
+      GoRuntimeType: 1040672
       GoKind: 22
       Pointee: 2590 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 819
+      ID: 817
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 908896
+      GoRuntimeType: 908224
       GoKind: 22
       Pointee: 734 BaseType net/http.http2ConnectionError
     - __kind: PointerType
@@ -18232,7 +18232,7 @@ Types:
       ID: 1594
       Name: '*net/http.http2ErrCode'
       ByteSize: 8
-      GoRuntimeType: 1038368
+      GoRuntimeType: 1038240
       GoKind: 22
       Pointee: 1159 BaseType net/http.http2ErrCode
     - __kind: PointerType
@@ -18243,52 +18243,52 @@ Types:
       GoKind: 22
       Pointee: 1788 StructureType net/http.http2FrameHeader
     - __kind: PointerType
-      ID: 1492
+      ID: 1490
       Name: '*net/http.http2FrameType'
       ByteSize: 8
-      GoRuntimeType: 907360
+      GoRuntimeType: 906688
       GoKind: 22
-      Pointee: 1425 BaseType net/http.http2FrameType
+      Pointee: 1423 BaseType net/http.http2FrameType
     - __kind: PointerType
-      ID: 820
+      ID: 818
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
-      GoRuntimeType: 908992
+      GoRuntimeType: 908320
       GoKind: 22
-      Pointee: 821 StructureType net/http.http2GoAwayError
+      Pointee: 819 StructureType net/http.http2GoAwayError
     - __kind: PointerType
       ID: 1851
       Name: '*net/http.http2GoAwayFrame'
       ByteSize: 8
-      GoRuntimeType: 1635904
+      GoRuntimeType: 1635136
       GoKind: 22
       Pointee: 1852 StructureType net/http.http2GoAwayFrame
     - __kind: PointerType
       ID: 2069
       Name: '*net/http.http2HeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 1856576
+      GoRuntimeType: 1856352
       GoKind: 22
       Pointee: 2068 StructureType net/http.http2HeadersFrame
     - __kind: PointerType
       ID: 2166
       Name: '*net/http.http2MetaHeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 2021952
+      GoRuntimeType: 2021664
       GoKind: 22
       Pointee: 2167 StructureType net/http.http2MetaHeadersFrame
     - __kind: PointerType
       ID: 1853
       Name: '*net/http.http2PingFrame'
       ByteSize: 8
-      GoRuntimeType: 1636096
+      GoRuntimeType: 1635328
       GoKind: 22
       Pointee: 1854 StructureType net/http.http2PingFrame
     - __kind: PointerType
       ID: 1855
       Name: '*net/http.http2PriorityFrame'
       ByteSize: 8
-      GoRuntimeType: 1636288
+      GoRuntimeType: 1635520
       GoKind: 22
       Pointee: 1856 StructureType net/http.http2PriorityFrame
     - __kind: PointerType
@@ -18309,16 +18309,16 @@ Types:
       ID: 1595
       Name: '*net/http.http2Setting'
       ByteSize: 8
-      GoRuntimeType: 1038496
+      GoRuntimeType: 1038368
       GoKind: 22
       Pointee: 1596 StructureType net/http.http2Setting
     - __kind: PointerType
-      ID: 1493
+      ID: 1491
       Name: '*net/http.http2SettingID'
       ByteSize: 8
-      GoRuntimeType: 907648
+      GoRuntimeType: 906976
       GoKind: 22
-      Pointee: 1426 BaseType net/http.http2SettingID
+      Pointee: 1424 BaseType net/http.http2SettingID
     - __kind: PointerType
       ID: 2126
       Name: '*net/http.http2SettingsFrame'
@@ -18330,14 +18330,14 @@ Types:
       ID: 1138
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1426720
+      GoRuntimeType: 1426560
       GoKind: 22
       Pointee: 1139 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 1857
       Name: '*net/http.http2UnknownFrame'
       ByteSize: 8
-      GoRuntimeType: 1637632
+      GoRuntimeType: 1636864
       GoKind: 22
       Pointee: 1858 StructureType net/http.http2UnknownFrame
     - __kind: PointerType
@@ -18351,16 +18351,16 @@ Types:
       ID: 2635
       Name: '*net/http.http2clientStream'
       ByteSize: 8
-      GoRuntimeType: 2022240
+      GoRuntimeType: 2021952
       GoKind: 22
       Pointee: 2636 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 824
+      ID: 822
       Name: '*net/http.http2connError'
       ByteSize: 8
-      GoRuntimeType: 909568
+      GoRuntimeType: 908896
       GoKind: 22
-      Pointee: 825 StructureType net/http.http2connError
+      Pointee: 823 StructureType net/http.http2connError
     - __kind: PointerType
       ID: 1267
       Name: '*net/http.http2dataBuffer'
@@ -18369,10 +18369,10 @@ Types:
       GoKind: 22
       Pointee: 1268 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 823
+      ID: 821
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 909472
+      GoRuntimeType: 908800
       GoKind: 22
       Pointee: 738 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
@@ -18384,14 +18384,14 @@ Types:
       ID: 2585
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
-      GoRuntimeType: 1039904
+      GoRuntimeType: 1039776
       GoKind: 22
       Pointee: 2586 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 827
+      ID: 825
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 909760
+      GoRuntimeType: 909088
       GoKind: 22
       Pointee: 744 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
@@ -18400,10 +18400,10 @@ Types:
       ByteSize: 8
       Pointee: 745 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 826
+      ID: 824
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 909664
+      GoRuntimeType: 908992
       GoKind: 22
       Pointee: 741 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
@@ -18415,28 +18415,28 @@ Types:
       ID: 1110
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1209728
+      GoRuntimeType: 1209216
       GoKind: 22
       Pointee: 1111 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 2581
       Name: '*net/http.http2missingBody'
       ByteSize: 8
-      GoRuntimeType: 1039648
+      GoRuntimeType: 1039520
       GoKind: 22
       Pointee: 2582 StructureType net/http.http2missingBody
     - __kind: PointerType
       ID: 2591
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
-      GoRuntimeType: 1041056
+      GoRuntimeType: 1040928
       GoKind: 22
       Pointee: 2592 StructureType net/http.http2noBodyReader
     - __kind: PointerType
       ID: 1041
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1040928
+      GoRuntimeType: 1040800
       GoKind: 22
       Pointee: 1042 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
@@ -18447,10 +18447,10 @@ Types:
       GoKind: 22
       Pointee: 1322 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 822
+      ID: 820
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 909376
+      GoRuntimeType: 908704
       GoKind: 22
       Pointee: 735 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
@@ -18462,98 +18462,98 @@ Types:
       ID: 1205
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
-      GoRuntimeType: 909856
+      GoRuntimeType: 909184
       GoKind: 22
       Pointee: 1206 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
       ID: 2583
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
-      GoRuntimeType: 1039776
+      GoRuntimeType: 1039648
       GoKind: 22
       Pointee: 2584 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
       ID: 2579
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
-      GoRuntimeType: 1039264
+      GoRuntimeType: 1039136
       GoKind: 22
       Pointee: 2580 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
       ID: 2613
       Name: '*net/http.noBody'
       ByteSize: 8
-      GoRuntimeType: 1208960
+      GoRuntimeType: 1208448
       GoKind: 22
       Pointee: 2614 StructureType net/http.noBody
     - __kind: PointerType
       ID: 1037
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1040544
+      GoRuntimeType: 1040416
       GoKind: 22
       Pointee: 1038 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1849
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1635520
+      GoRuntimeType: 1634752
       GoKind: 22
       Pointee: 1850 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 1269
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2190336
+      GoRuntimeType: 2189920
       GoKind: 22
       Pointee: 1270 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1225
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1040416
+      GoRuntimeType: 1040288
       GoKind: 22
       Pointee: 1226 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 2577
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
-      GoRuntimeType: 1038880
+      GoRuntimeType: 1038752
       GoKind: 22
       Pointee: 2578 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
       ID: 1259
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1426880
+      GoRuntimeType: 1426720
       GoKind: 22
       Pointee: 1260 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 828
+      ID: 826
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
-      GoRuntimeType: 909952
+      GoRuntimeType: 909280
       GoKind: 22
-      Pointee: 829 StructureType net/http.requestBodyReadError
+      Pointee: 827 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 1599
       Name: '*net/http.socksAddr'
       ByteSize: 8
-      GoRuntimeType: 1039008
+      GoRuntimeType: 1038880
       GoKind: 22
       Pointee: 1600 UnresolvedPointeeType net/http.socksAddr
     - __kind: PointerType
       ID: 1140
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1428000
+      GoRuntimeType: 1427840
       GoKind: 22
       Pointee: 1141 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 1108
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1209600
+      GoRuntimeType: 1209088
       GoKind: 22
       Pointee: 1109 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
@@ -18567,23 +18567,23 @@ Types:
       ID: 1039
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1040672
+      GoRuntimeType: 1040544
       GoKind: 22
       Pointee: 1040 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1301
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1857024
+      GoRuntimeType: 1856800
       GoKind: 22
       Pointee: 1302 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 817
+      ID: 815
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
-      GoRuntimeType: 908128
+      GoRuntimeType: 907456
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 816 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 2601
       Name: '*net/http/httputil.failureToReadBody'
@@ -18705,14 +18705,14 @@ Types:
       ID: 1148
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1431200
+      GoRuntimeType: 1431040
       GoKind: 22
       Pointee: 1149 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 846
+      ID: 844
       Name: '*net/url.EscapeError'
       ByteSize: 8
-      GoRuntimeType: 913216
+      GoRuntimeType: 912544
       GoKind: 22
       Pointee: 747 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
@@ -18721,10 +18721,10 @@ Types:
       ByteSize: 8
       Pointee: 748 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 847
+      ID: 845
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
-      GoRuntimeType: 913312
+      GoRuntimeType: 912640
       GoKind: 22
       Pointee: 750 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
@@ -18743,7 +18743,7 @@ Types:
       ID: 1671
       Name: '*net/url.Userinfo'
       ByteSize: 8
-      GoRuntimeType: 1215232
+      GoRuntimeType: 1214720
       GoKind: 22
       Pointee: 1672 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
@@ -19015,19 +19015,19 @@ Types:
       GoKind: 22
       Pointee: 785 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 1489
+      ID: 1511
       Name: '*reflect.ChanDir'
       ByteSize: 8
-      GoRuntimeType: 906304
+      GoRuntimeType: 915712
       GoKind: 22
-      Pointee: 1422 BaseType reflect.ChanDir
+      Pointee: 1431 BaseType reflect.ChanDir
     - __kind: PointerType
-      ID: 1490
+      ID: 1512
       Name: '*reflect.Kind'
       ByteSize: 8
-      GoRuntimeType: 906496
+      GoRuntimeType: 915904
       GoKind: 22
-      Pointee: 1423 BaseType reflect.Kind
+      Pointee: 1432 BaseType reflect.Kind
     - __kind: PointerType
       ID: 2518
       Name: '*reflect.Value'
@@ -19036,12 +19036,12 @@ Types:
       GoKind: 22
       Pointee: 2519 StructureType reflect.Value
     - __kind: PointerType
-      ID: 815
+      ID: 866
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 906880
+      GoRuntimeType: 916288
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType reflect.ValueError
+      Pointee: 867 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 2502
       Name: '*reflect.rtype'
@@ -19261,12 +19261,12 @@ Types:
       GoKind: 22
       Pointee: 36 BaseType runtime.waitReason
     - __kind: PointerType
-      ID: 1499
+      ID: 1497
       Name: '*runtime/debug.BuildInfo'
       ByteSize: 8
-      GoRuntimeType: 912160
+      GoRuntimeType: 911488
       GoKind: 22
-      Pointee: 1500 UnresolvedPointeeType runtime/debug.BuildInfo
+      Pointee: 1498 UnresolvedPointeeType runtime/debug.BuildInfo
     - __kind: PointerType
       ID: 1513
       Name: '*runtime/pprof.labelMap'
@@ -31351,7 +31351,7 @@ Types:
     - __kind: ArrayType
       ID: 1934
       Name: '[0]func()'
-      GoRuntimeType: 737024
+      GoRuntimeType: 735008
       GoKind: 17
       HasCount: true
       Element: 62 GoSubroutineType func()
@@ -31673,7 +31673,7 @@ Types:
       ID: 2015
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 698848
+      GoRuntimeType: 697984
       GoKind: 17
       Count: 8
       HasCount: true
@@ -31682,7 +31682,7 @@ Types:
       ID: 1414
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
-      GoRuntimeType: 484608
+      GoRuntimeType: 484416
       GoKind: 23
       RawFields:
         - Name: array
@@ -32242,7 +32242,7 @@ Types:
       ID: 393
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
-      GoRuntimeType: 484160
+      GoRuntimeType: 483968
       GoKind: 23
       RawFields:
         - Name: array
@@ -32265,7 +32265,7 @@ Types:
       ID: 396
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
-      GoRuntimeType: 484352
+      GoRuntimeType: 484160
       GoKind: 23
       RawFields:
         - Name: array
@@ -32311,7 +32311,7 @@ Types:
       ID: 366
       Name: '[]go.shape.float64'
       ByteSize: 24
-      GoRuntimeType: 486720
+      GoRuntimeType: 486592
       GoKind: 23
       RawFields:
         - Name: array
@@ -32898,7 +32898,7 @@ Types:
       ID: 2199
       Name: '[]vendor/golang.org/x/net/http2/hpack.HeaderField'
       ByteSize: 24
-      GoRuntimeType: 496288
+      GoRuntimeType: 495456
       GoKind: 23
       RawFields:
         - Name: array
@@ -33141,7 +33141,7 @@ Types:
       ID: 158
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1290816
+      GoRuntimeType: 1290688
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33193,7 +33193,7 @@ Types:
       ID: 712
       Name: context.canceler
       ByteSize: 16
-      GoRuntimeType: 1118176
+      GoRuntimeType: 1117280
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33205,7 +33205,7 @@ Types:
     - __kind: StructureType
       ID: 1085
       Name: context.deadlineExceededError
-      GoRuntimeType: 1474144
+      GoRuntimeType: 1473024
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
@@ -33236,7 +33236,7 @@ Types:
       ID: 433
       Name: context.timerCtx
       ByteSize: 112
-      GoRuntimeType: 1624768
+      GoRuntimeType: 1624384
       GoKind: 25
       RawFields:
         - Name: cancelCtx
@@ -33266,7 +33266,7 @@ Types:
       ID: 417
       Name: context.valueCtx
       ByteSize: 48
-      GoRuntimeType: 1849856
+      GoRuntimeType: 1848736
       GoKind: 25
       RawFields:
         - Name: Context
@@ -33711,7 +33711,7 @@ Types:
       ID: 762
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 839040
+      GoRuntimeType: 838848
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1232
@@ -33724,13 +33724,13 @@ Types:
       GoRuntimeType: 839232
       GoKind: 8
     - __kind: BaseType
-      ID: 1428
+      ID: 1426
       Name: encoding/json.Delim
       ByteSize: 4
-      GoRuntimeType: 837696
+      GoRuntimeType: 837504
       GoKind: 5
     - __kind: UnresolvedPointeeType
-      ID: 839
+      ID: 837
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -33757,19 +33757,19 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 831
+      ID: 829
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 835
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 835
+      ID: 833
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 833
+      ID: 831
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -33777,10 +33777,10 @@ Types:
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 841
+      ID: 839
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1429440
+      GoRuntimeType: 1429280
       GoKind: 25
       RawFields:
         - Name: error
@@ -33862,7 +33862,7 @@ Types:
       ID: 2668
       Name: fmt.ScanState
       ByteSize: 16
-      GoRuntimeType: 1473344
+      GoRuntimeType: 1475424
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33875,7 +33875,7 @@ Types:
       ID: 405
       Name: fmt.Stringer
       ByteSize: 16
-      GoRuntimeType: 1029920
+      GoRuntimeType: 1030944
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33983,7 +33983,7 @@ Types:
       ID: 2017
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
       ByteSize: 4
-      GoRuntimeType: 1770592
+      GoRuntimeType: 1770016
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 2182
@@ -33997,7 +33997,7 @@ Types:
       ID: 2018
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
       ByteSize: 4
-      GoRuntimeType: 1770784
+      GoRuntimeType: 1770208
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 2484
@@ -34058,7 +34058,7 @@ Types:
       Name: github.com/DataDog/datadog-agent/pkg/version.Version
       ByteSize: 8
     - __kind: StructureType
-      ID: 850
+      ID: 848
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1741824
@@ -34074,7 +34074,7 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 852
+      ID: 850
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34082,7 +34082,7 @@ Types:
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 856
+      ID: 854
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1120864
       GoKind: 25
@@ -34095,7 +34095,7 @@ Types:
       ID: 756
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
-      GoRuntimeType: 838464
+      GoRuntimeType: 838272
       GoKind: 24
       RawFields:
         - Name: str
@@ -34163,13 +34163,13 @@ Types:
       ID: 1175
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
-      GoRuntimeType: 590240
+      GoRuntimeType: 590176
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 753
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
-      GoRuntimeType: 838368
+      GoRuntimeType: 838176
       GoKind: 24
       RawFields:
         - Name: str
@@ -34188,7 +34188,7 @@ Types:
       ID: 759
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
-      GoRuntimeType: 838560
+      GoRuntimeType: 838368
       GoKind: 24
       RawFields:
         - Name: str
@@ -34399,7 +34399,7 @@ Types:
       ID: 395
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
-      GoRuntimeType: 1925440
+      GoRuntimeType: 1925184
       GoKind: 25
       RawFields:
         - Name: TraceID
@@ -34472,7 +34472,7 @@ Types:
       ID: 383
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 1290944
+      GoRuntimeType: 1290816
       GoKind: 21
       HeaderType: 385 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
@@ -34493,7 +34493,7 @@ Types:
       ID: 1416
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
-      GoRuntimeType: 587424
+      GoRuntimeType: 587360
       GoKind: 10
     - __kind: StructureType
       ID: 398
@@ -34522,7 +34522,7 @@ Types:
       ID: 728
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
-      GoRuntimeType: 1925696
+      GoRuntimeType: 1925440
       GoKind: 25
       RawFields:
         - Name: Type
@@ -34553,7 +34553,7 @@ Types:
       ID: 403
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
-      GoRuntimeType: 2118784
+      GoRuntimeType: 2118432
       GoKind: 25
       RawFields:
         - Name: mu
@@ -34590,7 +34590,7 @@ Types:
       ID: 404
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
-      GoRuntimeType: 902752
+      GoRuntimeType: 902272
       GoKind: 17
       Count: 16
       HasCount: true
@@ -34609,7 +34609,7 @@ Types:
       ID: 1576
       Name: github.com/DataDog/dd-trace-go/v2/internal.TraceSource
       ByteSize: 1
-      GoRuntimeType: 997088
+      GoRuntimeType: 996992
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1370
@@ -34656,16 +34656,16 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/waf.Feature
       ByteSize: 8
     - __kind: BaseType
-      ID: 1424
+      ID: 1422
       Name: github.com/DataDog/dd-trace-go/v2/internal/log.Level
       ByteSize: 8
-      GoRuntimeType: 836640
+      GoRuntimeType: 836448
       GoKind: 2
     - __kind: GoContextImplementationType
       ID: 413
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
-      GoRuntimeType: 1638784
+      GoRuntimeType: 1638016
       GoKind: 25
       RawFields:
         - Name: Context
@@ -35057,24 +35057,24 @@ Types:
           Offset: 56
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1511
+      ID: 1509
       Name: github.com/cihub/seelog.CfgParseParams
       ByteSize: 8
     - __kind: BaseType
-      ID: 1431
+      ID: 1429
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
-      GoRuntimeType: 838848
+      GoRuntimeType: 838656
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 2028
       Name: github.com/cihub/seelog.LogLevelException
       ByteSize: 8
     - __kind: StructureType
-      ID: 858
+      ID: 856
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1431680
+      GoRuntimeType: 1431520
       GoKind: 25
       RawFields:
         - Name: message
@@ -35085,15 +35085,15 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 860
+      ID: 858
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1431840
+      GoRuntimeType: 1431680
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 858 StructureType github.com/cihub/seelog.baseError
+          Type: 856 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1272
       Name: github.com/cihub/seelog.connWriter
@@ -35131,11 +35131,11 @@ Types:
       Name: github.com/cihub/seelog.listConstraints
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1508
+      ID: 1506
       Name: github.com/cihub/seelog.logFormattedMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1506
+      ID: 1504
       Name: github.com/cihub/seelog.logMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -35143,15 +35143,15 @@ Types:
       Name: github.com/cihub/seelog.minMaxConstraints
       ByteSize: 8
     - __kind: StructureType
-      ID: 864
+      ID: 862
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1432160
+      GoRuntimeType: 1432000
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 858 StructureType github.com/cihub/seelog.baseError
+          Type: 856 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1612
       Name: github.com/cihub/seelog.offConstraints
@@ -35198,25 +35198,25 @@ Types:
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 862
+      ID: 860
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1432000
+      GoRuntimeType: 1431840
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 858 StructureType github.com/cihub/seelog.baseError
+          Type: 856 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 866
+      ID: 864
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1432320
+      GoRuntimeType: 1432160
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 858 StructureType github.com/cihub/seelog.baseError
+          Type: 856 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1749
       Name: github.com/cihub/seelog.xmlNode
@@ -35841,7 +35841,7 @@ Types:
       ID: 1097
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1855232
+      GoRuntimeType: 1855008
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -35874,7 +35874,7 @@ Types:
       ID: 1103
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1855680
+      GoRuntimeType: 1855456
       GoKind: 25
       RawFields:
         - Name: Value
@@ -35890,13 +35890,13 @@ Types:
       ID: 1007
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 996512
+      GoRuntimeType: 996416
       GoKind: 8
     - __kind: StructureType
       ID: 1095
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1855008
+      GoRuntimeType: 1854784
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -35916,13 +35916,13 @@ Types:
       ID: 1185
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
-      GoRuntimeType: 836736
+      GoRuntimeType: 836544
       GoKind: 8
     - __kind: StructureType
       ID: 1093
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1854784
+      GoRuntimeType: 1854560
       GoKind: 25
       RawFields:
         - Name: Method
@@ -35938,7 +35938,7 @@ Types:
       ID: 1101
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1767904
+      GoRuntimeType: 1767328
       GoKind: 25
       RawFields:
         - Name: Value
@@ -35951,7 +35951,7 @@ Types:
       ID: 1099
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1855456
+      GoRuntimeType: 1855232
       GoKind: 25
       RawFields:
         - Name: Value
@@ -35971,7 +35971,7 @@ Types:
       ID: 1107
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1634560
+      GoRuntimeType: 1633792
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -35993,7 +35993,7 @@ Types:
       ID: 1105
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1768096
+      GoRuntimeType: 1767520
       GoKind: 25
       RawFields:
         - Name: cause
@@ -38659,7 +38659,7 @@ Types:
       ID: 2647
       Name: io.Closer
       ByteSize: 16
-      GoRuntimeType: 1030944
+      GoRuntimeType: 1031968
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38684,7 +38684,7 @@ Types:
       ID: 1290
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1198080
+      GoRuntimeType: 1201280
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38697,7 +38697,7 @@ Types:
       ID: 406
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1030304
+      GoRuntimeType: 1031328
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38714,7 +38714,7 @@ Types:
       ID: 1277
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1117664
+      GoRuntimeType: 1117920
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38727,7 +38727,7 @@ Types:
       ID: 134
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1030048
+      GoRuntimeType: 1031072
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38740,7 +38740,7 @@ Types:
       ID: 2646
       Name: io.WriterTo
       ByteSize: 16
-      GoRuntimeType: 1030816
+      GoRuntimeType: 1031840
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38752,13 +38752,13 @@ Types:
     - __kind: StructureType
       ID: 1248
       Name: io.discard
-      GoRuntimeType: 1473824
+      GoRuntimeType: 1475904
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 2552
       Name: io.eofReader
-      GoRuntimeType: 1117408
+      GoRuntimeType: 1117664
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -38773,7 +38773,7 @@ Types:
       ID: 2576
       Name: io.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1560544
+      GoRuntimeType: 1562144
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -38783,7 +38783,7 @@ Types:
       ID: 2610
       Name: io.nopCloserWriterTo
       ByteSize: 16
-      GoRuntimeType: 1624384
+      GoRuntimeType: 1625536
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -38830,7 +38830,7 @@ Types:
       ID: 1676
       Name: log/slog.Attr
       ByteSize: 40
-      GoRuntimeType: 1775968
+      GoRuntimeType: 1775392
       GoKind: 25
       RawFields:
         - Name: Key
@@ -38840,16 +38840,16 @@ Types:
           Offset: 16
           Type: 2019 StructureType log/slog.Value
     - __kind: BaseType
-      ID: 1432
+      ID: 1430
       Name: log/slog.Kind
       ByteSize: 8
-      GoRuntimeType: 838944
+      GoRuntimeType: 838752
       GoKind: 2
     - __kind: BaseType
       ID: 1779
       Name: log/slog.Level
       ByteSize: 8
-      GoRuntimeType: 1495264
+      GoRuntimeType: 1494144
       GoKind: 2
     - __kind: StructureType
       ID: 2019
@@ -41436,16 +41436,16 @@ Types:
       Name: net.DNSError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1429
+      ID: 1427
       Name: net.Flags
       ByteSize: 8
-      GoRuntimeType: 837888
+      GoRuntimeType: 837696
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 1501
+      ID: 1499
       Name: net.HardwareAddr
       ByteSize: 24
-      GoRuntimeType: 912640
+      GoRuntimeType: 911968
       GoKind: 23
       RawFields:
         - Name: array
@@ -41457,9 +41457,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1502 GoSliceDataType net.HardwareAddr.array
+      Data: 1500 GoSliceDataType net.HardwareAddr.array
     - __kind: GoSliceDataType
-      ID: 1502
+      ID: 1500
       Name: net.HardwareAddr.array
       DynamicSizeClass: slice
       ByteSize: 1
@@ -41499,7 +41499,7 @@ Types:
       ID: 1604
       Name: net.IPMask
       ByteSize: 24
-      GoRuntimeType: 1044128
+      GoRuntimeType: 1044000
       GoKind: 23
       RawFields:
         - Name: array
@@ -41613,10 +41613,10 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: BaseType
-      ID: 1430
+      ID: 1428
       Name: net.hostLookupOrder
       ByteSize: 8
-      GoRuntimeType: 837984
+      GoRuntimeType: 837792
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1378
@@ -41635,14 +41635,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 841
       Name: net.notFoundError
       ByteSize: 8
     - __kind: GoContextImplementationType
       ID: 415
       Name: net.onlyValuesCtx
       ByteSize: 32
-      GoRuntimeType: 1772896
+      GoRuntimeType: 1772320
       GoKind: 25
       RawFields:
         - Name: Context
@@ -41654,7 +41654,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: StructureType
-      ID: 845
+      ID: 843
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1741632
@@ -41704,10 +41704,10 @@ Types:
       Name: net.timeoutError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1427
+      ID: 1425
       Name: net/http.ConnState
       ByteSize: 8
-      GoRuntimeType: 837120
+      GoRuntimeType: 836928
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1598
@@ -41736,7 +41736,7 @@ Types:
       ID: 2554
       Name: net/http.bodyLocked
       ByteSize: 8
-      GoRuntimeType: 1427040
+      GoRuntimeType: 1426880
       GoKind: 25
       RawFields:
         - Name: b
@@ -41746,7 +41746,7 @@ Types:
       ID: 1204
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1427200
+      GoRuntimeType: 1427040
       GoKind: 25
       RawFields:
         - Name: w
@@ -41761,7 +41761,7 @@ Types:
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 1495
+      ID: 1493
       Name: net/http.connectMethodKey
       ByteSize: 56
       GoRuntimeType: 1838144
@@ -41780,14 +41780,14 @@ Types:
           Offset: 48
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1497
+      ID: 1495
       Name: net/http.contextKey
       ByteSize: 8
     - __kind: StructureType
       ID: 2558
       Name: net/http.errorReader
       ByteSize: 16
-      GoRuntimeType: 1427360
+      GoRuntimeType: 1427200
       GoKind: 25
       RawFields:
         - Name: err
@@ -41797,7 +41797,7 @@ Types:
       ID: 2560
       Name: net/http.finishAsyncByteRead
       ByteSize: 8
-      GoRuntimeType: 1427520
+      GoRuntimeType: 1427360
       GoKind: 25
       RawFields:
         - Name: tw
@@ -41811,13 +41811,13 @@ Types:
       ID: 734
       Name: net/http.http2ConnectionError
       ByteSize: 4
-      GoRuntimeType: 837216
+      GoRuntimeType: 837024
       GoKind: 10
     - __kind: StructureType
       ID: 1941
       Name: net/http.http2ContinuationFrame
       ByteSize: 40
-      GoRuntimeType: 1770016
+      GoRuntimeType: 1769440
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41830,7 +41830,7 @@ Types:
       ID: 1936
       Name: net/http.http2DataFrame
       ByteSize: 40
-      GoRuntimeType: 1768288
+      GoRuntimeType: 1767712
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41843,13 +41843,13 @@ Types:
       ID: 1159
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 996608
+      GoRuntimeType: 996512
       GoKind: 10
     - __kind: BaseType
       ID: 2014
       Name: net/http.http2Flags
       ByteSize: 1
-      GoRuntimeType: 836928
+      GoRuntimeType: 836736
       GoKind: 8
     - __kind: StructureType
       ID: 1788
@@ -41863,7 +41863,7 @@ Types:
           Type: 6 BaseType bool
         - Name: Type
           Offset: 1
-          Type: 1425 BaseType net/http.http2FrameType
+          Type: 1423 BaseType net/http.http2FrameType
         - Name: Flags
           Offset: 2
           Type: 2014 BaseType net/http.http2Flags
@@ -41874,13 +41874,13 @@ Types:
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1425
+      ID: 1423
       Name: net/http.http2FrameType
       ByteSize: 1
-      GoRuntimeType: 836832
+      GoRuntimeType: 836640
       GoKind: 8
     - __kind: StructureType
-      ID: 821
+      ID: 819
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1740288
@@ -41899,7 +41899,7 @@ Types:
       ID: 1852
       Name: net/http.http2GoAwayFrame
       ByteSize: 48
-      GoRuntimeType: 1929536
+      GoRuntimeType: 1929280
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41918,7 +41918,7 @@ Types:
       ID: 2068
       Name: net/http.http2HeadersFrame
       ByteSize: 48
-      GoRuntimeType: 1856352
+      GoRuntimeType: 1856128
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41950,7 +41950,7 @@ Types:
       ID: 1854
       Name: net/http.http2PingFrame
       ByteSize: 20
-      GoRuntimeType: 1768480
+      GoRuntimeType: 1767904
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41992,7 +41992,7 @@ Types:
       ID: 1939
       Name: net/http.http2PushPromiseFrame
       ByteSize: 40
-      GoRuntimeType: 1858144
+      GoRuntimeType: 1857920
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42008,7 +42008,7 @@ Types:
       ID: 1790
       Name: net/http.http2RSTStreamFrame
       ByteSize: 16
-      GoRuntimeType: 1768672
+      GoRuntimeType: 1768096
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42026,21 +42026,21 @@ Types:
       RawFields:
         - Name: ID
           Offset: 0
-          Type: 1426 BaseType net/http.http2SettingID
+          Type: 1424 BaseType net/http.http2SettingID
         - Name: Val
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1426
+      ID: 1424
       Name: net/http.http2SettingID
       ByteSize: 2
-      GoRuntimeType: 837024
+      GoRuntimeType: 836832
       GoKind: 9
     - __kind: StructureType
       ID: 2016
       Name: net/http.http2SettingsFrame
       ByteSize: 40
-      GoRuntimeType: 1768864
+      GoRuntimeType: 1768288
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42053,7 +42053,7 @@ Types:
       ID: 1139
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1912960
+      GoRuntimeType: 1912704
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -42069,7 +42069,7 @@ Types:
       ID: 1858
       Name: net/http.http2UnknownFrame
       ByteSize: 40
-      GoRuntimeType: 1769824
+      GoRuntimeType: 1769248
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42082,7 +42082,7 @@ Types:
       ID: 1792
       Name: net/http.http2WindowUpdateFrame
       ByteSize: 16
-      GoRuntimeType: 1769056
+      GoRuntimeType: 1768480
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42096,7 +42096,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 823
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1606496
@@ -42116,7 +42116,7 @@ Types:
       ID: 738
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 837408
+      GoRuntimeType: 837216
       GoKind: 24
       RawFields:
         - Name: str
@@ -42139,7 +42139,7 @@ Types:
       ID: 744
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 837600
+      GoRuntimeType: 837408
       GoKind: 24
       RawFields:
         - Name: str
@@ -42158,7 +42158,7 @@ Types:
       ID: 741
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 837504
+      GoRuntimeType: 837312
       GoKind: 24
       RawFields:
         - Name: str
@@ -42203,7 +42203,7 @@ Types:
       ID: 735
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 837312
+      GoRuntimeType: 837120
       GoKind: 24
       RawFields:
         - Name: str
@@ -42241,7 +42241,7 @@ Types:
       ID: 1299
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
-      GoRuntimeType: 1426400
+      GoRuntimeType: 1426240
       GoKind: 20
       RawFields:
         - Name: tab
@@ -42263,7 +42263,7 @@ Types:
     - __kind: ArrayType
       ID: 1287
       Name: net/http.incomparable
-      GoRuntimeType: 907936
+      GoRuntimeType: 907264
       GoKind: 17
       HasCount: true
       Element: 62 GoSubroutineType func()
@@ -42274,7 +42274,7 @@ Types:
     - __kind: StructureType
       ID: 2614
       Name: net/http.noBody
-      GoRuntimeType: 1485664
+      GoRuntimeType: 1484544
       GoKind: 25
       RawFields: []
     - __kind: StructureType
@@ -42313,7 +42313,7 @@ Types:
       ID: 1260
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1813568
+      GoRuntimeType: 1813120
       GoKind: 25
       RawFields:
         - Name: _
@@ -42326,10 +42326,10 @@ Types:
           Offset: 8
           Type: 1290 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 829
+      ID: 827
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1428160
+      GoRuntimeType: 1428000
       GoKind: 25
       RawFields:
         - Name: error
@@ -42346,7 +42346,7 @@ Types:
     - __kind: StructureType
       ID: 1109
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1486944
+      GoRuntimeType: 1485824
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -42367,7 +42367,7 @@ Types:
       ID: 1302
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2039488
+      GoRuntimeType: 2039200
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -42377,7 +42377,7 @@ Types:
           Offset: 16
           Type: 1182 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 816
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -42545,7 +42545,7 @@ Types:
       ID: 747
       Name: net/url.EscapeError
       ByteSize: 16
-      GoRuntimeType: 838080
+      GoRuntimeType: 837888
       GoKind: 24
       RawFields:
         - Name: str
@@ -42564,7 +42564,7 @@ Types:
       ID: 750
       Name: net/url.InvalidHostError
       ByteSize: 16
-      GoRuntimeType: 838176
+      GoRuntimeType: 837984
       GoKind: 24
       RawFields:
         - Name: str
@@ -42663,7 +42663,7 @@ Types:
       ID: 710
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
-      GoRuntimeType: 693600
+      GoRuntimeType: 692160
       GoKind: 17
       Count: 8
       HasCount: true
@@ -42744,7 +42744,7 @@ Types:
       ID: 725
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
-      GoRuntimeType: 694240
+      GoRuntimeType: 692800
       GoKind: 17
       Count: 8
       HasCount: true
@@ -42753,7 +42753,7 @@ Types:
       ID: 2539
       Name: noalg.[8]struct { key string; elem *regexp.Regexp }
       ByteSize: 192
-      GoRuntimeType: 695392
+      GoRuntimeType: 694240
       GoKind: 17
       Count: 8
       HasCount: true
@@ -42780,7 +42780,7 @@ Types:
       ID: 692
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
-      GoRuntimeType: 694144
+      GoRuntimeType: 692704
       GoKind: 17
       Count: 8
       HasCount: true
@@ -42969,7 +42969,7 @@ Types:
       ID: 709
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
-      GoRuntimeType: 1308864
+      GoRuntimeType: 1308736
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43086,7 +43086,7 @@ Types:
       ID: 724
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
-      GoRuntimeType: 1309760
+      GoRuntimeType: 1309632
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43099,7 +43099,7 @@ Types:
       ID: 2538
       Name: noalg.map.group[string]*regexp.Regexp
       ByteSize: 200
-      GoRuntimeType: 1310528
+      GoRuntimeType: 1310400
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43138,7 +43138,7 @@ Types:
       ID: 691
       Name: noalg.map.group[string]float64
       ByteSize: 200
-      GoRuntimeType: 1309504
+      GoRuntimeType: 1309376
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43392,7 +43392,7 @@ Types:
       ID: 711
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
-      GoRuntimeType: 1308736
+      GoRuntimeType: 1308608
       GoKind: 25
       RawFields:
         - Name: key
@@ -43509,7 +43509,7 @@ Types:
       ID: 726
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
-      GoRuntimeType: 1309632
+      GoRuntimeType: 1309504
       GoKind: 25
       RawFields:
         - Name: key
@@ -43522,7 +43522,7 @@ Types:
       ID: 2540
       Name: noalg.struct { key string; elem *regexp.Regexp }
       ByteSize: 24
-      GoRuntimeType: 1310400
+      GoRuntimeType: 1310272
       GoKind: 25
       RawFields:
         - Name: key
@@ -43561,7 +43561,7 @@ Types:
       ID: 693
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
-      GoRuntimeType: 1309376
+      GoRuntimeType: 1309248
       GoKind: 25
       RawFields:
         - Name: key
@@ -43880,16 +43880,16 @@ Types:
       GoRuntimeType: 843360
       GoKind: 2
     - __kind: BaseType
-      ID: 1422
+      ID: 1431
       Name: reflect.ChanDir
       ByteSize: 8
-      GoRuntimeType: 836448
+      GoRuntimeType: 838944
       GoKind: 2
     - __kind: BaseType
-      ID: 1423
+      ID: 1432
       Name: reflect.Kind
       ByteSize: 8
-      GoRuntimeType: 836544
+      GoRuntimeType: 839040
       GoKind: 7
     - __kind: StructureType
       ID: 2519
@@ -43908,14 +43908,14 @@ Types:
           Offset: 16
           Type: 2520 BaseType reflect.flag
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 867
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: BaseType
       ID: 2520
       Name: reflect.flag
       ByteSize: 8
-      GoRuntimeType: 1766944
+      GoRuntimeType: 1775584
       GoKind: 12
     - __kind: UnresolvedPointeeType
       ID: 2503
@@ -44883,7 +44883,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1500
+      ID: 1498
       Name: runtime/debug.BuildInfo
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -44939,7 +44939,7 @@ Types:
       ID: 2606
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
-      GoRuntimeType: 1721248
+      GoRuntimeType: 1720672
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -44952,7 +44952,7 @@ Types:
       ID: 2604
       Name: struct { io.Reader; io.WriterTo }
       ByteSize: 32
-      GoRuntimeType: 1721056
+      GoRuntimeType: 1720480
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -46442,10 +46442,10 @@ Issues:
       issue:
         Kind: 7
         Message: return value selector (e.g., @return.r0) must be used for multi-value returns
-GoModuledataInfo: {FirstModuledataAddr: "0x181f540", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x1821540", TypesOffset: 296}
 GoMapHashInfo:
-    UseAeshashAddr: "0x191252a"
-    AeskeyschedAddr: "0x1913600"
+    UseAeshashAddr: "0x191452a"
+    AeskeyschedAddr: "0x1915600"
 CommonTypes:
     G: 24 StructureType runtime.g
     M: 31 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -20,11 +20,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3023 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xcf39ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf43aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3024 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xcf3a05", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf43e5", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -40,11 +40,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2858 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0xced5ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedaea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2859 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0xced625", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedb25", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -66,11 +66,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2861 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0xced68a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedb8a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2862 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0xced6bd", Frameless: false}]
+              InjectionPoints: [{PC: "0xcedbbd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -91,11 +91,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2992 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xcf1fce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf28ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2993 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcf208a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf298a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -183,7 +183,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2870 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0xcedf40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -248,11 +248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2894 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0xcf0060", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf07c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2895 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0xcf0072", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf07d2", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -274,7 +274,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2823 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0xce89c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8b60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -340,7 +340,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3021 EventRootType Probe[main.testByteSliceInvalidUtf8]
-              InjectionPoints: [{PC: "0xcf32e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3be0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -362,7 +362,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3022 EventRootType Probe[main.testByteSliceMultibyteUtf8]
-              InjectionPoints: [{PC: "0xcf3300", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3c00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -383,7 +383,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2837 EventRootType Probe[main.testCaptureContextImpl]
-              InjectionPoints: [{PC: "0xce9720", Frameless: true}]
+              InjectionPoints: [{PC: "0xce99a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -410,7 +410,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3042 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xcf3e80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4a40", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -418,7 +418,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: ""
       segments: []
@@ -430,15 +430,15 @@ Probes:
             - Kind: Line
               Type: 3104 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcece0e"
+                - PC: "0xced24e"
                   Frameless: false
-                - PC: "0xcece91"
+                - PC: "0xced2d1"
                   Frameless: false
-                - PC: "0xcecfd2"
+                - PC: "0xced412"
                   Frameless: false
-                - PC: "0xced05c"
+                - PC: "0xced49c"
                   Frameless: false
-                - PC: "0xced12f"
+                - PC: "0xced56f"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -447,7 +447,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       when: {dsl: x == 3, json: {eq: [{ref: x}, 3]}}
       sampling: {snapshotsPerSecond: 100}
       template: ""
@@ -460,15 +460,15 @@ Probes:
             - Kind: Line
               Type: 3105 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcece0e"
+                - PC: "0xced24e"
                   Frameless: false
-                - PC: "0xcece91"
+                - PC: "0xced2d1"
                   Frameless: false
-                - PC: "0xcecfd2"
+                - PC: "0xced412"
                   Frameless: false
-                - PC: "0xced05c"
+                - PC: "0xced49c"
                   Frameless: false
-                - PC: "0xced12f"
+                - PC: "0xced56f"
                   Frameless: false
               Condition:
                 Type: 6 BaseType bool
@@ -494,7 +494,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: x={x}
       segments: [x=, {json: {ref: x}, dsl: x}]
@@ -506,15 +506,15 @@ Probes:
             - Kind: Line
               Type: 3106 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcece0e"
+                - PC: "0xced24e"
                   Frameless: false
-                - PC: "0xcece91"
+                - PC: "0xced2d1"
                   Frameless: false
-                - PC: "0xcecfd2"
+                - PC: "0xced412"
                   Frameless: false
-                - PC: "0xced05c"
+                - PC: "0xced49c"
                   Frameless: false
-                - PC: "0xced12f"
+                - PC: "0xced56f"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -542,7 +542,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2889 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xcef9c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceff80", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -561,7 +561,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2890 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0xcef9c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceff80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -587,7 +587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3048 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xcf3f60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4b20", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -625,7 +625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2896 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0xcf0080", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf07e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -655,7 +655,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2888 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0xcef980", Frameless: true}]
+              InjectionPoints: [{PC: "0xceff40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -684,11 +684,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2957 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0xcf120e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1b0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2958 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0xcf12d1", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1bd1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -710,7 +710,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2904 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0xcf0440", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0c60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -732,7 +732,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2829 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0xce8ea0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -754,7 +754,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2830 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0xce8ec0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -776,7 +776,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2825 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0xce8ba0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8d40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -798,7 +798,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2826 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0xce8bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8d60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -820,7 +820,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2827 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0xce8d20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8ec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -842,7 +842,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2828 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0xce8d40", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8ee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -864,7 +864,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3009 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xcf3120", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -891,7 +891,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3012 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xcf3180", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -919,7 +919,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3035 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xcf3b00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf45e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -941,7 +941,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3049 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xcf3fc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4b80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -962,7 +962,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3050 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xcf3fe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4ba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -984,7 +984,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2860 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0xced660", Frameless: true}]
+              InjectionPoints: [{PC: "0xcedb60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -999,7 +999,7 @@ Probes:
       where:
         methodName: main.testErrorAtLine
         sourceFile: complex.go
-        lines: ["108"]
+        lines: ["111"]
       tags:
         - config_diff:arch=amd64,toolchain=go1.26rc1
         - skip_integration:arch=arm64,toolchain=go1.25.0
@@ -1018,7 +1018,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2824 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0xce8a74", Frameless: false}]
+              InjectionPoints: [{PC: "0xce8c14", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -1046,11 +1046,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2842 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0xceb9ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebe2a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2843 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0xceba2c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebe6c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1072,11 +1072,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2840 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0xceb8ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebd0e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2841 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0xceb95b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcebd9b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1098,11 +1098,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2852 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0xced2c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xced700", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2853 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0xced2c5", Frameless: true}]
+              InjectionPoints: [{PC: "0xced705", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1124,11 +1124,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2854 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0xced2e4", Frameless: false}]
+              InjectionPoints: [{PC: "0xced724", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2855 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0xced325", Frameless: false}]
+              InjectionPoints: [{PC: "0xced765", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1143,7 +1143,7 @@ Probes:
       where:
         methodName: main.testFramelessArray
         sourceFile: inlined.go
-        lines: ["93"]
+        lines: ["96"]
       sampling: {snapshotsPerSecond: 100}
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
@@ -1153,7 +1153,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2856 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0xced2e8", Frameless: false}]
+              InjectionPoints: [{PC: "0xced728", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1175,11 +1175,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3090 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf6a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf7800", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3091 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf6a67", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf7807", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1193,11 +1193,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3092 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xcf6a84", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf7824", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3093 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xcf6ad5", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf7875", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1220,11 +1220,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3086 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xcf69ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf776a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3087 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xcf69d9", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf7779", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1238,11 +1238,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3088 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xcf6a0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf77aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3089 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xcf6a22", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf77c2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1265,14 +1265,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 3094 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf6ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf7880", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3095 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xcf6b00"
+                - PC: "0xcf78a0"
                   Frameless: true
-                - PC: "0xcf6b03"
+                - PC: "0xcf78a3"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1287,14 +1287,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 3096 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf6b2a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf78ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3097 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xcf6b8b"
+                - PC: "0xcf792b"
                   Frameless: false
-                - PC: "0xcf6b93"
+                - PC: "0xcf7933"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1321,7 +1321,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3098 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xcf6ae5", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf7885", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1333,7 +1333,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3099 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xcf6b3f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf78df", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1354,11 +1354,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3074 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xcf6680", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf7420", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3075 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xcf6690", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf7430", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1372,11 +1372,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3076 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xcf6760", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf7500", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3077 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xcf6768", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf7508", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1400,11 +1400,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3062 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf61b3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf6f53", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3063 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf633a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf70da", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1446,11 +1446,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3066 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xcf63aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf714a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3067 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf63b9", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf7159", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1473,11 +1473,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3100 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xcf6be0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf7980", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3101 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xcf6be6", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf7986", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1491,11 +1491,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3102 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xcf6c4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf79ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3103 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xcf6c6d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf7a0d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1518,11 +1518,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3058 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf6100", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf6ea0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3059 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf6103", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf6ea3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1536,11 +1536,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3060 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf6120", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf6ec0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3061 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf612b", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf6ecb", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1563,11 +1563,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3078 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xcf6820", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf75c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3079 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xcf6827", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf75c7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1581,11 +1581,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3080 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xcf68aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf764a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3081 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xcf68d3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf7673", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1608,11 +1608,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3068 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf6620", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf73c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3069 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf6623", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf73c3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1626,11 +1626,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3070 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xcf6640", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf73e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3071 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xcf6643", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf73e3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1644,11 +1644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3072 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xcf6660", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf7400", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3073 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xcf6663", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf7403", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1671,11 +1671,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3082 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xcf6980", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf7720", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3083 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xcf6987", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf7727", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1689,11 +1689,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3084 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xcf69a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf7740", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3085 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf69ae", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf774e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1716,11 +1716,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3054 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf60c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf6e60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3055 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf60c3", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf6e63", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1734,11 +1734,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3056 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf60e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf6e80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3057 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf60eb", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf6e8b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1761,14 +1761,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2892 EventRootType Probe[main.(*Server).handleOrder]
-              InjectionPoints: [{PC: "0xcefd73", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf03f3", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2893 EventRootType Probe[main.(*Server).handleOrder]Return
               InjectionPoints:
-                - PC: "0xcefea1"
+                - PC: "0xcf0521"
                   Frameless: false
-                - PC: "0xceff69"
+                - PC: "0xcf05e9"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1791,11 +1791,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2844 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0xcecfaa", Frameless: false}]
+              InjectionPoints: [{PC: "0xced3ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2845 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0xced00e", Frameless: false}]
+              InjectionPoints: [{PC: "0xced44e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1822,11 +1822,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2846 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0xced04e", Frameless: false}]
+              InjectionPoints: [{PC: "0xced48e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2847 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0xced0de", Frameless: false}]
+              InjectionPoints: [{PC: "0xced51e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1853,11 +1853,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2848 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0xced12a", Frameless: false}]
+              InjectionPoints: [{PC: "0xced56a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2849 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0xced16b", Frameless: false}]
+              InjectionPoints: [{PC: "0xced5ab", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1879,7 +1879,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3110 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0xced0a6", Frameless: false}]
+              InjectionPoints: [{PC: "0xced4e6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1897,11 +1897,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2850 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0xced1ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xced5ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2851 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0xced293", Frameless: false}]
+              InjectionPoints: [{PC: "0xced6d3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1919,7 +1919,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3111 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0xced1b3", Frameless: false}]
+              InjectionPoints: [{PC: "0xced5f3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1930,7 +1930,7 @@ Probes:
       where:
         methodName: main.testInlinedBCA
         sourceFile: inlined.go
-        lines: ["63"]
+        lines: ["66"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCA
       segments: [testInlinedBCA]
@@ -1940,7 +1940,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3112 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0xced1b3", Frameless: false}]
+              InjectionPoints: [{PC: "0xced5f3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1958,7 +1958,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3113 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0xced25b", Frameless: false}]
+              InjectionPoints: [{PC: "0xced69b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1969,7 +1969,7 @@ Probes:
       where:
         methodName: main.testInlinedBCB
         sourceFile: inlined.go
-        lines: ["67"]
+        lines: ["70"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCB
       segments: [testInlinedBCB]
@@ -1979,7 +1979,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3114 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0xced25b", Frameless: false}]
+              InjectionPoints: [{PC: "0xced69b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -2000,7 +2000,7 @@ Probes:
               InjectionPoints:
                 - PC: "0xce6ce1"
                   Frameless: true
-                - PC: "0xcede06"
+                - PC: "0xcee3a6"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2021,20 +2021,20 @@ Probes:
             - Kind: Entry
               Type: 3107 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0xcece0a"
+                - PC: "0xced24a"
                   Frameless: false
-                - PC: "0xcece91"
+                - PC: "0xced2d1"
                   Frameless: false
-                - PC: "0xcecfd2"
+                - PC: "0xced412"
                   Frameless: false
-                - PC: "0xced05c"
+                - PC: "0xced49c"
                   Frameless: false
-                - PC: "0xced12f"
+                - PC: "0xced56f"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 3108 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0xcece4a", Frameless: false}]
+              InjectionPoints: [{PC: "0xced28a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2049,7 +2049,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2060,15 +2060,15 @@ Probes:
             - Kind: Line
               Type: 3109 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0xcece0e"
+                - PC: "0xced24e"
                   Frameless: false
-                - PC: "0xcece91"
+                - PC: "0xced2d1"
                   Frameless: false
-                - PC: "0xcecfd2"
+                - PC: "0xced412"
                   Frameless: false
-                - PC: "0xced05c"
+                - PC: "0xced49c"
                   Frameless: false
-                - PC: "0xced12f"
+                - PC: "0xced56f"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2091,7 +2091,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3115 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0xced2c1", Frameless: true}]
+              InjectionPoints: [{PC: "0xced701", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2106,7 +2106,7 @@ Probes:
       where:
         methodName: main.testInlinedSq
         sourceFile: inlined.go
-        lines: ["75"]
+        lines: ["78"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2116,7 +2116,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3116 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0xced2c1", Frameless: true}]
+              InjectionPoints: [{PC: "0xced701", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2140,9 +2140,9 @@ Probes:
             - Kind: Entry
               Type: 3117 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0xced30d"
+                - PC: "0xced74d"
                   Frameless: false
-                - PC: "0xced3a3"
+                - PC: "0xced847"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2275,7 +2275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2857 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0xced5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcedac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2302,7 +2302,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3037 EventRootType Probe[main.testInvalidUtf8Strings]
-              InjectionPoints: [{PC: "0xcf3b40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -2328,11 +2328,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2990 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xcf1e4e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf274e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2991 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcf1fad", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf28ad", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2354,7 +2354,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2898 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0xcf0260", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2369,7 +2369,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["230"]
+        lines: ["233"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
@@ -2379,7 +2379,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2833 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xce8f3a", Frameless: false}]
+              InjectionPoints: [{PC: "0xce90da", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2390,7 +2390,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["237"]
+        lines: ["240"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2401,7 +2401,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2834 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xce8fff", Frameless: false}]
+              InjectionPoints: [{PC: "0xce919f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2412,7 +2412,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["242"]
+        lines: ["245"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2423,7 +2423,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2835 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0xce90c5", Frameless: false}]
+              InjectionPoints: [{PC: "0xce9265", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2466,11 +2466,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2996 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xcf22f3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf2bf3", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2997 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xcf2522", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf2e22", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2533,7 +2533,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2838 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0xce9a20", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9ca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2557,7 +2557,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2839 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0xceb5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xceb920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2579,7 +2579,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2868 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0xcedf00", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee4c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2601,7 +2601,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2875 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0xcedfc0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2623,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2885 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0xcee100", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee6c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2645,7 +2645,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2887 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0xcee140", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2667,7 +2667,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2886 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0xcee120", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee6e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2689,7 +2689,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2872 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0xcedf80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2711,7 +2711,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2884 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0xcee0e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee6a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2733,7 +2733,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2883 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0xcee0c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2757,7 +2757,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2873 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcedfa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2781,7 +2781,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2874 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0xcedfa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2803,7 +2803,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2882 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0xcee0a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2825,7 +2825,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2881 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0xcee080", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2847,7 +2847,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2866 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0xcedec0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2869,7 +2869,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2867 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0xcedee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee4a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2891,7 +2891,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2865 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0xcedea0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2913,7 +2913,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2876 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0xcedfe0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2935,7 +2935,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2879 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0xcee040", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2957,7 +2957,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2880 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0xcee060", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2979,7 +2979,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2877 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0xcee000", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3003,7 +3003,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2878 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0xcee020", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -3025,7 +3025,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3032 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcf3ac0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf45a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3048,7 +3048,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3033 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcf3ac0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf45a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3095,11 +3095,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2998 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xcf25b3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf2eb3", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2999 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xcf27e2", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf30e2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3161,7 +3161,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3038 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0xcf3b60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3184,7 +3184,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3039 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0xcf3b60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3210,11 +3210,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3002 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xcf292e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf322e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3003 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xcf29fd", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf32fd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3245,11 +3245,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2994 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xcf20ae", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf29ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2995 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xcf22cb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf2bcb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3275,11 +3275,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2935 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcf104e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf194e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2936 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcf10ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf19ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3315,7 +3315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2891 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0xcefb40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3356,11 +3356,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2929 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcf0faa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf18aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2930 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcf101b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf191b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3384,11 +3384,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2931 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcf0faa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf18aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2932 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcf101b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf191b", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3407,11 +3407,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2937 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcf104e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf194e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2938 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcf10ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf19ef", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3431,11 +3431,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2939 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcf104e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf194e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2940 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcf10ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf19ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3468,11 +3468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2933 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0xcf0faa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf18aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2934 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0xcf101b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf191b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3500,7 +3500,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3044 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcf3f40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3525,7 +3525,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3045 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcf3f40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3556,7 +3556,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3046 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcf3f40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3581,7 +3581,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3047 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcf3f40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3608,7 +3608,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2903 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0xcf0400", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0c20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3635,7 +3635,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3016 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xcf3200", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3662,7 +3662,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3013 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xcf31a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3697,7 +3697,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3015 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xcf31e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3ae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3729,7 +3729,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3031 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xcf3aa0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3751,7 +3751,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2899 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0xcf0280", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3773,7 +3773,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2871 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0xcedf60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3795,7 +3795,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2897 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0xcf0240", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3819,11 +3819,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2905 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcf086a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf116a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2906 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcf08bb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf11bb", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3843,11 +3843,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2949 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcf112e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1a2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2950 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcf11cd", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1acd", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3892,11 +3892,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2915 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcf098e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf128e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2916 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcf0a45", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1345", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3938,11 +3938,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2907 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcf086a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf116a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2908 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcf08bb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf11bb", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3987,11 +3987,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2917 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcf098e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf128e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2918 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcf0a45", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1345", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -4035,11 +4035,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2951 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcf112e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1a2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2952 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcf11cd", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1acd", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -4056,11 +4056,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2953 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcf112e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1a2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2954 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcf11cd", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1acd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -4082,11 +4082,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2909 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcf086a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf116a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2910 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcf08bb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf11bb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -4109,18 +4109,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2925 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0xcf0c4e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf154e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2926 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0xcf0cf5"
+                - PC: "0xcf15f5"
                   Frameless: false
-                - PC: "0xcf0d44"
+                - PC: "0xcf1644"
                   Frameless: false
-                - PC: "0xcf0e0f"
+                - PC: "0xcf170f"
                   Frameless: false
-                - PC: "0xcf0e19"
+                - PC: "0xcf1719"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4148,18 +4148,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2923 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0xcf0aee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf13ee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2924 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0xcf0b44"
+                - PC: "0xcf1444"
                   Frameless: false
-                - PC: "0xcf0b93"
+                - PC: "0xcf1493"
                   Frameless: false
-                - PC: "0xcf0bd3"
+                - PC: "0xcf14d3"
                   Frameless: false
-                - PC: "0xcf0c0f"
+                - PC: "0xcf150f"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4186,11 +4186,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2968 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xcf18ca", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf21ca", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2969 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xcf192f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf222f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4207,11 +4207,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2970 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xcf194a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf224a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2971 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xcf198b", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf228b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4228,11 +4228,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2972 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xcf19aa", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf22aa", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2973 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xcf19e6", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf22e6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4249,11 +4249,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2976 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xcf1a8e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf238e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2977 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xcf1b0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf240a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4270,11 +4270,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2988 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xcf1dea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf26ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2989 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xcf1e30", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf2730", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4291,11 +4291,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2964 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xcf178a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf208a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2965 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xcf17e6", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf20e6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4313,14 +4313,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2921 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0xcf0a6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf136a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2922 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0xcf0aa4"
+                - PC: "0xcf13a4"
                   Frameless: false
-                - PC: "0xcf0aae"
+                - PC: "0xcf13ae"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4342,11 +4342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2911 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0xcf086a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf116a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2912 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0xcf08bb", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf11bb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4367,11 +4367,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2919 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0xcf098e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf128e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2920 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0xcf0a45", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1345", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4392,11 +4392,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2913 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0xcf08ea", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf11ea", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2914 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0xcf0954", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1254", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4418,14 +4418,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2927 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0xcf0e4e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf174e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2928 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0xcf0f1d"
+                - PC: "0xcf181d"
                   Frameless: false
-                - PC: "0xcf0f27"
+                - PC: "0xcf1827"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4447,11 +4447,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2966 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xcf180e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf210e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2967 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xcf18a3", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf21a3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4468,11 +4468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2962 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xcf168e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1f8e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2963 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xcf1767", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf2067", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4489,11 +4489,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2980 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xcf1c0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf250a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2981 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xcf1c6c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf256c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4510,11 +4510,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2974 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xcf1a0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf230a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2975 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xcf1a58", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf2358", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4531,11 +4531,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2986 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xcf1d6a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf266a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2987 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xcf1db6", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf26b6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4555,7 +4555,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2959 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0xcf140f", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1d0f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4576,11 +4576,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2984 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xcf1d0a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf260a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2985 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xcf1d4e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf264e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4597,11 +4597,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2960 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xcf160a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1f0a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2961 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xcf1671", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1f71", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4618,11 +4618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2982 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xcf1c8a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf258a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2983 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xcf1cef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf25ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4639,11 +4639,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2978 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xcf1b2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf242e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2979 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xcf1bd2", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf24d2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4696,11 +4696,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2941 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcf104e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf194e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2942 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcf10ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf19ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4746,7 +4746,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2809 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0xce86c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce87a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4768,7 +4768,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2807 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0xce8680", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4790,7 +4790,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2820 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0xce8820", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4808,7 +4808,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2821 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0xce8840", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4826,7 +4826,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2810 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0xce86e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce87c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4848,7 +4848,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2812 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0xce8720", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4871,7 +4871,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2813 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0xce8740", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4893,7 +4893,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2814 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0xce8760", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4922,7 +4922,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2811 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0xce8700", Frameless: true}]
+              InjectionPoints: [{PC: "0xce87e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4953,7 +4953,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2808 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0xce86a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4975,7 +4975,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3025 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xcf3a20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4997,7 +4997,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2815 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0xce8780", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8860", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5019,7 +5019,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2817 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0xce87c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce88a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5041,7 +5041,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2818 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0xce87e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce88c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5063,7 +5063,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2819 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0xce8800", Frameless: true}]
+              InjectionPoints: [{PC: "0xce88e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5085,7 +5085,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2816 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0xce87a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5107,7 +5107,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3019 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xcf3240", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3b40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5129,7 +5129,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3010 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xcf3140", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5151,7 +5151,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2869 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0xcedf20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -5172,11 +5172,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2955 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0xcf112e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1a2e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2956 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0xcf11cd", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf1acd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5197,11 +5197,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3000 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xcf288a", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf318a", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3001 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xcf28fe", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf31fe", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5245,7 +5245,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2902 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0xcf03c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0be0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5267,7 +5267,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3014 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xcf31c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5289,7 +5289,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2831 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0xce8ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0xce9080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5311,7 +5311,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2832 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0xce8f00", Frameless: true}]
+              InjectionPoints: [{PC: "0xce90a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5333,7 +5333,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3043 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xcf3e80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5360,7 +5360,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3011 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xcf3160", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5387,7 +5387,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2863 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0xced6e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcedbe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5408,11 +5408,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3004 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xcf2a2e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf332e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3005 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xcf2ae4", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf33e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5434,7 +5434,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3041 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xcf3d40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5455,7 +5455,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3040 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xcf3d20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf48e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5482,7 +5482,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2864 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0xcede80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcee440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5515,7 +5515,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3020 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xcf3260", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3b60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5555,7 +5555,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3036 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xcf3b20", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5587,7 +5587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2836 EventRootType Probe[main.testTakeContext]
-              InjectionPoints: [{PC: "0xce9540", Frameless: true}]
+              InjectionPoints: [{PC: "0xce97c0", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
       version: 0
@@ -5603,11 +5603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2943 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcf104e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf194e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2944 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcf10ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf19ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5628,11 +5628,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2945 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcf104e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf194e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2946 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcf10ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf19ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5655,11 +5655,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2947 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0xcf104e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf194e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2948 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0xcf10ef", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf19ef", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5691,7 +5691,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3026 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xcf3a40", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5723,7 +5723,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3027 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcf3a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5753,7 +5753,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3028 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcf3a60", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5785,7 +5785,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3029 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcf3a80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5815,7 +5815,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3030 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcf3a80", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf4560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5847,7 +5847,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3052 EventRootType Probe[main.testTimeFixedZone]
-              InjectionPoints: [{PC: "0xcf50e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf5d80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5869,7 +5869,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3053 EventRootType Probe[main.testTimeMonotonic]
-              InjectionPoints: [{PC: "0xcf5100", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf5da0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -5891,7 +5891,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3051 EventRootType Probe[main.testTimeUTC]
-              InjectionPoints: [{PC: "0xcf50c0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf5d60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5913,7 +5913,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2822 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0xce8860", Frameless: true}]
+              InjectionPoints: [{PC: "0xce8940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6045,7 +6045,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2901 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0xcf02e0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6067,7 +6067,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3008 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xcf3100", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -6089,7 +6089,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3034 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xcf3ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf45c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6111,7 +6111,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2900 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0xcf02a0", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf0ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6155,7 +6155,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3017 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcf3220", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3b20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6177,7 +6177,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3018 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcf3220", Frameless: true}]
+              InjectionPoints: [{PC: "0xcf3b20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6200,14 +6200,14 @@ Probes:
             - Kind: Entry
               Type: 3118 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0xced4ea"
+                - PC: "0xced9ea"
                   Frameless: false
-                - PC: "0xcf6e5a"
+                - PC: "0xcf7bfa"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 3119 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0xced525", Frameless: false}]
+              InjectionPoints: [{PC: "0xceda25", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -6229,11 +6229,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3006 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xcf2b0e", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf340e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3007 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcf2b8c", Frameless: false}]
+              InjectionPoints: [{PC: "0xcf348c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -6530,13 +6530,13 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xce8680..0xce8681]
+      OutOfLinePCRanges: [0xce8760..0xce8761]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xce8680..0xce8681
+            - Range: 0xce8760..0xce8761
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6544,13 +6544,13 @@ Subprograms:
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0xce86a0..0xce86a1]
+      OutOfLinePCRanges: [0xce8780..0xce8781]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xce86a0..0xce86a1
+            - Range: 0xce8780..0xce8781
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6558,109 +6558,11 @@ Subprograms:
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0xce86c0..0xce86c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 6 BaseType bool
-          Locations:
-            - Range: 0xce86c0..0xce86c1
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 24
-      Name: main.testSingleInt
-      OutOfLinePCRanges: [0xce86e0..0xce86e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xce86e0..0xce86e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 25
-      Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xce8700..0xce8701]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 22 BaseType int8
-          Locations:
-            - Range: 0xce8700..0xce8701
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 26
-      Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xce8720..0xce8721]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 112 BaseType int16
-          Locations:
-            - Range: 0xce8720..0xce8721
-              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 27
-      Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xce8740..0xce8741]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 12 BaseType int32
-          Locations:
-            - Range: 0xce8740..0xce8741
-              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 28
-      Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xce8760..0xce8761]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 14 BaseType int64
-          Locations:
-            - Range: 0xce8760..0xce8761
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 29
-      Name: main.testSingleUint
-      OutOfLinePCRanges: [0xce8780..0xce8781]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 16 BaseType uint
-          Locations:
-            - Range: 0xce8780..0xce8781
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 30
-      Name: main.testSingleUint8
       OutOfLinePCRanges: [0xce87a0..0xce87a1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 BaseType uint8
+          Type: 6 BaseType bool
           Locations:
             - Range: 0xce87a0..0xce87a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
@@ -6668,15 +6570,113 @@ Subprograms:
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
+    - ID: 24
+      Name: main.testSingleInt
+      OutOfLinePCRanges: [0xce87c0..0xce87c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xce87c0..0xce87c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 25
+      Name: main.testSingleInt8
+      OutOfLinePCRanges: [0xce87e0..0xce87e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 22 BaseType int8
+          Locations:
+            - Range: 0xce87e0..0xce87e1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 26
+      Name: main.testSingleInt16
+      OutOfLinePCRanges: [0xce8800..0xce8801]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 112 BaseType int16
+          Locations:
+            - Range: 0xce8800..0xce8801
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 27
+      Name: main.testSingleInt32
+      OutOfLinePCRanges: [0xce8820..0xce8821]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 12 BaseType int32
+          Locations:
+            - Range: 0xce8820..0xce8821
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 28
+      Name: main.testSingleInt64
+      OutOfLinePCRanges: [0xce8840..0xce8841]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 14 BaseType int64
+          Locations:
+            - Range: 0xce8840..0xce8841
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 29
+      Name: main.testSingleUint
+      OutOfLinePCRanges: [0xce8860..0xce8861]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 16 BaseType uint
+          Locations:
+            - Range: 0xce8860..0xce8861
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 30
+      Name: main.testSingleUint8
+      OutOfLinePCRanges: [0xce8880..0xce8881]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 5 BaseType uint8
+          Locations:
+            - Range: 0xce8880..0xce8881
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0xce87c0..0xce87c1]
+      OutOfLinePCRanges: [0xce88a0..0xce88a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0xce87c0..0xce87c1
+            - Range: 0xce88a0..0xce88a1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6684,13 +6684,13 @@ Subprograms:
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xce87e0..0xce87e1]
+      OutOfLinePCRanges: [0xce88c0..0xce88c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint32
           Locations:
-            - Range: 0xce87e0..0xce87e1
+            - Range: 0xce88c0..0xce88c1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6698,13 +6698,13 @@ Subprograms:
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0xce8800..0xce8801]
+      OutOfLinePCRanges: [0xce88e0..0xce88e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xce8800..0xce8801
+            - Range: 0xce88e0..0xce88e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6712,13 +6712,13 @@ Subprograms:
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xce8820..0xce8821]
+      OutOfLinePCRanges: [0xce8900..0xce8901]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 BaseType float32
           Locations:
-            - Range: 0xce8820..0xce8821
+            - Range: 0xce8900..0xce8901
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6726,13 +6726,13 @@ Subprograms:
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xce8840..0xce8841]
+      OutOfLinePCRanges: [0xce8920..0xce8921]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xce8840..0xce8841
+            - Range: 0xce8920..0xce8921
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6740,13 +6740,13 @@ Subprograms:
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xce8860..0xce8861]
+      OutOfLinePCRanges: [0xce8940..0xce8941]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 136 BaseType main.typeAlias
           Locations:
-            - Range: 0xce8860..0xce8861
+            - Range: 0xce8940..0xce8941
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6754,13 +6754,13 @@ Subprograms:
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xce89c0..0xce89c1]
+      OutOfLinePCRanges: [0xce8b60..0xce8b61]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 137 StructureType main.bigStruct
           Locations:
-            - Range: 0xce89c0..0xce89c1
+            - Range: 0xce8b60..0xce8b61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6780,51 +6780,51 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0xce8a20..0xce8b25]
+      OutOfLinePCRanges: [0xce8bc0..0xce8cc5]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xce8a20..0xce8a38
+            - Range: 0xce8bc0..0xce8bd8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xce8a20..0xce8b25, Pieces: []}]
+          Locations: [{Range: 0xce8bc0..0xce8cc5, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: x
           Type: 9 BaseType int
-          Locations: [{Range: 0xce8a20..0xce8b25, Pieces: []}]
+          Locations: [{Range: 0xce8bc0..0xce8cc5, Pieces: []}]
           Role: Local
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: err
           Type: 17 GoInterfaceType error
           Locations:
-            - Range: 0xce8a53..0xce8a6f
+            - Range: 0xce8bf3..0xce8c0f
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0xce8a6f..0xce8add
+            - Range: 0xce8c0f..0xce8c7d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce8add..0xce8ae0
+            - Range: 0xce8c7d..0xce8c80
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce8ae0..0xce8b25
+            - Range: 0xce8c80..0xce8cc5
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}, {Size: 8, Op: null}]
           Role: Local
           DictIndex: -1
@@ -6832,13 +6832,13 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0xce8ba0..0xce8ba1]
+      OutOfLinePCRanges: [0xce8d40..0xce8d41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 141 StructureType main.deepPtr1
           Locations:
-            - Range: 0xce8ba0..0xce8ba1
+            - Range: 0xce8d40..0xce8d41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6846,13 +6846,13 @@ Subprograms:
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0xce8bc0..0xce8bc1]
+      OutOfLinePCRanges: [0xce8d60..0xce8d61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 144 PointerType *main.deepPtr7
           Locations:
-            - Range: 0xce8bc0..0xce8bc1
+            - Range: 0xce8d60..0xce8d61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6860,13 +6860,13 @@ Subprograms:
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0xce8d20..0xce8d21]
+      OutOfLinePCRanges: [0xce8ec0..0xce8ec1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 146 StructureType main.deepSlice1
           Locations:
-            - Range: 0xce8d20..0xce8d21
+            - Range: 0xce8ec0..0xce8ec1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6880,53 +6880,11 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0xce8d40..0xce8d41]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 150 PointerType *main.deepSlice7
-          Locations:
-            - Range: 0xce8d40..0xce8d41
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 43
-      Name: main.testDeepMap1
-      OutOfLinePCRanges: [0xce8ea0..0xce8ea1]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 152 StructureType main.deepMap1
-          Locations:
-            - Range: 0xce8ea0..0xce8ea1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 44
-      Name: main.testDeepMap7
-      OutOfLinePCRanges: [0xce8ec0..0xce8ec1]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 158 PointerType *main.deepMap7
-          Locations:
-            - Range: 0xce8ec0..0xce8ec1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 45
-      Name: main.testStringType1
       OutOfLinePCRanges: [0xce8ee0..0xce8ee1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 160 PointerType *main.stringType1
+          Type: 150 PointerType *main.deepSlice7
           Locations:
             - Range: 0xce8ee0..0xce8ee1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -6934,15 +6892,57 @@ Subprograms:
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
+    - ID: 43
+      Name: main.testDeepMap1
+      OutOfLinePCRanges: [0xce9040..0xce9041]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 152 StructureType main.deepMap1
+          Locations:
+            - Range: 0xce9040..0xce9041
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 44
+      Name: main.testDeepMap7
+      OutOfLinePCRanges: [0xce9060..0xce9061]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 158 PointerType *main.deepMap7
+          Locations:
+            - Range: 0xce9060..0xce9061
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 45
+      Name: main.testStringType1
+      OutOfLinePCRanges: [0xce9080..0xce9081]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 160 PointerType *main.stringType1
+          Locations:
+            - Range: 0xce9080..0xce9081
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0xce8f00..0xce8f01]
+      OutOfLinePCRanges: [0xce90a0..0xce90a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 162 PointerType **main.stringType2
           Locations:
-            - Range: 0xce8f00..0xce8f01
+            - Range: 0xce90a0..0xce90a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6950,15 +6950,15 @@ Subprograms:
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0xce8f20..0xce9158]
+      OutOfLinePCRanges: [0xce90c0..0xce92f8]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce8fff..0xce9017
+            - Range: 0xce919f..0xce91b7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce90c5..0xce90dd
+            - Range: 0xce9265..0xce927d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -6966,17 +6966,17 @@ Subprograms:
         - Name: aPerArch
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce8fe8..0xce8feb
+            - Range: 0xce9188..0xce918b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce8feb..0xce8fff
+            - Range: 0xce918b..0xce919f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce8fff..0xce9017
+            - Range: 0xce919f..0xce91b7
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xce9017..0xce90b8
+            - Range: 0xce91b7..0xce9258
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0xce90b8..0xce90c5
+            - Range: 0xce9258..0xce9265
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xce90c5..0xce9158
+            - Range: 0xce9265..0xce92f8
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
           Role: Local
           DictIndex: -1
@@ -6984,21 +6984,21 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xce8fe2..0xce8feb
+            - Range: 0xce9182..0xce918b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce8feb..0xce8feb
+            - Range: 0xce918b..0xce918b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce8feb..0xce8fff
+            - Range: 0xce918b..0xce919f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce8fff..0xce90b8
+            - Range: 0xce919f..0xce9258
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0xce90b8..0xce90bd
+            - Range: 0xce9258..0xce925d
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0xce90bd..0xce90c5
+            - Range: 0xce925d..0xce9265
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xce90c5..0xce90ca
+            - Range: 0xce9265..0xce926a
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-            - Range: 0xce90ca..0xce9158
+            - Range: 0xce926a..0xce92f8
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
           Role: Local
           DictIndex: -1
@@ -7006,13 +7006,13 @@ Subprograms:
       DictRegister: null
     - ID: 48
       Name: main.testTakeContext
-      OutOfLinePCRanges: [0xce9540..0xce9541]
+      OutOfLinePCRanges: [0xce97c0..0xce97c1]
       InlinePCRanges: []
       Variables:
         - Name: ctx
           Type: 164 GoInterfaceType context.Context
           Locations:
-            - Range: 0xce9540..0xce9541
+            - Range: 0xce97c0..0xce97c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7024,13 +7024,13 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testCaptureContextImpl
-      OutOfLinePCRanges: [0xce9720..0xce9721]
+      OutOfLinePCRanges: [0xce99a0..0xce99a1]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 165 PointerType *main.contextImpl
           Locations:
-            - Range: 0xce9720..0xce9721
+            - Range: 0xce99a0..0xce99a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7038,13 +7038,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0xce9a20..0xce9a21]
+      OutOfLinePCRanges: [0xce9ca0..0xce9ca1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 167 StructureType main.manyPointers
           Locations:
-            - Range: 0xce9a20..0xce9a21
+            - Range: 0xce9ca0..0xce9ca1
               Pieces: [{Size: 560, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7052,13 +7052,13 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0xceb5c0..0xceb5c1]
+      OutOfLinePCRanges: [0xceb920..0xceb921]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 170 GoSliceHeaderType []string
           Locations:
-            - Range: 0xceb5c0..0xceb5c1
+            - Range: 0xceb920..0xceb921
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7072,13 +7072,13 @@ Subprograms:
       DictRegister: null
     - ID: 52
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xceb8c0..0xceb9c5]
+      OutOfLinePCRanges: [0xcebd00..0xcebe05]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 171 StructureType main.esotericStack
           Locations:
-            - Range: 0xceb8c0..0xceb913
+            - Range: 0xcebd00..0xcebd53
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -7098,7 +7098,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xceb913..0xceb918
+            - Range: 0xcebd53..0xcebd58
               Pieces:
                 - Size: 4
                   Op: null
@@ -7118,7 +7118,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xceb918..0xceb91d
+            - Range: 0xcebd58..0xcebd5d
               Pieces:
                 - Size: 4
                   Op: null
@@ -7144,13 +7144,13 @@ Subprograms:
       DictRegister: null
     - ID: 53
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xceb9e0..0xceba43]
+      OutOfLinePCRanges: [0xcebe20..0xcebe83]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 174 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xceb9e0..0xceba0d
+            - Range: 0xcebe20..0xcebe4d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7158,13 +7158,13 @@ Subprograms:
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xcecfa0..0xced028]
+      OutOfLinePCRanges: [0xced3e0..0xced468]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcecfa0..0xcecfb5
+            - Range: 0xced3e0..0xced3f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7172,13 +7172,13 @@ Subprograms:
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xced040..0xced105]
+      OutOfLinePCRanges: [0xced480..0xced545]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xced040..0xced056
+            - Range: 0xced480..0xced496
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7186,7 +7186,7 @@ Subprograms:
         - Name: "y"
           Type: 9 BaseType int
           Locations:
-            - Range: 0xced040..0xced067
+            - Range: 0xced480..0xced4a7
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7194,9 +7194,9 @@ Subprograms:
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0xced056..0xced067
+            - Range: 0xced496..0xced4a7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xced067..0xced105
+            - Range: 0xced4a7..0xced545
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
           DictIndex: -1
@@ -7204,13 +7204,13 @@ Subprograms:
       DictRegister: null
     - ID: 56
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xced120..0xced182]
+      OutOfLinePCRanges: [0xced560..0xced5c2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xced120..0xced13a
+            - Range: 0xced560..0xced57a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7218,17 +7218,17 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xced1a0..0xced2a5]
+      OutOfLinePCRanges: [0xced5e0..0xced6e5]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0xced1fb..0xced205
+            - Range: 0xced63b..0xced645
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xced205..0xced215
+            - Range: 0xced645..0xced655
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xced215..0xced229
+            - Range: 0xced655..0xced669
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7236,11 +7236,11 @@ Subprograms:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xced1f6..0xced200
+            - Range: 0xced636..0xced640
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xced200..0xced215
+            - Range: 0xced640..0xced655
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xced215..0xced224
+            - Range: 0xced655..0xced664
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7248,13 +7248,13 @@ Subprograms:
       DictRegister: null
     - ID: 58
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xced2c0..0xced2c6]
+      OutOfLinePCRanges: [0xced700..0xced706]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xced2c0..0xced2c5
+            - Range: 0xced700..0xced705
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7262,9 +7262,9 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xced2c0..0xced2c5
+            - Range: 0xced700..0xced705
               Pieces: []
-            - Range: 0xced2c5..0xced2c6
+            - Range: 0xced705..0xced706
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -7272,13 +7272,13 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xced2e0..0xced32b]
+      OutOfLinePCRanges: [0xced720..0xced76b]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 176 ArrayType [5]int
           Locations:
-            - Range: 0xced2e0..0xced32b
+            - Range: 0xced720..0xced76b
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7286,11 +7286,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xced2e0..0xced325
+            - Range: 0xced720..0xced765
               Pieces: []
-            - Range: 0xced325..0xced326
+            - Range: 0xced765..0xced766
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xced326..0xced32b
+            - Range: 0xced766..0xced76b
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7298,13 +7298,13 @@ Subprograms:
       DictRegister: null
     - ID: 60
       Name: main.testInterface
-      OutOfLinePCRanges: [0xced5c0..0xced5c1]
+      OutOfLinePCRanges: [0xcedac0..0xcedac1]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 177 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xced5c0..0xced5c1
+            - Range: 0xcedac0..0xcedac1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7316,19 +7316,19 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testAny
-      OutOfLinePCRanges: [0xced5e0..0xced646]
+      OutOfLinePCRanges: [0xcedae0..0xcedb46]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 61 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xced5e0..0xced609
+            - Range: 0xcedae0..0xcedb09
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xced609..0xced60e
+            - Range: 0xcedb09..0xcedb0e
               Pieces:
                 - Size: 8
                   Op: null
@@ -7340,15 +7340,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xced5e0..0xced625
+            - Range: 0xcedae0..0xcedb25
               Pieces: []
-            - Range: 0xced625..0xced626
+            - Range: 0xcedb25..0xcedb26
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xced626..0xced646
+            - Range: 0xcedb26..0xcedb46
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7356,13 +7356,13 @@ Subprograms:
       DictRegister: null
     - ID: 62
       Name: main.testError
-      OutOfLinePCRanges: [0xced660..0xced661]
+      OutOfLinePCRanges: [0xcedb60..0xcedb61]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 17 GoInterfaceType error
           Locations:
-            - Range: 0xced660..0xced661
+            - Range: 0xcedb60..0xcedb61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7374,13 +7374,13 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xced680..0xced6d4]
+      OutOfLinePCRanges: [0xcedb80..0xcedbd4]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 178 PointerType *interface {}
           Locations:
-            - Range: 0xced680..0xced6a6
+            - Range: 0xcedb80..0xcedba6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7388,15 +7388,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xced680..0xced6bd
+            - Range: 0xcedb80..0xcedbbd
               Pieces: []
-            - Range: 0xced6bd..0xced6be
+            - Range: 0xcedbbd..0xcedbbe
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xced6be..0xced6d4
+            - Range: 0xcedbbe..0xcedbd4
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7404,13 +7404,13 @@ Subprograms:
       DictRegister: null
     - ID: 64
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xced6e0..0xced6e1]
+      OutOfLinePCRanges: [0xcedbe0..0xcedbe1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 179 StructureType main.structWithAny
           Locations:
-            - Range: 0xced6e0..0xced6e1
+            - Range: 0xcedbe0..0xcedbe1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7422,13 +7422,13 @@ Subprograms:
       DictRegister: null
     - ID: 65
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcede80..0xcede81]
+      OutOfLinePCRanges: [0xcee440..0xcee441]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 180 StructureType main.structWithMap
           Locations:
-            - Range: 0xcede80..0xcede81
+            - Range: 0xcee440..0xcee441
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7436,13 +7436,13 @@ Subprograms:
       DictRegister: null
     - ID: 66
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcedea0..0xcedea1]
+      OutOfLinePCRanges: [0xcee460..0xcee461]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 186 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xcedea0..0xcedea1
+            - Range: 0xcee460..0xcee461
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7450,13 +7450,13 @@ Subprograms:
       DictRegister: null
     - ID: 67
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcedec0..0xcedec1]
+      OutOfLinePCRanges: [0xcee480..0xcee481]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 191 GoMapType map[string]int
           Locations:
-            - Range: 0xcedec0..0xcedec1
+            - Range: 0xcee480..0xcee481
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7464,13 +7464,13 @@ Subprograms:
       DictRegister: null
     - ID: 68
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcedee0..0xcedee1]
+      OutOfLinePCRanges: [0xcee4a0..0xcee4a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 196 GoMapType map[string][]string
           Locations:
-            - Range: 0xcedee0..0xcedee1
+            - Range: 0xcee4a0..0xcee4a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7478,13 +7478,13 @@ Subprograms:
       DictRegister: null
     - ID: 69
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcedf00..0xcedf01]
+      OutOfLinePCRanges: [0xcee4c0..0xcee4c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 201 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0xcedf00..0xcedf01
+            - Range: 0xcee4c0..0xcee4c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7492,13 +7492,13 @@ Subprograms:
       DictRegister: null
     - ID: 70
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcedf20..0xcedf21]
+      OutOfLinePCRanges: [0xcee4e0..0xcee4e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 191 GoMapType map[string]int
           Locations:
-            - Range: 0xcedf20..0xcedf21
+            - Range: 0xcee4e0..0xcee4e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7506,13 +7506,13 @@ Subprograms:
       DictRegister: null
     - ID: 71
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcedf40..0xcedf41]
+      OutOfLinePCRanges: [0xcee500..0xcee501]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 206 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xcedf40..0xcedf41
+            - Range: 0xcee500..0xcee501
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7520,13 +7520,13 @@ Subprograms:
       DictRegister: null
     - ID: 72
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcedf60..0xcedf61]
+      OutOfLinePCRanges: [0xcee520..0xcee521]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 207 PointerType *map[string]int
           Locations:
-            - Range: 0xcedf60..0xcedf61
+            - Range: 0xcee520..0xcee521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7534,13 +7534,13 @@ Subprograms:
       DictRegister: null
     - ID: 73
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xcedf80..0xcedf81]
+      OutOfLinePCRanges: [0xcee540..0xcee541]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 181 GoMapType map[int]int
           Locations:
-            - Range: 0xcedf80..0xcedf81
+            - Range: 0xcee540..0xcee541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7548,13 +7548,13 @@ Subprograms:
       DictRegister: null
     - ID: 74
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0xcedfa0..0xcedfa1]
+      OutOfLinePCRanges: [0xcee560..0xcee561]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 208 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcedfa0..0xcedfa1
+            - Range: 0xcee560..0xcee561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7562,13 +7562,13 @@ Subprograms:
       DictRegister: null
     - ID: 75
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xcedfc0..0xcedfc1]
+      OutOfLinePCRanges: [0xcee580..0xcee581]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 208 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcedfc0..0xcedfc1
+            - Range: 0xcee580..0xcee581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7576,13 +7576,13 @@ Subprograms:
       DictRegister: null
     - ID: 76
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xcedfe0..0xcedfe1]
+      OutOfLinePCRanges: [0xcee5a0..0xcee5a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 213 GoMapType map[bool]main.node
           Locations:
-            - Range: 0xcedfe0..0xcedfe1
+            - Range: 0xcee5a0..0xcee5a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7590,13 +7590,13 @@ Subprograms:
       DictRegister: null
     - ID: 77
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xcee000..0xcee001]
+      OutOfLinePCRanges: [0xcee5c0..0xcee5c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 218 GoMapType map[int]uint8
           Locations:
-            - Range: 0xcee000..0xcee001
+            - Range: 0xcee5c0..0xcee5c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7604,13 +7604,13 @@ Subprograms:
       DictRegister: null
     - ID: 78
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xcee020..0xcee021]
+      OutOfLinePCRanges: [0xcee5e0..0xcee5e1]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 218 GoMapType map[int]uint8
           Locations:
-            - Range: 0xcee020..0xcee021
+            - Range: 0xcee5e0..0xcee5e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7618,13 +7618,13 @@ Subprograms:
       DictRegister: null
     - ID: 79
       Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xcee040..0xcee041]
+      OutOfLinePCRanges: [0xcee600..0xcee601]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 223 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcee040..0xcee041
+            - Range: 0xcee600..0xcee601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7632,13 +7632,13 @@ Subprograms:
       DictRegister: null
     - ID: 80
       Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0xcee060..0xcee061]
+      OutOfLinePCRanges: [0xcee620..0xcee621]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 223 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcee060..0xcee061
+            - Range: 0xcee620..0xcee621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7646,13 +7646,13 @@ Subprograms:
       DictRegister: null
     - ID: 81
       Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0xcee080..0xcee081]
+      OutOfLinePCRanges: [0xcee640..0xcee641]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 223 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcee080..0xcee081
+            - Range: 0xcee640..0xcee641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7660,13 +7660,13 @@ Subprograms:
       DictRegister: null
     - ID: 82
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0xcee0a0..0xcee0a1]
+      OutOfLinePCRanges: [0xcee660..0xcee661]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 228 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0xcee0a0..0xcee0a1
+            - Range: 0xcee660..0xcee661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7674,13 +7674,13 @@ Subprograms:
       DictRegister: null
     - ID: 83
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0xcee0c0..0xcee0c1]
+      OutOfLinePCRanges: [0xcee680..0xcee681]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 233 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0xcee0c0..0xcee0c1
+            - Range: 0xcee680..0xcee681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7688,13 +7688,13 @@ Subprograms:
       DictRegister: null
     - ID: 84
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0xcee0e0..0xcee0e1]
+      OutOfLinePCRanges: [0xcee6a0..0xcee6a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 238 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0xcee0e0..0xcee0e1
+            - Range: 0xcee6a0..0xcee6a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7702,13 +7702,13 @@ Subprograms:
       DictRegister: null
     - ID: 85
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0xcee100..0xcee101]
+      OutOfLinePCRanges: [0xcee6c0..0xcee6c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 243 GoMapType map[struct {}]int
           Locations:
-            - Range: 0xcee100..0xcee101
+            - Range: 0xcee6c0..0xcee6c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7716,13 +7716,13 @@ Subprograms:
       DictRegister: null
     - ID: 86
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0xcee120..0xcee121]
+      OutOfLinePCRanges: [0xcee6e0..0xcee6e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 248 GoMapType map[int]struct {}
           Locations:
-            - Range: 0xcee120..0xcee121
+            - Range: 0xcee6e0..0xcee6e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7730,13 +7730,13 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0xcee140..0xcee141]
+      OutOfLinePCRanges: [0xcee700..0xcee701]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 253 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0xcee140..0xcee141
+            - Range: 0xcee700..0xcee701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7744,13 +7744,13 @@ Subprograms:
       DictRegister: null
     - ID: 88
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcef980..0xcef981]
+      OutOfLinePCRanges: [0xceff40..0xceff41]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xcef980..0xcef981
+            - Range: 0xceff40..0xceff41
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7758,7 +7758,7 @@ Subprograms:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xcef980..0xcef981
+            - Range: 0xceff40..0xceff41
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7766,7 +7766,7 @@ Subprograms:
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0xcef980..0xcef981
+            - Range: 0xceff40..0xceff41
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7774,13 +7774,13 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0xcef9c0..0xcef9c1]
+      OutOfLinePCRanges: [0xceff80..0xceff81]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xcef9c0..0xcef9c1
+            - Range: 0xceff80..0xceff81
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7788,7 +7788,7 @@ Subprograms:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcef9c0..0xcef9c1
+            - Range: 0xceff80..0xceff81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7800,7 +7800,7 @@ Subprograms:
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0xcef9c0..0xcef9c1
+            - Range: 0xceff80..0xceff81
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7808,13 +7808,13 @@ Subprograms:
       DictRegister: null
     - ID: 90
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcefb40..0xcefb41]
+      OutOfLinePCRanges: [0xcf0100..0xcf0101]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcefb40..0xcefb41
+            - Range: 0xcf0100..0xcf0101
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7822,7 +7822,7 @@ Subprograms:
         - Name: b
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xcefb40..0xcefb41
+            - Range: 0xcf0100..0xcf0101
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7830,7 +7830,7 @@ Subprograms:
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xcefb40..0xcefb41
+            - Range: 0xcf0100..0xcf0101
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7838,7 +7838,7 @@ Subprograms:
         - Name: d
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcefb40..0xcefb41
+            - Range: 0xcf0100..0xcf0101
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7846,7 +7846,7 @@ Subprograms:
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcefb40..0xcefb41
+            - Range: 0xcf0100..0xcf0101
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7858,13 +7858,13 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.(*Server).handleOrder
-      OutOfLinePCRanges: [0xcefd60..0xceff94]
+      OutOfLinePCRanges: [0xcf03e0..0xcf0614]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 258 PointerType *main.Server
           Locations:
-            - Range: 0xcefd60..0xcefdb6
+            - Range: 0xcf03e0..0xcf0436
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7872,9 +7872,9 @@ Subprograms:
         - Name: req
           Type: 260 PointerType *main.Request
           Locations:
-            - Range: 0xcefd60..0xcefdb3
+            - Range: 0xcf03e0..0xcf0433
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcefdb3..0xceff94
+            - Range: 0xcf0433..0xcf0614
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7882,23 +7882,23 @@ Subprograms:
         - Name: ~r0
           Type: 17 GoInterfaceType error
           Locations:
-            - Range: 0xcefd60..0xcefea1
+            - Range: 0xcf03e0..0xcf0521
               Pieces: []
-            - Range: 0xcefea1..0xcefea2
+            - Range: 0xcf0521..0xcf0522
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcefea2..0xceff69
+            - Range: 0xcf0522..0xcf05e9
               Pieces: []
-            - Range: 0xceff69..0xceff6a
+            - Range: 0xcf05e9..0xcf05ea
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xceff6a..0xceff94
+            - Range: 0xcf05ea..0xcf0614
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7906,13 +7906,13 @@ Subprograms:
       DictRegister: null
     - ID: 92
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0xcf0060..0xcf0073]
+      OutOfLinePCRanges: [0xcf07c0..0xcf07d3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xcf0060..0xcf0072
+            - Range: 0xcf07c0..0xcf07d2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7920,9 +7920,9 @@ Subprograms:
         - Name: ~r0
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xcf0060..0xcf0072
+            - Range: 0xcf07c0..0xcf07d2
               Pieces: []
-            - Range: 0xcf0072..0xcf0073
+            - Range: 0xcf07d2..0xcf07d3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -7930,13 +7930,13 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcf0080..0xcf0081]
+      OutOfLinePCRanges: [0xcf07e0..0xcf07e1]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 262 GoChannelType chan bool
           Locations:
-            - Range: 0xcf0080..0xcf0081
+            - Range: 0xcf07e0..0xcf07e1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7944,13 +7944,13 @@ Subprograms:
       DictRegister: null
     - ID: 94
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcf0240..0xcf0241]
+      OutOfLinePCRanges: [0xcf0a60..0xcf0a61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 263 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcf0240..0xcf0241
+            - Range: 0xcf0a60..0xcf0a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7958,13 +7958,13 @@ Subprograms:
       DictRegister: null
     - ID: 95
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcf0260..0xcf0261]
+      OutOfLinePCRanges: [0xcf0a80..0xcf0a81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 265 StructureType main.node
           Locations:
-            - Range: 0xcf0260..0xcf0261
+            - Range: 0xcf0a80..0xcf0a81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7976,13 +7976,13 @@ Subprograms:
       DictRegister: null
     - ID: 96
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcf0280..0xcf0281]
+      OutOfLinePCRanges: [0xcf0aa0..0xcf0aa1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 266 PointerType *main.node
           Locations:
-            - Range: 0xcf0280..0xcf0281
+            - Range: 0xcf0aa0..0xcf0aa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7990,13 +7990,13 @@ Subprograms:
       DictRegister: null
     - ID: 97
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcf02a0..0xcf02a1]
+      OutOfLinePCRanges: [0xcf0ac0..0xcf0ac1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcf02a0..0xcf02a1
+            - Range: 0xcf0ac0..0xcf0ac1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8004,13 +8004,13 @@ Subprograms:
       DictRegister: null
     - ID: 98
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcf02e0..0xcf02e1]
+      OutOfLinePCRanges: [0xcf0b00..0xcf0b01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 115 PointerType *uint
           Locations:
-            - Range: 0xcf02e0..0xcf02e1
+            - Range: 0xcf0b00..0xcf0b01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8018,13 +8018,13 @@ Subprograms:
       DictRegister: null
     - ID: 99
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcf03c0..0xcf03c1]
+      OutOfLinePCRanges: [0xcf0be0..0xcf0be1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 104 PointerType *string
           Locations:
-            - Range: 0xcf03c0..0xcf03c1
+            - Range: 0xcf0be0..0xcf0be1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8032,13 +8032,13 @@ Subprograms:
       DictRegister: null
     - ID: 100
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcf0400..0xcf0401]
+      OutOfLinePCRanges: [0xcf0c20..0xcf0c21]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 13 PointerType *bool
           Locations:
-            - Range: 0xcf0400..0xcf0401
+            - Range: 0xcf0c20..0xcf0c21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8046,7 +8046,7 @@ Subprograms:
         - Name: a
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcf0400..0xcf0401
+            - Range: 0xcf0c20..0xcf0c21
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8054,13 +8054,13 @@ Subprograms:
       DictRegister: null
     - ID: 101
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcf0440..0xcf0441]
+      OutOfLinePCRanges: [0xcf0c60..0xcf0c61]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 267 PointerType *main.t
           Locations:
-            - Range: 0xcf0440..0xcf0441
+            - Range: 0xcf0c60..0xcf0c61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8068,13 +8068,13 @@ Subprograms:
       DictRegister: null
     - ID: 102
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcf0860..0xcf08d2]
+      OutOfLinePCRanges: [0xcf1160..0xcf11d2]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf0860..0xcf0872
+            - Range: 0xcf1160..0xcf1172
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8082,11 +8082,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf0860..0xcf08bb
+            - Range: 0xcf1160..0xcf11bb
               Pieces: []
-            - Range: 0xcf08bb..0xcf08bc
+            - Range: 0xcf11bb..0xcf11bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf08bc..0xcf08d2
+            - Range: 0xcf11bc..0xcf11d2
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8094,9 +8094,9 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf0872..0xcf0885
+            - Range: 0xcf1172..0xcf1185
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf0885..0xcf08d2
+            - Range: 0xcf1185..0xcf11d2
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: -1
@@ -8104,15 +8104,15 @@ Subprograms:
       DictRegister: null
     - ID: 103
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xcf08e0..0xcf096f]
+      OutOfLinePCRanges: [0xcf11e0..0xcf126f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf08e0..0xcf08fa
+            - Range: 0xcf11e0..0xcf11fa
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf08fa..0xcf096f
+            - Range: 0xcf11fa..0xcf126f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8120,11 +8120,11 @@ Subprograms:
         - Name: ~r0
           Type: 107 PointerType *int
           Locations:
-            - Range: 0xcf08e0..0xcf0954
+            - Range: 0xcf11e0..0xcf1254
               Pieces: []
-            - Range: 0xcf0954..0xcf0955
+            - Range: 0xcf1254..0xcf1255
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf0955..0xcf096f
+            - Range: 0xcf1255..0xcf126f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8132,9 +8132,9 @@ Subprograms:
         - Name: '&result'
           Type: 107 PointerType *int
           Locations:
-            - Range: 0xcf08ff..0xcf0919
+            - Range: 0xcf11ff..0xcf1219
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf0919..0xcf096f
+            - Range: 0xcf1219..0xcf126f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
           DictIndex: -1
@@ -8142,13 +8142,13 @@ Subprograms:
       DictRegister: null
     - ID: 104
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcf0980..0xcf0a5f]
+      OutOfLinePCRanges: [0xcf1280..0xcf135f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf0980..0xcf09e3
+            - Range: 0xcf1280..0xcf12e3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8156,27 +8156,27 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf0980..0xcf0a45
+            - Range: 0xcf1280..0xcf1345
               Pieces: []
-            - Range: 0xcf0a45..0xcf0a46
+            - Range: 0xcf1345..0xcf1346
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf0a46..0xcf0a5f
+            - Range: 0xcf1346..0xcf135f
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf0980..0xcf0a5f, Pieces: []}]
+          Locations: [{Range: 0xcf1280..0xcf135f, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf0996..0xcf09e8
+            - Range: 0xcf1296..0xcf12e8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcf09e8..0xcf0a5f
+            - Range: 0xcf12e8..0xcf135f
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
           DictIndex: -1
@@ -8184,9 +8184,9 @@ Subprograms:
         - Name: resultFloat
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xcf09af..0xcf09e8
+            - Range: 0xcf12af..0xcf12e8
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcf09e8..0xcf0a5f
+            - Range: 0xcf12e8..0xcf135f
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
@@ -8194,13 +8194,13 @@ Subprograms:
       DictRegister: null
     - ID: 105
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xcf0a60..0xcf0ac4]
+      OutOfLinePCRanges: [0xcf1360..0xcf13c4]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcf0a60..0xcf0a77
+            - Range: 0xcf1360..0xcf1377
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8208,23 +8208,23 @@ Subprograms:
         - Name: ~r0
           Type: 17 GoInterfaceType error
           Locations:
-            - Range: 0xcf0a60..0xcf0aa4
+            - Range: 0xcf1360..0xcf13a4
               Pieces: []
-            - Range: 0xcf0aa4..0xcf0aa5
+            - Range: 0xcf13a4..0xcf13a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0aa5..0xcf0aae
+            - Range: 0xcf13a5..0xcf13ae
               Pieces: []
-            - Range: 0xcf0aae..0xcf0aaf
+            - Range: 0xcf13ae..0xcf13af
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0aaf..0xcf0ac4
+            - Range: 0xcf13af..0xcf13c4
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8232,37 +8232,37 @@ Subprograms:
       DictRegister: null
     - ID: 106
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcf0ae0..0xcf0c3c]
+      OutOfLinePCRanges: [0xcf13e0..0xcf153c]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 61 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcf0ae0..0xcf0b2b
+            - Range: 0xcf13e0..0xcf142b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0b2b..0xcf0b36
+            - Range: 0xcf142b..0xcf1436
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0b67..0xcf0b6a
+            - Range: 0xcf1467..0xcf146a
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0b9e..0xcf0ba5
+            - Range: 0xcf149e..0xcf14a5
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0bde..0xcf0be5
+            - Range: 0xcf14de..0xcf14e5
               Pieces:
                 - Size: 8
                   Op: null
@@ -8274,7 +8274,7 @@ Subprograms:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcf0ae0..0xcf0b36
+            - Range: 0xcf13e0..0xcf1436
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8282,39 +8282,39 @@ Subprograms:
         - Name: ~r0
           Type: 61 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcf0ae0..0xcf0b44
+            - Range: 0xcf13e0..0xcf1444
               Pieces: []
-            - Range: 0xcf0b44..0xcf0b45
+            - Range: 0xcf1444..0xcf1445
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0b45..0xcf0b93
+            - Range: 0xcf1445..0xcf1493
               Pieces: []
-            - Range: 0xcf0b93..0xcf0b94
+            - Range: 0xcf1493..0xcf1494
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0b94..0xcf0bd3
+            - Range: 0xcf1494..0xcf14d3
               Pieces: []
-            - Range: 0xcf0bd3..0xcf0bd4
+            - Range: 0xcf14d3..0xcf14d4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0bd4..0xcf0c0f
+            - Range: 0xcf14d4..0xcf150f
               Pieces: []
-            - Range: 0xcf0c0f..0xcf0c10
+            - Range: 0xcf150f..0xcf1510
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0c10..0xcf0c3c
+            - Range: 0xcf1510..0xcf153c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8322,39 +8322,39 @@ Subprograms:
         - Name: ~r1
           Type: 17 GoInterfaceType error
           Locations:
-            - Range: 0xcf0ae0..0xcf0b44
+            - Range: 0xcf13e0..0xcf1444
               Pieces: []
-            - Range: 0xcf0b44..0xcf0b45
+            - Range: 0xcf1444..0xcf1445
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf0b45..0xcf0b93
+            - Range: 0xcf1445..0xcf1493
               Pieces: []
-            - Range: 0xcf0b93..0xcf0b94
+            - Range: 0xcf1493..0xcf1494
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf0b94..0xcf0bd3
+            - Range: 0xcf1494..0xcf14d3
               Pieces: []
-            - Range: 0xcf0bd3..0xcf0bd4
+            - Range: 0xcf14d3..0xcf14d4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf0bd4..0xcf0c0f
+            - Range: 0xcf14d4..0xcf150f
               Pieces: []
-            - Range: 0xcf0c0f..0xcf0c10
+            - Range: 0xcf150f..0xcf1510
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf0c10..0xcf0c3c
+            - Range: 0xcf1510..0xcf153c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8362,7 +8362,7 @@ Subprograms:
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf0b2b..0xcf0b31
+            - Range: 0xcf142b..0xcf1431
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8370,25 +8370,25 @@ Subprograms:
       DictRegister: null
     - ID: 107
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcf0c40..0xcf0e3d]
+      OutOfLinePCRanges: [0xcf1540..0xcf173d]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 61 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcf0c40..0xcf0c8b
+            - Range: 0xcf1540..0xcf158b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0c8b..0xcf0c92
+            - Range: 0xcf158b..0xcf1592
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcf0c92..0xcf0e3d
+            - Range: 0xcf1592..0xcf173d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -8400,39 +8400,39 @@ Subprograms:
         - Name: ~r0
           Type: 61 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcf0c40..0xcf0cf5
+            - Range: 0xcf1540..0xcf15f5
               Pieces: []
-            - Range: 0xcf0cf5..0xcf0cf6
+            - Range: 0xcf15f5..0xcf15f6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0cf6..0xcf0d44
+            - Range: 0xcf15f6..0xcf1644
               Pieces: []
-            - Range: 0xcf0d44..0xcf0d45
+            - Range: 0xcf1644..0xcf1645
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0d45..0xcf0e0f
+            - Range: 0xcf1645..0xcf170f
               Pieces: []
-            - Range: 0xcf0e0f..0xcf0e10
+            - Range: 0xcf170f..0xcf1710
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0e10..0xcf0e19
+            - Range: 0xcf1710..0xcf1719
               Pieces: []
-            - Range: 0xcf0e19..0xcf0e1a
+            - Range: 0xcf1719..0xcf171a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0e1a..0xcf0e3d
+            - Range: 0xcf171a..0xcf173d
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8440,7 +8440,7 @@ Subprograms:
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf0ce0..0xcf0ce6
+            - Range: 0xcf15e0..0xcf15e6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8448,7 +8448,7 @@ Subprograms:
         - Name: '&result'
           Type: 107 PointerType *int
           Locations:
-            - Range: 0xcf0d25..0xcf0d44
+            - Range: 0xcf1625..0xcf1644
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8456,35 +8456,35 @@ Subprograms:
       DictRegister: null
     - ID: 108
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcf0e40..0xcf0f94]
+      OutOfLinePCRanges: [0xcf1740..0xcf1894]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 61 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcf0e40..0xcf0e80
+            - Range: 0xcf1740..0xcf1780
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0e80..0xcf0ed0
+            - Range: 0xcf1780..0xcf17d0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcf0ed0..0xcf0f2d
+            - Range: 0xcf17d0..0xcf182d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcf0f2d..0xcf0f51
+            - Range: 0xcf182d..0xcf1851
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcf0f51..0xcf0f58
+            - Range: 0xcf1851..0xcf1858
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcf0f58..0xcf0f94
+            - Range: 0xcf1858..0xcf1894
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8492,23 +8492,23 @@ Subprograms:
         - Name: ~r0
           Type: 177 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcf0e40..0xcf0f1d
+            - Range: 0xcf1740..0xcf181d
               Pieces: []
-            - Range: 0xcf0f1d..0xcf0f1e
+            - Range: 0xcf181d..0xcf181e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0f1e..0xcf0f27
+            - Range: 0xcf181e..0xcf1827
               Pieces: []
-            - Range: 0xcf0f27..0xcf0f28
+            - Range: 0xcf1827..0xcf1828
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0f28..0xcf0f94
+            - Range: 0xcf1828..0xcf1894
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8516,39 +8516,39 @@ Subprograms:
         - Name: b
           Type: 177 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcf0e40..0xcf0e80
+            - Range: 0xcf1740..0xcf1780
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0e80..0xcf0ed0
+            - Range: 0xcf1780..0xcf17d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcf0ed0..0xcf0ed7
+            - Range: 0xcf17d0..0xcf17d7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcf0ed7..0xcf0f23
+            - Range: 0xcf17d7..0xcf1823
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcf0f23..0xcf0f25
+            - Range: 0xcf1823..0xcf1825
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcf0f25..0xcf0f27
+            - Range: 0xcf1825..0xcf1827
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcf0f27..0xcf0f94
+            - Range: 0xcf1827..0xcf1894
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
           DictIndex: -1
@@ -8556,13 +8556,13 @@ Subprograms:
       DictRegister: null
     - ID: 109
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcf0fa0..0xcf1035]
+      OutOfLinePCRanges: [0xcf18a0..0xcf1935]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf0fa0..0xcf0fb1
+            - Range: 0xcf18a0..0xcf18b1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8570,11 +8570,11 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf0fa0..0xcf101b
+            - Range: 0xcf18a0..0xcf191b
               Pieces: []
-            - Range: 0xcf101b..0xcf101c
+            - Range: 0xcf191b..0xcf191c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf101c..0xcf1035
+            - Range: 0xcf191c..0xcf1935
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8582,13 +8582,13 @@ Subprograms:
       DictRegister: null
     - ID: 110
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcf1040..0xcf1109]
+      OutOfLinePCRanges: [0xcf1940..0xcf1a09]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1040..0xcf1092
+            - Range: 0xcf1940..0xcf1992
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8596,11 +8596,11 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1040..0xcf10ef
+            - Range: 0xcf1940..0xcf19ef
               Pieces: []
-            - Range: 0xcf10ef..0xcf10f0
+            - Range: 0xcf19ef..0xcf19f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf10f0..0xcf1109
+            - Range: 0xcf19f0..0xcf1a09
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8608,11 +8608,11 @@ Subprograms:
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1040..0xcf10ef
+            - Range: 0xcf1940..0xcf19ef
               Pieces: []
-            - Range: 0xcf10ef..0xcf10f0
+            - Range: 0xcf19ef..0xcf19f0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcf10f0..0xcf1109
+            - Range: 0xcf19f0..0xcf1a09
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8620,15 +8620,15 @@ Subprograms:
       DictRegister: null
     - ID: 111
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcf1120..0xcf11e7]
+      OutOfLinePCRanges: [0xcf1a20..0xcf1ae7]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1120..0xcf1165
+            - Range: 0xcf1a20..0xcf1a65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf1165..0xcf11e7
+            - Range: 0xcf1a65..0xcf1ae7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8636,11 +8636,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1120..0xcf11cd
+            - Range: 0xcf1a20..0xcf1acd
               Pieces: []
-            - Range: 0xcf11cd..0xcf11ce
+            - Range: 0xcf1acd..0xcf1ace
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf11ce..0xcf11e7
+            - Range: 0xcf1ace..0xcf1ae7
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8648,11 +8648,11 @@ Subprograms:
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1120..0xcf11cd
+            - Range: 0xcf1a20..0xcf1acd
               Pieces: []
-            - Range: 0xcf11cd..0xcf11ce
+            - Range: 0xcf1acd..0xcf1ace
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcf11ce..0xcf11e7
+            - Range: 0xcf1ace..0xcf1ae7
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8660,11 +8660,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1120..0xcf11cd
+            - Range: 0xcf1a20..0xcf1acd
               Pieces: []
-            - Range: 0xcf11cd..0xcf11ce
+            - Range: 0xcf1acd..0xcf1ace
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcf11ce..0xcf11e7
+            - Range: 0xcf1ace..0xcf1ae7
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8672,15 +8672,15 @@ Subprograms:
       DictRegister: null
     - ID: 112
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0xcf1200..0xcf12ef]
+      OutOfLinePCRanges: [0xcf1b00..0xcf1bef]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1200..0xcf1245
+            - Range: 0xcf1b00..0xcf1b45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf1245..0xcf12ef
+            - Range: 0xcf1b45..0xcf1bef
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8688,11 +8688,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1200..0xcf12d1
+            - Range: 0xcf1b00..0xcf1bd1
               Pieces: []
-            - Range: 0xcf12d1..0xcf12d2
+            - Range: 0xcf1bd1..0xcf1bd2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf12d2..0xcf12ef
+            - Range: 0xcf1bd2..0xcf1bef
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8700,15 +8700,15 @@ Subprograms:
         - Name: r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf1200..0xcf12d1
+            - Range: 0xcf1b00..0xcf1bd1
               Pieces: []
-            - Range: 0xcf12d1..0xcf12d2
+            - Range: 0xcf1bd1..0xcf1bd2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf12d2..0xcf12ef
+            - Range: 0xcf1bd2..0xcf1bef
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8716,15 +8716,15 @@ Subprograms:
       DictRegister: null
     - ID: 113
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0xcf1300..0xcf150f]
+      OutOfLinePCRanges: [0xcf1c00..0xcf1e0f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1300..0xcf1386
+            - Range: 0xcf1c00..0xcf1c86
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf1386..0xcf150f
+            - Range: 0xcf1c86..0xcf1e0f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8732,7 +8732,7 @@ Subprograms:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf1337..0xcf150f
+            - Range: 0xcf1c37..0xcf1e0f
               Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
           Role: Return
           DictIndex: -1
@@ -8740,7 +8740,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf133d..0xcf150f
+            - Range: 0xcf1c3d..0xcf1e0f
               Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
           Role: Return
           DictIndex: -1
@@ -8748,17 +8748,17 @@ Subprograms:
       DictRegister: null
     - ID: 114
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xcf1600..0xcf167e]
+      OutOfLinePCRanges: [0xcf1f00..0xcf1f7e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 22 BaseType int8
           Locations:
-            - Range: 0xcf1600..0xcf1671
+            - Range: 0xcf1f00..0xcf1f71
               Pieces: []
-            - Range: 0xcf1671..0xcf1672
+            - Range: 0xcf1f71..0xcf1f72
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf1672..0xcf167e
+            - Range: 0xcf1f72..0xcf1f7e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8766,11 +8766,11 @@ Subprograms:
         - Name: ~r1
           Type: 112 BaseType int16
           Locations:
-            - Range: 0xcf1600..0xcf1671
+            - Range: 0xcf1f00..0xcf1f71
               Pieces: []
-            - Range: 0xcf1671..0xcf1672
+            - Range: 0xcf1f71..0xcf1f72
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcf1672..0xcf167e
+            - Range: 0xcf1f72..0xcf1f7e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8778,11 +8778,11 @@ Subprograms:
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xcf1600..0xcf1671
+            - Range: 0xcf1f00..0xcf1f71
               Pieces: []
-            - Range: 0xcf1671..0xcf1672
+            - Range: 0xcf1f71..0xcf1f72
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcf1672..0xcf167e
+            - Range: 0xcf1f72..0xcf1f7e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8790,11 +8790,11 @@ Subprograms:
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0xcf1600..0xcf1671
+            - Range: 0xcf1f00..0xcf1f71
               Pieces: []
-            - Range: 0xcf1671..0xcf1672
+            - Range: 0xcf1f71..0xcf1f72
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcf1672..0xcf167e
+            - Range: 0xcf1f72..0xcf1f7e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8802,11 +8802,11 @@ Subprograms:
         - Name: ~r4
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0xcf1600..0xcf1671
+            - Range: 0xcf1f00..0xcf1f71
               Pieces: []
-            - Range: 0xcf1671..0xcf1672
+            - Range: 0xcf1f71..0xcf1f72
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcf1672..0xcf167e
+            - Range: 0xcf1f72..0xcf1f7e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8814,11 +8814,11 @@ Subprograms:
         - Name: ~r5
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0xcf1600..0xcf1671
+            - Range: 0xcf1f00..0xcf1f71
               Pieces: []
-            - Range: 0xcf1671..0xcf1672
+            - Range: 0xcf1f71..0xcf1f72
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcf1672..0xcf167e
+            - Range: 0xcf1f72..0xcf1f7e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8826,11 +8826,11 @@ Subprograms:
         - Name: ~r6
           Type: 4 BaseType uint32
           Locations:
-            - Range: 0xcf1600..0xcf1671
+            - Range: 0xcf1f00..0xcf1f71
               Pieces: []
-            - Range: 0xcf1671..0xcf1672
+            - Range: 0xcf1f71..0xcf1f72
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcf1672..0xcf167e
+            - Range: 0xcf1f72..0xcf1f7e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8838,11 +8838,11 @@ Subprograms:
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xcf1600..0xcf1671
+            - Range: 0xcf1f00..0xcf1f71
               Pieces: []
-            - Range: 0xcf1671..0xcf1672
+            - Range: 0xcf1f71..0xcf1f72
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcf1672..0xcf167e
+            - Range: 0xcf1f72..0xcf1f7e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8850,107 +8850,107 @@ Subprograms:
       DictRegister: null
     - ID: 115
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xcf1680..0xcf1777]
+      OutOfLinePCRanges: [0xcf1f80..0xcf2077]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1680..0xcf1777, Pieces: []}]
+          Locations: [{Range: 0xcf1f80..0xcf2077, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1680..0xcf1777, Pieces: []}]
+          Locations: [{Range: 0xcf1f80..0xcf2077, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1680..0xcf1777, Pieces: []}]
+          Locations: [{Range: 0xcf1f80..0xcf2077, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1680..0xcf1777, Pieces: []}]
+          Locations: [{Range: 0xcf1f80..0xcf2077, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1680..0xcf1777, Pieces: []}]
+          Locations: [{Range: 0xcf1f80..0xcf2077, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r5
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1680..0xcf1777, Pieces: []}]
+          Locations: [{Range: 0xcf1f80..0xcf2077, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r6
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1680..0xcf1777, Pieces: []}]
+          Locations: [{Range: 0xcf1f80..0xcf2077, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r7
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1680..0xcf1777, Pieces: []}]
+          Locations: [{Range: 0xcf1f80..0xcf2077, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r8
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1680..0xcf1777, Pieces: []}]
+          Locations: [{Range: 0xcf1f80..0xcf2077, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r9
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1680..0xcf1777, Pieces: []}]
+          Locations: [{Range: 0xcf1f80..0xcf2077, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r10
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1680..0xcf1777, Pieces: []}]
+          Locations: [{Range: 0xcf1f80..0xcf2077, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r11
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1680..0xcf1777, Pieces: []}]
+          Locations: [{Range: 0xcf1f80..0xcf2077, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r12
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1680..0xcf1777, Pieces: []}]
+          Locations: [{Range: 0xcf1f80..0xcf2077, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r13
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1680..0xcf1777, Pieces: []}]
+          Locations: [{Range: 0xcf1f80..0xcf2077, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r14
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1680..0xcf1777, Pieces: []}]
+          Locations: [{Range: 0xcf1f80..0xcf2077, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: onlyOnAmd64_16
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xcf1680..0xcf1767
+            - Range: 0xcf1f80..0xcf2067
               Pieces: []
-            - Range: 0xcf1767..0xcf1768
+            - Range: 0xcf2067..0xcf2068
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcf1768..0xcf1777
+            - Range: 0xcf2068..0xcf2077
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8958,11 +8958,11 @@ Subprograms:
         - Name: bothArmAndAmd64
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xcf1680..0xcf1767
+            - Range: 0xcf1f80..0xcf2067
               Pieces: []
-            - Range: 0xcf1767..0xcf1768
+            - Range: 0xcf2067..0xcf2068
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcf1768..0xcf1777
+            - Range: 0xcf2068..0xcf2077
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8970,35 +8970,35 @@ Subprograms:
       DictRegister: null
     - ID: 116
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xcf1780..0xcf17f3]
+      OutOfLinePCRanges: [0xcf2080..0xcf20f3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 105 BaseType complex64
-          Locations: [{Range: 0xcf1780..0xcf17f3, Pieces: []}]
+          Locations: [{Range: 0xcf2080..0xcf20f3, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 20 BaseType complex128
-          Locations: [{Range: 0xcf1780..0xcf17f3, Pieces: []}]
+          Locations: [{Range: 0xcf2080..0xcf20f3, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 117
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xcf1800..0xcf18b3]
+      OutOfLinePCRanges: [0xcf2100..0xcf21b3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 269 StructureType main.largeStruct
           Locations:
-            - Range: 0xcf1800..0xcf18a3
+            - Range: 0xcf2100..0xcf21a3
               Pieces: []
-            - Range: 0xcf18a3..0xcf18a4
+            - Range: 0xcf21a3..0xcf21a4
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xcf18a4..0xcf18b3
+            - Range: 0xcf21a4..0xcf21b3
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9006,17 +9006,17 @@ Subprograms:
       DictRegister: null
     - ID: 118
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xcf18c0..0xcf193c]
+      OutOfLinePCRanges: [0xcf21c0..0xcf223c]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 270 ArrayType [3]int
           Locations:
-            - Range: 0xcf18c0..0xcf192f
+            - Range: 0xcf21c0..0xcf222f
               Pieces: []
-            - Range: 0xcf192f..0xcf1930
+            - Range: 0xcf222f..0xcf2230
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcf1930..0xcf193c
+            - Range: 0xcf2230..0xcf223c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9024,17 +9024,17 @@ Subprograms:
       DictRegister: null
     - ID: 119
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xcf1940..0xcf1998]
+      OutOfLinePCRanges: [0xcf2240..0xcf2298]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 271 ArrayType [1]int
           Locations:
-            - Range: 0xcf1940..0xcf198b
+            - Range: 0xcf2240..0xcf228b
               Pieces: []
-            - Range: 0xcf198b..0xcf198c
+            - Range: 0xcf228b..0xcf228c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf198c..0xcf1998
+            - Range: 0xcf228c..0xcf2298
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9042,17 +9042,17 @@ Subprograms:
       DictRegister: null
     - ID: 120
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xcf19a0..0xcf19f3]
+      OutOfLinePCRanges: [0xcf22a0..0xcf22f3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 272 ArrayType [0]int
           Locations:
-            - Range: 0xcf19a0..0xcf19e6
+            - Range: 0xcf22a0..0xcf22e6
               Pieces: []
-            - Range: 0xcf19e6..0xcf19e7
+            - Range: 0xcf22e6..0xcf22e7
               Pieces: []
-            - Range: 0xcf19e7..0xcf19f3
+            - Range: 0xcf22e7..0xcf22f3
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9060,29 +9060,29 @@ Subprograms:
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xcf1a00..0xcf1a67]
+      OutOfLinePCRanges: [0xcf2300..0xcf2367]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 273 StructureType main.mixedStruct
-          Locations: [{Range: 0xcf1a00..0xcf1a67, Pieces: []}]
+          Locations: [{Range: 0xcf2300..0xcf2367, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 122
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xcf1a80..0xcf1b1a]
+      OutOfLinePCRanges: [0xcf2380..0xcf241a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1a80..0xcf1b0a
+            - Range: 0xcf2380..0xcf240a
               Pieces: []
-            - Range: 0xcf1b0a..0xcf1b0b
+            - Range: 0xcf240a..0xcf240b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf1b0b..0xcf1b1a
+            - Range: 0xcf240b..0xcf241a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9090,11 +9090,11 @@ Subprograms:
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1a80..0xcf1b0a
+            - Range: 0xcf2380..0xcf240a
               Pieces: []
-            - Range: 0xcf1b0a..0xcf1b0b
+            - Range: 0xcf240a..0xcf240b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcf1b0b..0xcf1b1a
+            - Range: 0xcf240b..0xcf241a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9102,11 +9102,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1a80..0xcf1b0a
+            - Range: 0xcf2380..0xcf240a
               Pieces: []
-            - Range: 0xcf1b0a..0xcf1b0b
+            - Range: 0xcf240a..0xcf240b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcf1b0b..0xcf1b1a
+            - Range: 0xcf240b..0xcf241a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9114,11 +9114,11 @@ Subprograms:
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1a80..0xcf1b0a
+            - Range: 0xcf2380..0xcf240a
               Pieces: []
-            - Range: 0xcf1b0a..0xcf1b0b
+            - Range: 0xcf240a..0xcf240b
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcf1b0b..0xcf1b1a
+            - Range: 0xcf240b..0xcf241a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9126,11 +9126,11 @@ Subprograms:
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1a80..0xcf1b0a
+            - Range: 0xcf2380..0xcf240a
               Pieces: []
-            - Range: 0xcf1b0a..0xcf1b0b
+            - Range: 0xcf240a..0xcf240b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcf1b0b..0xcf1b1a
+            - Range: 0xcf240b..0xcf241a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9138,11 +9138,11 @@ Subprograms:
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1a80..0xcf1b0a
+            - Range: 0xcf2380..0xcf240a
               Pieces: []
-            - Range: 0xcf1b0a..0xcf1b0b
+            - Range: 0xcf240a..0xcf240b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcf1b0b..0xcf1b1a
+            - Range: 0xcf240b..0xcf241a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9150,11 +9150,11 @@ Subprograms:
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1a80..0xcf1b0a
+            - Range: 0xcf2380..0xcf240a
               Pieces: []
-            - Range: 0xcf1b0a..0xcf1b0b
+            - Range: 0xcf240a..0xcf240b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcf1b0b..0xcf1b1a
+            - Range: 0xcf240b..0xcf241a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9162,11 +9162,11 @@ Subprograms:
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1a80..0xcf1b0a
+            - Range: 0xcf2380..0xcf240a
               Pieces: []
-            - Range: 0xcf1b0a..0xcf1b0b
+            - Range: 0xcf240a..0xcf240b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcf1b0b..0xcf1b1a
+            - Range: 0xcf240b..0xcf241a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9174,11 +9174,11 @@ Subprograms:
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf1a80..0xcf1b0a
+            - Range: 0xcf2380..0xcf240a
               Pieces: []
-            - Range: 0xcf1b0a..0xcf1b0b
+            - Range: 0xcf240a..0xcf240b
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcf1b0b..0xcf1b1a
+            - Range: 0xcf240b..0xcf241a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9186,17 +9186,17 @@ Subprograms:
       DictRegister: null
     - ID: 123
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xcf1b20..0xcf1be5]
+      OutOfLinePCRanges: [0xcf2420..0xcf24e5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 274 StructureType main.wideStruct
           Locations:
-            - Range: 0xcf1b20..0xcf1bd2
+            - Range: 0xcf2420..0xcf24d2
               Pieces: []
-            - Range: 0xcf1bd2..0xcf1bd3
+            - Range: 0xcf24d2..0xcf24d3
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xcf1bd3..0xcf1be5
+            - Range: 0xcf24d3..0xcf24e5
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9204,57 +9204,57 @@ Subprograms:
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xcf1c00..0xcf1c79]
+      OutOfLinePCRanges: [0xcf2500..0xcf2579]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1c00..0xcf1c6c
+            - Range: 0xcf2500..0xcf256c
               Pieces: []
-            - Range: 0xcf1c6c..0xcf1c6d
+            - Range: 0xcf256c..0xcf256d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf1c6d..0xcf1c79
+            - Range: 0xcf256d..0xcf2579
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1c00..0xcf1c79, Pieces: []}]
+          Locations: [{Range: 0xcf2500..0xcf2579, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf1c00..0xcf1c6c
+            - Range: 0xcf2500..0xcf256c
               Pieces: []
-            - Range: 0xcf1c6c..0xcf1c6d
+            - Range: 0xcf256c..0xcf256d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcf1c6d..0xcf1c79
+            - Range: 0xcf256d..0xcf2579
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1c00..0xcf1c79, Pieces: []}]
+          Locations: [{Range: 0xcf2500..0xcf2579, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf1c00..0xcf1c6c
+            - Range: 0xcf2500..0xcf256c
               Pieces: []
-            - Range: 0xcf1c6c..0xcf1c6d
+            - Range: 0xcf256c..0xcf256d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf1c6d..0xcf1c79
+            - Range: 0xcf256d..0xcf2579
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9262,17 +9262,17 @@ Subprograms:
       DictRegister: null
     - ID: 125
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xcf1c80..0xcf1cfc]
+      OutOfLinePCRanges: [0xcf2580..0xcf25fc]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 275 StructureType main.structWithArray
           Locations:
-            - Range: 0xcf1c80..0xcf1cef
+            - Range: 0xcf2580..0xcf25ef
               Pieces: []
-            - Range: 0xcf1cef..0xcf1cf0
+            - Range: 0xcf25ef..0xcf25f0
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcf1cf0..0xcf1cfc
+            - Range: 0xcf25f0..0xcf25fc
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9280,47 +9280,47 @@ Subprograms:
       DictRegister: null
     - ID: 126
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xcf1d00..0xcf1d5b]
+      OutOfLinePCRanges: [0xcf2600..0xcf265b]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1d00..0xcf1d5b, Pieces: []}]
+          Locations: [{Range: 0xcf2600..0xcf265b, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 127
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xcf1d60..0xcf1dc7]
+      OutOfLinePCRanges: [0xcf2660..0xcf26c7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float32
-          Locations: [{Range: 0xcf1d60..0xcf1dc7, Pieces: []}]
+          Locations: [{Range: 0xcf2660..0xcf26c7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcf1d60..0xcf1dc7, Pieces: []}]
+          Locations: [{Range: 0xcf2660..0xcf26c7, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 128
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xcf1de0..0xcf1e3d]
+      OutOfLinePCRanges: [0xcf26e0..0xcf273d]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcf1de0..0xcf1e30
+            - Range: 0xcf26e0..0xcf2730
               Pieces: []
-            - Range: 0xcf1e30..0xcf1e31
+            - Range: 0xcf2730..0xcf2731
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf1e31..0xcf1e3d
+            - Range: 0xcf2731..0xcf273d
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9328,11 +9328,11 @@ Subprograms:
         - Name: ~r1
           Type: 3 BaseType uintptr
           Locations:
-            - Range: 0xcf1de0..0xcf1e30
+            - Range: 0xcf26e0..0xcf2730
               Pieces: []
-            - Range: 0xcf1e30..0xcf1e31
+            - Range: 0xcf2730..0xcf2731
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcf1e31..0xcf1e3d
+            - Range: 0xcf2731..0xcf273d
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9340,13 +9340,13 @@ Subprograms:
       DictRegister: null
     - ID: 129
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xcf1e40..0xcf1fbd]
+      OutOfLinePCRanges: [0xcf2740..0xcf28bd]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 269 StructureType main.largeStruct
           Locations:
-            - Range: 0xcf1e40..0xcf1fbd
+            - Range: 0xcf2740..0xcf28bd
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9354,11 +9354,11 @@ Subprograms:
         - Name: ~r0
           Type: 269 StructureType main.largeStruct
           Locations:
-            - Range: 0xcf1e40..0xcf1fad
+            - Range: 0xcf2740..0xcf28ad
               Pieces: []
-            - Range: 0xcf1fad..0xcf1fae
+            - Range: 0xcf28ad..0xcf28ae
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xcf1fae..0xcf1fbd
+            - Range: 0xcf28ae..0xcf28bd
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9366,13 +9366,13 @@ Subprograms:
       DictRegister: null
     - ID: 130
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xcf1fc0..0xcf209a]
+      OutOfLinePCRanges: [0xcf28c0..0xcf299a]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 270 ArrayType [3]int
           Locations:
-            - Range: 0xcf1fc0..0xcf209a
+            - Range: 0xcf28c0..0xcf299a
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9380,11 +9380,11 @@ Subprograms:
         - Name: ~r0
           Type: 270 ArrayType [3]int
           Locations:
-            - Range: 0xcf1fc0..0xcf208a
+            - Range: 0xcf28c0..0xcf298a
               Pieces: []
-            - Range: 0xcf208a..0xcf208b
+            - Range: 0xcf298a..0xcf298b
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcf208b..0xcf209a
+            - Range: 0xcf298b..0xcf299a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9392,13 +9392,13 @@ Subprograms:
       DictRegister: null
     - ID: 131
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xcf20a0..0xcf22db]
+      OutOfLinePCRanges: [0xcf29a0..0xcf2bdb]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 269 StructureType main.largeStruct
           Locations:
-            - Range: 0xcf20a0..0xcf22db
+            - Range: 0xcf29a0..0xcf2bdb
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9406,7 +9406,7 @@ Subprograms:
         - Name: s2
           Type: 269 StructureType main.largeStruct
           Locations:
-            - Range: 0xcf20a0..0xcf22db
+            - Range: 0xcf29a0..0xcf2bdb
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
@@ -9414,11 +9414,11 @@ Subprograms:
         - Name: ~r0
           Type: 269 StructureType main.largeStruct
           Locations:
-            - Range: 0xcf20a0..0xcf22cb
+            - Range: 0xcf29a0..0xcf2bcb
               Pieces: []
-            - Range: 0xcf22cb..0xcf22cc
+            - Range: 0xcf2bcb..0xcf2bcc
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xcf22cc..0xcf22db
+            - Range: 0xcf2bcc..0xcf2bdb
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9426,15 +9426,15 @@ Subprograms:
       DictRegister: null
     - ID: 132
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xcf22e0..0xcf258f]
+      OutOfLinePCRanges: [0xcf2be0..0xcf2e8f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf22e0..0xcf23a7
+            - Range: 0xcf2be0..0xcf2ca7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf23a7..0xcf258f
+            - Range: 0xcf2ca7..0xcf2e8f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -9442,9 +9442,9 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf22e0..0xcf23a7
+            - Range: 0xcf2be0..0xcf2ca7
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcf23a7..0xcf258f
+            - Range: 0xcf2ca7..0xcf2e8f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -9452,9 +9452,9 @@ Subprograms:
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf22e0..0xcf234a
+            - Range: 0xcf2be0..0xcf2c4a
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcf234a..0xcf258f
+            - Range: 0xcf2c4a..0xcf2e8f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
@@ -9462,9 +9462,9 @@ Subprograms:
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf22e0..0xcf23a7
+            - Range: 0xcf2be0..0xcf2ca7
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcf23a7..0xcf258f
+            - Range: 0xcf2ca7..0xcf2e8f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
@@ -9472,9 +9472,9 @@ Subprograms:
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf22e0..0xcf23a7
+            - Range: 0xcf2be0..0xcf2ca7
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcf23a7..0xcf258f
+            - Range: 0xcf2ca7..0xcf2e8f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
@@ -9482,9 +9482,9 @@ Subprograms:
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf22e0..0xcf23a7
+            - Range: 0xcf2be0..0xcf2ca7
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcf23a7..0xcf258f
+            - Range: 0xcf2ca7..0xcf2e8f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
@@ -9492,9 +9492,9 @@ Subprograms:
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf22e0..0xcf23a7
+            - Range: 0xcf2be0..0xcf2ca7
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcf23a7..0xcf258f
+            - Range: 0xcf2ca7..0xcf2e8f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
@@ -9502,9 +9502,9 @@ Subprograms:
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf22e0..0xcf23a7
+            - Range: 0xcf2be0..0xcf2ca7
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcf23a7..0xcf258f
+            - Range: 0xcf2ca7..0xcf2e8f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
@@ -9512,9 +9512,9 @@ Subprograms:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf22e0..0xcf23a7
+            - Range: 0xcf2be0..0xcf2ca7
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xcf23a7..0xcf258f
+            - Range: 0xcf2ca7..0xcf2e8f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
@@ -9522,11 +9522,11 @@ Subprograms:
         - Name: ~r0
           Type: 122 ArrayType [2]int
           Locations:
-            - Range: 0xcf22e0..0xcf2522
+            - Range: 0xcf2be0..0xcf2e22
               Pieces: []
-            - Range: 0xcf2522..0xcf2523
+            - Range: 0xcf2e22..0xcf2e23
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcf2523..0xcf258f
+            - Range: 0xcf2e23..0xcf2e8f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9534,15 +9534,15 @@ Subprograms:
       DictRegister: null
     - ID: 133
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xcf25a0..0xcf2865]
+      OutOfLinePCRanges: [0xcf2ea0..0xcf3165]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf25a0..0xcf264a
+            - Range: 0xcf2ea0..0xcf2f4a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf264a..0xcf2865
+            - Range: 0xcf2f4a..0xcf3165
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
@@ -9550,9 +9550,9 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf25a0..0xcf264a
+            - Range: 0xcf2ea0..0xcf2f4a
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcf264a..0xcf2865
+            - Range: 0xcf2f4a..0xcf3165
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
@@ -9560,9 +9560,9 @@ Subprograms:
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf25a0..0xcf2602
+            - Range: 0xcf2ea0..0xcf2f02
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcf2602..0xcf2865
+            - Range: 0xcf2f02..0xcf3165
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
@@ -9570,9 +9570,9 @@ Subprograms:
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf25a0..0xcf264a
+            - Range: 0xcf2ea0..0xcf2f4a
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcf264a..0xcf2865
+            - Range: 0xcf2f4a..0xcf3165
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
@@ -9580,9 +9580,9 @@ Subprograms:
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf25a0..0xcf264a
+            - Range: 0xcf2ea0..0xcf2f4a
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcf264a..0xcf2865
+            - Range: 0xcf2f4a..0xcf3165
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
@@ -9590,9 +9590,9 @@ Subprograms:
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf25a0..0xcf264a
+            - Range: 0xcf2ea0..0xcf2f4a
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcf264a..0xcf2865
+            - Range: 0xcf2f4a..0xcf3165
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
@@ -9600,9 +9600,9 @@ Subprograms:
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf25a0..0xcf264a
+            - Range: 0xcf2ea0..0xcf2f4a
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcf264a..0xcf2865
+            - Range: 0xcf2f4a..0xcf3165
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
@@ -9610,9 +9610,9 @@ Subprograms:
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf25a0..0xcf264a
+            - Range: 0xcf2ea0..0xcf2f4a
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcf264a..0xcf2865
+            - Range: 0xcf2f4a..0xcf3165
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
@@ -9620,7 +9620,7 @@ Subprograms:
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf25a0..0xcf2865
+            - Range: 0xcf2ea0..0xcf3165
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -9632,11 +9632,11 @@ Subprograms:
         - Name: ~r0
           Type: 269 StructureType main.largeStruct
           Locations:
-            - Range: 0xcf25a0..0xcf27e2
+            - Range: 0xcf2ea0..0xcf30e2
               Pieces: []
-            - Range: 0xcf27e2..0xcf27e3
+            - Range: 0xcf30e2..0xcf30e3
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xcf27e3..0xcf2865
+            - Range: 0xcf30e3..0xcf3165
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9644,13 +9644,13 @@ Subprograms:
       DictRegister: null
     - ID: 134
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xcf2880..0xcf290e]
+      OutOfLinePCRanges: [0xcf3180..0xcf320e]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 176 ArrayType [5]int
           Locations:
-            - Range: 0xcf2880..0xcf290e
+            - Range: 0xcf3180..0xcf320e
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9658,11 +9658,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf2880..0xcf28fe
+            - Range: 0xcf3180..0xcf31fe
               Pieces: []
-            - Range: 0xcf28fe..0xcf28ff
+            - Range: 0xcf31fe..0xcf31ff
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf28ff..0xcf290e
+            - Range: 0xcf31ff..0xcf320e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9670,11 +9670,11 @@ Subprograms:
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf2880..0xcf28fe
+            - Range: 0xcf3180..0xcf31fe
               Pieces: []
-            - Range: 0xcf28fe..0xcf28ff
+            - Range: 0xcf31fe..0xcf31ff
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcf28ff..0xcf290e
+            - Range: 0xcf31ff..0xcf320e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9682,11 +9682,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf2880..0xcf28fe
+            - Range: 0xcf3180..0xcf31fe
               Pieces: []
-            - Range: 0xcf28fe..0xcf28ff
+            - Range: 0xcf31fe..0xcf31ff
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcf28ff..0xcf290e
+            - Range: 0xcf31ff..0xcf320e
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9694,13 +9694,13 @@ Subprograms:
       DictRegister: null
     - ID: 135
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xcf2920..0xcf2a0d]
+      OutOfLinePCRanges: [0xcf3220..0xcf330d]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 122 ArrayType [2]int
           Locations:
-            - Range: 0xcf2920..0xcf2a0d
+            - Range: 0xcf3220..0xcf330d
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9708,7 +9708,7 @@ Subprograms:
         - Name: b
           Type: 270 ArrayType [3]int
           Locations:
-            - Range: 0xcf2920..0xcf2a0d
+            - Range: 0xcf3220..0xcf330d
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -9716,11 +9716,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf2920..0xcf29fd
+            - Range: 0xcf3220..0xcf32fd
               Pieces: []
-            - Range: 0xcf29fd..0xcf29fe
+            - Range: 0xcf32fd..0xcf32fe
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf29fe..0xcf2a0d
+            - Range: 0xcf32fe..0xcf330d
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9728,11 +9728,11 @@ Subprograms:
         - Name: ~r1
           Type: 122 ArrayType [2]int
           Locations:
-            - Range: 0xcf2920..0xcf29fd
+            - Range: 0xcf3220..0xcf32fd
               Pieces: []
-            - Range: 0xcf29fd..0xcf29fe
+            - Range: 0xcf32fd..0xcf32fe
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xcf29fe..0xcf2a0d
+            - Range: 0xcf32fe..0xcf330d
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9740,13 +9740,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xcf2a20..0xcf2af4]
+      OutOfLinePCRanges: [0xcf3320..0xcf33f4]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 275 StructureType main.structWithArray
           Locations:
-            - Range: 0xcf2a20..0xcf2af4
+            - Range: 0xcf3320..0xcf33f4
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9754,11 +9754,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf2a20..0xcf2ae4
+            - Range: 0xcf3320..0xcf33e4
               Pieces: []
-            - Range: 0xcf2ae4..0xcf2ae5
+            - Range: 0xcf33e4..0xcf33e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf2ae5..0xcf2af4
+            - Range: 0xcf33e5..0xcf33f4
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9766,11 +9766,11 @@ Subprograms:
         - Name: ~r1
           Type: 275 StructureType main.structWithArray
           Locations:
-            - Range: 0xcf2a20..0xcf2ae4
+            - Range: 0xcf3320..0xcf33e4
               Pieces: []
-            - Range: 0xcf2ae4..0xcf2ae5
+            - Range: 0xcf33e4..0xcf33e5
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcf2ae5..0xcf2af4
+            - Range: 0xcf33e5..0xcf33f4
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9778,7 +9778,7 @@ Subprograms:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf2aae..0xcf2af4
+            - Range: 0xcf33ae..0xcf33f4
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -9786,25 +9786,25 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xcf2b00..0xcf2ba6]
+      OutOfLinePCRanges: [0xcf3400..0xcf34a6]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 ArrayType [0]int
-          Locations: [{Range: 0xcf2b00..0xcf2ba6, Pieces: []}]
+          Locations: [{Range: 0xcf3400..0xcf34a6, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf2b00..0xcf2b45
+            - Range: 0xcf3400..0xcf3445
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf2b45..0xcf2b67
+            - Range: 0xcf3445..0xcf3467
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcf2b67..0xcf2b7a
+            - Range: 0xcf3467..0xcf347a
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcf2b7a..0xcf2ba6
+            - Range: 0xcf347a..0xcf34a6
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
@@ -9812,11 +9812,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf2b00..0xcf2b8c
+            - Range: 0xcf3400..0xcf348c
               Pieces: []
-            - Range: 0xcf2b8c..0xcf2b8d
+            - Range: 0xcf348c..0xcf348d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf2b8d..0xcf2ba6
+            - Range: 0xcf348d..0xcf34a6
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9824,11 +9824,11 @@ Subprograms:
         - Name: ~r1
           Type: 272 ArrayType [0]int
           Locations:
-            - Range: 0xcf2b00..0xcf2b8c
+            - Range: 0xcf3400..0xcf348c
               Pieces: []
-            - Range: 0xcf2b8c..0xcf2b8d
+            - Range: 0xcf348c..0xcf348d
               Pieces: []
-            - Range: 0xcf2b8d..0xcf2ba6
+            - Range: 0xcf348d..0xcf34a6
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9836,13 +9836,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcf3100..0xcf3101]
+      OutOfLinePCRanges: [0xcf3a00..0xcf3a01]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 276 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcf3100..0xcf3101
+            - Range: 0xcf3a00..0xcf3a01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9856,13 +9856,13 @@ Subprograms:
       DictRegister: null
     - ID: 139
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcf3120..0xcf3121]
+      OutOfLinePCRanges: [0xcf3a20..0xcf3a21]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 276 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcf3120..0xcf3121
+            - Range: 0xcf3a20..0xcf3a21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9876,13 +9876,13 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcf3140..0xcf3141]
+      OutOfLinePCRanges: [0xcf3a40..0xcf3a41]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 277 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xcf3140..0xcf3141
+            - Range: 0xcf3a40..0xcf3a41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9896,13 +9896,13 @@ Subprograms:
       DictRegister: null
     - ID: 141
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcf3160..0xcf3161]
+      OutOfLinePCRanges: [0xcf3a60..0xcf3a61]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 279 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcf3160..0xcf3161
+            - Range: 0xcf3a60..0xcf3a61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9916,7 +9916,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf3160..0xcf3161
+            - Range: 0xcf3a60..0xcf3a61
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9924,13 +9924,13 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcf3180..0xcf3181]
+      OutOfLinePCRanges: [0xcf3a80..0xcf3a81]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 279 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcf3180..0xcf3181
+            - Range: 0xcf3a80..0xcf3a81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9944,7 +9944,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf3180..0xcf3181
+            - Range: 0xcf3a80..0xcf3a81
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9952,13 +9952,13 @@ Subprograms:
       DictRegister: null
     - ID: 143
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcf31a0..0xcf31a1]
+      OutOfLinePCRanges: [0xcf3aa0..0xcf3aa1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 279 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcf31a0..0xcf31a1
+            - Range: 0xcf3aa0..0xcf3aa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9972,7 +9972,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcf31a0..0xcf31a1
+            - Range: 0xcf3aa0..0xcf3aa1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -9980,13 +9980,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcf31c0..0xcf31c1]
+      OutOfLinePCRanges: [0xcf3ac0..0xcf3ac1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 170 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcf31c0..0xcf31c1
+            - Range: 0xcf3ac0..0xcf3ac1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10000,13 +10000,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcf31e0..0xcf31e1]
+      OutOfLinePCRanges: [0xcf3ae0..0xcf3ae1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 22 BaseType int8
           Locations:
-            - Range: 0xcf31e0..0xcf31e1
+            - Range: 0xcf3ae0..0xcf3ae1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10014,7 +10014,7 @@ Subprograms:
         - Name: s
           Type: 282 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcf31e0..0xcf31e1
+            - Range: 0xcf3ae0..0xcf3ae1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10028,7 +10028,7 @@ Subprograms:
         - Name: x
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcf31e0..0xcf31e1
+            - Range: 0xcf3ae0..0xcf3ae1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10036,13 +10036,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcf3200..0xcf3201]
+      OutOfLinePCRanges: [0xcf3b00..0xcf3b01]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 283 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcf3200..0xcf3201
+            - Range: 0xcf3b00..0xcf3b01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10056,13 +10056,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcf3220..0xcf3221]
+      OutOfLinePCRanges: [0xcf3b20..0xcf3b21]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 276 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcf3220..0xcf3221
+            - Range: 0xcf3b20..0xcf3b21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10076,13 +10076,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xcf3240..0xcf3241]
+      OutOfLinePCRanges: [0xcf3b40..0xcf3b41]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 284 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0xcf3240..0xcf3241
+            - Range: 0xcf3b40..0xcf3b41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10096,13 +10096,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xcf3260..0xcf3261]
+      OutOfLinePCRanges: [0xcf3b60..0xcf3b61]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 276 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcf3260..0xcf3261
+            - Range: 0xcf3b60..0xcf3b61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10116,7 +10116,7 @@ Subprograms:
         - Name: bs
           Type: 276 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcf3260..0xcf3261
+            - Range: 0xcf3b60..0xcf3b61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10130,7 +10130,7 @@ Subprograms:
         - Name: cs
           Type: 276 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcf3260..0xcf3261
+            - Range: 0xcf3b60..0xcf3b61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -10144,13 +10144,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testByteSliceInvalidUtf8
-      OutOfLinePCRanges: [0xcf32e0..0xcf32e1]
+      OutOfLinePCRanges: [0xcf3be0..0xcf3be1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 41 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0xcf32e0..0xcf32e1
+            - Range: 0xcf3be0..0xcf3be1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10164,13 +10164,13 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testByteSliceMultibyteUtf8
-      OutOfLinePCRanges: [0xcf3300..0xcf3301]
+      OutOfLinePCRanges: [0xcf3c00..0xcf3c01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 41 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0xcf3300..0xcf3301
+            - Range: 0xcf3c00..0xcf3c01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10184,21 +10184,21 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.stackC
-      OutOfLinePCRanges: [0xcf39c0..0xcf3a12]
+      OutOfLinePCRanges: [0xcf43a0..0xcf43f2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf39c0..0xcf3a05
+            - Range: 0xcf43a0..0xcf43e5
               Pieces: []
-            - Range: 0xcf3a05..0xcf3a06
+            - Range: 0xcf43e5..0xcf43e6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf3a06..0xcf3a12
+            - Range: 0xcf43e6..0xcf43f2
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10206,13 +10206,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcf3a20..0xcf3a21]
+      OutOfLinePCRanges: [0xcf4500..0xcf4501]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3a20..0xcf3a21
+            - Range: 0xcf4500..0xcf4501
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10224,13 +10224,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcf3a40..0xcf3a41]
+      OutOfLinePCRanges: [0xcf4520..0xcf4521]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3a40..0xcf3a41
+            - Range: 0xcf4520..0xcf4521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10242,7 +10242,7 @@ Subprograms:
         - Name: "y"
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3a40..0xcf3a41
+            - Range: 0xcf4520..0xcf4521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10254,7 +10254,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3a40..0xcf3a41
+            - Range: 0xcf4520..0xcf4521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10266,13 +10266,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcf3a60..0xcf3a61]
+      OutOfLinePCRanges: [0xcf4540..0xcf4541]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 286 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcf3a60..0xcf3a61
+            - Range: 0xcf4540..0xcf4541
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10292,13 +10292,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcf3a80..0xcf3a81]
+      OutOfLinePCRanges: [0xcf4560..0xcf4561]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 287 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcf3a80..0xcf3a81
+            - Range: 0xcf4560..0xcf4561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10306,13 +10306,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcf3aa0..0xcf3aa1]
+      OutOfLinePCRanges: [0xcf4580..0xcf4581]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 288 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcf3aa0..0xcf3aa1
+            - Range: 0xcf4580..0xcf4581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10320,13 +10320,13 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcf3ac0..0xcf3ac1]
+      OutOfLinePCRanges: [0xcf45a0..0xcf45a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3ac0..0xcf3ac1
+            - Range: 0xcf45a0..0xcf45a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10338,13 +10338,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcf3ae0..0xcf3ae1]
+      OutOfLinePCRanges: [0xcf45c0..0xcf45c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3ae0..0xcf3ae1
+            - Range: 0xcf45c0..0xcf45c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10356,13 +10356,13 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcf3b00..0xcf3b01]
+      OutOfLinePCRanges: [0xcf45e0..0xcf45e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3b00..0xcf3b01
+            - Range: 0xcf45e0..0xcf45e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10374,13 +10374,13 @@ Subprograms:
       DictRegister: null
     - ID: 161
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xcf3b20..0xcf3b21]
+      OutOfLinePCRanges: [0xcf4600..0xcf4601]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3b20..0xcf3b21
+            - Range: 0xcf4600..0xcf4601
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10392,7 +10392,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3b20..0xcf3b21
+            - Range: 0xcf4600..0xcf4601
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10404,7 +10404,7 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3b20..0xcf3b21
+            - Range: 0xcf4600..0xcf4601
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10416,13 +10416,13 @@ Subprograms:
       DictRegister: null
     - ID: 162
       Name: main.testInvalidUtf8Strings
-      OutOfLinePCRanges: [0xcf3b40..0xcf3b41]
+      OutOfLinePCRanges: [0xcf4620..0xcf4621]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3b40..0xcf3b41
+            - Range: 0xcf4620..0xcf4621
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10434,7 +10434,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3b40..0xcf3b41
+            - Range: 0xcf4620..0xcf4621
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10446,13 +10446,13 @@ Subprograms:
       DictRegister: null
     - ID: 163
       Name: main.testMultibyteUtf8String
-      OutOfLinePCRanges: [0xcf3b60..0xcf3b61]
+      OutOfLinePCRanges: [0xcf4640..0xcf4641]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf3b60..0xcf3b61
+            - Range: 0xcf4640..0xcf4641
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10464,13 +10464,13 @@ Subprograms:
       DictRegister: null
     - ID: 164
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcf3d20..0xcf3d21]
+      OutOfLinePCRanges: [0xcf48e0..0xcf48e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 290 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcf3d20..0xcf3d21
+            - Range: 0xcf48e0..0xcf48e1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10478,13 +10478,13 @@ Subprograms:
       DictRegister: null
     - ID: 165
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcf3d40..0xcf3d41]
+      OutOfLinePCRanges: [0xcf4900..0xcf4901]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 303 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcf3d40..0xcf3d41
+            - Range: 0xcf4900..0xcf4901
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10504,13 +10504,13 @@ Subprograms:
       DictRegister: null
     - ID: 166
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcf3e80..0xcf3e81]
+      OutOfLinePCRanges: [0xcf4a40..0xcf4a41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 StructureType main.aStruct
           Locations:
-            - Range: 0xcf3e80..0xcf3e81
+            - Range: 0xcf4a40..0xcf4a41
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10532,13 +10532,13 @@ Subprograms:
       DictRegister: null
     - ID: 167
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xcf3f40..0xcf3f41]
+      OutOfLinePCRanges: [0xcf4b00..0xcf4b01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xcf3f40..0xcf3f41
+            - Range: 0xcf4b00..0xcf4b01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10546,13 +10546,13 @@ Subprograms:
       DictRegister: null
     - ID: 168
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xcf3f60..0xcf3f61]
+      OutOfLinePCRanges: [0xcf4b20..0xcf4b21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 337 StructureType main.tenStrings
           Locations:
-            - Range: 0xcf3f60..0xcf3f61
+            - Range: 0xcf4b20..0xcf4b21
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10560,25 +10560,25 @@ Subprograms:
       DictRegister: null
     - ID: 169
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcf3fc0..0xcf3fc1]
+      OutOfLinePCRanges: [0xcf4b80..0xcf4b81]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 338 StructureType main.emptyStruct
-          Locations: [{Range: 0xcf3fc0..0xcf3fc1, Pieces: []}]
+          Locations: [{Range: 0xcf4b80..0xcf4b81, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 170
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcf3fe0..0xcf3fe1]
+      OutOfLinePCRanges: [0xcf4ba0..0xcf4ba1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 339 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xcf3fe0..0xcf3fe1
+            - Range: 0xcf4ba0..0xcf4ba1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10586,13 +10586,13 @@ Subprograms:
       DictRegister: null
     - ID: 171
       Name: main.testTimeUTC
-      OutOfLinePCRanges: [0xcf50c0..0xcf50c1]
+      OutOfLinePCRanges: [0xcf5d60..0xcf5d61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 GoTimeType time.Time
           Locations:
-            - Range: 0xcf50c0..0xcf50c1
+            - Range: 0xcf5d60..0xcf5d61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10606,13 +10606,13 @@ Subprograms:
       DictRegister: null
     - ID: 172
       Name: main.testTimeFixedZone
-      OutOfLinePCRanges: [0xcf50e0..0xcf50e1]
+      OutOfLinePCRanges: [0xcf5d80..0xcf5d81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 GoTimeType time.Time
           Locations:
-            - Range: 0xcf50e0..0xcf50e1
+            - Range: 0xcf5d80..0xcf5d81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10626,13 +10626,13 @@ Subprograms:
       DictRegister: null
     - ID: 173
       Name: main.testTimeMonotonic
-      OutOfLinePCRanges: [0xcf5100..0xcf5101]
+      OutOfLinePCRanges: [0xcf5da0..0xcf5da1]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 343 StructureType main.timeCapture
           Locations:
-            - Range: 0xcf5100..0xcf5101
+            - Range: 0xcf5da0..0xcf5da1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10646,13 +10646,13 @@ Subprograms:
       DictRegister: null
     - ID: 174
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xcf60c0..0xcf60c4]
+      OutOfLinePCRanges: [0xcf6e60..0xcf6e64]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0xcf60c0..0xcf60c4
+            - Range: 0xcf6e60..0xcf6e64
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10660,9 +10660,9 @@ Subprograms:
         - Name: ~r0
           Type: 345 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf60c0..0xcf60c3
+            - Range: 0xcf6e60..0xcf6e63
               Pieces: []
-            - Range: 0xcf60c3..0xcf60c4
+            - Range: 0xcf6e63..0xcf6e64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -10670,19 +10670,19 @@ Subprograms:
       DictRegister: 0
     - ID: 175
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xcf60e0..0xcf60ec]
+      OutOfLinePCRanges: [0xcf6e80..0xcf6e8c]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf60e0..0xcf60eb
+            - Range: 0xcf6e80..0xcf6e8b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf60eb..0xcf60ec
+            - Range: 0xcf6e8b..0xcf6e8c
               Pieces:
                 - Size: 8
                   Op: null
@@ -10694,9 +10694,9 @@ Subprograms:
         - Name: ~r0
           Type: 347 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xcf60e0..0xcf60eb
+            - Range: 0xcf6e80..0xcf6e8b
               Pieces: []
-            - Range: 0xcf60eb..0xcf60ec
+            - Range: 0xcf6e8b..0xcf6e8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10708,13 +10708,13 @@ Subprograms:
       DictRegister: 0
     - ID: 176
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xcf6100..0xcf6104]
+      OutOfLinePCRanges: [0xcf6ea0..0xcf6ea4]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 345 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf6100..0xcf6104
+            - Range: 0xcf6ea0..0xcf6ea4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10722,9 +10722,9 @@ Subprograms:
         - Name: ~r0
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0xcf6100..0xcf6103
+            - Range: 0xcf6ea0..0xcf6ea3
               Pieces: []
-            - Range: 0xcf6103..0xcf6104
+            - Range: 0xcf6ea3..0xcf6ea4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -10732,19 +10732,19 @@ Subprograms:
       DictRegister: 0
     - ID: 177
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xcf6120..0xcf612c]
+      OutOfLinePCRanges: [0xcf6ec0..0xcf6ecc]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 347 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xcf6120..0xcf612b
+            - Range: 0xcf6ec0..0xcf6ecb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf612b..0xcf612c
+            - Range: 0xcf6ecb..0xcf6ecc
               Pieces:
                 - Size: 8
                   Op: null
@@ -10756,9 +10756,9 @@ Subprograms:
         - Name: ~r0
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf6120..0xcf612b
+            - Range: 0xcf6ec0..0xcf6ecb
               Pieces: []
-            - Range: 0xcf612b..0xcf612c
+            - Range: 0xcf6ecb..0xcf6ecc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10770,13 +10770,13 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xcf61a0..0xcf6385]
+      OutOfLinePCRanges: [0xcf6f40..0xcf7125]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 348 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf61a0..0xcf61de
+            - Range: 0xcf6f40..0xcf6f7e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10784,7 +10784,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf61de..0xcf61e9
+            - Range: 0xcf6f7e..0xcf6f89
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10792,7 +10792,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xcf61e9..0xcf6385
+            - Range: 0xcf6f89..0xcf7125
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -10806,9 +10806,9 @@ Subprograms:
         - Name: pred
           Type: 350 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xcf61a0..0xcf61e9
+            - Range: 0xcf6f40..0xcf6f89
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcf61e9..0xcf6385
+            - Range: 0xcf6f89..0xcf7125
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
@@ -10816,9 +10816,9 @@ Subprograms:
         - Name: ~r0
           Type: 348 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf61a0..0xcf633a
+            - Range: 0xcf6f40..0xcf70da
               Pieces: []
-            - Range: 0xcf633a..0xcf633b
+            - Range: 0xcf70da..0xcf70db
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10826,7 +10826,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf633b..0xcf6385
+            - Range: 0xcf70db..0xcf7125
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -10834,7 +10834,7 @@ Subprograms:
         - Name: result
           Type: 348 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf61e9..0xcf6216
+            - Range: 0xcf6f89..0xcf6fb6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10842,7 +10842,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf6216..0xcf6216
+            - Range: 0xcf6fb6..0xcf6fb6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10850,7 +10850,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf6216..0xcf624c
+            - Range: 0xcf6fb6..0xcf6fec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -10858,7 +10858,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf624c..0xcf6305
+            - Range: 0xcf6fec..0xcf70a5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -10866,7 +10866,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf6305..0xcf6316
+            - Range: 0xcf70a5..0xcf70b6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -10874,7 +10874,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf6316..0xcf6328
+            - Range: 0xcf70b6..0xcf70c8
               Pieces:
                 - Size: 8
                   Op: null
@@ -10882,7 +10882,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf6331..0xcf6337
+            - Range: 0xcf70d1..0xcf70d7
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10890,7 +10890,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf6337..0xcf6385
+            - Range: 0xcf70d7..0xcf7125
               Pieces:
                 - Size: 8
                   Op: null
@@ -10904,9 +10904,9 @@ Subprograms:
         - Name: item
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0xcf623f..0xcf624c
+            - Range: 0xcf6fdf..0xcf6fec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf624c..0xcf6305
+            - Range: 0xcf6fec..0xcf70a5
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: 4
@@ -10914,13 +10914,13 @@ Subprograms:
       DictRegister: 0
     - ID: 179
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xcf63a0..0xcf63e4]
+      OutOfLinePCRanges: [0xcf7140..0xcf7184]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 345 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf63a0..0xcf63b9
+            - Range: 0xcf7140..0xcf7159
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10928,7 +10928,7 @@ Subprograms:
         - Name: f
           Type: 351 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xcf63a0..0xcf63b9
+            - Range: 0xcf7140..0xcf7159
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -10936,15 +10936,15 @@ Subprograms:
         - Name: ~r0
           Type: 347 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xcf63a0..0xcf63b9
+            - Range: 0xcf7140..0xcf7159
               Pieces: []
-            - Range: 0xcf63b9..0xcf63ba
+            - Range: 0xcf7159..0xcf715a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf63ba..0xcf63e4
+            - Range: 0xcf715a..0xcf7184
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -10952,13 +10952,13 @@ Subprograms:
       DictRegister: 0
     - ID: 180
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xcf6620..0xcf6624]
+      OutOfLinePCRanges: [0xcf73c0..0xcf73c4]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 349 PointerType *go.shape.int
           Locations:
-            - Range: 0xcf6620..0xcf6624
+            - Range: 0xcf73c0..0xcf73c4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10966,9 +10966,9 @@ Subprograms:
         - Name: ~r0
           Type: 349 PointerType *go.shape.int
           Locations:
-            - Range: 0xcf6620..0xcf6623
+            - Range: 0xcf73c0..0xcf73c3
               Pieces: []
-            - Range: 0xcf6623..0xcf6624
+            - Range: 0xcf73c3..0xcf73c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -10976,13 +10976,13 @@ Subprograms:
       DictRegister: 0
     - ID: 181
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xcf6640..0xcf6644]
+      OutOfLinePCRanges: [0xcf73e0..0xcf73e4]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 352 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xcf6640..0xcf6644
+            - Range: 0xcf73e0..0xcf73e4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10990,9 +10990,9 @@ Subprograms:
         - Name: ~r0
           Type: 352 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0xcf6640..0xcf6643
+            - Range: 0xcf73e0..0xcf73e3
               Pieces: []
-            - Range: 0xcf6643..0xcf6644
+            - Range: 0xcf73e3..0xcf73e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11000,13 +11000,13 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xcf6660..0xcf6664]
+      OutOfLinePCRanges: [0xcf7400..0xcf7404]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 354 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xcf6660..0xcf6664
+            - Range: 0xcf7400..0xcf7404
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11014,9 +11014,9 @@ Subprograms:
         - Name: ~r0
           Type: 354 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xcf6660..0xcf6663
+            - Range: 0xcf7400..0xcf7403
               Pieces: []
-            - Range: 0xcf6663..0xcf6664
+            - Range: 0xcf7403..0xcf7404
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11024,13 +11024,13 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xcf6680..0xcf6691]
+      OutOfLinePCRanges: [0xcf7420..0xcf7431]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 356 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xcf6680..0xcf6691
+            - Range: 0xcf7420..0xcf7431
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11038,9 +11038,9 @@ Subprograms:
         - Name: ~r0
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf6680..0xcf6690
+            - Range: 0xcf7420..0xcf7430
               Pieces: []
-            - Range: 0xcf6690..0xcf6691
+            - Range: 0xcf7430..0xcf7431
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11052,13 +11052,13 @@ Subprograms:
       DictRegister: 0
     - ID: 184
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xcf6760..0xcf6769]
+      OutOfLinePCRanges: [0xcf7500..0xcf7509]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 358 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xcf6760..0xcf6769
+            - Range: 0xcf7500..0xcf7509
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11066,9 +11066,9 @@ Subprograms:
         - Name: ~r0
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0xcf6760..0xcf6768
+            - Range: 0xcf7500..0xcf7508
               Pieces: []
-            - Range: 0xcf6768..0xcf6769
+            - Range: 0xcf7508..0xcf7509
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11076,13 +11076,13 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xcf6820..0xcf6828]
+      OutOfLinePCRanges: [0xcf75c0..0xcf75c8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 359 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xcf6820..0xcf6828
+            - Range: 0xcf75c0..0xcf75c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11090,7 +11090,7 @@ Subprograms:
         - Name: k
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0xcf6820..0xcf6828
+            - Range: 0xcf75c0..0xcf75c8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11098,7 +11098,7 @@ Subprograms:
         - Name: v
           Type: 361 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf6820..0xcf6828
+            - Range: 0xcf75c0..0xcf75c8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11106,13 +11106,13 @@ Subprograms:
       DictRegister: 3
     - ID: 186
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xcf68a0..0xcf690e]
+      OutOfLinePCRanges: [0xcf7640..0xcf76ae]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 362 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xcf68a0..0xcf690e
+            - Range: 0xcf7640..0xcf76ae
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11120,7 +11120,7 @@ Subprograms:
         - Name: k
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf68a0..0xcf690e
+            - Range: 0xcf7640..0xcf76ae
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -11132,7 +11132,7 @@ Subprograms:
         - Name: v
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0xcf68a0..0xcf690e
+            - Range: 0xcf7640..0xcf76ae
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11140,13 +11140,13 @@ Subprograms:
       DictRegister: 3
     - ID: 187
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xcf6980..0xcf6988]
+      OutOfLinePCRanges: [0xcf7720..0xcf7728]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf6980..0xcf6988
+            - Range: 0xcf7720..0xcf7728
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11158,7 +11158,7 @@ Subprograms:
         - Name: b
           Type: 361 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf6980..0xcf6988
+            - Range: 0xcf7720..0xcf7728
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11166,9 +11166,9 @@ Subprograms:
         - Name: ~r0
           Type: 361 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf6980..0xcf6987
+            - Range: 0xcf7720..0xcf7727
               Pieces: []
-            - Range: 0xcf6987..0xcf6988
+            - Range: 0xcf7727..0xcf7728
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
@@ -11176,9 +11176,9 @@ Subprograms:
         - Name: ~r1
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf6980..0xcf6987
+            - Range: 0xcf7720..0xcf7727
               Pieces: []
-            - Range: 0xcf6987..0xcf6988
+            - Range: 0xcf7727..0xcf7728
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11190,13 +11190,13 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xcf69a0..0xcf69af]
+      OutOfLinePCRanges: [0xcf7740..0xcf774f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0xcf69a0..0xcf69ae
+            - Range: 0xcf7740..0xcf774e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11204,13 +11204,13 @@ Subprograms:
         - Name: b
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf69a0..0xcf69ab
+            - Range: 0xcf7740..0xcf774b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf69ab..0xcf69af
+            - Range: 0xcf774b..0xcf774f
               Pieces:
                 - Size: 8
                   Op: null
@@ -11222,9 +11222,9 @@ Subprograms:
         - Name: ~r0
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf69a0..0xcf69ae
+            - Range: 0xcf7740..0xcf774e
               Pieces: []
-            - Range: 0xcf69ae..0xcf69af
+            - Range: 0xcf774e..0xcf774f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11236,9 +11236,9 @@ Subprograms:
         - Name: ~r1
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0xcf69a0..0xcf69ae
+            - Range: 0xcf7740..0xcf774e
               Pieces: []
-            - Range: 0xcf69ae..0xcf69af
+            - Range: 0xcf774e..0xcf774f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
@@ -11246,13 +11246,13 @@ Subprograms:
       DictRegister: 0
     - ID: 189
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xcf69c0..0xcf69fa]
+      OutOfLinePCRanges: [0xcf7760..0xcf779a]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 364 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xcf69c0..0xcf69d9
+            - Range: 0xcf7760..0xcf7779
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11260,15 +11260,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf69c0..0xcf69d9
+            - Range: 0xcf7760..0xcf7779
               Pieces: []
-            - Range: 0xcf69d9..0xcf69da
+            - Range: 0xcf7779..0xcf777a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf69da..0xcf69fa
+            - Range: 0xcf777a..0xcf779a
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11276,19 +11276,19 @@ Subprograms:
       DictRegister: 0
     - ID: 190
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xcf6a00..0xcf6a4d]
+      OutOfLinePCRanges: [0xcf77a0..0xcf77ed]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 365 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xcf6a00..0xcf6a1f
+            - Range: 0xcf77a0..0xcf77bf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf6a1f..0xcf6a22
+            - Range: 0xcf77bf..0xcf77c2
               Pieces:
                 - Size: 8
                   Op: null
@@ -11300,15 +11300,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcf6a00..0xcf6a22
+            - Range: 0xcf77a0..0xcf77c2
               Pieces: []
-            - Range: 0xcf6a22..0xcf6a23
+            - Range: 0xcf77c2..0xcf77c3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf6a23..0xcf6a4d
+            - Range: 0xcf77c3..0xcf77ed
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11316,13 +11316,13 @@ Subprograms:
       DictRegister: 0
     - ID: 191
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xcf6a60..0xcf6a68]
+      OutOfLinePCRanges: [0xcf7800..0xcf7808]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 366 PointerType *go.shape.string
           Locations:
-            - Range: 0xcf6a60..0xcf6a67
+            - Range: 0xcf7800..0xcf7807
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11330,9 +11330,9 @@ Subprograms:
         - Name: ~r0
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf6a60..0xcf6a67
+            - Range: 0xcf7800..0xcf7807
               Pieces: []
-            - Range: 0xcf6a67..0xcf6a68
+            - Range: 0xcf7807..0xcf7808
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11344,13 +11344,13 @@ Subprograms:
       DictRegister: 0
     - ID: 192
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xcf6a80..0xcf6adb]
+      OutOfLinePCRanges: [0xcf7820..0xcf787b]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 367 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xcf6a80..0xcf6ac1
+            - Range: 0xcf7820..0xcf7861
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11358,9 +11358,9 @@ Subprograms:
         - Name: ~r0
           Type: 368 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xcf6a80..0xcf6ad5
+            - Range: 0xcf7820..0xcf7875
               Pieces: []
-            - Range: 0xcf6ad5..0xcf6ad6
+            - Range: 0xcf7875..0xcf7876
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11374,7 +11374,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xcf6ad6..0xcf6adb
+            - Range: 0xcf7876..0xcf787b
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11382,13 +11382,13 @@ Subprograms:
       DictRegister: 0
     - ID: 193
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xcf6ae0..0xcf6b04]
+      OutOfLinePCRanges: [0xcf7880..0xcf78a4]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 348 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf6ae0..0xcf6b04
+            - Range: 0xcf7880..0xcf78a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11402,7 +11402,7 @@ Subprograms:
         - Name: needle
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0xcf6ae0..0xcf6b04
+            - Range: 0xcf7880..0xcf78a4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11410,13 +11410,13 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcf6ae0..0xcf6b00
+            - Range: 0xcf7880..0xcf78a0
               Pieces: []
-            - Range: 0xcf6b00..0xcf6b01
+            - Range: 0xcf78a0..0xcf78a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf6b01..0xcf6b03
+            - Range: 0xcf78a1..0xcf78a3
               Pieces: []
-            - Range: 0xcf6b03..0xcf6b04
+            - Range: 0xcf78a3..0xcf78a4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -11424,13 +11424,13 @@ Subprograms:
       DictRegister: 0
     - ID: 194
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xcf6b20..0xcf6bdf]
+      OutOfLinePCRanges: [0xcf78c0..0xcf797f]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 369 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xcf6b20..0xcf6b3d
+            - Range: 0xcf78c0..0xcf78dd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11438,7 +11438,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf6b3d..0xcf6b3f
+            - Range: 0xcf78dd..0xcf78df
               Pieces:
                 - Size: 8
                   Op: null
@@ -11452,13 +11452,13 @@ Subprograms:
         - Name: needle
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf6b20..0xcf6b6c
+            - Range: 0xcf78c0..0xcf790c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xcf6b6c..0xcf6bdf
+            - Range: 0xcf790c..0xcf797f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -11470,15 +11470,15 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcf6b20..0xcf6b8b
+            - Range: 0xcf78c0..0xcf792b
               Pieces: []
-            - Range: 0xcf6b8b..0xcf6b8c
+            - Range: 0xcf792b..0xcf792c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf6b8c..0xcf6b93
+            - Range: 0xcf792c..0xcf7933
               Pieces: []
-            - Range: 0xcf6b93..0xcf6b94
+            - Range: 0xcf7933..0xcf7934
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf6b94..0xcf6bdf
+            - Range: 0xcf7934..0xcf797f
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11486,13 +11486,13 @@ Subprograms:
         - Name: v
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf6b4f..0xcf6b61
+            - Range: 0xcf78ef..0xcf7901
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcf6b61..0xcf6b6c
+            - Range: 0xcf7901..0xcf790c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11504,13 +11504,13 @@ Subprograms:
       DictRegister: 0
     - ID: 195
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xcf6be0..0xcf6be7]
+      OutOfLinePCRanges: [0xcf7980..0xcf7987]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 370 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xcf6be0..0xcf6be6
+            - Range: 0xcf7980..0xcf7986
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11518,7 +11518,7 @@ Subprograms:
         - Name: value
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0xcf6be0..0xcf6be7
+            - Range: 0xcf7980..0xcf7987
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11526,9 +11526,9 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcf6be0..0xcf6be6
+            - Range: 0xcf7980..0xcf7986
               Pieces: []
-            - Range: 0xcf6be6..0xcf6be7
+            - Range: 0xcf7986..0xcf7987
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
@@ -11536,25 +11536,25 @@ Subprograms:
       DictRegister: 3
     - ID: 196
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xcf6c40..0xcf6cac]
+      OutOfLinePCRanges: [0xcf79e0..0xcf7a4c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 371 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xcf6c40..0xcf6c60
+            - Range: 0xcf79e0..0xcf7a00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf6c60..0xcf6c68
+            - Range: 0xcf7a00..0xcf7a08
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf6c68..0xcf6c6d
+            - Range: 0xcf7a08..0xcf7a0d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11566,7 +11566,7 @@ Subprograms:
         - Name: value
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf6c40..0xcf6c6d
+            - Range: 0xcf79e0..0xcf7a0d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -11578,11 +11578,11 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0xcf6c40..0xcf6c6d
+            - Range: 0xcf79e0..0xcf7a0d
               Pieces: []
-            - Range: 0xcf6c6d..0xcf6c6e
+            - Range: 0xcf7a0d..0xcf7a0e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf6c6e..0xcf6cac
+            - Range: 0xcf7a0e..0xcf7a4c
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11828,31 +11828,31 @@ Subprograms:
       DictRegister: null
     - ID: 199
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xcece00..0xcece62]
+      OutOfLinePCRanges: [0xced240..0xced2a2]
       InlinePCRanges:
-        - Ranges: [0xcece91..0xcececd]
-          RootRanges: [0xcece80..0xcecef1]
-        - Ranges: [0xcecfd2..0xced00e]
-          RootRanges: [0xcecfa0..0xced028]
-        - Ranges: [0xced05c..0xced098]
-          RootRanges: [0xced040..0xced105]
-        - Ranges: [0xced12f..0xced16b]
-          RootRanges: [0xced120..0xced182]
+        - Ranges: [0xced2d1..0xced30d]
+          RootRanges: [0xced2c0..0xced331]
+        - Ranges: [0xced412..0xced44e]
+          RootRanges: [0xced3e0..0xced468]
+        - Ranges: [0xced49c..0xced4d8]
+          RootRanges: [0xced480..0xced545]
+        - Ranges: [0xced56f..0xced5ab]
+          RootRanges: [0xced560..0xced5c2]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xcece00..0xcece19
+            - Range: 0xced240..0xced259
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcece91..0xcece9c
+            - Range: 0xced2d1..0xced2dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcecfd2..0xcecfdd
+            - Range: 0xced412..0xced41d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xced056..0xced067
+            - Range: 0xced496..0xced4a7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xced067..0xced105
+            - Range: 0xced4a7..0xced545
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xced120..0xced13a
+            - Range: 0xced560..0xced57a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11862,37 +11862,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xced0a6..0xced0de]
-          RootRanges: [0xced040..0xced105]
+        - Ranges: [0xced4e6..0xced51e]
+          RootRanges: [0xced480..0xced545]
       Variables: []
       DictRegister: null
     - ID: 201
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xced1b3..0xced1f1]
-          RootRanges: [0xced1a0..0xced2a5]
+        - Ranges: [0xced5f3..0xced631]
+          RootRanges: [0xced5e0..0xced6e5]
       Variables: []
       DictRegister: null
     - ID: 202
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xced25b..0xced293]
-          RootRanges: [0xced1a0..0xced2a5]
+        - Ranges: [0xced69b..0xced6d3]
+          RootRanges: [0xced5e0..0xced6e5]
       Variables: []
       DictRegister: null
     - ID: 203
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xced2c1..0xced2c5]
-          RootRanges: [0xced2c0..0xced2c6]
+        - Ranges: [0xced701..0xced705]
+          RootRanges: [0xced700..0xced706]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xced2c0..0xced2c5
+            - Range: 0xced700..0xced705
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -11902,33 +11902,33 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xced30d..0xced325]
-          RootRanges: [0xced2e0..0xced32b]
-        - Ranges: [0xced3a3..0xced3c1]
-          RootRanges: [0xced340..0xced4c5]
+        - Ranges: [0xced74d..0xced765]
+          RootRanges: [0xced720..0xced76b]
+        - Ranges: [0xced847..0xced865]
+          RootRanges: [0xced780..0xced998]
       Variables:
         - Name: a
           Type: 176 ArrayType [5]int
           Locations:
-            - Range: 0xced2ec..0xced32b
+            - Range: 0xced72c..0xced76b
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xced387..0xced4c5
-              Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
+            - Range: 0xced82b..0xced998
+              Pieces: [{Size: 40, Op: {CfaOffset: -152}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 205
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0xced4e0..0xced546]
+      OutOfLinePCRanges: [0xced9e0..0xceda46]
       InlinePCRanges:
-        - Ranges: [0xcf6e5a..0xcf6e88]
-          RootRanges: [0xcf6e40..0xcf6ea5]
+        - Ranges: [0xcf7bfa..0xcf7c28]
+          RootRanges: [0xcf7be0..0xcf7c45]
       Variables:
         - Name: b
           Type: 376 StructureType main.firstBehavior
           Locations:
-            - Range: 0xced4e0..0xced4fe
+            - Range: 0xced9e0..0xced9fe
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11940,15 +11940,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xced4e0..0xced525
+            - Range: 0xced9e0..0xceda25
               Pieces: []
-            - Range: 0xced525..0xced526
+            - Range: 0xceda25..0xceda26
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xced526..0xced546
+            - Range: 0xceda26..0xceda46
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11958,8 +11958,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcede06..0xcede0d]
-          RootRanges: [0xcedd60..0xcede6a]
+        - Ranges: [0xcee3a6..0xcee3ad]
+          RootRanges: [0xcee280..0xcee43a]
         - Ranges: [0xce6ce1..0xce6ce9]
           RootRanges: [0xce6ce0..0xce6cea]
       Variables: []
@@ -12647,7 +12647,7 @@ Types:
       ID: 2657
       Name: '*compress/gzip.Reader'
       ByteSize: 8
-      GoRuntimeType: 1651104
+      GoRuntimeType: 1650336
       GoKind: 22
       Pointee: 2658 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
@@ -12668,7 +12668,7 @@ Types:
       ID: 426
       Name: '*context.backgroundCtx'
       ByteSize: 8
-      GoRuntimeType: 1574528
+      GoRuntimeType: 1574048
       GoKind: 22
       Pointee: 427 GoContextImplementationType context.backgroundCtx
     - __kind: PointerType
@@ -12682,21 +12682,21 @@ Types:
       ID: 1090
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1206432
+      GoRuntimeType: 1204768
       GoKind: 22
       Pointee: 1091 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 413
       Name: '*context.emptyCtx'
       ByteSize: 8
-      GoRuntimeType: 1433216
+      GoRuntimeType: 1433056
       GoKind: 22
       Pointee: 414 GoContextImplementationType context.emptyCtx
     - __kind: PointerType
       ID: 415
       Name: '*context.stopCtx'
       ByteSize: 8
-      GoRuntimeType: 1433376
+      GoRuntimeType: 1433216
       GoKind: 22
       Pointee: 416 GoContextImplementationType context.stopCtx
     - __kind: PointerType
@@ -12710,21 +12710,21 @@ Types:
       ID: 428
       Name: '*context.todoCtx'
       ByteSize: 8
-      GoRuntimeType: 1574688
+      GoRuntimeType: 1574208
       GoKind: 22
       Pointee: 429 GoContextImplementationType context.todoCtx
     - __kind: PointerType
       ID: 422
       Name: '*context.valueCtx'
       ByteSize: 8
-      GoRuntimeType: 1574208
+      GoRuntimeType: 1573728
       GoKind: 22
       Pointee: 423 GoContextImplementationType context.valueCtx
     - __kind: PointerType
       ID: 424
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
-      GoRuntimeType: 1574368
+      GoRuntimeType: 1573888
       GoKind: 22
       Pointee: 425 GoContextImplementationType context.withoutCancelCtx
     - __kind: PointerType
@@ -13142,17 +13142,17 @@ Types:
       GoKind: 22
       Pointee: 981 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 877
+      ID: 875
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 924864
+      GoRuntimeType: 924192
       GoKind: 22
       Pointee: 772 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
       ID: 1237
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1056320
+      GoRuntimeType: 1056192
       GoKind: 22
       Pointee: 1238 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -13163,31 +13163,31 @@ Types:
       GoKind: 22
       Pointee: 773 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 1502
+      ID: 1500
       Name: '*encoding/json.Delim'
       ByteSize: 8
-      GoRuntimeType: 919776
+      GoRuntimeType: 919104
       GoKind: 22
-      Pointee: 1431 BaseType encoding/json.Delim
+      Pointee: 1429 BaseType encoding/json.Delim
     - __kind: PointerType
-      ID: 848
+      ID: 846
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 919680
+      GoRuntimeType: 919008
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 847 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
       ID: 1049
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1052480
+      GoRuntimeType: 1052352
       GoKind: 22
       Pointee: 1050 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
       ID: 1679
       Name: '*encoding/json.Number'
       ByteSize: 8
-      GoRuntimeType: 1220768
+      GoRuntimeType: 1220256
       GoKind: 22
       Pointee: 1661 GoStringHeaderType encoding/json.Number
     - __kind: PointerType
@@ -13196,33 +13196,33 @@ Types:
       ByteSize: 8
       Pointee: 1662 GoStringDataType encoding/json.Number.str
     - __kind: PointerType
-      ID: 840
+      ID: 838
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 919296
+      GoRuntimeType: 918624
       GoKind: 22
-      Pointee: 841 UnresolvedPointeeType encoding/json.SyntaxError
-    - __kind: PointerType
-      ID: 846
-      Name: '*encoding/json.UnmarshalTypeError'
-      ByteSize: 8
-      GoRuntimeType: 919584
-      GoKind: 22
-      Pointee: 847 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 839 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
       ID: 844
-      Name: '*encoding/json.UnsupportedTypeError'
+      Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
-      GoRuntimeType: 919488
+      GoRuntimeType: 918912
       GoKind: 22
-      Pointee: 845 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 845 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
       ID: 842
+      Name: '*encoding/json.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 918816
+      GoKind: 22
+      Pointee: 843 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 840
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
-      GoRuntimeType: 919392
+      GoRuntimeType: 918720
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 841 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
       ID: 1378
       Name: '*encoding/json.encodeState'
@@ -13231,12 +13231,12 @@ Types:
       GoKind: 22
       Pointee: 1379 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 850
+      ID: 848
       Name: '*encoding/json.jsonError'
       ByteSize: 8
-      GoRuntimeType: 920064
+      GoRuntimeType: 919392
       GoKind: 22
-      Pointee: 851 StructureType encoding/json.jsonError
+      Pointee: 849 StructureType encoding/json.jsonError
     - __kind: PointerType
       ID: 1245
       Name: '*encoding/pem.lineBreaker'
@@ -13262,14 +13262,14 @@ Types:
       ID: 814
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 910080
+      GoRuntimeType: 910944
       GoKind: 22
       Pointee: 815 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 1016
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1038016
+      GoRuntimeType: 1039040
       GoKind: 22
       Pointee: 1017 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -13304,21 +13304,21 @@ Types:
       ID: 2558
       Name: '*fmt.stringReader'
       ByteSize: 8
-      GoRuntimeType: 910176
+      GoRuntimeType: 911040
       GoKind: 22
       Pointee: 2559 UnresolvedPointeeType fmt.stringReader
     - __kind: PointerType
       ID: 1018
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1038144
+      GoRuntimeType: 1039168
       GoKind: 22
       Pointee: 1019 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 1020
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1038272
+      GoRuntimeType: 1039296
       GoKind: 22
       Pointee: 1021 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -13360,7 +13360,7 @@ Types:
       ID: 2084
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType'
       ByteSize: 8
-      GoRuntimeType: 1876864
+      GoRuntimeType: 1876640
       GoKind: 22
       Pointee: 2031 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
     - __kind: PointerType
@@ -13381,7 +13381,7 @@ Types:
       ID: 2085
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType'
       ByteSize: 8
-      GoRuntimeType: 1877088
+      GoRuntimeType: 1876864
       GoKind: 22
       Pointee: 2032 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
     - __kind: PointerType
@@ -13469,45 +13469,45 @@ Types:
       GoKind: 22
       Pointee: 1737 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/version.Version
     - __kind: PointerType
-      ID: 859
+      ID: 857
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
-      GoRuntimeType: 922464
+      GoRuntimeType: 921792
       GoKind: 22
-      Pointee: 860 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 858 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 861
+      ID: 859
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
-      GoRuntimeType: 922560
+      GoRuntimeType: 921888
       GoKind: 22
-      Pointee: 862 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 860 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
       ID: 1183
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
-      GoRuntimeType: 922272
+      GoRuntimeType: 921600
       GoKind: 22
       Pointee: 1184 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 865
+      ID: 863
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
-      GoRuntimeType: 922848
+      GoRuntimeType: 922176
       GoKind: 22
-      Pointee: 866 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 864 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
       ID: 1185
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
-      GoRuntimeType: 922368
+      GoRuntimeType: 921696
       GoKind: 22
       Pointee: 1186 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 863
+      ID: 861
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
-      GoRuntimeType: 922656
+      GoRuntimeType: 921984
       GoKind: 22
       Pointee: 766 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
@@ -13516,10 +13516,10 @@ Types:
       ByteSize: 8
       Pointee: 767 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 858
+      ID: 856
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
-      GoRuntimeType: 922176
+      GoRuntimeType: 921504
       GoKind: 22
       Pointee: 763 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
@@ -13528,10 +13528,10 @@ Types:
       ByteSize: 8
       Pointee: 764 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 864
+      ID: 862
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
-      GoRuntimeType: 922752
+      GoRuntimeType: 922080
       GoKind: 22
       Pointee: 769 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
@@ -13543,7 +13543,7 @@ Types:
       ID: 1257
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1224096
+      GoRuntimeType: 1223584
       GoKind: 22
       Pointee: 1258 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
@@ -13564,14 +13564,14 @@ Types:
       ID: 1793
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule'
       ByteSize: 8
-      GoRuntimeType: 1574848
+      GoRuntimeType: 1574368
       GoKind: 22
       Pointee: 1794 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule
     - __kind: PointerType
       ID: 1485
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType'
       ByteSize: 8
-      GoRuntimeType: 910656
+      GoRuntimeType: 910176
       GoKind: 22
       Pointee: 1422 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType
     - __kind: PointerType
@@ -13592,14 +13592,14 @@ Types:
       ID: 400
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
-      GoRuntimeType: 1206688
+      GoRuntimeType: 1205024
       GoKind: 22
       Pointee: 401 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
       ID: 1488
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate'
       ByteSize: 8
-      GoRuntimeType: 910944
+      GoRuntimeType: 910464
       GoKind: 22
       Pointee: 1489 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate
     - __kind: PointerType
@@ -13613,7 +13613,7 @@ Types:
       ID: 1486
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule'
       ByteSize: 8
-      GoRuntimeType: 910848
+      GoRuntimeType: 910368
       GoKind: 22
       Pointee: 1487 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule
     - __kind: PointerType
@@ -13627,35 +13627,35 @@ Types:
       ID: 1678
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance'
       ByteSize: 8
-      GoRuntimeType: 1208096
+      GoRuntimeType: 1206432
       GoKind: 22
       Pointee: 1584 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance
     - __kind: PointerType
       ID: 2357
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter'
       ByteSize: 8
-      GoRuntimeType: 910752
+      GoRuntimeType: 910272
       GoKind: 22
       Pointee: 2358 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter
     - __kind: PointerType
       ID: 403
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
-      GoRuntimeType: 1206816
+      GoRuntimeType: 1205152
       GoKind: 22
       Pointee: 404 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
       ID: 2720
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
-      GoRuntimeType: 1207456
+      GoRuntimeType: 1205792
       GoKind: 22
       Pointee: 2721 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
       ID: 737
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      GoRuntimeType: 1207584
+      GoRuntimeType: 1205920
       GoKind: 22
       Pointee: 738 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
@@ -13683,7 +13683,7 @@ Types:
       ID: 1755
       Name: '*github.com/DataDog/dd-trace-go/v2/internal.TraceSource'
       ByteSize: 8
-      GoRuntimeType: 1438816
+      GoRuntimeType: 1438656
       GoKind: 22
       Pointee: 1585 BaseType github.com/DataDog/dd-trace-go/v2/internal.TraceSource
     - __kind: PointerType
@@ -13767,7 +13767,7 @@ Types:
       ID: 418
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
-      GoRuntimeType: 1439136
+      GoRuntimeType: 1438976
       GoKind: 22
       Pointee: 419 GoContextImplementationType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
@@ -13781,21 +13781,21 @@ Types:
       ID: 1617
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource'
       ByteSize: 8
-      GoRuntimeType: 1054528
+      GoRuntimeType: 1054400
       GoKind: 22
       Pointee: 1618 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource
     - __kind: PointerType
       ID: 1619
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource'
       ByteSize: 8
-      GoRuntimeType: 1054656
+      GoRuntimeType: 1054528
       GoKind: 22
       Pointee: 1620 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource
     - __kind: PointerType
       ID: 1611
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey'
       ByteSize: 8
-      GoRuntimeType: 1052096
+      GoRuntimeType: 1051968
       GoKind: 22
       Pointee: 1612 StructureType github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey
     - __kind: PointerType
@@ -14010,47 +14010,47 @@ Types:
       GoKind: 22
       Pointee: 2469 StructureType github.com/Masterminds/semver/v3.Version
     - __kind: PointerType
-      ID: 1514
+      ID: 1512
       Name: '*github.com/cihub/seelog.CfgParseParams'
       ByteSize: 8
-      GoRuntimeType: 924672
+      GoRuntimeType: 924000
       GoKind: 22
-      Pointee: 1515 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
+      Pointee: 1513 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
     - __kind: PointerType
-      ID: 1513
+      ID: 1511
       Name: '*github.com/cihub/seelog.LogLevel'
       ByteSize: 8
-      GoRuntimeType: 923808
+      GoRuntimeType: 923136
       GoKind: 22
-      Pointee: 1434 BaseType github.com/cihub/seelog.LogLevel
+      Pointee: 1432 BaseType github.com/cihub/seelog.LogLevel
     - __kind: PointerType
       ID: 2041
       Name: '*github.com/cihub/seelog.LogLevelException'
       ByteSize: 8
-      GoRuntimeType: 1833184
+      GoRuntimeType: 1832736
       GoKind: 22
       Pointee: 2042 UnresolvedPointeeType github.com/cihub/seelog.LogLevelException
     - __kind: PointerType
-      ID: 867
+      ID: 865
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
-      GoRuntimeType: 924000
+      GoRuntimeType: 923328
       GoKind: 22
-      Pointee: 868 StructureType github.com/cihub/seelog.baseError
+      Pointee: 866 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 1298
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1833632
+      GoRuntimeType: 1833184
       GoKind: 22
       Pointee: 1299 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 869
+      ID: 867
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
-      GoRuntimeType: 924096
+      GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 870 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 868 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 1277
       Name: '*github.com/cihub/seelog.connWriter'
@@ -14062,42 +14062,42 @@ Types:
       ID: 1233
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1055168
+      GoRuntimeType: 1055040
       GoKind: 22
       Pointee: 1234 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1760
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1443296
+      GoRuntimeType: 1443136
       GoKind: 22
       Pointee: 1761 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
       ID: 1873
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
-      GoRuntimeType: 1662432
+      GoRuntimeType: 1661664
       GoKind: 22
       Pointee: 1874 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
       ID: 1267
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1442816
+      GoRuntimeType: 1442656
       GoKind: 22
       Pointee: 1268 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
       ID: 1877
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1663200
+      GoRuntimeType: 1662432
       GoKind: 22
       Pointee: 1878 UnresolvedPointeeType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
       ID: 1756
       Name: '*github.com/cihub/seelog.formattedWriter'
       ByteSize: 8
-      GoRuntimeType: 1442976
+      GoRuntimeType: 1442816
       GoKind: 22
       Pointee: 1757 UnresolvedPointeeType github.com/cihub/seelog.formattedWriter
     - __kind: PointerType
@@ -14111,42 +14111,42 @@ Types:
       ID: 1684
       Name: '*github.com/cihub/seelog.listConstraints'
       ByteSize: 8
-      GoRuntimeType: 1226400
+      GoRuntimeType: 1225888
       GoKind: 22
       Pointee: 1685 UnresolvedPointeeType github.com/cihub/seelog.listConstraints
     - __kind: PointerType
-      ID: 1511
+      ID: 1509
       Name: '*github.com/cihub/seelog.logFormattedMessage'
       ByteSize: 8
-      GoRuntimeType: 923712
+      GoRuntimeType: 923040
       GoKind: 22
-      Pointee: 1512 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
+      Pointee: 1510 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
     - __kind: PointerType
-      ID: 1509
+      ID: 1507
       Name: '*github.com/cihub/seelog.logMessage'
       ByteSize: 8
-      GoRuntimeType: 923616
+      GoRuntimeType: 922944
       GoKind: 22
-      Pointee: 1510 UnresolvedPointeeType github.com/cihub/seelog.logMessage
+      Pointee: 1508 UnresolvedPointeeType github.com/cihub/seelog.logMessage
     - __kind: PointerType
       ID: 1623
       Name: '*github.com/cihub/seelog.minMaxConstraints'
       ByteSize: 8
-      GoRuntimeType: 1055680
+      GoRuntimeType: 1055552
       GoKind: 22
       Pointee: 1624 UnresolvedPointeeType github.com/cihub/seelog.minMaxConstraints
     - __kind: PointerType
-      ID: 873
+      ID: 871
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
-      GoRuntimeType: 924288
+      GoRuntimeType: 923616
       GoKind: 22
-      Pointee: 874 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 872 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 1621
       Name: '*github.com/cihub/seelog.offConstraints'
       ByteSize: 8
-      GoRuntimeType: 1055552
+      GoRuntimeType: 1055424
       GoKind: 22
       Pointee: 1622 UnresolvedPointeeType github.com/cihub/seelog.offConstraints
     - __kind: PointerType
@@ -14174,35 +14174,35 @@ Types:
       ID: 1235
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1055296
+      GoRuntimeType: 1055168
       GoKind: 22
       Pointee: 1236 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
       ID: 1875
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1662624
+      GoRuntimeType: 1661856
       GoKind: 22
       Pointee: 1876 UnresolvedPointeeType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 871
+      ID: 869
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
-      GoRuntimeType: 924192
+      GoRuntimeType: 923520
       GoKind: 22
-      Pointee: 872 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 870 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 875
+      ID: 873
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
-      GoRuntimeType: 924384
+      GoRuntimeType: 923712
       GoKind: 22
-      Pointee: 876 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 874 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 1758
       Name: '*github.com/cihub/seelog.xmlNode'
       ByteSize: 8
-      GoRuntimeType: 1443136
+      GoRuntimeType: 1442976
       GoKind: 22
       Pointee: 1759 UnresolvedPointeeType github.com/cihub/seelog.xmlNode
     - __kind: PointerType
@@ -15054,42 +15054,42 @@ Types:
       ID: 1102
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1215264
+      GoRuntimeType: 1214752
       GoKind: 22
       Pointee: 1103 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 1096
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1214880
+      GoRuntimeType: 1214368
       GoKind: 22
       Pointee: 1097 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 1035
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1046592
+      GoRuntimeType: 1046464
       GoKind: 22
       Pointee: 1036 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 1108
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1215648
+      GoRuntimeType: 1215136
       GoKind: 22
       Pointee: 1109 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 1034
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1046464
+      GoRuntimeType: 1046336
       GoKind: 22
       Pointee: 1013 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 1100
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1215136
+      GoRuntimeType: 1214624
       GoKind: 22
       Pointee: 1101 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
@@ -15100,31 +15100,31 @@ Types:
       GoKind: 22
       Pointee: 2696 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Reader
     - __kind: PointerType
-      ID: 1495
+      ID: 1493
       Name: '*github.com/tinylib/msgp/msgp.Type'
       ByteSize: 8
-      GoRuntimeType: 915744
+      GoRuntimeType: 915072
       GoKind: 22
       Pointee: 1191 BaseType github.com/tinylib/msgp/msgp.Type
     - __kind: PointerType
       ID: 1098
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1215008
+      GoRuntimeType: 1214496
       GoKind: 22
       Pointee: 1099 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 1106
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1215520
+      GoRuntimeType: 1215008
       GoKind: 22
       Pointee: 1107 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 1104
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1215392
+      GoRuntimeType: 1214880
       GoKind: 22
       Pointee: 1105 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
@@ -15138,28 +15138,28 @@ Types:
       ID: 1112
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1216032
+      GoRuntimeType: 1215520
       GoKind: 22
       Pointee: 1113 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 1039
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1046848
+      GoRuntimeType: 1046720
       GoKind: 22
       Pointee: 1040 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 1037
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1046720
+      GoRuntimeType: 1046592
       GoKind: 22
       Pointee: 1038 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 1110
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1215904
+      GoRuntimeType: 1215392
       GoKind: 22
       Pointee: 1111 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -17229,77 +17229,77 @@ Types:
       ID: 2562
       Name: '*io.LimitedReader'
       ByteSize: 8
-      GoRuntimeType: 910368
+      GoRuntimeType: 911232
       GoKind: 22
       Pointee: 2563 UnresolvedPointeeType io.LimitedReader
     - __kind: PointerType
       ID: 2672
       Name: '*io.PipeReader'
       ByteSize: 8
-      GoRuntimeType: 1867680
+      GoRuntimeType: 1869920
       GoKind: 22
       Pointee: 2673 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
       ID: 1255
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1206176
+      GoRuntimeType: 1209376
       GoKind: 22
       Pointee: 1256 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 2646
       Name: '*io.SectionReader'
       ByteSize: 8
-      GoRuntimeType: 1573888
+      GoRuntimeType: 1575488
       GoKind: 22
       Pointee: 2647 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
       ID: 1253
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1205792
+      GoRuntimeType: 1208992
       GoKind: 22
       Pointee: 1254 StructureType io.discard
     - __kind: PointerType
       ID: 2564
       Name: '*io.eofReader'
       ByteSize: 8
-      GoRuntimeType: 910464
+      GoRuntimeType: 911328
       GoKind: 22
       Pointee: 2565 StructureType io.eofReader
     - __kind: PointerType
       ID: 2620
       Name: '*io.multiReader'
       ByteSize: 8
-      GoRuntimeType: 1205536
+      GoRuntimeType: 1208736
       GoKind: 22
       Pointee: 2621 UnresolvedPointeeType io.multiReader
     - __kind: PointerType
       ID: 1227
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1039040
+      GoRuntimeType: 1040064
       GoKind: 22
       Pointee: 1228 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 2588
       Name: '*io.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1039296
+      GoRuntimeType: 1040320
       GoKind: 22
       Pointee: 2589 StructureType io.nopCloser
     - __kind: PointerType
       ID: 2622
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
-      GoRuntimeType: 1205664
+      GoRuntimeType: 1208864
       GoKind: 22
       Pointee: 2623 StructureType io.nopCloserWriterTo
     - __kind: PointerType
       ID: 2560
       Name: '*io.teeReader'
       ByteSize: 8
-      GoRuntimeType: 910272
+      GoRuntimeType: 911136
       GoKind: 22
       Pointee: 2561 UnresolvedPointeeType io.teeReader
     - __kind: PointerType
@@ -17327,21 +17327,21 @@ Types:
       ID: 1686
       Name: '*log/slog.Attr'
       ByteSize: 8
-      GoRuntimeType: 1227040
+      GoRuntimeType: 1226528
       GoKind: 22
       Pointee: 1687 StructureType log/slog.Attr
     - __kind: PointerType
-      ID: 1516
+      ID: 1514
       Name: '*log/slog.Kind'
       ByteSize: 8
-      GoRuntimeType: 924768
+      GoRuntimeType: 924096
       GoKind: 22
-      Pointee: 1435 BaseType log/slog.Kind
+      Pointee: 1433 BaseType log/slog.Kind
     - __kind: PointerType
       ID: 2043
       Name: '*log/slog.Level'
       ByteSize: 8
-      GoRuntimeType: 1834080
+      GoRuntimeType: 1833632
       GoKind: 22
       Pointee: 1789 BaseType log/slog.Level
     - __kind: PointerType
@@ -17872,7 +17872,7 @@ Types:
       ID: 2659
       Name: '*math/rand/v2.ChaCha8'
       ByteSize: 8
-      GoRuntimeType: 1659552
+      GoRuntimeType: 1658784
       GoKind: 22
       Pointee: 2660 UnresolvedPointeeType math/rand/v2.ChaCha8
     - __kind: PointerType
@@ -17921,21 +17921,21 @@ Types:
       ID: 1119
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1221920
+      GoRuntimeType: 1221408
       GoKind: 22
       Pointee: 1120 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 1150
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1441056
+      GoRuntimeType: 1440896
       GoKind: 22
       Pointee: 1151 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1507
+      ID: 1505
       Name: '*net.HardwareAddr.array'
       ByteSize: 8
-      Pointee: 1506 GoSliceDataType net.HardwareAddr.array
+      Pointee: 1504 GoSliceDataType net.HardwareAddr.array
     - __kind: PointerType
       ID: 2367
       Name: '*net.IP'
@@ -17959,14 +17959,14 @@ Types:
       ID: 1360
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2269568
+      GoRuntimeType: 2268608
       GoKind: 22
       Pointee: 1361 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 1613
       Name: '*net.IPMask'
       ByteSize: 8
-      GoRuntimeType: 1053120
+      GoRuntimeType: 1052992
       GoKind: 22
       Pointee: 1614 GoSliceHeaderType net.IPMask
     - __kind: PointerType
@@ -17978,28 +17978,28 @@ Types:
       ID: 1680
       Name: '*net.IPNet'
       ByteSize: 8
-      GoRuntimeType: 1221664
+      GoRuntimeType: 1221152
       GoKind: 22
       Pointee: 1681 UnresolvedPointeeType net.IPNet
     - __kind: PointerType
       ID: 1148
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1440736
+      GoRuntimeType: 1440576
       GoKind: 22
       Pointee: 1149 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 1121
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1222048
+      GoRuntimeType: 1221536
       GoKind: 22
       Pointee: 1122 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 2039
       Name: '*net.TCPAddr'
       ByteSize: 8
-      GoRuntimeType: 1832512
+      GoRuntimeType: 1832064
       GoKind: 22
       Pointee: 2040 UnresolvedPointeeType net.TCPAddr
     - __kind: PointerType
@@ -18013,7 +18013,7 @@ Types:
       ID: 2037
       Name: '*net.UDPAddr'
       ByteSize: 8
-      GoRuntimeType: 1832288
+      GoRuntimeType: 1831840
       GoKind: 22
       Pointee: 2038 UnresolvedPointeeType net.UDPAddr
     - __kind: PointerType
@@ -18041,7 +18041,7 @@ Types:
       ID: 1118
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1221152
+      GoRuntimeType: 1220640
       GoKind: 22
       Pointee: 1087 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -18053,37 +18053,37 @@ Types:
       ID: 2182
       Name: '*net.addrPortUDPAddr'
       ByteSize: 8
-      GoRuntimeType: 2044384
+      GoRuntimeType: 2044096
       GoKind: 22
       Pointee: 2183 StructureType net.addrPortUDPAddr
     - __kind: PointerType
       ID: 1051
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1053376
+      GoRuntimeType: 1053248
       GoKind: 22
       Pointee: 1052 StructureType net.canceledError
     - __kind: PointerType
       ID: 1338
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2044096
+      GoRuntimeType: 2043808
       GoKind: 22
       Pointee: 1339 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1192
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1878656
+      GoRuntimeType: 1878432
       GoKind: 22
       Pointee: 1193 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1508
+      ID: 1506
       Name: '*net.hostLookupOrder'
       ByteSize: 8
-      GoRuntimeType: 921408
+      GoRuntimeType: 920736
       GoKind: 22
-      Pointee: 1433 BaseType net.hostLookupOrder
+      Pointee: 1431 BaseType net.hostLookupOrder
     - __kind: PointerType
       ID: 1382
       Name: '*net.netFD'
@@ -18092,26 +18092,26 @@ Types:
       GoKind: 22
       Pointee: 1383 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 852
+      ID: 850
       Name: '*net.notFoundError'
       ByteSize: 8
-      GoRuntimeType: 921024
+      GoRuntimeType: 920352
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType net.notFoundError
+      Pointee: 851 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 420
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
-      GoRuntimeType: 1440896
+      GoRuntimeType: 1440736
       GoKind: 22
       Pointee: 421 GoContextImplementationType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 854
+      ID: 852
       Name: '*net.result·2'
       ByteSize: 8
-      GoRuntimeType: 921696
+      GoRuntimeType: 921024
       GoKind: 22
-      Pointee: 855 StructureType net.result·2
+      Pointee: 853 StructureType net.result·2
     - __kind: PointerType
       ID: 1364
       Name: '*net.tcpConnWithoutReadFrom'
@@ -18130,112 +18130,112 @@ Types:
       ID: 1123
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1222688
+      GoRuntimeType: 1222176
       GoKind: 22
       Pointee: 1124 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 1152
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1441216
+      GoRuntimeType: 1441056
       GoKind: 22
       Pointee: 1153 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 1607
       Name: '*net/http.Cookie'
       ByteSize: 8
-      GoRuntimeType: 1047616
+      GoRuntimeType: 1047488
       GoKind: 22
       Pointee: 1608 UnresolvedPointeeType net/http.Cookie
     - __kind: PointerType
       ID: 1041
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1049408
+      GoRuntimeType: 1049280
       GoKind: 22
       Pointee: 1042 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 2036
       Name: '*net/http.Protocols'
       ByteSize: 8
-      GoRuntimeType: 1831616
+      GoRuntimeType: 1831168
       GoKind: 22
       Pointee: 1951 StructureType net/http.Protocols
     - __kind: PointerType
       ID: 2634
       Name: '*net/http.body'
       ByteSize: 8
-      GoRuntimeType: 1832064
+      GoRuntimeType: 1831616
       GoKind: 22
       Pointee: 2635 UnresolvedPointeeType net/http.body
     - __kind: PointerType
       ID: 2624
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
-      GoRuntimeType: 1217056
+      GoRuntimeType: 1216544
       GoKind: 22
       Pointee: 2625 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
       ID: 2566
       Name: '*net/http.bodyLocked'
       ByteSize: 8
-      GoRuntimeType: 916608
+      GoRuntimeType: 915936
       GoKind: 22
       Pointee: 2567 StructureType net/http.bodyLocked
     - __kind: PointerType
       ID: 1209
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
-      GoRuntimeType: 916800
+      GoRuntimeType: 916128
       GoKind: 22
       Pointee: 1210 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
       ID: 2568
       Name: '*net/http.byteReader'
       ByteSize: 8
-      GoRuntimeType: 916896
+      GoRuntimeType: 916224
       GoKind: 22
       Pointee: 2569 UnresolvedPointeeType net/http.byteReader
     - __kind: PointerType
       ID: 2602
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
-      GoRuntimeType: 1049280
+      GoRuntimeType: 1049152
       GoKind: 22
       Pointee: 2603 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 1498
+      ID: 1496
       Name: '*net/http.connectMethodKey'
       ByteSize: 8
-      GoRuntimeType: 917376
+      GoRuntimeType: 916704
       GoKind: 22
-      Pointee: 1499 StructureType net/http.connectMethodKey
+      Pointee: 1497 StructureType net/http.connectMethodKey
     - __kind: PointerType
-      ID: 1500
+      ID: 1498
       Name: '*net/http.contextKey'
       ByteSize: 8
-      GoRuntimeType: 918720
+      GoRuntimeType: 918048
       GoKind: 22
-      Pointee: 1501 UnresolvedPointeeType net/http.contextKey
+      Pointee: 1499 UnresolvedPointeeType net/http.contextKey
     - __kind: PointerType
       ID: 2590
       Name: '*net/http.eofReader'
       ByteSize: 8
-      GoRuntimeType: 1047872
+      GoRuntimeType: 1047744
       GoKind: 22
       Pointee: 2591 StructureType net/http.eofReader
     - __kind: PointerType
       ID: 2570
       Name: '*net/http.errorReader'
       ByteSize: 8
-      GoRuntimeType: 916992
+      GoRuntimeType: 916320
       GoKind: 22
       Pointee: 2571 StructureType net/http.errorReader
     - __kind: PointerType
       ID: 2572
       Name: '*net/http.finishAsyncByteRead'
       ByteSize: 8
-      GoRuntimeType: 917088
+      GoRuntimeType: 916416
       GoKind: 22
       Pointee: 2573 StructureType net/http.finishAsyncByteRead
     - __kind: PointerType
@@ -18246,10 +18246,10 @@ Types:
       GoKind: 22
       Pointee: 2653 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 829
+      ID: 827
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 917472
+      GoRuntimeType: 916800
       GoKind: 22
       Pointee: 744 BaseType net/http.http2ConnectionError
     - __kind: PointerType
@@ -18270,7 +18270,7 @@ Types:
       ID: 1604
       Name: '*net/http.http2ErrCode'
       ByteSize: 8
-      GoRuntimeType: 1047360
+      GoRuntimeType: 1047232
       GoKind: 22
       Pointee: 1165 BaseType net/http.http2ErrCode
     - __kind: PointerType
@@ -18281,52 +18281,52 @@ Types:
       GoKind: 22
       Pointee: 1798 StructureType net/http.http2FrameHeader
     - __kind: PointerType
-      ID: 1496
+      ID: 1494
       Name: '*net/http.http2FrameType'
       ByteSize: 8
-      GoRuntimeType: 915936
+      GoRuntimeType: 915264
       GoKind: 22
-      Pointee: 1428 BaseType net/http.http2FrameType
+      Pointee: 1426 BaseType net/http.http2FrameType
     - __kind: PointerType
-      ID: 830
+      ID: 828
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
-      GoRuntimeType: 917568
+      GoRuntimeType: 916896
       GoKind: 22
-      Pointee: 831 StructureType net/http.http2GoAwayError
+      Pointee: 829 StructureType net/http.http2GoAwayError
     - __kind: PointerType
       ID: 1865
       Name: '*net/http.http2GoAwayFrame'
       ByteSize: 8
-      GoRuntimeType: 1651872
+      GoRuntimeType: 1651104
       GoKind: 22
       Pointee: 1866 StructureType net/http.http2GoAwayFrame
     - __kind: PointerType
       ID: 2083
       Name: '*net/http.http2HeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 1874624
+      GoRuntimeType: 1874400
       GoKind: 22
       Pointee: 2082 StructureType net/http.http2HeadersFrame
     - __kind: PointerType
       ID: 2180
       Name: '*net/http.http2MetaHeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 2043232
+      GoRuntimeType: 2042944
       GoKind: 22
       Pointee: 2181 StructureType net/http.http2MetaHeadersFrame
     - __kind: PointerType
       ID: 1867
       Name: '*net/http.http2PingFrame'
       ByteSize: 8
-      GoRuntimeType: 1652064
+      GoRuntimeType: 1651296
       GoKind: 22
       Pointee: 1868 StructureType net/http.http2PingFrame
     - __kind: PointerType
       ID: 1869
       Name: '*net/http.http2PriorityFrame'
       ByteSize: 8
-      GoRuntimeType: 1652256
+      GoRuntimeType: 1651488
       GoKind: 22
       Pointee: 1870 StructureType net/http.http2PriorityFrame
     - __kind: PointerType
@@ -18347,16 +18347,16 @@ Types:
       ID: 1605
       Name: '*net/http.http2Setting'
       ByteSize: 8
-      GoRuntimeType: 1047488
+      GoRuntimeType: 1047360
       GoKind: 22
       Pointee: 1606 StructureType net/http.http2Setting
     - __kind: PointerType
-      ID: 1497
+      ID: 1495
       Name: '*net/http.http2SettingID'
       ByteSize: 8
-      GoRuntimeType: 916224
+      GoRuntimeType: 915552
       GoKind: 22
-      Pointee: 1429 BaseType net/http.http2SettingID
+      Pointee: 1427 BaseType net/http.http2SettingID
     - __kind: PointerType
       ID: 2140
       Name: '*net/http.http2SettingsFrame'
@@ -18368,14 +18368,14 @@ Types:
       ID: 1144
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1437056
+      GoRuntimeType: 1436896
       GoKind: 22
       Pointee: 1145 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 1871
       Name: '*net/http.http2UnknownFrame'
       ByteSize: 8
-      GoRuntimeType: 1653600
+      GoRuntimeType: 1652832
       GoKind: 22
       Pointee: 1872 StructureType net/http.http2UnknownFrame
     - __kind: PointerType
@@ -18389,16 +18389,16 @@ Types:
       ID: 2648
       Name: '*net/http.http2clientStream'
       ByteSize: 8
-      GoRuntimeType: 2043520
+      GoRuntimeType: 2043232
       GoKind: 22
       Pointee: 2649 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 834
+      ID: 832
       Name: '*net/http.http2connError'
       ByteSize: 8
-      GoRuntimeType: 918144
+      GoRuntimeType: 917472
       GoKind: 22
-      Pointee: 835 StructureType net/http.http2connError
+      Pointee: 833 StructureType net/http.http2connError
     - __kind: PointerType
       ID: 1273
       Name: '*net/http.http2dataBuffer'
@@ -18407,10 +18407,10 @@ Types:
       GoKind: 22
       Pointee: 1274 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 833
+      ID: 831
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 918048
+      GoRuntimeType: 917376
       GoKind: 22
       Pointee: 748 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
@@ -18422,7 +18422,7 @@ Types:
       ID: 2596
       Name: '*net/http.http2eofReader'
       ByteSize: 8
-      GoRuntimeType: 1048768
+      GoRuntimeType: 1048640
       GoKind: 22
       Pointee: 2597 StructureType net/http.http2eofReader
     - __kind: PointerType
@@ -18433,10 +18433,10 @@ Types:
       GoKind: 22
       Pointee: 2651 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 837
+      ID: 835
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 918336
+      GoRuntimeType: 917664
       GoKind: 22
       Pointee: 754 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
@@ -18445,10 +18445,10 @@ Types:
       ByteSize: 8
       Pointee: 755 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 836
+      ID: 834
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 918240
+      GoRuntimeType: 917568
       GoKind: 22
       Pointee: 751 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
@@ -18460,28 +18460,28 @@ Types:
       ID: 1116
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1217952
+      GoRuntimeType: 1217440
       GoKind: 22
       Pointee: 1117 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 2598
       Name: '*net/http.http2missingBody'
       ByteSize: 8
-      GoRuntimeType: 1048896
+      GoRuntimeType: 1048768
       GoKind: 22
       Pointee: 2599 StructureType net/http.http2missingBody
     - __kind: PointerType
       ID: 2604
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
-      GoRuntimeType: 1050048
+      GoRuntimeType: 1049920
       GoKind: 22
       Pointee: 2605 StructureType net/http.http2noBodyReader
     - __kind: PointerType
       ID: 1047
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1049920
+      GoRuntimeType: 1049792
       GoKind: 22
       Pointee: 1048 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
@@ -18492,10 +18492,10 @@ Types:
       GoKind: 22
       Pointee: 1329 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 832
+      ID: 830
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 917952
+      GoRuntimeType: 917280
       GoKind: 22
       Pointee: 745 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
@@ -18507,42 +18507,42 @@ Types:
       ID: 1211
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
-      GoRuntimeType: 918432
+      GoRuntimeType: 917760
       GoKind: 22
       Pointee: 1212 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
       ID: 2600
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
-      GoRuntimeType: 1049024
+      GoRuntimeType: 1048896
       GoKind: 22
       Pointee: 2601 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
       ID: 2594
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
-      GoRuntimeType: 1048384
+      GoRuntimeType: 1048256
       GoKind: 22
       Pointee: 2595 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
       ID: 2626
       Name: '*net/http.noBody'
       ByteSize: 8
-      GoRuntimeType: 1217184
+      GoRuntimeType: 1216672
       GoKind: 22
       Pointee: 2627 StructureType net/http.noBody
     - __kind: PointerType
       ID: 1043
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1049664
+      GoRuntimeType: 1049536
       GoKind: 22
       Pointee: 1044 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1863
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1651488
+      GoRuntimeType: 1650720
       GoKind: 22
       Pointee: 1864 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
@@ -18556,49 +18556,49 @@ Types:
       ID: 1231
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1049536
+      GoRuntimeType: 1049408
       GoKind: 22
       Pointee: 1232 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 2592
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
-      GoRuntimeType: 1048000
+      GoRuntimeType: 1047872
       GoKind: 22
       Pointee: 2593 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
       ID: 1265
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1437216
+      GoRuntimeType: 1437056
       GoKind: 22
       Pointee: 1266 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 838
+      ID: 836
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
-      GoRuntimeType: 918528
+      GoRuntimeType: 917856
       GoKind: 22
-      Pointee: 839 StructureType net/http.requestBodyReadError
+      Pointee: 837 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 1609
       Name: '*net/http.socksAddr'
       ByteSize: 8
-      GoRuntimeType: 1048128
+      GoRuntimeType: 1048000
       GoKind: 22
       Pointee: 1610 UnresolvedPointeeType net/http.socksAddr
     - __kind: PointerType
       ID: 1146
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1438336
+      GoRuntimeType: 1438176
       GoKind: 22
       Pointee: 1147 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 1114
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1217824
+      GoRuntimeType: 1217312
       GoKind: 22
       Pointee: 1115 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
@@ -18612,23 +18612,23 @@ Types:
       ID: 1045
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1049792
+      GoRuntimeType: 1049664
       GoKind: 22
       Pointee: 1046 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1308
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1875072
+      GoRuntimeType: 1874848
       GoKind: 22
       Pointee: 1309 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 827
+      ID: 825
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
-      GoRuntimeType: 916704
+      GoRuntimeType: 916032
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 826 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 2614
       Name: '*net/http/httputil.failureToReadBody'
@@ -18750,14 +18750,14 @@ Types:
       ID: 1154
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1441536
+      GoRuntimeType: 1441376
       GoKind: 22
       Pointee: 1155 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 856
+      ID: 854
       Name: '*net/url.EscapeError'
       ByteSize: 8
-      GoRuntimeType: 921792
+      GoRuntimeType: 921120
       GoKind: 22
       Pointee: 757 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
@@ -18766,10 +18766,10 @@ Types:
       ByteSize: 8
       Pointee: 758 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 857
+      ID: 855
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
-      GoRuntimeType: 921888
+      GoRuntimeType: 921216
       GoKind: 22
       Pointee: 760 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
@@ -18788,7 +18788,7 @@ Types:
       ID: 1682
       Name: '*net/url.Userinfo'
       ByteSize: 8
-      GoRuntimeType: 1223456
+      GoRuntimeType: 1222944
       GoKind: 22
       Pointee: 1683 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
@@ -19060,19 +19060,19 @@ Types:
       GoKind: 22
       Pointee: 793 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 1493
+      ID: 1515
       Name: '*reflect.ChanDir'
       ByteSize: 8
-      GoRuntimeType: 914880
+      GoRuntimeType: 924288
       GoKind: 22
-      Pointee: 1425 BaseType reflect.ChanDir
+      Pointee: 1434 BaseType reflect.ChanDir
     - __kind: PointerType
-      ID: 1494
+      ID: 1516
       Name: '*reflect.Kind'
       ByteSize: 8
-      GoRuntimeType: 915072
+      GoRuntimeType: 924480
       GoKind: 22
-      Pointee: 1426 BaseType reflect.Kind
+      Pointee: 1435 BaseType reflect.Kind
     - __kind: PointerType
       ID: 2531
       Name: '*reflect.Value'
@@ -19081,12 +19081,12 @@ Types:
       GoKind: 22
       Pointee: 2532 StructureType reflect.Value
     - __kind: PointerType
-      ID: 825
+      ID: 876
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 915456
+      GoRuntimeType: 924864
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType reflect.ValueError
+      Pointee: 877 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 2515
       Name: '*reflect.rtype'
@@ -19313,12 +19313,12 @@ Types:
       GoKind: 22
       Pointee: 56 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 1503
+      ID: 1501
       Name: '*runtime/debug.BuildInfo'
       ByteSize: 8
-      GoRuntimeType: 920736
+      GoRuntimeType: 920064
       GoKind: 22
-      Pointee: 1504 UnresolvedPointeeType runtime/debug.BuildInfo
+      Pointee: 1502 UnresolvedPointeeType runtime/debug.BuildInfo
     - __kind: PointerType
       ID: 1517
       Name: '*runtime/pprof.labelMap'
@@ -31420,7 +31420,7 @@ Types:
     - __kind: ArrayType
       ID: 1948
       Name: '[0]func()'
-      GoRuntimeType: 743776
+      GoRuntimeType: 742432
       GoKind: 17
       HasCount: true
       Element: 66 GoSubroutineType func()
@@ -31742,7 +31742,7 @@ Types:
       ID: 2029
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 706016
+      GoRuntimeType: 705152
       GoKind: 17
       Count: 8
       HasCount: true
@@ -31751,7 +31751,7 @@ Types:
       ID: 1417
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
-      GoRuntimeType: 490336
+      GoRuntimeType: 490144
       GoKind: 23
       RawFields:
         - Name: array
@@ -32311,7 +32311,7 @@ Types:
       ID: 399
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
-      GoRuntimeType: 489888
+      GoRuntimeType: 489696
       GoKind: 23
       RawFields:
         - Name: array
@@ -32334,7 +32334,7 @@ Types:
       ID: 402
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
-      GoRuntimeType: 490080
+      GoRuntimeType: 489888
       GoKind: 23
       RawFields:
         - Name: array
@@ -32380,7 +32380,7 @@ Types:
       ID: 372
       Name: '[]go.shape.float64'
       ByteSize: 24
-      GoRuntimeType: 492448
+      GoRuntimeType: 492320
       GoKind: 23
       RawFields:
         - Name: array
@@ -32967,7 +32967,7 @@ Types:
       ID: 2213
       Name: '[]vendor/golang.org/x/net/http2/hpack.HeaderField'
       ByteSize: 24
-      GoRuntimeType: 502208
+      GoRuntimeType: 501248
       GoKind: 23
       RawFields:
         - Name: array
@@ -33210,7 +33210,7 @@ Types:
       ID: 164
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1300960
+      GoRuntimeType: 1300832
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33280,7 +33280,7 @@ Types:
       ID: 722
       Name: context.canceler
       ByteSize: 16
-      GoRuntimeType: 1126464
+      GoRuntimeType: 1125568
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33292,7 +33292,7 @@ Types:
     - __kind: StructureType
       ID: 1091
       Name: context.deadlineExceededError
-      GoRuntimeType: 1485408
+      GoRuntimeType: 1484288
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
@@ -33323,7 +33323,7 @@ Types:
       ID: 439
       Name: context.timerCtx
       ByteSize: 112
-      GoRuntimeType: 1640352
+      GoRuntimeType: 1639968
       GoKind: 25
       RawFields:
         - Name: cancelCtx
@@ -33353,7 +33353,7 @@ Types:
       ID: 423
       Name: context.valueCtx
       ByteSize: 48
-      GoRuntimeType: 1867904
+      GoRuntimeType: 1866784
       GoKind: 25
       RawFields:
         - Name: Context
@@ -33863,7 +33863,7 @@ Types:
       ID: 772
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 845888
+      GoRuntimeType: 845696
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1238
@@ -33876,13 +33876,13 @@ Types:
       GoRuntimeType: 846080
       GoKind: 8
     - __kind: BaseType
-      ID: 1431
+      ID: 1429
       Name: encoding/json.Delim
       ByteSize: 4
-      GoRuntimeType: 844544
+      GoRuntimeType: 844352
       GoKind: 5
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 847
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -33909,19 +33909,19 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 841
+      ID: 839
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 845
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 845
+      ID: 843
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 841
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -33929,10 +33929,10 @@ Types:
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 851
+      ID: 849
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1439776
+      GoRuntimeType: 1439616
       GoKind: 25
       RawFields:
         - Name: error
@@ -33983,7 +33983,7 @@ Types:
       ID: 2686
       Name: fmt.ScanState
       ByteSize: 16
-      GoRuntimeType: 1484608
+      GoRuntimeType: 1486688
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33996,7 +33996,7 @@ Types:
       ID: 411
       Name: fmt.Stringer
       ByteSize: 16
-      GoRuntimeType: 1038784
+      GoRuntimeType: 1039808
       GoKind: 20
       RawFields:
         - Name: tab
@@ -34104,7 +34104,7 @@ Types:
       ID: 2031
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
       ByteSize: 4
-      GoRuntimeType: 1788448
+      GoRuntimeType: 1787872
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 2196
@@ -34118,7 +34118,7 @@ Types:
       ID: 2032
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
       ByteSize: 4
-      GoRuntimeType: 1788640
+      GoRuntimeType: 1788064
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 2497
@@ -34179,7 +34179,7 @@ Types:
       Name: github.com/DataDog/datadog-agent/pkg/version.Version
       ByteSize: 8
     - __kind: StructureType
-      ID: 860
+      ID: 858
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1759328
@@ -34195,7 +34195,7 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 862
+      ID: 860
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34203,7 +34203,7 @@ Types:
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 866
+      ID: 864
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1129152
       GoKind: 25
@@ -34216,7 +34216,7 @@ Types:
       ID: 766
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
-      GoRuntimeType: 845312
+      GoRuntimeType: 845120
       GoKind: 24
       RawFields:
         - Name: str
@@ -34284,13 +34284,13 @@ Types:
       ID: 1181
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
-      GoRuntimeType: 595904
+      GoRuntimeType: 595840
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 763
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
-      GoRuntimeType: 845216
+      GoRuntimeType: 845024
       GoKind: 24
       RawFields:
         - Name: str
@@ -34309,7 +34309,7 @@ Types:
       ID: 769
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
-      GoRuntimeType: 845408
+      GoRuntimeType: 845216
       GoKind: 24
       RawFields:
         - Name: str
@@ -34520,7 +34520,7 @@ Types:
       ID: 401
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
-      GoRuntimeType: 1944320
+      GoRuntimeType: 1944064
       GoKind: 25
       RawFields:
         - Name: TraceID
@@ -34593,7 +34593,7 @@ Types:
       ID: 389
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 1301088
+      GoRuntimeType: 1300960
       GoKind: 21
       HeaderType: 391 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
@@ -34614,7 +34614,7 @@ Types:
       ID: 1419
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
-      GoRuntimeType: 593152
+      GoRuntimeType: 593088
       GoKind: 10
     - __kind: StructureType
       ID: 404
@@ -34643,7 +34643,7 @@ Types:
       ID: 738
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
-      GoRuntimeType: 1944576
+      GoRuntimeType: 1944320
       GoKind: 25
       RawFields:
         - Name: Type
@@ -34674,7 +34674,7 @@ Types:
       ID: 409
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
-      GoRuntimeType: 2140256
+      GoRuntimeType: 2139904
       GoKind: 25
       RawFields:
         - Name: mu
@@ -34711,7 +34711,7 @@ Types:
       ID: 410
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
-      GoRuntimeType: 911040
+      GoRuntimeType: 910560
       GoKind: 17
       Count: 16
       HasCount: true
@@ -34730,7 +34730,7 @@ Types:
       ID: 1585
       Name: github.com/DataDog/dd-trace-go/v2/internal.TraceSource
       ByteSize: 1
-      GoRuntimeType: 1006144
+      GoRuntimeType: 1006048
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1375
@@ -34777,16 +34777,16 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/waf.Feature
       ByteSize: 8
     - __kind: BaseType
-      ID: 1427
+      ID: 1425
       Name: github.com/DataDog/dd-trace-go/v2/internal/log.Level
       ByteSize: 8
-      GoRuntimeType: 843488
+      GoRuntimeType: 843296
       GoKind: 2
     - __kind: GoContextImplementationType
       ID: 419
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
-      GoRuntimeType: 1654560
+      GoRuntimeType: 1653792
       GoKind: 25
       RawFields:
         - Name: Context
@@ -35178,24 +35178,24 @@ Types:
           Offset: 56
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1515
+      ID: 1513
       Name: github.com/cihub/seelog.CfgParseParams
       ByteSize: 8
     - __kind: BaseType
-      ID: 1434
+      ID: 1432
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
-      GoRuntimeType: 845696
+      GoRuntimeType: 845504
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 2042
       Name: github.com/cihub/seelog.LogLevelException
       ByteSize: 8
     - __kind: StructureType
-      ID: 868
+      ID: 866
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1442016
+      GoRuntimeType: 1441856
       GoKind: 25
       RawFields:
         - Name: message
@@ -35206,15 +35206,15 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 870
+      ID: 868
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1442176
+      GoRuntimeType: 1442016
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 868 StructureType github.com/cihub/seelog.baseError
+          Type: 866 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1278
       Name: github.com/cihub/seelog.connWriter
@@ -35252,11 +35252,11 @@ Types:
       Name: github.com/cihub/seelog.listConstraints
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1512
+      ID: 1510
       Name: github.com/cihub/seelog.logFormattedMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1510
+      ID: 1508
       Name: github.com/cihub/seelog.logMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -35264,15 +35264,15 @@ Types:
       Name: github.com/cihub/seelog.minMaxConstraints
       ByteSize: 8
     - __kind: StructureType
-      ID: 874
+      ID: 872
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1442496
+      GoRuntimeType: 1442336
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 868 StructureType github.com/cihub/seelog.baseError
+          Type: 866 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1622
       Name: github.com/cihub/seelog.offConstraints
@@ -35319,25 +35319,25 @@ Types:
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 872
+      ID: 870
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1442336
+      GoRuntimeType: 1442176
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 868 StructureType github.com/cihub/seelog.baseError
+          Type: 866 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 876
+      ID: 874
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1442656
+      GoRuntimeType: 1442496
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 868 StructureType github.com/cihub/seelog.baseError
+          Type: 866 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1759
       Name: github.com/cihub/seelog.xmlNode
@@ -35962,7 +35962,7 @@ Types:
       ID: 1103
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1873280
+      GoRuntimeType: 1873056
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -35995,7 +35995,7 @@ Types:
       ID: 1109
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1873728
+      GoRuntimeType: 1873504
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36011,13 +36011,13 @@ Types:
       ID: 1013
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 1005568
+      GoRuntimeType: 1005472
       GoKind: 8
     - __kind: StructureType
       ID: 1101
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1873056
+      GoRuntimeType: 1872832
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -36037,13 +36037,13 @@ Types:
       ID: 1191
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
-      GoRuntimeType: 843584
+      GoRuntimeType: 843392
       GoKind: 8
     - __kind: StructureType
       ID: 1099
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1872832
+      GoRuntimeType: 1872608
       GoKind: 25
       RawFields:
         - Name: Method
@@ -36059,7 +36059,7 @@ Types:
       ID: 1107
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1786144
+      GoRuntimeType: 1785568
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36072,7 +36072,7 @@ Types:
       ID: 1105
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1873504
+      GoRuntimeType: 1873280
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36092,7 +36092,7 @@ Types:
       ID: 1113
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1650528
+      GoRuntimeType: 1649760
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -36114,7 +36114,7 @@ Types:
       ID: 1111
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1786336
+      GoRuntimeType: 1785760
       GoKind: 25
       RawFields:
         - Name: cause
@@ -38783,7 +38783,7 @@ Types:
       ID: 2665
       Name: io.Closer
       ByteSize: 16
-      GoRuntimeType: 1039808
+      GoRuntimeType: 1040832
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38808,7 +38808,7 @@ Types:
       ID: 1297
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1205920
+      GoRuntimeType: 1209120
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38821,7 +38821,7 @@ Types:
       ID: 412
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1039168
+      GoRuntimeType: 1040192
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38838,7 +38838,7 @@ Types:
       ID: 1283
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1125952
+      GoRuntimeType: 1126208
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38851,7 +38851,7 @@ Types:
       ID: 140
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1038912
+      GoRuntimeType: 1039936
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38864,7 +38864,7 @@ Types:
       ID: 2664
       Name: io.WriterTo
       ByteSize: 16
-      GoRuntimeType: 1039680
+      GoRuntimeType: 1040704
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38876,13 +38876,13 @@ Types:
     - __kind: StructureType
       ID: 1254
       Name: io.discard
-      GoRuntimeType: 1485088
+      GoRuntimeType: 1487168
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 2565
       Name: io.eofReader
-      GoRuntimeType: 1125696
+      GoRuntimeType: 1125952
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -38897,7 +38897,7 @@ Types:
       ID: 2589
       Name: io.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1573728
+      GoRuntimeType: 1575328
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -38907,7 +38907,7 @@ Types:
       ID: 2623
       Name: io.nopCloserWriterTo
       ByteSize: 16
-      GoRuntimeType: 1639968
+      GoRuntimeType: 1641120
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -38954,7 +38954,7 @@ Types:
       ID: 1687
       Name: log/slog.Attr
       ByteSize: 40
-      GoRuntimeType: 1793824
+      GoRuntimeType: 1793248
       GoKind: 25
       RawFields:
         - Name: Key
@@ -38964,16 +38964,16 @@ Types:
           Offset: 16
           Type: 2033 StructureType log/slog.Value
     - __kind: BaseType
-      ID: 1435
+      ID: 1433
       Name: log/slog.Kind
       ByteSize: 8
-      GoRuntimeType: 845792
+      GoRuntimeType: 845600
       GoKind: 2
     - __kind: BaseType
       ID: 1789
       Name: log/slog.Level
       ByteSize: 8
-      GoRuntimeType: 1507328
+      GoRuntimeType: 1506208
       GoKind: 2
     - __kind: StructureType
       ID: 2033
@@ -41560,16 +41560,16 @@ Types:
       Name: net.DNSError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1432
+      ID: 1430
       Name: net.Flags
       ByteSize: 8
-      GoRuntimeType: 844736
+      GoRuntimeType: 844544
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 1505
+      ID: 1503
       Name: net.HardwareAddr
       ByteSize: 24
-      GoRuntimeType: 921216
+      GoRuntimeType: 920544
       GoKind: 23
       RawFields:
         - Name: array
@@ -41581,9 +41581,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1506 GoSliceDataType net.HardwareAddr.array
+      Data: 1504 GoSliceDataType net.HardwareAddr.array
     - __kind: GoSliceDataType
-      ID: 1506
+      ID: 1504
       Name: net.HardwareAddr.array
       DynamicSizeClass: slice
       ByteSize: 1
@@ -41623,7 +41623,7 @@ Types:
       ID: 1614
       Name: net.IPMask
       ByteSize: 24
-      GoRuntimeType: 1053248
+      GoRuntimeType: 1053120
       GoKind: 23
       RawFields:
         - Name: array
@@ -41737,10 +41737,10 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: BaseType
-      ID: 1433
+      ID: 1431
       Name: net.hostLookupOrder
       ByteSize: 8
-      GoRuntimeType: 844832
+      GoRuntimeType: 844640
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1383
@@ -41759,14 +41759,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 851
       Name: net.notFoundError
       ByteSize: 8
     - __kind: GoContextImplementationType
       ID: 421
       Name: net.onlyValuesCtx
       ByteSize: 32
-      GoRuntimeType: 1790752
+      GoRuntimeType: 1790176
       GoKind: 25
       RawFields:
         - Name: Context
@@ -41778,7 +41778,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: StructureType
-      ID: 855
+      ID: 853
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1759136
@@ -41828,10 +41828,10 @@ Types:
       Name: net.timeoutError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1430
+      ID: 1428
       Name: net/http.ConnState
       ByteSize: 8
-      GoRuntimeType: 843968
+      GoRuntimeType: 843776
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1608
@@ -41860,7 +41860,7 @@ Types:
       ID: 2567
       Name: net/http.bodyLocked
       ByteSize: 8
-      GoRuntimeType: 1437376
+      GoRuntimeType: 1437216
       GoKind: 25
       RawFields:
         - Name: b
@@ -41870,7 +41870,7 @@ Types:
       ID: 1210
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1437536
+      GoRuntimeType: 1437376
       GoKind: 25
       RawFields:
         - Name: w
@@ -41885,7 +41885,7 @@ Types:
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 1499
+      ID: 1497
       Name: net/http.connectMethodKey
       ByteSize: 56
       GoRuntimeType: 1856416
@@ -41904,7 +41904,7 @@ Types:
           Offset: 48
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1501
+      ID: 1499
       Name: net/http.contextKey
       ByteSize: 8
     - __kind: StructureType
@@ -41917,7 +41917,7 @@ Types:
       ID: 2571
       Name: net/http.errorReader
       ByteSize: 16
-      GoRuntimeType: 1437696
+      GoRuntimeType: 1437536
       GoKind: 25
       RawFields:
         - Name: err
@@ -41927,7 +41927,7 @@ Types:
       ID: 2573
       Name: net/http.finishAsyncByteRead
       ByteSize: 8
-      GoRuntimeType: 1437856
+      GoRuntimeType: 1437696
       GoKind: 25
       RawFields:
         - Name: tw
@@ -41941,13 +41941,13 @@ Types:
       ID: 744
       Name: net/http.http2ConnectionError
       ByteSize: 4
-      GoRuntimeType: 844064
+      GoRuntimeType: 843872
       GoKind: 10
     - __kind: StructureType
       ID: 1955
       Name: net/http.http2ContinuationFrame
       ByteSize: 40
-      GoRuntimeType: 1788064
+      GoRuntimeType: 1787488
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41960,7 +41960,7 @@ Types:
       ID: 1950
       Name: net/http.http2DataFrame
       ByteSize: 40
-      GoRuntimeType: 1786528
+      GoRuntimeType: 1785952
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41973,13 +41973,13 @@ Types:
       ID: 1165
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 1005664
+      GoRuntimeType: 1005568
       GoKind: 10
     - __kind: BaseType
       ID: 2028
       Name: net/http.http2Flags
       ByteSize: 1
-      GoRuntimeType: 843776
+      GoRuntimeType: 843584
       GoKind: 8
     - __kind: StructureType
       ID: 1798
@@ -41993,7 +41993,7 @@ Types:
           Type: 6 BaseType bool
         - Name: Type
           Offset: 1
-          Type: 1428 BaseType net/http.http2FrameType
+          Type: 1426 BaseType net/http.http2FrameType
         - Name: Flags
           Offset: 2
           Type: 2028 BaseType net/http.http2Flags
@@ -42004,13 +42004,13 @@ Types:
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1428
+      ID: 1426
       Name: net/http.http2FrameType
       ByteSize: 1
-      GoRuntimeType: 843680
+      GoRuntimeType: 843488
       GoKind: 8
     - __kind: StructureType
-      ID: 831
+      ID: 829
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1757408
@@ -42029,7 +42029,7 @@ Types:
       ID: 1866
       Name: net/http.http2GoAwayFrame
       ByteSize: 48
-      GoRuntimeType: 1948416
+      GoRuntimeType: 1948160
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42048,7 +42048,7 @@ Types:
       ID: 2082
       Name: net/http.http2HeadersFrame
       ByteSize: 48
-      GoRuntimeType: 1874400
+      GoRuntimeType: 1874176
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42080,7 +42080,7 @@ Types:
       ID: 1868
       Name: net/http.http2PingFrame
       ByteSize: 20
-      GoRuntimeType: 1786720
+      GoRuntimeType: 1786144
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42106,7 +42106,7 @@ Types:
       ID: 2076
       Name: net/http.http2PriorityParam
       ByteSize: 8
-      GoRuntimeType: 1930560
+      GoRuntimeType: 1930304
       GoKind: 25
       RawFields:
         - Name: StreamDep
@@ -42128,7 +42128,7 @@ Types:
       ID: 1953
       Name: net/http.http2PushPromiseFrame
       ByteSize: 40
-      GoRuntimeType: 1876416
+      GoRuntimeType: 1876192
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42144,7 +42144,7 @@ Types:
       ID: 1800
       Name: net/http.http2RSTStreamFrame
       ByteSize: 16
-      GoRuntimeType: 1786912
+      GoRuntimeType: 1786336
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42162,21 +42162,21 @@ Types:
       RawFields:
         - Name: ID
           Offset: 0
-          Type: 1429 BaseType net/http.http2SettingID
+          Type: 1427 BaseType net/http.http2SettingID
         - Name: Val
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1429
+      ID: 1427
       Name: net/http.http2SettingID
       ByteSize: 2
-      GoRuntimeType: 843872
+      GoRuntimeType: 843680
       GoKind: 9
     - __kind: StructureType
       ID: 2030
       Name: net/http.http2SettingsFrame
       ByteSize: 40
-      GoRuntimeType: 1787104
+      GoRuntimeType: 1786528
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42189,7 +42189,7 @@ Types:
       ID: 1145
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1930816
+      GoRuntimeType: 1930560
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -42205,7 +42205,7 @@ Types:
       ID: 1872
       Name: net/http.http2UnknownFrame
       ByteSize: 40
-      GoRuntimeType: 1787872
+      GoRuntimeType: 1787296
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42218,7 +42218,7 @@ Types:
       ID: 1802
       Name: net/http.http2WindowUpdateFrame
       ByteSize: 16
-      GoRuntimeType: 1787296
+      GoRuntimeType: 1786720
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42232,7 +42232,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 835
+      ID: 833
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1621600
@@ -42252,7 +42252,7 @@ Types:
       ID: 748
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 844256
+      GoRuntimeType: 844064
       GoKind: 24
       RawFields:
         - Name: str
@@ -42281,7 +42281,7 @@ Types:
       ID: 754
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 844448
+      GoRuntimeType: 844256
       GoKind: 24
       RawFields:
         - Name: str
@@ -42300,7 +42300,7 @@ Types:
       ID: 751
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 844352
+      GoRuntimeType: 844160
       GoKind: 24
       RawFields:
         - Name: str
@@ -42345,7 +42345,7 @@ Types:
       ID: 745
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 844160
+      GoRuntimeType: 843968
       GoKind: 24
       RawFields:
         - Name: str
@@ -42389,7 +42389,7 @@ Types:
     - __kind: ArrayType
       ID: 1294
       Name: net/http.incomparable
-      GoRuntimeType: 916512
+      GoRuntimeType: 915840
       GoKind: 17
       HasCount: true
       Element: 66 GoSubroutineType func()
@@ -42400,7 +42400,7 @@ Types:
     - __kind: StructureType
       ID: 2627
       Name: net/http.noBody
-      GoRuntimeType: 1497888
+      GoRuntimeType: 1496768
       GoKind: 25
       RawFields: []
     - __kind: StructureType
@@ -42439,7 +42439,7 @@ Types:
       ID: 1266
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1831840
+      GoRuntimeType: 1831392
       GoKind: 25
       RawFields:
         - Name: _
@@ -42452,10 +42452,10 @@ Types:
           Offset: 8
           Type: 1297 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 839
+      ID: 837
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1438496
+      GoRuntimeType: 1438336
       GoKind: 25
       RawFields:
         - Name: error
@@ -42472,7 +42472,7 @@ Types:
     - __kind: StructureType
       ID: 1115
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1499008
+      GoRuntimeType: 1497888
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -42493,7 +42493,7 @@ Types:
       ID: 1309
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2061632
+      GoRuntimeType: 2061344
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -42503,7 +42503,7 @@ Types:
           Offset: 16
           Type: 1188 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 826
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -42671,7 +42671,7 @@ Types:
       ID: 757
       Name: net/url.EscapeError
       ByteSize: 16
-      GoRuntimeType: 844928
+      GoRuntimeType: 844736
       GoKind: 24
       RawFields:
         - Name: str
@@ -42690,7 +42690,7 @@ Types:
       ID: 760
       Name: net/url.InvalidHostError
       ByteSize: 16
-      GoRuntimeType: 845024
+      GoRuntimeType: 844832
       GoKind: 24
       RawFields:
         - Name: str
@@ -42789,7 +42789,7 @@ Types:
       ID: 720
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
-      GoRuntimeType: 700768
+      GoRuntimeType: 699328
       GoKind: 17
       Count: 8
       HasCount: true
@@ -42870,7 +42870,7 @@ Types:
       ID: 735
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
-      GoRuntimeType: 701408
+      GoRuntimeType: 699968
       GoKind: 17
       Count: 8
       HasCount: true
@@ -42879,7 +42879,7 @@ Types:
       ID: 2552
       Name: noalg.[8]struct { key string; elem *regexp.Regexp }
       ByteSize: 192
-      GoRuntimeType: 702560
+      GoRuntimeType: 701408
       GoKind: 17
       Count: 8
       HasCount: true
@@ -42906,7 +42906,7 @@ Types:
       ID: 702
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
-      GoRuntimeType: 701312
+      GoRuntimeType: 699872
       GoKind: 17
       Count: 8
       HasCount: true
@@ -43095,7 +43095,7 @@ Types:
       ID: 719
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
-      GoRuntimeType: 1319392
+      GoRuntimeType: 1319264
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43212,7 +43212,7 @@ Types:
       ID: 734
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
-      GoRuntimeType: 1320416
+      GoRuntimeType: 1320288
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43225,7 +43225,7 @@ Types:
       ID: 2551
       Name: noalg.map.group[string]*regexp.Regexp
       ByteSize: 200
-      GoRuntimeType: 1321184
+      GoRuntimeType: 1321056
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43264,7 +43264,7 @@ Types:
       ID: 701
       Name: noalg.map.group[string]float64
       ByteSize: 200
-      GoRuntimeType: 1320160
+      GoRuntimeType: 1320032
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43518,7 +43518,7 @@ Types:
       ID: 721
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
-      GoRuntimeType: 1319264
+      GoRuntimeType: 1319136
       GoKind: 25
       RawFields:
         - Name: key
@@ -43635,7 +43635,7 @@ Types:
       ID: 736
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
-      GoRuntimeType: 1320288
+      GoRuntimeType: 1320160
       GoKind: 25
       RawFields:
         - Name: key
@@ -43648,7 +43648,7 @@ Types:
       ID: 2553
       Name: noalg.struct { key string; elem *regexp.Regexp }
       ByteSize: 24
-      GoRuntimeType: 1321056
+      GoRuntimeType: 1320928
       GoKind: 25
       RawFields:
         - Name: key
@@ -43687,7 +43687,7 @@ Types:
       ID: 703
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
-      GoRuntimeType: 1320032
+      GoRuntimeType: 1319904
       GoKind: 25
       RawFields:
         - Name: key
@@ -44006,16 +44006,16 @@ Types:
       GoRuntimeType: 850304
       GoKind: 2
     - __kind: BaseType
-      ID: 1425
+      ID: 1434
       Name: reflect.ChanDir
       ByteSize: 8
-      GoRuntimeType: 843296
+      GoRuntimeType: 845792
       GoKind: 2
     - __kind: BaseType
-      ID: 1426
+      ID: 1435
       Name: reflect.Kind
       ByteSize: 8
-      GoRuntimeType: 843392
+      GoRuntimeType: 845888
       GoKind: 7
     - __kind: StructureType
       ID: 2532
@@ -44034,14 +44034,14 @@ Types:
           Offset: 16
           Type: 2533 BaseType reflect.flag
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 877
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: BaseType
       ID: 2533
       Name: reflect.flag
       ByteSize: 8
-      GoRuntimeType: 1785184
+      GoRuntimeType: 1793440
       GoKind: 12
     - __kind: UnresolvedPointeeType
       ID: 2516
@@ -45039,7 +45039,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1504
+      ID: 1502
       Name: runtime/debug.BuildInfo
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -45095,7 +45095,7 @@ Types:
       ID: 2619
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
-      GoRuntimeType: 1738752
+      GoRuntimeType: 1737984
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -45108,7 +45108,7 @@ Types:
       ID: 2617
       Name: struct { io.Reader; io.WriterTo }
       ByteSize: 32
-      GoRuntimeType: 1738560
+      GoRuntimeType: 1737792
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -46602,10 +46602,10 @@ Issues:
       issue:
         Kind: 7
         Message: return value selector (e.g., @return.r0) must be used for multi-value returns
-GoModuledataInfo: {FirstModuledataAddr: "0x186ed00", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x1870d00", TypesOffset: 296}
 GoMapHashInfo:
-    UseAeshashAddr: "0x197032a"
-    AeskeyschedAddr: "0x1971420"
+    UseAeshashAddr: "0x197232a"
+    AeskeyschedAddr: "0x1973420"
 CommonTypes:
     G: 25 StructureType runtime.g
     M: 32 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -20,11 +20,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2786 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x8996e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x89a1e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2787 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x89971c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89a21c", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -40,11 +40,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2621 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x894138", Frameless: false}]
+              InjectionPoints: [{PC: "0x894708", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2622 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x894164", Frameless: false}]
+              InjectionPoints: [{PC: "0x894734", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -66,11 +66,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2624 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x8941b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894788", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2625 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x8941e4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8947b4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -91,11 +91,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2755 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x89815c", Frameless: false}]
+              InjectionPoints: [{PC: "0x898b7c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2756 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8981f4", Frameless: false}]
+              InjectionPoints: [{PC: "0x898c14", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -183,7 +183,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2633 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x894940", Frameless: true}]
+              InjectionPoints: [{PC: "0x894fc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -248,11 +248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2657 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x8962a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896b00", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2658 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x8962dc", Frameless: true}]
+              InjectionPoints: [{PC: "0x896b3c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -274,11 +274,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2585 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x88fd70", Frameless: true}]
+              InjectionPoints: [{PC: "0x88ff50", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2586 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0x88fd88", Frameless: true}]
+              InjectionPoints: [{PC: "0x88ff68", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -344,7 +344,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2784 EventRootType Probe[main.testByteSliceInvalidUtf8]
-              InjectionPoints: [{PC: "0x899110", Frameless: true}]
+              InjectionPoints: [{PC: "0x899b30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -366,7 +366,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2785 EventRootType Probe[main.testByteSliceMultibyteUtf8]
-              InjectionPoints: [{PC: "0x899120", Frameless: true}]
+              InjectionPoints: [{PC: "0x899b40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -387,7 +387,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2600 EventRootType Probe[main.testCaptureContextImpl]
-              InjectionPoints: [{PC: "0x890a00", Frameless: true}]
+              InjectionPoints: [{PC: "0x890cd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -414,11 +414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2808 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x899a90", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a7a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2809 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x899aac", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a7bc", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -426,7 +426,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: ""
       segments: []
@@ -438,15 +438,15 @@ Probes:
             - Kind: Line
               Type: 2872 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x8939d8"
+                - PC: "0x893eb8"
                   Frameless: false
-                - PC: "0x893a4c"
+                - PC: "0x893f2c"
                   Frameless: false
-                - PC: "0x893b98"
+                - PC: "0x894078"
                   Frameless: false
-                - PC: "0x893c14"
+                - PC: "0x8940f4"
                   Frameless: false
-                - PC: "0x893cdc"
+                - PC: "0x8941bc"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -455,7 +455,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       when: {dsl: x == 3, json: {eq: [{ref: x}, 3]}}
       sampling: {snapshotsPerSecond: 100}
       template: ""
@@ -468,15 +468,15 @@ Probes:
             - Kind: Line
               Type: 2873 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x8939d8"
+                - PC: "0x893eb8"
                   Frameless: false
-                - PC: "0x893a4c"
+                - PC: "0x893f2c"
                   Frameless: false
-                - PC: "0x893b98"
+                - PC: "0x894078"
                   Frameless: false
-                - PC: "0x893c14"
+                - PC: "0x8940f4"
                   Frameless: false
-                - PC: "0x893cdc"
+                - PC: "0x8941bc"
                   Frameless: false
               Condition:
                 Type: 6 BaseType bool
@@ -502,7 +502,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: x={x}
       segments: [x=, {json: {ref: x}, dsl: x}]
@@ -514,15 +514,15 @@ Probes:
             - Kind: Line
               Type: 2874 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x8939d8"
+                - PC: "0x893eb8"
                   Frameless: false
-                - PC: "0x893a4c"
+                - PC: "0x893f2c"
                   Frameless: false
-                - PC: "0x893b98"
+                - PC: "0x894078"
                   Frameless: false
-                - PC: "0x893c14"
+                - PC: "0x8940f4"
                   Frameless: false
-                - PC: "0x893cdc"
+                - PC: "0x8941bc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -550,7 +550,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2652 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x895dd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896450", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -569,7 +569,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2653 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x895dd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896450", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -595,7 +595,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2816 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x899b40", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a850", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -633,7 +633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2659 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x8962e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896b40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -663,7 +663,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2651 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x895db0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896430", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -692,11 +692,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2720 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x897358", Frameless: false}]
+              InjectionPoints: [{PC: "0x897d78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2721 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x897408", Frameless: false}]
+              InjectionPoints: [{PC: "0x897e28", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -718,7 +718,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2667 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x896590", Frameless: true}]
+              InjectionPoints: [{PC: "0x896ed0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -740,7 +740,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2592 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x890270", Frameless: true}]
+              InjectionPoints: [{PC: "0x890450", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -762,7 +762,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2593 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x890280", Frameless: true}]
+              InjectionPoints: [{PC: "0x890460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -784,7 +784,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2588 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x88ff60", Frameless: true}]
+              InjectionPoints: [{PC: "0x890140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -806,7 +806,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2589 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x88ff70", Frameless: true}]
+              InjectionPoints: [{PC: "0x890150", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -828,7 +828,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2590 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x890110", Frameless: true}]
+              InjectionPoints: [{PC: "0x8902f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -850,7 +850,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2591 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x890120", Frameless: true}]
+              InjectionPoints: [{PC: "0x890300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -872,7 +872,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2772 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x899030", Frameless: true}]
+              InjectionPoints: [{PC: "0x899a50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -899,7 +899,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2775 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x899060", Frameless: true}]
+              InjectionPoints: [{PC: "0x899a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -927,7 +927,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2800 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x8997c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a3e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -949,7 +949,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2817 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x899b90", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a8a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -970,7 +970,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2818 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x899ba0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a8b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -992,7 +992,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2623 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x894190", Frameless: true}]
+              InjectionPoints: [{PC: "0x894760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1007,7 +1007,7 @@ Probes:
       where:
         methodName: main.testErrorAtLine
         sourceFile: complex.go
-        lines: ["108"]
+        lines: ["111"]
       tags:
         - config_diff:arch=amd64,toolchain=go1.26rc1
         - skip_integration:arch=arm64,toolchain=go1.25.0
@@ -1026,7 +1026,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2587 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x88fdfc", Frameless: false}]
+              InjectionPoints: [{PC: "0x88ffdc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -1054,11 +1054,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2605 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x8929e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x892ec8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2606 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x892a24", Frameless: false}]
+              InjectionPoints: [{PC: "0x892f04", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1080,11 +1080,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2603 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x8928fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x892ddc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2604 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x89296c", Frameless: false}]
+              InjectionPoints: [{PC: "0x892e4c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1106,11 +1106,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2615 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x893e60", Frameless: true}]
+              InjectionPoints: [{PC: "0x894340", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2616 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x893e68", Frameless: true}]
+              InjectionPoints: [{PC: "0x894348", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1132,11 +1132,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2617 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x893e7c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89435c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2618 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x893eb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x894398", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1151,7 +1151,7 @@ Probes:
       where:
         methodName: main.testFramelessArray
         sourceFile: inlined.go
-        lines: ["93"]
+        lines: ["96"]
       sampling: {snapshotsPerSecond: 100}
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
@@ -1161,7 +1161,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2619 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x893e7c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89435c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1183,11 +1183,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2858 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x89c060", Frameless: true}]
+              InjectionPoints: [{PC: "0x89cf40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2859 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x89c068", Frameless: true}]
+              InjectionPoints: [{PC: "0x89cf48", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1201,11 +1201,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2860 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x89c080", Frameless: false}]
+              InjectionPoints: [{PC: "0x89cf60", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2861 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x89c0bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x89cf9c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1228,11 +1228,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2854 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x89bfc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x89cea8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2855 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x89bfd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x89ceb8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1246,11 +1246,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2856 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x89c018", Frameless: false}]
+              InjectionPoints: [{PC: "0x89cef8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2857 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x89c030", Frameless: false}]
+              InjectionPoints: [{PC: "0x89cf10", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1273,14 +1273,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2862 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x89c0d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89cfb0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2863 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x89c0f8"
+                - PC: "0x89cfd8"
                   Frameless: true
-                - PC: "0x89c100"
+                - PC: "0x89cfe0"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1295,14 +1295,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2864 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x89c128", Frameless: false}]
+              InjectionPoints: [{PC: "0x89d008", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2865 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x89c188"
+                - PC: "0x89d068"
                   Frameless: false
-                - PC: "0x89c198"
+                - PC: "0x89d078"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1329,7 +1329,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2866 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x89c0d4", Frameless: true}]
+              InjectionPoints: [{PC: "0x89cfb4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1341,7 +1341,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2867 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x89c138", Frameless: false}]
+              InjectionPoints: [{PC: "0x89d018", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1362,11 +1362,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2842 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x89bca0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89cb80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2843 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x89bca8", Frameless: true}]
+              InjectionPoints: [{PC: "0x89cb88", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1380,11 +1380,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2844 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x89bd30", Frameless: true}]
+              InjectionPoints: [{PC: "0x89cc10", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2845 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x89bd34", Frameless: true}]
+              InjectionPoints: [{PC: "0x89cc14", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1408,11 +1408,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2830 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x89b848", Frameless: false}]
+              InjectionPoints: [{PC: "0x89c728", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2831 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x89b91c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89c7fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1454,11 +1454,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2834 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x89b978", Frameless: false}]
+              InjectionPoints: [{PC: "0x89c858", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2835 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x89b988", Frameless: false}]
+              InjectionPoints: [{PC: "0x89c868", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1481,11 +1481,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2868 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x89c1e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89d0c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2869 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x89c1e8", Frameless: true}]
+              InjectionPoints: [{PC: "0x89d0c8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1499,11 +1499,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2870 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x89c288", Frameless: false}]
+              InjectionPoints: [{PC: "0x89d168", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2871 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x89c2ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x89d18c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1526,11 +1526,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2826 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x89b7a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89c680", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2827 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x89b7a4", Frameless: true}]
+              InjectionPoints: [{PC: "0x89c684", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1544,11 +1544,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2828 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x89b7b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89c690", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2829 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x89b7bc", Frameless: true}]
+              InjectionPoints: [{PC: "0x89c69c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1571,11 +1571,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2846 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x89bdd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89ccb0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2847 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x89bdd8", Frameless: true}]
+              InjectionPoints: [{PC: "0x89ccb8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1589,11 +1589,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2848 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x89be78", Frameless: false}]
+              InjectionPoints: [{PC: "0x89cd58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2849 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x89bea4", Frameless: false}]
+              InjectionPoints: [{PC: "0x89cd84", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1616,11 +1616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2836 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x89bc70", Frameless: true}]
+              InjectionPoints: [{PC: "0x89cb50", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2837 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x89bc74", Frameless: true}]
+              InjectionPoints: [{PC: "0x89cb54", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1634,11 +1634,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2838 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x89bc80", Frameless: true}]
+              InjectionPoints: [{PC: "0x89cb60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2839 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x89bc84", Frameless: true}]
+              InjectionPoints: [{PC: "0x89cb64", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1652,11 +1652,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2840 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x89bc90", Frameless: true}]
+              InjectionPoints: [{PC: "0x89cb70", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2841 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x89bc94", Frameless: true}]
+              InjectionPoints: [{PC: "0x89cb74", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1679,11 +1679,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2850 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x89bf80", Frameless: true}]
+              InjectionPoints: [{PC: "0x89ce60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2851 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x89bf88", Frameless: true}]
+              InjectionPoints: [{PC: "0x89ce68", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1697,11 +1697,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2852 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x89bf90", Frameless: true}]
+              InjectionPoints: [{PC: "0x89ce70", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2853 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x89bfa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89ce80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1724,11 +1724,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2822 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x89b780", Frameless: true}]
+              InjectionPoints: [{PC: "0x89c660", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2823 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x89b784", Frameless: true}]
+              InjectionPoints: [{PC: "0x89c664", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1742,11 +1742,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2824 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x89b790", Frameless: true}]
+              InjectionPoints: [{PC: "0x89c670", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2825 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x89b79c", Frameless: true}]
+              InjectionPoints: [{PC: "0x89c67c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1769,14 +1769,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2655 EventRootType Probe[main.(*Server).handleOrder]
-              InjectionPoints: [{PC: "0x89604c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8967bc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2656 EventRootType Probe[main.(*Server).handleOrder]Return
               InjectionPoints:
-                - PC: "0x896104"
+                - PC: "0x896874"
                   Frameless: false
-                - PC: "0x8961bc"
+                - PC: "0x89692c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1799,11 +1799,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2607 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x893b78", Frameless: false}]
+              InjectionPoints: [{PC: "0x894058", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2608 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x893bd0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8940b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1830,11 +1830,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2609 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x893c08", Frameless: false}]
+              InjectionPoints: [{PC: "0x8940e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2610 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x893c90", Frameless: false}]
+              InjectionPoints: [{PC: "0x894170", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1861,11 +1861,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2611 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x893cd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8941b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2612 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x893d14", Frameless: false}]
+              InjectionPoints: [{PC: "0x8941f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1887,7 +1887,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2878 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x893c58", Frameless: false}]
+              InjectionPoints: [{PC: "0x894138", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1905,11 +1905,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2613 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x893d58", Frameless: false}]
+              InjectionPoints: [{PC: "0x894238", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2614 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x893e48", Frameless: false}]
+              InjectionPoints: [{PC: "0x894328", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1927,7 +1927,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2879 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x893d5c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89423c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1938,7 +1938,7 @@ Probes:
       where:
         methodName: main.testInlinedBCA
         sourceFile: inlined.go
-        lines: ["63"]
+        lines: ["66"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCA
       segments: [testInlinedBCA]
@@ -1948,7 +1948,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2880 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x893d5c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89423c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1966,7 +1966,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2881 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x893e10", Frameless: false}]
+              InjectionPoints: [{PC: "0x8942f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1977,7 +1977,7 @@ Probes:
       where:
         methodName: main.testInlinedBCB
         sourceFile: inlined.go
-        lines: ["67"]
+        lines: ["70"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCB
       segments: [testInlinedBCB]
@@ -1987,7 +1987,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2882 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x893e10", Frameless: false}]
+              InjectionPoints: [{PC: "0x8942f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -2008,7 +2008,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x88e394"
                   Frameless: true
-                - PC: "0x894878"
+                - PC: "0x894ec4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2029,20 +2029,20 @@ Probes:
             - Kind: Entry
               Type: 2875 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x8939d8"
+                - PC: "0x893eb8"
                   Frameless: false
-                - PC: "0x893a4c"
+                - PC: "0x893f2c"
                   Frameless: false
-                - PC: "0x893b98"
+                - PC: "0x894078"
                   Frameless: false
-                - PC: "0x893c14"
+                - PC: "0x8940f4"
                   Frameless: false
-                - PC: "0x893cdc"
+                - PC: "0x8941bc"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 2876 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x893a10", Frameless: false}]
+              InjectionPoints: [{PC: "0x893ef0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2057,7 +2057,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2068,15 +2068,15 @@ Probes:
             - Kind: Line
               Type: 2877 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x8939d8"
+                - PC: "0x893eb8"
                   Frameless: false
-                - PC: "0x893a4c"
+                - PC: "0x893f2c"
                   Frameless: false
-                - PC: "0x893b98"
+                - PC: "0x894078"
                   Frameless: false
-                - PC: "0x893c14"
+                - PC: "0x8940f4"
                   Frameless: false
-                - PC: "0x893cdc"
+                - PC: "0x8941bc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2099,7 +2099,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2883 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x893e64", Frameless: true}]
+              InjectionPoints: [{PC: "0x894344", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2114,7 +2114,7 @@ Probes:
       where:
         methodName: main.testInlinedSq
         sourceFile: inlined.go
-        lines: ["75"]
+        lines: ["78"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2124,7 +2124,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2884 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x893e64", Frameless: true}]
+              InjectionPoints: [{PC: "0x894344", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2148,9 +2148,9 @@ Probes:
             - Kind: Entry
               Type: 2885 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x893e94"
+                - PC: "0x894374"
                   Frameless: false
-                - PC: "0x893f2c"
+                - PC: "0x894458"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2283,7 +2283,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2620 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x894110", Frameless: true}]
+              InjectionPoints: [{PC: "0x8946e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2310,7 +2310,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2802 EventRootType Probe[main.testInvalidUtf8Strings]
-              InjectionPoints: [{PC: "0x8997e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2753 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x897f80", Frameless: false}]
+              InjectionPoints: [{PC: "0x8989a0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2754 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8980d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x898af8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2362,7 +2362,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2661 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x8964a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2377,7 +2377,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["230"]
+        lines: ["233"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
@@ -2387,7 +2387,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2596 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x8902cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8904ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2398,7 +2398,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["237"]
+        lines: ["240"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2409,7 +2409,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2597 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x890360", Frameless: false}]
+              InjectionPoints: [{PC: "0x890540", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2420,7 +2420,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["242"]
+        lines: ["245"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2431,7 +2431,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2598 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x89040c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8905ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2474,11 +2474,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2759 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x89848c", Frameless: false}]
+              InjectionPoints: [{PC: "0x898eac", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2760 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x8985fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x89901c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2541,7 +2541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2601 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0x890cd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x890fa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2565,7 +2565,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2602 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0x892640", Frameless: true}]
+              InjectionPoints: [{PC: "0x892a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2587,7 +2587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2631 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x894920", Frameless: true}]
+              InjectionPoints: [{PC: "0x894fa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2609,7 +2609,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2638 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x894980", Frameless: true}]
+              InjectionPoints: [{PC: "0x895000", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2631,7 +2631,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2648 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x894a20", Frameless: true}]
+              InjectionPoints: [{PC: "0x8950a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2653,7 +2653,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2650 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x894a40", Frameless: true}]
+              InjectionPoints: [{PC: "0x8950c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2675,7 +2675,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2649 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x894a30", Frameless: true}]
+              InjectionPoints: [{PC: "0x8950b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2697,7 +2697,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2635 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x894960", Frameless: true}]
+              InjectionPoints: [{PC: "0x894fe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2719,7 +2719,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2647 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x894a10", Frameless: true}]
+              InjectionPoints: [{PC: "0x895090", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2741,7 +2741,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2646 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x894a00", Frameless: true}]
+              InjectionPoints: [{PC: "0x895080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2765,7 +2765,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2636 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x894970", Frameless: true}]
+              InjectionPoints: [{PC: "0x894ff0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2789,7 +2789,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2637 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x894970", Frameless: true}]
+              InjectionPoints: [{PC: "0x894ff0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2811,7 +2811,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2645 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x8949f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x895070", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2833,7 +2833,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2644 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x8949e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x895060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2855,7 +2855,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2629 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x894900", Frameless: true}]
+              InjectionPoints: [{PC: "0x894f80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2877,7 +2877,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2630 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x894910", Frameless: true}]
+              InjectionPoints: [{PC: "0x894f90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2899,7 +2899,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2628 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x8948f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894f70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2921,7 +2921,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2639 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x894990", Frameless: true}]
+              InjectionPoints: [{PC: "0x895010", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2943,7 +2943,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2642 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x8949c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x895040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2965,7 +2965,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2643 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x8949d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x895050", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2987,7 +2987,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2640 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x8949a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x895020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3011,7 +3011,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2641 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x8949b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x895030", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -3033,7 +3033,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2797 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x8997a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a3c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3056,7 +3056,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2798 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x8997a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a3c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3103,11 +3103,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2761 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x898680", Frameless: false}]
+              InjectionPoints: [{PC: "0x8990a0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2762 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x898830", Frameless: false}]
+              InjectionPoints: [{PC: "0x899250", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3169,7 +3169,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2803 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0x8997f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a410", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3192,7 +3192,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2804 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0x8997f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a410", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3218,11 +3218,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2765 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x89895c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89937c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2766 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x898a00", Frameless: false}]
+              InjectionPoints: [{PC: "0x899420", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3253,11 +3253,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2757 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x898230", Frameless: false}]
+              InjectionPoints: [{PC: "0x898c50", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2758 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x898400", Frameless: false}]
+              InjectionPoints: [{PC: "0x898e20", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3283,11 +3283,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2698 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8971b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x897bd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2699 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x897244", Frameless: false}]
+              InjectionPoints: [{PC: "0x897c64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3323,7 +3323,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2654 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x895e90", Frameless: true}]
+              InjectionPoints: [{PC: "0x896510", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3364,11 +3364,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2692 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x897118", Frameless: false}]
+              InjectionPoints: [{PC: "0x897b38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2693 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x897178", Frameless: false}]
+              InjectionPoints: [{PC: "0x897b98", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3392,11 +3392,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2694 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x897118", Frameless: false}]
+              InjectionPoints: [{PC: "0x897b38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2695 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x897178", Frameless: false}]
+              InjectionPoints: [{PC: "0x897b98", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3415,11 +3415,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2700 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8971b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x897bd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2701 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x897244", Frameless: false}]
+              InjectionPoints: [{PC: "0x897c64", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3439,11 +3439,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2702 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8971b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x897bd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2703 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x897244", Frameless: false}]
+              InjectionPoints: [{PC: "0x897c64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3476,11 +3476,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2696 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x897118", Frameless: false}]
+              InjectionPoints: [{PC: "0x897b38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2697 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x897178", Frameless: false}]
+              InjectionPoints: [{PC: "0x897b98", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3508,7 +3508,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2812 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x899b30", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3533,7 +3533,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2813 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x899b30", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3564,7 +3564,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2814 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x899b30", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3589,7 +3589,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2815 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x899b30", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3616,7 +3616,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2666 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x896570", Frameless: true}]
+              InjectionPoints: [{PC: "0x896eb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3643,7 +3643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2779 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x8990a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x899ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3670,7 +3670,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2776 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x899070", Frameless: true}]
+              InjectionPoints: [{PC: "0x899a90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3705,7 +3705,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2778 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x899090", Frameless: true}]
+              InjectionPoints: [{PC: "0x899ab0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3737,7 +3737,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2796 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x899790", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a3b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3759,7 +3759,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2662 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x8964b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896df0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3781,7 +3781,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2634 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x894950", Frameless: true}]
+              InjectionPoints: [{PC: "0x894fd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3803,7 +3803,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2660 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x896490", Frameless: true}]
+              InjectionPoints: [{PC: "0x896dd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3827,11 +3827,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2668 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x8969b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8973d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2669 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x8969fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x89741c", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3851,11 +3851,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2712 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x897288", Frameless: false}]
+              InjectionPoints: [{PC: "0x897ca8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2713 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x897314", Frameless: false}]
+              InjectionPoints: [{PC: "0x897d34", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3900,11 +3900,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2678 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x896ad8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8974f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2679 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x896b70", Frameless: false}]
+              InjectionPoints: [{PC: "0x897590", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3946,11 +3946,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2670 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x8969b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8973d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2671 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x8969fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x89741c", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3995,11 +3995,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2680 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x896ad8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8974f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2681 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x896b70", Frameless: false}]
+              InjectionPoints: [{PC: "0x897590", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -4043,11 +4043,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2714 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x897288", Frameless: false}]
+              InjectionPoints: [{PC: "0x897ca8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2715 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x897314", Frameless: false}]
+              InjectionPoints: [{PC: "0x897d34", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -4064,11 +4064,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2716 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x897288", Frameless: false}]
+              InjectionPoints: [{PC: "0x897ca8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2717 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x897314", Frameless: false}]
+              InjectionPoints: [{PC: "0x897d34", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -4090,11 +4090,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2672 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x8969b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8973d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2673 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x8969fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x89741c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -4117,18 +4117,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2688 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x896da8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8977c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2689 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x896e48"
+                - PC: "0x897868"
                   Frameless: false
-                - PC: "0x896e90"
+                - PC: "0x8978b0"
                   Frameless: false
-                - PC: "0x896f54"
+                - PC: "0x897974"
                   Frameless: false
-                - PC: "0x896f68"
+                - PC: "0x897988"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4156,18 +4156,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2686 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x896c28", Frameless: false}]
+              InjectionPoints: [{PC: "0x897648", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2687 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x896c94"
+                - PC: "0x8976b4"
                   Frameless: false
-                - PC: "0x896ce0"
+                - PC: "0x897700"
                   Frameless: false
-                - PC: "0x896d20"
+                - PC: "0x897740"
                   Frameless: false
-                - PC: "0x896d60"
+                - PC: "0x897780"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4194,11 +4194,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2731 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x89798c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8983ac", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2732 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x8979e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x898400", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4215,11 +4215,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2733 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x897a18", Frameless: false}]
+              InjectionPoints: [{PC: "0x898438", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2734 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x897a54", Frameless: false}]
+              InjectionPoints: [{PC: "0x898474", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4236,11 +4236,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2735 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x897a88", Frameless: false}]
+              InjectionPoints: [{PC: "0x8984a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2736 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x897ac0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8984e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4257,11 +4257,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2739 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x897b78", Frameless: false}]
+              InjectionPoints: [{PC: "0x898598", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2740 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x897bdc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8985fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4278,11 +4278,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2751 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x897f08", Frameless: false}]
+              InjectionPoints: [{PC: "0x898928", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2752 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x897f48", Frameless: false}]
+              InjectionPoints: [{PC: "0x898968", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4299,11 +4299,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2727 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x897838", Frameless: false}]
+              InjectionPoints: [{PC: "0x898258", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2728 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x897884", Frameless: false}]
+              InjectionPoints: [{PC: "0x8982a4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4321,14 +4321,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2684 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x896ba8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8975c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2685 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x896bd8"
+                - PC: "0x8975f8"
                   Frameless: false
-                - PC: "0x896bec"
+                - PC: "0x89760c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4350,11 +4350,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2674 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x8969b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8973d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2675 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x8969fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x89741c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4375,11 +4375,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2682 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x896ad8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8974f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2683 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x896b70", Frameless: false}]
+              InjectionPoints: [{PC: "0x897590", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4400,11 +4400,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2676 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x896a38", Frameless: false}]
+              InjectionPoints: [{PC: "0x897458", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2677 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x896a9c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8974bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4426,14 +4426,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2690 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x896fa8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8979c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2691 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x897078"
+                - PC: "0x897a98"
                   Frameless: false
-                - PC: "0x89708c"
+                - PC: "0x897aac"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4455,11 +4455,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2729 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x8978c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8982e0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2730 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x897954", Frameless: false}]
+              InjectionPoints: [{PC: "0x898374", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4476,11 +4476,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2725 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x897778", Frameless: false}]
+              InjectionPoints: [{PC: "0x898198", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2726 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x8977fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x89821c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4497,11 +4497,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2743 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x897cf8", Frameless: false}]
+              InjectionPoints: [{PC: "0x898718", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2744 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x897d50", Frameless: false}]
+              InjectionPoints: [{PC: "0x898770", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4518,11 +4518,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2737 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x897af8", Frameless: false}]
+              InjectionPoints: [{PC: "0x898518", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2738 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x897b40", Frameless: false}]
+              InjectionPoints: [{PC: "0x898560", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4539,11 +4539,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2749 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x897e88", Frameless: false}]
+              InjectionPoints: [{PC: "0x8988a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2750 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x897ecc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8988ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4563,7 +4563,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2722 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x897508", Frameless: false}]
+              InjectionPoints: [{PC: "0x897f28", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4584,11 +4584,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2747 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x897e18", Frameless: false}]
+              InjectionPoints: [{PC: "0x898838", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2748 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x897e58", Frameless: false}]
+              InjectionPoints: [{PC: "0x898878", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4605,11 +4605,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2723 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x8976e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x898108", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2724 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x897740", Frameless: false}]
+              InjectionPoints: [{PC: "0x898160", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4626,11 +4626,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2745 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x897d8c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8987ac", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2746 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x897de0", Frameless: false}]
+              InjectionPoints: [{PC: "0x898800", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4647,11 +4647,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2741 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x897c20", Frameless: false}]
+              InjectionPoints: [{PC: "0x898640", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2742 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x897cc4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8986e4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4704,11 +4704,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2704 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8971b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x897bd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2705 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x897244", Frameless: false}]
+              InjectionPoints: [{PC: "0x897c64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4754,7 +4754,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2571 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x88fb90", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fc80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4776,7 +4776,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2569 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x88fb70", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fc60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4798,7 +4798,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2582 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x88fc40", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fd30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4816,7 +4816,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2583 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x88fc50", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fd40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4834,7 +4834,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2572 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x88fba0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fc90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4856,7 +4856,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2574 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x88fbc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fcb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4879,7 +4879,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2575 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x88fbd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fcc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4901,7 +4901,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2576 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x88fbe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fcd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4930,7 +4930,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2573 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x88fbb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4961,7 +4961,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2570 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x88fb80", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fc70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4983,7 +4983,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2788 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x899740", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5005,7 +5005,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2577 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x88fbf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fce0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5027,7 +5027,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2579 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x88fc10", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fd00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5049,7 +5049,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2580 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x88fc20", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fd10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5071,7 +5071,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2581 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x88fc30", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fd20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5093,7 +5093,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2578 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x88fc00", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fcf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5115,7 +5115,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2782 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x8990c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x899ae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5137,7 +5137,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2773 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x899040", Frameless: true}]
+              InjectionPoints: [{PC: "0x899a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5159,7 +5159,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2632 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x894930", Frameless: true}]
+              InjectionPoints: [{PC: "0x894fb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -5180,11 +5180,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2718 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x897288", Frameless: false}]
+              InjectionPoints: [{PC: "0x897ca8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2719 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x897314", Frameless: false}]
+              InjectionPoints: [{PC: "0x897d34", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5205,11 +5205,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2763 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x8988b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8992d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2764 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x89891c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89933c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5253,7 +5253,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2665 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x896550", Frameless: true}]
+              InjectionPoints: [{PC: "0x896e90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5275,7 +5275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2777 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x899080", Frameless: true}]
+              InjectionPoints: [{PC: "0x899aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5297,7 +5297,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2594 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x890290", Frameless: true}]
+              InjectionPoints: [{PC: "0x890470", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5319,7 +5319,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2595 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x8902a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x890480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5341,11 +5341,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2810 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x899a90", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a7a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2811 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x899aac", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a7bc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5372,7 +5372,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2774 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x899050", Frameless: true}]
+              InjectionPoints: [{PC: "0x899a70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5399,7 +5399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2626 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x894210", Frameless: true}]
+              InjectionPoints: [{PC: "0x8947e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5420,11 +5420,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2767 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x898a3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x89945c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2768 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x898acc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8994ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5446,11 +5446,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2806 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x8999a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a6b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2807 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x8999b8", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a6c8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5471,7 +5471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2805 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x899990", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a6a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5498,7 +5498,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2627 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x8948e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x894f60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5531,7 +5531,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2783 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x8990d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x899af0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5571,7 +5571,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2801 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x8997d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a3f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2599 EventRootType Probe[main.testTakeContext]
-              InjectionPoints: [{PC: "0x890830", Frameless: true}]
+              InjectionPoints: [{PC: "0x890b00", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
       version: 0
@@ -5619,11 +5619,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2706 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8971b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x897bd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2707 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x897244", Frameless: false}]
+              InjectionPoints: [{PC: "0x897c64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5644,11 +5644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2708 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8971b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x897bd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2709 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x897244", Frameless: false}]
+              InjectionPoints: [{PC: "0x897c64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5671,11 +5671,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2710 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8971b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x897bd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2711 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x897244", Frameless: false}]
+              InjectionPoints: [{PC: "0x897c64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5707,7 +5707,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2789 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x899750", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a370", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5739,11 +5739,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2790 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x899760", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a380", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2791 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x899778", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a398", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5773,11 +5773,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2792 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x899760", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a380", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2793 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x899778", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a398", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5809,7 +5809,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2794 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x899780", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a3a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5839,7 +5839,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2795 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x899780", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a3a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5871,7 +5871,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2820 EventRootType Probe[main.testTimeFixedZone]
-              InjectionPoints: [{PC: "0x89a6d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89b4c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5893,7 +5893,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2821 EventRootType Probe[main.testTimeMonotonic]
-              InjectionPoints: [{PC: "0x89a6e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89b4d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -5915,7 +5915,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2819 EventRootType Probe[main.testTimeUTC]
-              InjectionPoints: [{PC: "0x89a6c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89b4b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5937,7 +5937,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2584 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x88fc60", Frameless: true}]
+              InjectionPoints: [{PC: "0x88fd50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6069,7 +6069,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2664 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x8964e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896e20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6091,7 +6091,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2771 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x899020", Frameless: true}]
+              InjectionPoints: [{PC: "0x899a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -6113,7 +6113,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2799 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x8997b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x89a3d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6135,7 +6135,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2663 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x8964c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x896e00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6179,7 +6179,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2780 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x8990b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x899ad0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6201,7 +6201,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2781 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x8990b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x899ad0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6224,14 +6224,14 @@ Probes:
             - Kind: Entry
               Type: 2886 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x894038"
+                - PC: "0x894608"
                   Frameless: false
-                - PC: "0x89c4cc"
+                - PC: "0x89d3ac"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 2887 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x894070", Frameless: false}]
+              InjectionPoints: [{PC: "0x894640", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -6253,11 +6253,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2769 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x898b08", Frameless: false}]
+              InjectionPoints: [{PC: "0x899528", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2770 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x898b74", Frameless: false}]
+              InjectionPoints: [{PC: "0x899594", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -6554,13 +6554,13 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x88fb70..0x88fb80]
+      OutOfLinePCRanges: [0x88fc60..0x88fc70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x88fb70..0x88fb80
+            - Range: 0x88fc60..0x88fc70
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6568,13 +6568,13 @@ Subprograms:
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x88fb80..0x88fb90]
+      OutOfLinePCRanges: [0x88fc70..0x88fc80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int32
           Locations:
-            - Range: 0x88fb80..0x88fb90
+            - Range: 0x88fc70..0x88fc80
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6582,13 +6582,13 @@ Subprograms:
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x88fb90..0x88fba0]
+      OutOfLinePCRanges: [0x88fc80..0x88fc90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x88fb90..0x88fba0
+            - Range: 0x88fc80..0x88fc90
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6596,13 +6596,13 @@ Subprograms:
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x88fba0..0x88fbb0]
+      OutOfLinePCRanges: [0x88fc90..0x88fca0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType int
           Locations:
-            - Range: 0x88fba0..0x88fbb0
+            - Range: 0x88fc90..0x88fca0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6610,13 +6610,13 @@ Subprograms:
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x88fbb0..0x88fbc0]
+      OutOfLinePCRanges: [0x88fca0..0x88fcb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x88fbb0..0x88fbc0
+            - Range: 0x88fca0..0x88fcb0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6624,13 +6624,13 @@ Subprograms:
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x88fbc0..0x88fbd0]
+      OutOfLinePCRanges: [0x88fcb0..0x88fcc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 92 BaseType int16
           Locations:
-            - Range: 0x88fbc0..0x88fbd0
+            - Range: 0x88fcb0..0x88fcc0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6638,13 +6638,13 @@ Subprograms:
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x88fbd0..0x88fbe0]
+      OutOfLinePCRanges: [0x88fcc0..0x88fcd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int32
           Locations:
-            - Range: 0x88fbd0..0x88fbe0
+            - Range: 0x88fcc0..0x88fcd0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6652,13 +6652,13 @@ Subprograms:
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x88fbe0..0x88fbf0]
+      OutOfLinePCRanges: [0x88fcd0..0x88fce0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType int64
           Locations:
-            - Range: 0x88fbe0..0x88fbf0
+            - Range: 0x88fcd0..0x88fce0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6666,13 +6666,13 @@ Subprograms:
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x88fbf0..0x88fc00]
+      OutOfLinePCRanges: [0x88fce0..0x88fcf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType uint
           Locations:
-            - Range: 0x88fbf0..0x88fc00
+            - Range: 0x88fce0..0x88fcf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6680,13 +6680,13 @@ Subprograms:
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x88fc00..0x88fc10]
+      OutOfLinePCRanges: [0x88fcf0..0x88fd00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x88fc00..0x88fc10
+            - Range: 0x88fcf0..0x88fd00
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6694,13 +6694,13 @@ Subprograms:
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x88fc10..0x88fc20]
+      OutOfLinePCRanges: [0x88fd00..0x88fd10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType uint16
           Locations:
-            - Range: 0x88fc10..0x88fc20
+            - Range: 0x88fd00..0x88fd10
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6708,13 +6708,13 @@ Subprograms:
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x88fc20..0x88fc30]
+      OutOfLinePCRanges: [0x88fd10..0x88fd20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint32
           Locations:
-            - Range: 0x88fc20..0x88fc30
+            - Range: 0x88fd10..0x88fd20
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6722,13 +6722,13 @@ Subprograms:
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x88fc30..0x88fc40]
+      OutOfLinePCRanges: [0x88fd20..0x88fd30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType uint64
           Locations:
-            - Range: 0x88fc30..0x88fc40
+            - Range: 0x88fd20..0x88fd30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6736,13 +6736,13 @@ Subprograms:
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x88fc40..0x88fc50]
+      OutOfLinePCRanges: [0x88fd30..0x88fd40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x88fc40..0x88fc50
+            - Range: 0x88fd30..0x88fd40
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6750,13 +6750,13 @@ Subprograms:
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x88fc50..0x88fc60]
+      OutOfLinePCRanges: [0x88fd40..0x88fd50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 BaseType float64
           Locations:
-            - Range: 0x88fc50..0x88fc60
+            - Range: 0x88fd40..0x88fd50
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6764,13 +6764,13 @@ Subprograms:
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x88fc60..0x88fc70]
+      OutOfLinePCRanges: [0x88fd50..0x88fd60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 123 BaseType main.typeAlias
           Locations:
-            - Range: 0x88fc60..0x88fc70
+            - Range: 0x88fd50..0x88fd60
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6778,13 +6778,13 @@ Subprograms:
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x88fd70..0x88fd90]
+      OutOfLinePCRanges: [0x88ff50..0x88ff70]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 124 StructureType main.bigStruct
           Locations:
-            - Range: 0x88fd70..0x88fd90
+            - Range: 0x88ff50..0x88ff70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6804,51 +6804,51 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x88fdb0..0x88fed0]
+      OutOfLinePCRanges: [0x88ff90..0x8900b0]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x88fdb0..0x88fdd0
+            - Range: 0x88ff90..0x88ffb0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r0
           Type: 11 BaseType int
-          Locations: [{Range: 0x88fdb0..0x88fed0, Pieces: []}]
+          Locations: [{Range: 0x88ff90..0x8900b0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: x
           Type: 11 BaseType int
-          Locations: [{Range: 0x88fdb0..0x88fed0, Pieces: []}]
+          Locations: [{Range: 0x88ff90..0x8900b0, Pieces: []}]
           Role: Local
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: err
           Type: 20 GoInterfaceType error
           Locations:
-            - Range: 0x88fde8..0x88fe08
+            - Range: 0x88ffc8..0x88ffe8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x88fe08..0x88fe38
+            - Range: 0x88ffe8..0x890018
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88fe38..0x88fe3c
+            - Range: 0x890018..0x89001c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: -64}
-            - Range: 0x88fe3c..0x88fed0
+            - Range: 0x89001c..0x8900b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
@@ -6860,13 +6860,13 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x88ff60..0x88ff70]
+      OutOfLinePCRanges: [0x890140..0x890150]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 128 StructureType main.deepPtr1
           Locations:
-            - Range: 0x88ff60..0x88ff70
+            - Range: 0x890140..0x890150
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6874,13 +6874,13 @@ Subprograms:
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x88ff70..0x88ff80]
+      OutOfLinePCRanges: [0x890150..0x890160]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 131 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x88ff70..0x88ff80
+            - Range: 0x890150..0x890160
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6888,13 +6888,13 @@ Subprograms:
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x890110..0x890120]
+      OutOfLinePCRanges: [0x8902f0..0x890300]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 133 StructureType main.deepSlice1
           Locations:
-            - Range: 0x890110..0x890120
+            - Range: 0x8902f0..0x890300
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6908,13 +6908,13 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x890120..0x890130]
+      OutOfLinePCRanges: [0x890300..0x890310]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 137 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x890120..0x890130
+            - Range: 0x890300..0x890310
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6922,13 +6922,13 @@ Subprograms:
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x890270..0x890280]
+      OutOfLinePCRanges: [0x890450..0x890460]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 139 StructureType main.deepMap1
           Locations:
-            - Range: 0x890270..0x890280
+            - Range: 0x890450..0x890460
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6936,13 +6936,13 @@ Subprograms:
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x890280..0x890290]
+      OutOfLinePCRanges: [0x890460..0x890470]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 147 PointerType *main.deepMap7
           Locations:
-            - Range: 0x890280..0x890290
+            - Range: 0x890460..0x890470
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6950,13 +6950,13 @@ Subprograms:
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x890290..0x8902a0]
+      OutOfLinePCRanges: [0x890470..0x890480]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 149 PointerType *main.stringType1
           Locations:
-            - Range: 0x890290..0x8902a0
+            - Range: 0x890470..0x890480
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6964,13 +6964,13 @@ Subprograms:
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x8902a0..0x8902b0]
+      OutOfLinePCRanges: [0x890480..0x890490]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 151 PointerType **main.stringType2
           Locations:
-            - Range: 0x8902a0..0x8902b0
+            - Range: 0x890480..0x890490
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6978,15 +6978,15 @@ Subprograms:
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x8902b0..0x8904b0]
+      OutOfLinePCRanges: [0x890490..0x890690]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 11 BaseType int
           Locations:
-            - Range: 0x890378..0x890388
+            - Range: 0x890558..0x890568
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890428..0x890438
+            - Range: 0x890608..0x890618
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -6994,15 +6994,15 @@ Subprograms:
         - Name: aPerArch
           Type: 11 BaseType int
           Locations:
-            - Range: 0x890360..0x890364
+            - Range: 0x890540..0x890544
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x890364..0x890388
+            - Range: 0x890544..0x890568
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x890388..0x89041c
+            - Range: 0x890568..0x8905fc
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x89041c..0x890424
+            - Range: 0x8905fc..0x890604
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x890424..0x8904b0
+            - Range: 0x890604..0x890690
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
           DictIndex: -1
@@ -7010,21 +7010,21 @@ Subprograms:
         - Name: b
           Type: 11 BaseType int
           Locations:
-            - Range: 0x89035c..0x890364
+            - Range: 0x89053c..0x890544
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x890364..0x890364
+            - Range: 0x890544..0x890544
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x890364..0x890388
+            - Range: 0x890544..0x890568
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x890388..0x89041c
+            - Range: 0x890568..0x8905fc
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x89041c..0x890420
+            - Range: 0x8905fc..0x890600
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x890420..0x890424
+            - Range: 0x890600..0x890604
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x890424..0x890438
+            - Range: 0x890604..0x890618
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x890438..0x8904b0
+            - Range: 0x890618..0x890690
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
@@ -7032,13 +7032,13 @@ Subprograms:
       DictRegister: null
     - ID: 48
       Name: main.testTakeContext
-      OutOfLinePCRanges: [0x890830..0x890840]
+      OutOfLinePCRanges: [0x890b00..0x890b10]
       InlinePCRanges: []
       Variables:
         - Name: ctx
           Type: 153 GoInterfaceType context.Context
           Locations:
-            - Range: 0x890830..0x890840
+            - Range: 0x890b00..0x890b10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7050,13 +7050,13 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testCaptureContextImpl
-      OutOfLinePCRanges: [0x890a00..0x890a10]
+      OutOfLinePCRanges: [0x890cd0..0x890ce0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 154 PointerType *main.contextImpl
           Locations:
-            - Range: 0x890a00..0x890a10
+            - Range: 0x890cd0..0x890ce0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7064,13 +7064,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0x890cd0..0x890ce0]
+      OutOfLinePCRanges: [0x890fa0..0x890fb0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 156 StructureType main.manyPointers
           Locations:
-            - Range: 0x890cd0..0x890ce0
+            - Range: 0x890fa0..0x890fb0
               Pieces: [{Size: 560, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7078,13 +7078,13 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0x892640..0x892650]
+      OutOfLinePCRanges: [0x892a20..0x892a30]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 159 GoSliceHeaderType []string
           Locations:
-            - Range: 0x892640..0x892650
+            - Range: 0x892a20..0x892a30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7098,13 +7098,13 @@ Subprograms:
       DictRegister: null
     - ID: 52
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x8928e0..0x8929d0]
+      OutOfLinePCRanges: [0x892dc0..0x892eb0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 160 StructureType main.esotericStack
           Locations:
-            - Range: 0x8928e0..0x892928
+            - Range: 0x892dc0..0x892e08
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -7124,7 +7124,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x892928..0x89292c
+            - Range: 0x892e08..0x892e0c
               Pieces:
                 - Size: 4
                   Op: null
@@ -7144,7 +7144,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x89292c..0x892930
+            - Range: 0x892e0c..0x892e10
               Pieces:
                 - Size: 4
                   Op: null
@@ -7170,13 +7170,13 @@ Subprograms:
       DictRegister: null
     - ID: 53
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x8929d0..0x892a50]
+      OutOfLinePCRanges: [0x892eb0..0x892f30]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 163 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x8929d0..0x892a08
+            - Range: 0x892eb0..0x892ee8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7184,13 +7184,13 @@ Subprograms:
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x893b60..0x893bf0]
+      OutOfLinePCRanges: [0x894040..0x8940d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType int
           Locations:
-            - Range: 0x893b60..0x893b98
+            - Range: 0x894040..0x894078
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7198,13 +7198,13 @@ Subprograms:
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x893bf0..0x893cc0]
+      OutOfLinePCRanges: [0x8940d0..0x8941a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType int
           Locations:
-            - Range: 0x893bf0..0x893c0c
+            - Range: 0x8940d0..0x8940ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7212,7 +7212,7 @@ Subprograms:
         - Name: "y"
           Type: 11 BaseType int
           Locations:
-            - Range: 0x893bf0..0x893c1c
+            - Range: 0x8940d0..0x8940fc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7220,9 +7220,9 @@ Subprograms:
         - Name: z
           Type: 11 BaseType int
           Locations:
-            - Range: 0x893c0c..0x893c1c
+            - Range: 0x8940ec..0x8940fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893c1c..0x893cc0
+            - Range: 0x8940fc..0x8941a0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
@@ -7230,13 +7230,13 @@ Subprograms:
       DictRegister: null
     - ID: 56
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x893cc0..0x893d40]
+      OutOfLinePCRanges: [0x8941a0..0x894220]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType int
           Locations:
-            - Range: 0x893cc0..0x893ce4
+            - Range: 0x8941a0..0x8941c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7244,17 +7244,17 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x893d40..0x893e60]
+      OutOfLinePCRanges: [0x894220..0x894340]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 11 BaseType int
           Locations:
-            - Range: 0x893da8..0x893db0
+            - Range: 0x894288..0x894290
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x893db0..0x893dc8
+            - Range: 0x894290..0x8942a8
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x893dc8..0x893ddc
+            - Range: 0x8942a8..0x8942bc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7262,11 +7262,11 @@ Subprograms:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0x893da4..0x893dac
+            - Range: 0x894284..0x89428c
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x893dac..0x893dc8
+            - Range: 0x89428c..0x8942a8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x893dc8..0x893dd8
+            - Range: 0x8942a8..0x8942b8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7274,13 +7274,13 @@ Subprograms:
       DictRegister: null
     - ID: 58
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x893e60..0x893e70]
+      OutOfLinePCRanges: [0x894340..0x894350]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType int
           Locations:
-            - Range: 0x893e60..0x893e68
+            - Range: 0x894340..0x894348
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7288,11 +7288,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0x893e60..0x893e68
+            - Range: 0x894340..0x894348
               Pieces: []
-            - Range: 0x893e68..0x893e69
+            - Range: 0x894348..0x894349
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893e69..0x893e70
+            - Range: 0x894349..0x894350
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7300,13 +7300,13 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x893e70..0x893ed0]
+      OutOfLinePCRanges: [0x894350..0x8943b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 165 ArrayType [5]int
           Locations:
-            - Range: 0x893e70..0x893ed0
+            - Range: 0x894350..0x8943b0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7314,11 +7314,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0x893e70..0x893eb8
+            - Range: 0x894350..0x894398
               Pieces: []
-            - Range: 0x893eb8..0x893eb9
+            - Range: 0x894398..0x894399
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893eb9..0x893ed0
+            - Range: 0x894399..0x8943b0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7326,13 +7326,13 @@ Subprograms:
       DictRegister: null
     - ID: 60
       Name: main.testInterface
-      OutOfLinePCRanges: [0x894110..0x894120]
+      OutOfLinePCRanges: [0x8946e0..0x8946f0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 166 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x894110..0x894120
+            - Range: 0x8946e0..0x8946f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7344,19 +7344,19 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testAny
-      OutOfLinePCRanges: [0x894120..0x894190]
+      OutOfLinePCRanges: [0x8946f0..0x894760]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 55 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x894120..0x894150
+            - Range: 0x8946f0..0x894720
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x894150..0x894154
+            - Range: 0x894720..0x894724
               Pieces:
                 - Size: 8
                   Op: null
@@ -7368,15 +7368,15 @@ Subprograms:
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x894120..0x894164
+            - Range: 0x8946f0..0x894734
               Pieces: []
-            - Range: 0x894164..0x894165
+            - Range: 0x894734..0x894735
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x894165..0x894190
+            - Range: 0x894735..0x894760
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7384,13 +7384,13 @@ Subprograms:
       DictRegister: null
     - ID: 62
       Name: main.testError
-      OutOfLinePCRanges: [0x894190..0x8941a0]
+      OutOfLinePCRanges: [0x894760..0x894770]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 20 GoInterfaceType error
           Locations:
-            - Range: 0x894190..0x8941a0
+            - Range: 0x894760..0x894770
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7402,13 +7402,13 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x8941a0..0x894210]
+      OutOfLinePCRanges: [0x894770..0x8947e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 167 PointerType *interface {}
           Locations:
-            - Range: 0x8941a0..0x8941d0
+            - Range: 0x894770..0x8947a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7416,15 +7416,15 @@ Subprograms:
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x8941a0..0x8941e4
+            - Range: 0x894770..0x8947b4
               Pieces: []
-            - Range: 0x8941e4..0x8941e5
+            - Range: 0x8947b4..0x8947b5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8941e5..0x894210
+            - Range: 0x8947b5..0x8947e0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7432,13 +7432,13 @@ Subprograms:
       DictRegister: null
     - ID: 64
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x894210..0x894220]
+      OutOfLinePCRanges: [0x8947e0..0x8947f0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 168 StructureType main.structWithAny
           Locations:
-            - Range: 0x894210..0x894220
+            - Range: 0x8947e0..0x8947f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7450,13 +7450,13 @@ Subprograms:
       DictRegister: null
     - ID: 65
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x8948e0..0x8948f0]
+      OutOfLinePCRanges: [0x894f60..0x894f70]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 169 StructureType main.structWithMap
           Locations:
-            - Range: 0x8948e0..0x8948f0
+            - Range: 0x894f60..0x894f70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7464,13 +7464,13 @@ Subprograms:
       DictRegister: null
     - ID: 66
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x8948f0..0x894900]
+      OutOfLinePCRanges: [0x894f70..0x894f80]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 175 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x8948f0..0x894900
+            - Range: 0x894f70..0x894f80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7478,13 +7478,13 @@ Subprograms:
       DictRegister: null
     - ID: 67
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x894900..0x894910]
+      OutOfLinePCRanges: [0x894f80..0x894f90]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 180 GoMapType map[string]int
           Locations:
-            - Range: 0x894900..0x894910
+            - Range: 0x894f80..0x894f90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7492,13 +7492,13 @@ Subprograms:
       DictRegister: null
     - ID: 68
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x894910..0x894920]
+      OutOfLinePCRanges: [0x894f90..0x894fa0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 185 GoMapType map[string][]string
           Locations:
-            - Range: 0x894910..0x894920
+            - Range: 0x894f90..0x894fa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7506,13 +7506,13 @@ Subprograms:
       DictRegister: null
     - ID: 69
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x894920..0x894930]
+      OutOfLinePCRanges: [0x894fa0..0x894fb0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 190 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x894920..0x894930
+            - Range: 0x894fa0..0x894fb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7520,13 +7520,13 @@ Subprograms:
       DictRegister: null
     - ID: 70
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x894930..0x894940]
+      OutOfLinePCRanges: [0x894fb0..0x894fc0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 180 GoMapType map[string]int
           Locations:
-            - Range: 0x894930..0x894940
+            - Range: 0x894fb0..0x894fc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7534,13 +7534,13 @@ Subprograms:
       DictRegister: null
     - ID: 71
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x894940..0x894950]
+      OutOfLinePCRanges: [0x894fc0..0x894fd0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 195 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x894940..0x894950
+            - Range: 0x894fc0..0x894fd0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7548,13 +7548,13 @@ Subprograms:
       DictRegister: null
     - ID: 72
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x894950..0x894960]
+      OutOfLinePCRanges: [0x894fd0..0x894fe0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 196 PointerType *map[string]int
           Locations:
-            - Range: 0x894950..0x894960
+            - Range: 0x894fd0..0x894fe0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7562,13 +7562,13 @@ Subprograms:
       DictRegister: null
     - ID: 73
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x894960..0x894970]
+      OutOfLinePCRanges: [0x894fe0..0x894ff0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 170 GoMapType map[int]int
           Locations:
-            - Range: 0x894960..0x894970
+            - Range: 0x894fe0..0x894ff0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7576,13 +7576,13 @@ Subprograms:
       DictRegister: null
     - ID: 74
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x894970..0x894980]
+      OutOfLinePCRanges: [0x894ff0..0x895000]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 197 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x894970..0x894980
+            - Range: 0x894ff0..0x895000
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7590,13 +7590,13 @@ Subprograms:
       DictRegister: null
     - ID: 75
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x894980..0x894990]
+      OutOfLinePCRanges: [0x895000..0x895010]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 197 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x894980..0x894990
+            - Range: 0x895000..0x895010
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7604,13 +7604,13 @@ Subprograms:
       DictRegister: null
     - ID: 76
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x894990..0x8949a0]
+      OutOfLinePCRanges: [0x895010..0x895020]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 202 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x894990..0x8949a0
+            - Range: 0x895010..0x895020
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7618,13 +7618,13 @@ Subprograms:
       DictRegister: null
     - ID: 77
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x8949a0..0x8949b0]
+      OutOfLinePCRanges: [0x895020..0x895030]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 207 GoMapType map[int]uint8
           Locations:
-            - Range: 0x8949a0..0x8949b0
+            - Range: 0x895020..0x895030
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7632,13 +7632,13 @@ Subprograms:
       DictRegister: null
     - ID: 78
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x8949b0..0x8949c0]
+      OutOfLinePCRanges: [0x895030..0x895040]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 207 GoMapType map[int]uint8
           Locations:
-            - Range: 0x8949b0..0x8949c0
+            - Range: 0x895030..0x895040
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7646,13 +7646,13 @@ Subprograms:
       DictRegister: null
     - ID: 79
       Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x8949c0..0x8949d0]
+      OutOfLinePCRanges: [0x895040..0x895050]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 212 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x8949c0..0x8949d0
+            - Range: 0x895040..0x895050
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7660,13 +7660,13 @@ Subprograms:
       DictRegister: null
     - ID: 80
       Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x8949d0..0x8949e0]
+      OutOfLinePCRanges: [0x895050..0x895060]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 212 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x8949d0..0x8949e0
+            - Range: 0x895050..0x895060
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7674,13 +7674,13 @@ Subprograms:
       DictRegister: null
     - ID: 81
       Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x8949e0..0x8949f0]
+      OutOfLinePCRanges: [0x895060..0x895070]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 212 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x8949e0..0x8949f0
+            - Range: 0x895060..0x895070
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7688,13 +7688,13 @@ Subprograms:
       DictRegister: null
     - ID: 82
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x8949f0..0x894a00]
+      OutOfLinePCRanges: [0x895070..0x895080]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 217 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x8949f0..0x894a00
+            - Range: 0x895070..0x895080
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7702,13 +7702,13 @@ Subprograms:
       DictRegister: null
     - ID: 83
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x894a00..0x894a10]
+      OutOfLinePCRanges: [0x895080..0x895090]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 222 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x894a00..0x894a10
+            - Range: 0x895080..0x895090
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7716,13 +7716,13 @@ Subprograms:
       DictRegister: null
     - ID: 84
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x894a10..0x894a20]
+      OutOfLinePCRanges: [0x895090..0x8950a0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 227 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x894a10..0x894a20
+            - Range: 0x895090..0x8950a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7730,13 +7730,13 @@ Subprograms:
       DictRegister: null
     - ID: 85
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x894a20..0x894a30]
+      OutOfLinePCRanges: [0x8950a0..0x8950b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 232 GoMapType map[struct {}]int
           Locations:
-            - Range: 0x894a20..0x894a30
+            - Range: 0x8950a0..0x8950b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7744,13 +7744,13 @@ Subprograms:
       DictRegister: null
     - ID: 86
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x894a30..0x894a40]
+      OutOfLinePCRanges: [0x8950b0..0x8950c0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 237 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x894a30..0x894a40
+            - Range: 0x8950b0..0x8950c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7758,13 +7758,13 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0x894a40..0x894a50]
+      OutOfLinePCRanges: [0x8950c0..0x8950d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 242 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0x894a40..0x894a50
+            - Range: 0x8950c0..0x8950d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7772,13 +7772,13 @@ Subprograms:
       DictRegister: null
     - ID: 88
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x895db0..0x895dc0]
+      OutOfLinePCRanges: [0x896430..0x896440]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x895db0..0x895dc0
+            - Range: 0x896430..0x896440
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7786,7 +7786,7 @@ Subprograms:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x895db0..0x895dc0
+            - Range: 0x896430..0x896440
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7794,7 +7794,7 @@ Subprograms:
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x895db0..0x895dc0
+            - Range: 0x896430..0x896440
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7802,13 +7802,13 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x895dd0..0x895de0]
+      OutOfLinePCRanges: [0x896450..0x896460]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x895dd0..0x895de0
+            - Range: 0x896450..0x896460
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7816,7 +7816,7 @@ Subprograms:
         - Name: x
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x895dd0..0x895de0
+            - Range: 0x896450..0x896460
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7828,7 +7828,7 @@ Subprograms:
         - Name: "y"
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x895dd0..0x895de0
+            - Range: 0x896450..0x896460
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7836,13 +7836,13 @@ Subprograms:
       DictRegister: null
     - ID: 90
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x895e90..0x895ea0]
+      OutOfLinePCRanges: [0x896510..0x896520]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x895e90..0x895ea0
+            - Range: 0x896510..0x896520
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7850,7 +7850,7 @@ Subprograms:
         - Name: b
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x895e90..0x895ea0
+            - Range: 0x896510..0x896520
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7858,7 +7858,7 @@ Subprograms:
         - Name: c
           Type: 15 BaseType int32
           Locations:
-            - Range: 0x895e90..0x895ea0
+            - Range: 0x896510..0x896520
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7866,7 +7866,7 @@ Subprograms:
         - Name: d
           Type: 14 BaseType uint
           Locations:
-            - Range: 0x895e90..0x895ea0
+            - Range: 0x896510..0x896520
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7874,7 +7874,7 @@ Subprograms:
         - Name: e
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x895e90..0x895ea0
+            - Range: 0x896510..0x896520
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7886,13 +7886,13 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.(*Server).handleOrder
-      OutOfLinePCRanges: [0x896030..0x8961f0]
+      OutOfLinePCRanges: [0x8967a0..0x896960]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 247 PointerType *main.Server
           Locations:
-            - Range: 0x896030..0x896078
+            - Range: 0x8967a0..0x8967e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7900,9 +7900,9 @@ Subprograms:
         - Name: req
           Type: 249 PointerType *main.Request
           Locations:
-            - Range: 0x896030..0x896074
+            - Range: 0x8967a0..0x8967e4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x896074..0x8961f0
+            - Range: 0x8967e4..0x896960
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -7910,23 +7910,23 @@ Subprograms:
         - Name: ~r0
           Type: 20 GoInterfaceType error
           Locations:
-            - Range: 0x896030..0x896104
+            - Range: 0x8967a0..0x896874
               Pieces: []
-            - Range: 0x896104..0x896105
+            - Range: 0x896874..0x896875
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896105..0x8961bc
+            - Range: 0x896875..0x89692c
               Pieces: []
-            - Range: 0x8961bc..0x8961bd
+            - Range: 0x89692c..0x89692d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8961bd..0x8961f0
+            - Range: 0x89692d..0x896960
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7934,13 +7934,13 @@ Subprograms:
       DictRegister: null
     - ID: 92
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x8962a0..0x8962e0]
+      OutOfLinePCRanges: [0x896b00..0x896b40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType uint64
           Locations:
-            - Range: 0x8962a0..0x8962dc
+            - Range: 0x896b00..0x896b3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7948,11 +7948,11 @@ Subprograms:
         - Name: ~r0
           Type: 12 BaseType uint64
           Locations:
-            - Range: 0x8962a0..0x8962dc
+            - Range: 0x896b00..0x896b3c
               Pieces: []
-            - Range: 0x8962dc..0x8962dd
+            - Range: 0x896b3c..0x896b3d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8962dd..0x8962e0
+            - Range: 0x896b3d..0x896b40
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7960,13 +7960,13 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testChannel
-      OutOfLinePCRanges: [0x8962e0..0x8962f0]
+      OutOfLinePCRanges: [0x896b40..0x896b50]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 251 GoChannelType chan bool
           Locations:
-            - Range: 0x8962e0..0x8962f0
+            - Range: 0x896b40..0x896b50
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7974,13 +7974,13 @@ Subprograms:
       DictRegister: null
     - ID: 94
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x896490..0x8964a0]
+      OutOfLinePCRanges: [0x896dd0..0x896de0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x896490..0x8964a0
+            - Range: 0x896dd0..0x896de0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7988,13 +7988,13 @@ Subprograms:
       DictRegister: null
     - ID: 95
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x8964a0..0x8964b0]
+      OutOfLinePCRanges: [0x896de0..0x896df0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 254 StructureType main.node
           Locations:
-            - Range: 0x8964a0..0x8964b0
+            - Range: 0x896de0..0x896df0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8006,13 +8006,13 @@ Subprograms:
       DictRegister: null
     - ID: 96
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x8964b0..0x8964c0]
+      OutOfLinePCRanges: [0x896df0..0x896e00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 255 PointerType *main.node
           Locations:
-            - Range: 0x8964b0..0x8964c0
+            - Range: 0x896df0..0x896e00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8020,13 +8020,13 @@ Subprograms:
       DictRegister: null
     - ID: 97
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x8964c0..0x8964d0]
+      OutOfLinePCRanges: [0x896e00..0x896e10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 21 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x8964c0..0x8964d0
+            - Range: 0x896e00..0x896e10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8034,13 +8034,13 @@ Subprograms:
       DictRegister: null
     - ID: 98
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x8964e0..0x8964f0]
+      OutOfLinePCRanges: [0x896e20..0x896e30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 PointerType *uint
           Locations:
-            - Range: 0x8964e0..0x8964f0
+            - Range: 0x896e20..0x896e30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8048,13 +8048,13 @@ Subprograms:
       DictRegister: null
     - ID: 99
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x896550..0x896560]
+      OutOfLinePCRanges: [0x896e90..0x896ea0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 91 PointerType *string
           Locations:
-            - Range: 0x896550..0x896560
+            - Range: 0x896e90..0x896ea0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8062,13 +8062,13 @@ Subprograms:
       DictRegister: null
     - ID: 100
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x896570..0x896580]
+      OutOfLinePCRanges: [0x896eb0..0x896ec0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 7 PointerType *bool
           Locations:
-            - Range: 0x896570..0x896580
+            - Range: 0x896eb0..0x896ec0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8076,7 +8076,7 @@ Subprograms:
         - Name: a
           Type: 14 BaseType uint
           Locations:
-            - Range: 0x896570..0x896580
+            - Range: 0x896eb0..0x896ec0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8084,13 +8084,13 @@ Subprograms:
       DictRegister: null
     - ID: 101
       Name: main.testCycle
-      OutOfLinePCRanges: [0x896590..0x8965a0]
+      OutOfLinePCRanges: [0x896ed0..0x896ee0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 256 PointerType *main.t
           Locations:
-            - Range: 0x896590..0x8965a0
+            - Range: 0x896ed0..0x896ee0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8098,13 +8098,13 @@ Subprograms:
       DictRegister: null
     - ID: 102
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x8969a0..0x896a20]
+      OutOfLinePCRanges: [0x8973c0..0x897440]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0x8969a0..0x8969bc
+            - Range: 0x8973c0..0x8973dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8112,11 +8112,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0x8969a0..0x8969fc
+            - Range: 0x8973c0..0x89741c
               Pieces: []
-            - Range: 0x8969fc..0x8969fd
+            - Range: 0x89741c..0x89741d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8969fd..0x896a20
+            - Range: 0x89741d..0x897440
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8124,9 +8124,9 @@ Subprograms:
         - Name: result
           Type: 11 BaseType int
           Locations:
-            - Range: 0x8969bc..0x8969c8
+            - Range: 0x8973dc..0x8973e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8969c8..0x896a20
+            - Range: 0x8973e8..0x897440
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
@@ -8134,15 +8134,15 @@ Subprograms:
       DictRegister: null
     - ID: 103
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x896a20..0x896ac0]
+      OutOfLinePCRanges: [0x897440..0x8974e0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0x896a20..0x896a44
+            - Range: 0x897440..0x897464
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896a44..0x896ac0
+            - Range: 0x897464..0x8974e0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8150,11 +8150,11 @@ Subprograms:
         - Name: ~r0
           Type: 97 PointerType *int
           Locations:
-            - Range: 0x896a20..0x896a9c
+            - Range: 0x897440..0x8974bc
               Pieces: []
-            - Range: 0x896a9c..0x896a9d
+            - Range: 0x8974bc..0x8974bd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896a9d..0x896ac0
+            - Range: 0x8974bd..0x8974e0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8162,9 +8162,9 @@ Subprograms:
         - Name: '&result'
           Type: 97 PointerType *int
           Locations:
-            - Range: 0x896a48..0x896a64
+            - Range: 0x897468..0x897484
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896a64..0x896ac0
+            - Range: 0x897484..0x8974e0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
@@ -8172,13 +8172,13 @@ Subprograms:
       DictRegister: null
     - ID: 104
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x896ac0..0x896b90]
+      OutOfLinePCRanges: [0x8974e0..0x8975b0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0x896ac0..0x896b18
+            - Range: 0x8974e0..0x897538
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8186,27 +8186,27 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0x896ac0..0x896b70
+            - Range: 0x8974e0..0x897590
               Pieces: []
-            - Range: 0x896b70..0x896b71
+            - Range: 0x897590..0x897591
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896b71..0x896b90
+            - Range: 0x897591..0x8975b0
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0x896ac0..0x896b90, Pieces: []}]
+          Locations: [{Range: 0x8974e0..0x8975b0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: resultInt
           Type: 11 BaseType int
           Locations:
-            - Range: 0x896adc..0x896b1c
+            - Range: 0x8974fc..0x89753c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x896b1c..0x896b90
+            - Range: 0x89753c..0x8975b0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
@@ -8214,9 +8214,9 @@ Subprograms:
         - Name: resultFloat
           Type: 19 BaseType float64
           Locations:
-            - Range: 0x896aec..0x896b1c
+            - Range: 0x89750c..0x89753c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x896b1c..0x896b90
+            - Range: 0x89753c..0x8975b0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
@@ -8224,13 +8224,13 @@ Subprograms:
       DictRegister: null
     - ID: 105
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x896b90..0x896c10]
+      OutOfLinePCRanges: [0x8975b0..0x897630]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x896b90..0x896bb4
+            - Range: 0x8975b0..0x8975d4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8238,23 +8238,23 @@ Subprograms:
         - Name: ~r0
           Type: 20 GoInterfaceType error
           Locations:
-            - Range: 0x896b90..0x896bd8
+            - Range: 0x8975b0..0x8975f8
               Pieces: []
-            - Range: 0x896bd8..0x896bd9
+            - Range: 0x8975f8..0x8975f9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896bd9..0x896bec
+            - Range: 0x8975f9..0x89760c
               Pieces: []
-            - Range: 0x896bec..0x896bed
+            - Range: 0x89760c..0x89760d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896bed..0x896c10
+            - Range: 0x89760d..0x897630
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8262,37 +8262,37 @@ Subprograms:
       DictRegister: null
     - ID: 106
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x896c10..0x896d90]
+      OutOfLinePCRanges: [0x897630..0x8977b0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 55 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x896c10..0x896c68
+            - Range: 0x897630..0x897688
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896c68..0x896c6c
+            - Range: 0x897688..0x89768c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896cc4..0x896cc8
+            - Range: 0x8976e4..0x8976e8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x896cf4..0x896cf8
+            - Range: 0x897714..0x897718
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896d34..0x896d38
+            - Range: 0x897754..0x897758
               Pieces:
                 - Size: 8
                   Op: null
@@ -8304,7 +8304,7 @@ Subprograms:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x896c10..0x896c64
+            - Range: 0x897630..0x897684
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8312,39 +8312,39 @@ Subprograms:
         - Name: ~r0
           Type: 55 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x896c10..0x896c94
+            - Range: 0x897630..0x8976b4
               Pieces: []
-            - Range: 0x896c94..0x896c95
+            - Range: 0x8976b4..0x8976b5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896c95..0x896ce0
+            - Range: 0x8976b5..0x897700
               Pieces: []
-            - Range: 0x896ce0..0x896ce1
+            - Range: 0x897700..0x897701
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896ce1..0x896d20
+            - Range: 0x897701..0x897740
               Pieces: []
-            - Range: 0x896d20..0x896d21
+            - Range: 0x897740..0x897741
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896d21..0x896d60
+            - Range: 0x897741..0x897780
               Pieces: []
-            - Range: 0x896d60..0x896d61
+            - Range: 0x897780..0x897781
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896d61..0x896d90
+            - Range: 0x897781..0x8977b0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8352,39 +8352,39 @@ Subprograms:
         - Name: ~r1
           Type: 20 GoInterfaceType error
           Locations:
-            - Range: 0x896c10..0x896c94
+            - Range: 0x897630..0x8976b4
               Pieces: []
-            - Range: 0x896c94..0x896c95
+            - Range: 0x8976b4..0x8976b5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x896c95..0x896ce0
+            - Range: 0x8976b5..0x897700
               Pieces: []
-            - Range: 0x896ce0..0x896ce1
+            - Range: 0x897700..0x897701
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x896ce1..0x896d20
+            - Range: 0x897701..0x897740
               Pieces: []
-            - Range: 0x896d20..0x896d21
+            - Range: 0x897740..0x897741
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x896d21..0x896d60
+            - Range: 0x897741..0x897780
               Pieces: []
-            - Range: 0x896d60..0x896d61
+            - Range: 0x897780..0x897781
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x896d61..0x896d90
+            - Range: 0x897781..0x8977b0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8392,7 +8392,7 @@ Subprograms:
         - Name: val
           Type: 11 BaseType int
           Locations:
-            - Range: 0x896cc4..0x896ccc
+            - Range: 0x8976e4..0x8976ec
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8400,25 +8400,25 @@ Subprograms:
       DictRegister: null
     - ID: 107
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x896d90..0x896f90]
+      OutOfLinePCRanges: [0x8977b0..0x8979b0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 55 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x896d90..0x896dec
+            - Range: 0x8977b0..0x89780c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896dec..0x896df0
+            - Range: 0x89780c..0x897810
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x896df0..0x896f90
+            - Range: 0x897810..0x8979b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -8430,39 +8430,39 @@ Subprograms:
         - Name: ~r0
           Type: 55 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x896d90..0x896e48
+            - Range: 0x8977b0..0x897868
               Pieces: []
-            - Range: 0x896e48..0x896e49
+            - Range: 0x897868..0x897869
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896e49..0x896e90
+            - Range: 0x897869..0x8978b0
               Pieces: []
-            - Range: 0x896e90..0x896e91
+            - Range: 0x8978b0..0x8978b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896e91..0x896f54
+            - Range: 0x8978b1..0x897974
               Pieces: []
-            - Range: 0x896f54..0x896f55
+            - Range: 0x897974..0x897975
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896f55..0x896f68
+            - Range: 0x897975..0x897988
               Pieces: []
-            - Range: 0x896f68..0x896f69
+            - Range: 0x897988..0x897989
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896f69..0x896f90
+            - Range: 0x897989..0x8979b0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8470,7 +8470,7 @@ Subprograms:
         - Name: val
           Type: 11 BaseType int
           Locations:
-            - Range: 0x896e7c..0x896e84
+            - Range: 0x89789c..0x8978a4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8478,7 +8478,7 @@ Subprograms:
         - Name: '&result'
           Type: 97 PointerType *int
           Locations:
-            - Range: 0x896e2c..0x896e48
+            - Range: 0x89784c..0x897868
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8486,35 +8486,35 @@ Subprograms:
       DictRegister: null
     - ID: 108
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x896f90..0x897100]
+      OutOfLinePCRanges: [0x8979b0..0x897b20]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 55 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x896f90..0x896fcc
+            - Range: 0x8979b0..0x8979ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896fcc..0x89702c
+            - Range: 0x8979ec..0x897a4c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x89702c..0x897098
+            - Range: 0x897a4c..0x897ab8
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x897098..0x8970c0
+            - Range: 0x897ab8..0x897ae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8970c0..0x8970c4
+            - Range: 0x897ae0..0x897ae4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8970c4..0x897100
+            - Range: 0x897ae4..0x897b20
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -8522,23 +8522,23 @@ Subprograms:
         - Name: ~r0
           Type: 166 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x896f90..0x897078
+            - Range: 0x8979b0..0x897a98
               Pieces: []
-            - Range: 0x897078..0x897079
+            - Range: 0x897a98..0x897a99
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x897079..0x89708c
+            - Range: 0x897a99..0x897aac
               Pieces: []
-            - Range: 0x89708c..0x89708d
+            - Range: 0x897aac..0x897aad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89708d..0x897100
+            - Range: 0x897aad..0x897b20
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8546,39 +8546,39 @@ Subprograms:
         - Name: b
           Type: 166 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x896f90..0x896fcc
+            - Range: 0x8979b0..0x8979ec
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896fcc..0x89701c
+            - Range: 0x8979ec..0x897a3c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x89701c..0x89702c
+            - Range: 0x897a3c..0x897a4c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x89702c..0x897084
+            - Range: 0x897a4c..0x897aa4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x897084..0x897088
+            - Range: 0x897aa4..0x897aa8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x897088..0x89708c
+            - Range: 0x897aa8..0x897aac
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x89708c..0x897100
+            - Range: 0x897aac..0x897b20
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
@@ -8586,13 +8586,13 @@ Subprograms:
       DictRegister: null
     - ID: 109
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x897100..0x8971a0]
+      OutOfLinePCRanges: [0x897b20..0x897bc0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897100..0x89711c
+            - Range: 0x897b20..0x897b3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8600,11 +8600,11 @@ Subprograms:
         - Name: result
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897100..0x897178
+            - Range: 0x897b20..0x897b98
               Pieces: []
-            - Range: 0x897178..0x897179
+            - Range: 0x897b98..0x897b99
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897179..0x8971a0
+            - Range: 0x897b99..0x897bc0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8612,13 +8612,13 @@ Subprograms:
       DictRegister: null
     - ID: 110
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x8971a0..0x897270]
+      OutOfLinePCRanges: [0x897bc0..0x897c90]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0x8971a0..0x8971f0
+            - Range: 0x897bc0..0x897c10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8626,11 +8626,11 @@ Subprograms:
         - Name: result
           Type: 11 BaseType int
           Locations:
-            - Range: 0x8971a0..0x897244
+            - Range: 0x897bc0..0x897c64
               Pieces: []
-            - Range: 0x897244..0x897245
+            - Range: 0x897c64..0x897c65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897245..0x897270
+            - Range: 0x897c65..0x897c90
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8638,11 +8638,11 @@ Subprograms:
         - Name: result2
           Type: 11 BaseType int
           Locations:
-            - Range: 0x8971a0..0x897244
+            - Range: 0x897bc0..0x897c64
               Pieces: []
-            - Range: 0x897244..0x897245
+            - Range: 0x897c64..0x897c65
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x897245..0x897270
+            - Range: 0x897c65..0x897c90
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8650,15 +8650,15 @@ Subprograms:
       DictRegister: null
     - ID: 111
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x897270..0x897340]
+      OutOfLinePCRanges: [0x897c90..0x897d60]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897270..0x8972b0
+            - Range: 0x897c90..0x897cd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8972b0..0x897340
+            - Range: 0x897cd0..0x897d60
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8666,11 +8666,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897270..0x897314
+            - Range: 0x897c90..0x897d34
               Pieces: []
-            - Range: 0x897314..0x897315
+            - Range: 0x897d34..0x897d35
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897315..0x897340
+            - Range: 0x897d35..0x897d60
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8678,11 +8678,11 @@ Subprograms:
         - Name: result2
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897270..0x897314
+            - Range: 0x897c90..0x897d34
               Pieces: []
-            - Range: 0x897314..0x897315
+            - Range: 0x897d34..0x897d35
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x897315..0x897340
+            - Range: 0x897d35..0x897d60
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8690,11 +8690,11 @@ Subprograms:
         - Name: ~r2
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897270..0x897314
+            - Range: 0x897c90..0x897d34
               Pieces: []
-            - Range: 0x897314..0x897315
+            - Range: 0x897d34..0x897d35
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x897315..0x897340
+            - Range: 0x897d35..0x897d60
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8702,15 +8702,15 @@ Subprograms:
       DictRegister: null
     - ID: 112
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x897340..0x897430]
+      OutOfLinePCRanges: [0x897d60..0x897e50]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897340..0x897380
+            - Range: 0x897d60..0x897da0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897380..0x897430
+            - Range: 0x897da0..0x897e50
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8718,11 +8718,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897340..0x897408
+            - Range: 0x897d60..0x897e28
               Pieces: []
-            - Range: 0x897408..0x897409
+            - Range: 0x897e28..0x897e29
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897409..0x897430
+            - Range: 0x897e29..0x897e50
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8730,15 +8730,15 @@ Subprograms:
         - Name: r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x897340..0x897408
+            - Range: 0x897d60..0x897e28
               Pieces: []
-            - Range: 0x897408..0x897409
+            - Range: 0x897e28..0x897e29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x897409..0x897430
+            - Range: 0x897e29..0x897e50
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8746,15 +8746,15 @@ Subprograms:
       DictRegister: null
     - ID: 113
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x897430..0x8975f0]
+      OutOfLinePCRanges: [0x897e50..0x898010]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897430..0x897494
+            - Range: 0x897e50..0x897eb4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897494..0x8975f0
+            - Range: 0x897eb4..0x898010
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8762,7 +8762,7 @@ Subprograms:
         - Name: a
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x89745c..0x8975f0
+            - Range: 0x897e7c..0x898010
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
@@ -8770,7 +8770,7 @@ Subprograms:
         - Name: b
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x897460..0x8975f0
+            - Range: 0x897e80..0x898010
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
@@ -8778,17 +8778,17 @@ Subprograms:
       DictRegister: null
     - ID: 114
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x8976d0..0x897760]
+      OutOfLinePCRanges: [0x8980f0..0x898180]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x8976d0..0x897740
+            - Range: 0x8980f0..0x898160
               Pieces: []
-            - Range: 0x897740..0x897741
+            - Range: 0x898160..0x898161
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897741..0x897760
+            - Range: 0x898161..0x898180
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8796,11 +8796,11 @@ Subprograms:
         - Name: ~r1
           Type: 92 BaseType int16
           Locations:
-            - Range: 0x8976d0..0x897740
+            - Range: 0x8980f0..0x898160
               Pieces: []
-            - Range: 0x897740..0x897741
+            - Range: 0x898160..0x898161
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x897741..0x897760
+            - Range: 0x898161..0x898180
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8808,11 +8808,11 @@ Subprograms:
         - Name: ~r2
           Type: 15 BaseType int32
           Locations:
-            - Range: 0x8976d0..0x897740
+            - Range: 0x8980f0..0x898160
               Pieces: []
-            - Range: 0x897740..0x897741
+            - Range: 0x898160..0x898161
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x897741..0x897760
+            - Range: 0x898161..0x898180
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8820,11 +8820,11 @@ Subprograms:
         - Name: ~r3
           Type: 16 BaseType int64
           Locations:
-            - Range: 0x8976d0..0x897740
+            - Range: 0x8980f0..0x898160
               Pieces: []
-            - Range: 0x897740..0x897741
+            - Range: 0x898160..0x898161
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x897741..0x897760
+            - Range: 0x898161..0x898180
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8832,11 +8832,11 @@ Subprograms:
         - Name: ~r4
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x8976d0..0x897740
+            - Range: 0x8980f0..0x898160
               Pieces: []
-            - Range: 0x897740..0x897741
+            - Range: 0x898160..0x898161
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x897741..0x897760
+            - Range: 0x898161..0x898180
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8844,11 +8844,11 @@ Subprograms:
         - Name: ~r5
           Type: 9 BaseType uint16
           Locations:
-            - Range: 0x8976d0..0x897740
+            - Range: 0x8980f0..0x898160
               Pieces: []
-            - Range: 0x897740..0x897741
+            - Range: 0x898160..0x898161
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x897741..0x897760
+            - Range: 0x898161..0x898180
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8856,11 +8856,11 @@ Subprograms:
         - Name: ~r6
           Type: 4 BaseType uint32
           Locations:
-            - Range: 0x8976d0..0x897740
+            - Range: 0x8980f0..0x898160
               Pieces: []
-            - Range: 0x897740..0x897741
+            - Range: 0x898160..0x898161
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x897741..0x897760
+            - Range: 0x898161..0x898180
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8868,11 +8868,11 @@ Subprograms:
         - Name: ~r7
           Type: 12 BaseType uint64
           Locations:
-            - Range: 0x8976d0..0x897740
+            - Range: 0x8980f0..0x898160
               Pieces: []
-            - Range: 0x897740..0x897741
+            - Range: 0x898160..0x898161
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x897741..0x897760
+            - Range: 0x898161..0x898180
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8880,113 +8880,113 @@ Subprograms:
       DictRegister: null
     - ID: 115
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x897760..0x897820]
+      OutOfLinePCRanges: [0x898180..0x898240]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r5
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r6
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r7
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r8
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r9
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r10
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r11
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r12
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r13
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r14
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: onlyOnAmd64_16
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897760..0x897820, Pieces: []}]
+          Locations: [{Range: 0x898180..0x898240, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: bothArmAndAmd64
           Type: 19 BaseType float64
           Locations:
-            - Range: 0x897760..0x8977fc
+            - Range: 0x898180..0x89821c
               Pieces: []
-            - Range: 0x8977fc..0x8977fd
+            - Range: 0x89821c..0x89821d
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x8977fd..0x897820
+            - Range: 0x89821d..0x898240
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8994,33 +8994,33 @@ Subprograms:
       DictRegister: null
     - ID: 116
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x897820..0x8978a0]
+      OutOfLinePCRanges: [0x898240..0x8982c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 93 BaseType complex64
-          Locations: [{Range: 0x897820..0x8978a0, Pieces: []}]
+          Locations: [{Range: 0x898240..0x8982c0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 94 BaseType complex128
-          Locations: [{Range: 0x897820..0x8978a0, Pieces: []}]
+          Locations: [{Range: 0x898240..0x8982c0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 117
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x8978a0..0x897970]
+      OutOfLinePCRanges: [0x8982c0..0x898390]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 StructureType main.largeStruct
           Locations:
-            - Range: 0x8978a0..0x897954
+            - Range: 0x8982c0..0x898374
               Pieces: []
-            - Range: 0x897954..0x897955
+            - Range: 0x898374..0x898375
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9042,7 +9042,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x897955..0x897970
+            - Range: 0x898375..0x898390
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9050,17 +9050,17 @@ Subprograms:
       DictRegister: null
     - ID: 118
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x897970..0x897a00]
+      OutOfLinePCRanges: [0x898390..0x898420]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 ArrayType [3]int
           Locations:
-            - Range: 0x897970..0x8979e0
+            - Range: 0x898390..0x898400
               Pieces: []
-            - Range: 0x8979e0..0x8979e1
+            - Range: 0x898400..0x898401
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x8979e1..0x897a00
+            - Range: 0x898401..0x898420
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9068,17 +9068,17 @@ Subprograms:
       DictRegister: null
     - ID: 119
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x897a00..0x897a70]
+      OutOfLinePCRanges: [0x898420..0x898490]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 260 ArrayType [1]int
           Locations:
-            - Range: 0x897a00..0x897a54
+            - Range: 0x898420..0x898474
               Pieces: []
-            - Range: 0x897a54..0x897a55
+            - Range: 0x898474..0x898475
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897a55..0x897a70
+            - Range: 0x898475..0x898490
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9086,17 +9086,17 @@ Subprograms:
       DictRegister: null
     - ID: 120
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x897a70..0x897ae0]
+      OutOfLinePCRanges: [0x898490..0x898500]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 ArrayType [0]int
           Locations:
-            - Range: 0x897a70..0x897ac0
+            - Range: 0x898490..0x8984e0
               Pieces: []
-            - Range: 0x897ac0..0x897ac1
+            - Range: 0x8984e0..0x8984e1
               Pieces: []
-            - Range: 0x897ac1..0x897ae0
+            - Range: 0x8984e1..0x898500
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9104,29 +9104,29 @@ Subprograms:
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x897ae0..0x897b60]
+      OutOfLinePCRanges: [0x898500..0x898580]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 StructureType main.mixedStruct
-          Locations: [{Range: 0x897ae0..0x897b60, Pieces: []}]
+          Locations: [{Range: 0x898500..0x898580, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 122
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x897b60..0x897c00]
+      OutOfLinePCRanges: [0x898580..0x898620]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897b60..0x897bdc
+            - Range: 0x898580..0x8985fc
               Pieces: []
-            - Range: 0x897bdc..0x897bdd
+            - Range: 0x8985fc..0x8985fd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897bdd..0x897c00
+            - Range: 0x8985fd..0x898620
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9134,11 +9134,11 @@ Subprograms:
         - Name: ~r1
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897b60..0x897bdc
+            - Range: 0x898580..0x8985fc
               Pieces: []
-            - Range: 0x897bdc..0x897bdd
+            - Range: 0x8985fc..0x8985fd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x897bdd..0x897c00
+            - Range: 0x8985fd..0x898620
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9146,11 +9146,11 @@ Subprograms:
         - Name: ~r2
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897b60..0x897bdc
+            - Range: 0x898580..0x8985fc
               Pieces: []
-            - Range: 0x897bdc..0x897bdd
+            - Range: 0x8985fc..0x8985fd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x897bdd..0x897c00
+            - Range: 0x8985fd..0x898620
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9158,11 +9158,11 @@ Subprograms:
         - Name: ~r3
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897b60..0x897bdc
+            - Range: 0x898580..0x8985fc
               Pieces: []
-            - Range: 0x897bdc..0x897bdd
+            - Range: 0x8985fc..0x8985fd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x897bdd..0x897c00
+            - Range: 0x8985fd..0x898620
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9170,11 +9170,11 @@ Subprograms:
         - Name: ~r4
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897b60..0x897bdc
+            - Range: 0x898580..0x8985fc
               Pieces: []
-            - Range: 0x897bdc..0x897bdd
+            - Range: 0x8985fc..0x8985fd
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x897bdd..0x897c00
+            - Range: 0x8985fd..0x898620
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9182,11 +9182,11 @@ Subprograms:
         - Name: ~r5
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897b60..0x897bdc
+            - Range: 0x898580..0x8985fc
               Pieces: []
-            - Range: 0x897bdc..0x897bdd
+            - Range: 0x8985fc..0x8985fd
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x897bdd..0x897c00
+            - Range: 0x8985fd..0x898620
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9194,11 +9194,11 @@ Subprograms:
         - Name: ~r6
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897b60..0x897bdc
+            - Range: 0x898580..0x8985fc
               Pieces: []
-            - Range: 0x897bdc..0x897bdd
+            - Range: 0x8985fc..0x8985fd
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x897bdd..0x897c00
+            - Range: 0x8985fd..0x898620
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9206,11 +9206,11 @@ Subprograms:
         - Name: ~r7
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897b60..0x897bdc
+            - Range: 0x898580..0x8985fc
               Pieces: []
-            - Range: 0x897bdc..0x897bdd
+            - Range: 0x8985fc..0x8985fd
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x897bdd..0x897c00
+            - Range: 0x8985fd..0x898620
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9218,15 +9218,15 @@ Subprograms:
         - Name: ~r8
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x897b60..0x897bdc
+            - Range: 0x898580..0x8985fc
               Pieces: []
-            - Range: 0x897bdc..0x897bdd
+            - Range: 0x8985fc..0x8985fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x897bdd..0x897c00
+            - Range: 0x8985fd..0x898620
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9234,15 +9234,15 @@ Subprograms:
       DictRegister: null
     - ID: 123
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x897c00..0x897ce0]
+      OutOfLinePCRanges: [0x898620..0x898700]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 263 StructureType main.wideStruct
           Locations:
-            - Range: 0x897c00..0x897cc4
+            - Range: 0x898620..0x8986e4
               Pieces: []
-            - Range: 0x897cc4..0x897cc5
+            - Range: 0x8986e4..0x8986e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9266,7 +9266,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x897cc5..0x897ce0
+            - Range: 0x8986e5..0x898700
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9274,57 +9274,57 @@ Subprograms:
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x897ce0..0x897d70]
+      OutOfLinePCRanges: [0x898700..0x898790]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897ce0..0x897d50
+            - Range: 0x898700..0x898770
               Pieces: []
-            - Range: 0x897d50..0x897d51
+            - Range: 0x898770..0x898771
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897d51..0x897d70
+            - Range: 0x898771..0x898790
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897ce0..0x897d70, Pieces: []}]
+          Locations: [{Range: 0x898700..0x898790, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 11 BaseType int
           Locations:
-            - Range: 0x897ce0..0x897d50
+            - Range: 0x898700..0x898770
               Pieces: []
-            - Range: 0x897d50..0x897d51
+            - Range: 0x898770..0x898771
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x897d51..0x897d70
+            - Range: 0x898771..0x898790
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897ce0..0x897d70, Pieces: []}]
+          Locations: [{Range: 0x898700..0x898790, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x897ce0..0x897d50
+            - Range: 0x898700..0x898770
               Pieces: []
-            - Range: 0x897d50..0x897d51
+            - Range: 0x898770..0x898771
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x897d51..0x897d70
+            - Range: 0x898771..0x898790
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9332,17 +9332,17 @@ Subprograms:
       DictRegister: null
     - ID: 125
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x897d70..0x897e00]
+      OutOfLinePCRanges: [0x898790..0x898820]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 264 StructureType main.structWithArray
           Locations:
-            - Range: 0x897d70..0x897de0
+            - Range: 0x898790..0x898800
               Pieces: []
-            - Range: 0x897de0..0x897de1
+            - Range: 0x898800..0x898801
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x897de1..0x897e00
+            - Range: 0x898801..0x898820
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9350,47 +9350,47 @@ Subprograms:
       DictRegister: null
     - ID: 126
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x897e00..0x897e70]
+      OutOfLinePCRanges: [0x898820..0x898890]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897e00..0x897e70, Pieces: []}]
+          Locations: [{Range: 0x898820..0x898890, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 127
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x897e70..0x897ef0]
+      OutOfLinePCRanges: [0x898890..0x898910]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0x897e70..0x897ef0, Pieces: []}]
+          Locations: [{Range: 0x898890..0x898910, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 19 BaseType float64
-          Locations: [{Range: 0x897e70..0x897ef0, Pieces: []}]
+          Locations: [{Range: 0x898890..0x898910, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 128
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x897ef0..0x897f60]
+      OutOfLinePCRanges: [0x898910..0x898980]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x897ef0..0x897f48
+            - Range: 0x898910..0x898968
               Pieces: []
-            - Range: 0x897f48..0x897f49
+            - Range: 0x898968..0x898969
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x897f49..0x897f60
+            - Range: 0x898969..0x898980
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9398,11 +9398,11 @@ Subprograms:
         - Name: ~r1
           Type: 3 BaseType uintptr
           Locations:
-            - Range: 0x897ef0..0x897f48
+            - Range: 0x898910..0x898968
               Pieces: []
-            - Range: 0x897f48..0x897f49
+            - Range: 0x898968..0x898969
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x897f49..0x897f60
+            - Range: 0x898969..0x898980
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9410,13 +9410,13 @@ Subprograms:
       DictRegister: null
     - ID: 129
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x897f60..0x898140]
+      OutOfLinePCRanges: [0x898980..0x898b60]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 258 StructureType main.largeStruct
           Locations:
-            - Range: 0x897f60..0x897fcc
+            - Range: 0x898980..0x8989ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9438,7 +9438,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x897fcc..0x897fe0
+            - Range: 0x8989ec..0x898a00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9460,7 +9460,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x897fe0..0x897fe4
+            - Range: 0x898a00..0x898a04
               Pieces:
                 - Size: 8
                   Op: null
@@ -9488,9 +9488,9 @@ Subprograms:
         - Name: ~r0
           Type: 258 StructureType main.largeStruct
           Locations:
-            - Range: 0x897f60..0x8980d8
+            - Range: 0x898980..0x898af8
               Pieces: []
-            - Range: 0x8980d8..0x8980d9
+            - Range: 0x898af8..0x898af9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9512,7 +9512,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8980d9..0x898140
+            - Range: 0x898af9..0x898b60
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9520,13 +9520,13 @@ Subprograms:
       DictRegister: null
     - ID: 130
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x898140..0x898210]
+      OutOfLinePCRanges: [0x898b60..0x898c30]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 259 ArrayType [3]int
           Locations:
-            - Range: 0x898140..0x898210
+            - Range: 0x898b60..0x898c30
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9534,11 +9534,11 @@ Subprograms:
         - Name: ~r0
           Type: 259 ArrayType [3]int
           Locations:
-            - Range: 0x898140..0x8981f4
+            - Range: 0x898b60..0x898c14
               Pieces: []
-            - Range: 0x8981f4..0x8981f5
+            - Range: 0x898c14..0x898c15
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x8981f5..0x898210
+            - Range: 0x898c15..0x898c30
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9546,13 +9546,13 @@ Subprograms:
       DictRegister: null
     - ID: 131
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x898210..0x898470]
+      OutOfLinePCRanges: [0x898c30..0x898e90]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 258 StructureType main.largeStruct
           Locations:
-            - Range: 0x898210..0x898280
+            - Range: 0x898c30..0x898ca0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9574,7 +9574,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x898280..0x898294
+            - Range: 0x898ca0..0x898cb4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9596,7 +9596,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x898294..0x898298
+            - Range: 0x898cb4..0x898cb8
               Pieces:
                 - Size: 8
                   Op: null
@@ -9624,7 +9624,7 @@ Subprograms:
         - Name: s2
           Type: 258 StructureType main.largeStruct
           Locations:
-            - Range: 0x898210..0x898470
+            - Range: 0x898c30..0x898e90
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9632,9 +9632,9 @@ Subprograms:
         - Name: ~r0
           Type: 258 StructureType main.largeStruct
           Locations:
-            - Range: 0x898210..0x898400
+            - Range: 0x898c30..0x898e20
               Pieces: []
-            - Range: 0x898400..0x898401
+            - Range: 0x898e20..0x898e21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9656,7 +9656,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x898401..0x898470
+            - Range: 0x898e21..0x898e90
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9664,15 +9664,15 @@ Subprograms:
       DictRegister: null
     - ID: 132
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x898470..0x898660]
+      OutOfLinePCRanges: [0x898e90..0x899080]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898470..0x8984e8
+            - Range: 0x898e90..0x898f08
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8984e8..0x898660
+            - Range: 0x898f08..0x899080
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -9680,9 +9680,9 @@ Subprograms:
         - Name: b
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898470..0x8984e8
+            - Range: 0x898e90..0x898f08
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8984e8..0x898660
+            - Range: 0x898f08..0x899080
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
@@ -9690,9 +9690,9 @@ Subprograms:
         - Name: c
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898470..0x8984e8
+            - Range: 0x898e90..0x898f08
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8984e8..0x898660
+            - Range: 0x898f08..0x899080
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
@@ -9700,9 +9700,9 @@ Subprograms:
         - Name: d
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898470..0x8984e8
+            - Range: 0x898e90..0x898f08
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8984e8..0x898660
+            - Range: 0x898f08..0x899080
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
@@ -9710,9 +9710,9 @@ Subprograms:
         - Name: e
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898470..0x8984e8
+            - Range: 0x898e90..0x898f08
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8984e8..0x898660
+            - Range: 0x898f08..0x899080
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
@@ -9720,9 +9720,9 @@ Subprograms:
         - Name: f
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898470..0x8984e8
+            - Range: 0x898e90..0x898f08
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8984e8..0x898660
+            - Range: 0x898f08..0x899080
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
@@ -9730,9 +9730,9 @@ Subprograms:
         - Name: g
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898470..0x8984e8
+            - Range: 0x898e90..0x898f08
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8984e8..0x898660
+            - Range: 0x898f08..0x899080
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
@@ -9740,9 +9740,9 @@ Subprograms:
         - Name: h
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898470..0x8984e8
+            - Range: 0x898e90..0x898f08
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8984e8..0x898660
+            - Range: 0x898f08..0x899080
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
@@ -9750,9 +9750,9 @@ Subprograms:
         - Name: i
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898470..0x8984e8
+            - Range: 0x898e90..0x898f08
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x8984e8..0x898660
+            - Range: 0x898f08..0x899080
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
@@ -9760,11 +9760,11 @@ Subprograms:
         - Name: ~r0
           Type: 109 ArrayType [2]int
           Locations:
-            - Range: 0x898470..0x8985fc
+            - Range: 0x898e90..0x89901c
               Pieces: []
-            - Range: 0x8985fc..0x8985fd
+            - Range: 0x89901c..0x89901d
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x8985fd..0x898660
+            - Range: 0x89901d..0x899080
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9772,15 +9772,15 @@ Subprograms:
       DictRegister: null
     - ID: 133
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x898660..0x8988a0]
+      OutOfLinePCRanges: [0x899080..0x8992c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898660..0x8986e8
+            - Range: 0x899080..0x899108
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8986e8..0x8988a0
+            - Range: 0x899108..0x8992c0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9788,9 +9788,9 @@ Subprograms:
         - Name: b
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898660..0x8986e8
+            - Range: 0x899080..0x899108
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8986e8..0x8988a0
+            - Range: 0x899108..0x8992c0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -9798,9 +9798,9 @@ Subprograms:
         - Name: c
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898660..0x8986e8
+            - Range: 0x899080..0x899108
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8986e8..0x8988a0
+            - Range: 0x899108..0x8992c0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -9808,9 +9808,9 @@ Subprograms:
         - Name: d
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898660..0x8986e8
+            - Range: 0x899080..0x899108
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8986e8..0x8988a0
+            - Range: 0x899108..0x8992c0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
@@ -9818,9 +9818,9 @@ Subprograms:
         - Name: e
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898660..0x8986e8
+            - Range: 0x899080..0x899108
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8986e8..0x8988a0
+            - Range: 0x899108..0x8992c0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
@@ -9828,9 +9828,9 @@ Subprograms:
         - Name: f
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898660..0x8986e8
+            - Range: 0x899080..0x899108
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8986e8..0x8988a0
+            - Range: 0x899108..0x8992c0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
@@ -9838,9 +9838,9 @@ Subprograms:
         - Name: g
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898660..0x8986e8
+            - Range: 0x899080..0x899108
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8986e8..0x8988a0
+            - Range: 0x899108..0x8992c0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
@@ -9848,9 +9848,9 @@ Subprograms:
         - Name: h
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898660..0x8986e8
+            - Range: 0x899080..0x899108
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8986e8..0x8988a0
+            - Range: 0x899108..0x8992c0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
@@ -9858,13 +9858,13 @@ Subprograms:
         - Name: s
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x898660..0x8986e8
+            - Range: 0x899080..0x899108
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8986e8..0x8988a0
+            - Range: 0x899108..0x8992c0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9876,9 +9876,9 @@ Subprograms:
         - Name: ~r0
           Type: 258 StructureType main.largeStruct
           Locations:
-            - Range: 0x898660..0x898830
+            - Range: 0x899080..0x899250
               Pieces: []
-            - Range: 0x898830..0x898831
+            - Range: 0x899250..0x899251
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9900,7 +9900,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x898831..0x8988a0
+            - Range: 0x899251..0x8992c0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9908,13 +9908,13 @@ Subprograms:
       DictRegister: null
     - ID: 134
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x8988a0..0x898940]
+      OutOfLinePCRanges: [0x8992c0..0x899360]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 165 ArrayType [5]int
           Locations:
-            - Range: 0x8988a0..0x898940
+            - Range: 0x8992c0..0x899360
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9922,11 +9922,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0x8988a0..0x89891c
+            - Range: 0x8992c0..0x89933c
               Pieces: []
-            - Range: 0x89891c..0x89891d
+            - Range: 0x89933c..0x89933d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89891d..0x898940
+            - Range: 0x89933d..0x899360
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9934,11 +9934,11 @@ Subprograms:
         - Name: ~r1
           Type: 11 BaseType int
           Locations:
-            - Range: 0x8988a0..0x89891c
+            - Range: 0x8992c0..0x89933c
               Pieces: []
-            - Range: 0x89891c..0x89891d
+            - Range: 0x89933c..0x89933d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x89891d..0x898940
+            - Range: 0x89933d..0x899360
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9946,11 +9946,11 @@ Subprograms:
         - Name: ~r2
           Type: 11 BaseType int
           Locations:
-            - Range: 0x8988a0..0x89891c
+            - Range: 0x8992c0..0x89933c
               Pieces: []
-            - Range: 0x89891c..0x89891d
+            - Range: 0x89933c..0x89933d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x89891d..0x898940
+            - Range: 0x89933d..0x899360
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9958,13 +9958,13 @@ Subprograms:
       DictRegister: null
     - ID: 135
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x898940..0x898a20]
+      OutOfLinePCRanges: [0x899360..0x899440]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 109 ArrayType [2]int
           Locations:
-            - Range: 0x898940..0x898a20
+            - Range: 0x899360..0x899440
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9972,7 +9972,7 @@ Subprograms:
         - Name: b
           Type: 259 ArrayType [3]int
           Locations:
-            - Range: 0x898940..0x898a20
+            - Range: 0x899360..0x899440
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -9980,11 +9980,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898940..0x898a00
+            - Range: 0x899360..0x899420
               Pieces: []
-            - Range: 0x898a00..0x898a01
+            - Range: 0x899420..0x899421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898a01..0x898a20
+            - Range: 0x899421..0x899440
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9992,11 +9992,11 @@ Subprograms:
         - Name: ~r1
           Type: 109 ArrayType [2]int
           Locations:
-            - Range: 0x898940..0x898a00
+            - Range: 0x899360..0x899420
               Pieces: []
-            - Range: 0x898a00..0x898a01
+            - Range: 0x899420..0x899421
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x898a01..0x898a20
+            - Range: 0x899421..0x899440
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10004,13 +10004,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x898a20..0x898af0]
+      OutOfLinePCRanges: [0x899440..0x899510]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 264 StructureType main.structWithArray
           Locations:
-            - Range: 0x898a20..0x898af0
+            - Range: 0x899440..0x899510
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -10018,11 +10018,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898a20..0x898acc
+            - Range: 0x899440..0x8994ec
               Pieces: []
-            - Range: 0x898acc..0x898acd
+            - Range: 0x8994ec..0x8994ed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898acd..0x898af0
+            - Range: 0x8994ed..0x899510
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10030,11 +10030,11 @@ Subprograms:
         - Name: ~r1
           Type: 264 StructureType main.structWithArray
           Locations:
-            - Range: 0x898a20..0x898acc
+            - Range: 0x899440..0x8994ec
               Pieces: []
-            - Range: 0x898acc..0x898acd
+            - Range: 0x8994ec..0x8994ed
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x898acd..0x898af0
+            - Range: 0x8994ed..0x899510
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10042,7 +10042,7 @@ Subprograms:
         - Name: x
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898aa0..0x898af0
+            - Range: 0x8994c0..0x899510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -10050,25 +10050,25 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x898af0..0x898ba0]
+      OutOfLinePCRanges: [0x899510..0x8995c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 261 ArrayType [0]int
-          Locations: [{Range: 0x898af0..0x898ba0, Pieces: []}]
+          Locations: [{Range: 0x899510..0x8995c0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: b
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898af0..0x898b30
+            - Range: 0x899510..0x899550
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898b30..0x898b4c
+            - Range: 0x899550..0x89956c
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x898b4c..0x898b68
+            - Range: 0x89956c..0x899588
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x898b68..0x898ba0
+            - Range: 0x899588..0x8995c0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
@@ -10076,11 +10076,11 @@ Subprograms:
         - Name: ~r0
           Type: 11 BaseType int
           Locations:
-            - Range: 0x898af0..0x898b74
+            - Range: 0x899510..0x899594
               Pieces: []
-            - Range: 0x898b74..0x898b75
+            - Range: 0x899594..0x899595
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x898b75..0x898ba0
+            - Range: 0x899595..0x8995c0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10088,11 +10088,11 @@ Subprograms:
         - Name: ~r1
           Type: 261 ArrayType [0]int
           Locations:
-            - Range: 0x898af0..0x898b74
+            - Range: 0x899510..0x899594
               Pieces: []
-            - Range: 0x898b74..0x898b75
+            - Range: 0x899594..0x899595
               Pieces: []
-            - Range: 0x898b75..0x898ba0
+            - Range: 0x899595..0x8995c0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10100,13 +10100,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x899020..0x899030]
+      OutOfLinePCRanges: [0x899a40..0x899a50]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 265 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x899020..0x899030
+            - Range: 0x899a40..0x899a50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10120,13 +10120,13 @@ Subprograms:
       DictRegister: null
     - ID: 139
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x899030..0x899040]
+      OutOfLinePCRanges: [0x899a50..0x899a60]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 265 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x899030..0x899040
+            - Range: 0x899a50..0x899a60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10140,13 +10140,13 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x899040..0x899050]
+      OutOfLinePCRanges: [0x899a60..0x899a70]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 266 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x899040..0x899050
+            - Range: 0x899a60..0x899a70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10160,13 +10160,13 @@ Subprograms:
       DictRegister: null
     - ID: 141
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x899050..0x899060]
+      OutOfLinePCRanges: [0x899a70..0x899a80]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 268 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x899050..0x899060
+            - Range: 0x899a70..0x899a80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10180,7 +10180,7 @@ Subprograms:
         - Name: a
           Type: 11 BaseType int
           Locations:
-            - Range: 0x899050..0x899060
+            - Range: 0x899a70..0x899a80
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10188,13 +10188,13 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x899060..0x899070]
+      OutOfLinePCRanges: [0x899a80..0x899a90]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 268 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x899060..0x899070
+            - Range: 0x899a80..0x899a90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10208,7 +10208,7 @@ Subprograms:
         - Name: a
           Type: 11 BaseType int
           Locations:
-            - Range: 0x899060..0x899070
+            - Range: 0x899a80..0x899a90
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10216,13 +10216,13 @@ Subprograms:
       DictRegister: null
     - ID: 143
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x899070..0x899080]
+      OutOfLinePCRanges: [0x899a90..0x899aa0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 268 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x899070..0x899080
+            - Range: 0x899a90..0x899aa0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10236,7 +10236,7 @@ Subprograms:
         - Name: a
           Type: 11 BaseType int
           Locations:
-            - Range: 0x899070..0x899080
+            - Range: 0x899a90..0x899aa0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10244,13 +10244,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x899080..0x899090]
+      OutOfLinePCRanges: [0x899aa0..0x899ab0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 159 GoSliceHeaderType []string
           Locations:
-            - Range: 0x899080..0x899090
+            - Range: 0x899aa0..0x899ab0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10264,13 +10264,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x899090..0x8990a0]
+      OutOfLinePCRanges: [0x899ab0..0x899ac0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x899090..0x8990a0
+            - Range: 0x899ab0..0x899ac0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10278,7 +10278,7 @@ Subprograms:
         - Name: s
           Type: 271 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x899090..0x8990a0
+            - Range: 0x899ab0..0x899ac0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10292,7 +10292,7 @@ Subprograms:
         - Name: x
           Type: 14 BaseType uint
           Locations:
-            - Range: 0x899090..0x8990a0
+            - Range: 0x899ab0..0x899ac0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10300,13 +10300,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x8990a0..0x8990b0]
+      OutOfLinePCRanges: [0x899ac0..0x899ad0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 272 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x8990a0..0x8990b0
+            - Range: 0x899ac0..0x899ad0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10320,13 +10320,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x8990b0..0x8990c0]
+      OutOfLinePCRanges: [0x899ad0..0x899ae0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 265 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8990b0..0x8990c0
+            - Range: 0x899ad0..0x899ae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10340,13 +10340,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x8990c0..0x8990d0]
+      OutOfLinePCRanges: [0x899ae0..0x899af0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 273 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0x8990c0..0x8990d0
+            - Range: 0x899ae0..0x899af0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10360,13 +10360,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x8990d0..0x8990e0]
+      OutOfLinePCRanges: [0x899af0..0x899b00]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 265 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8990d0..0x8990e0
+            - Range: 0x899af0..0x899b00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10380,7 +10380,7 @@ Subprograms:
         - Name: bs
           Type: 265 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8990d0..0x8990e0
+            - Range: 0x899af0..0x899b00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10394,7 +10394,7 @@ Subprograms:
         - Name: cs
           Type: 265 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8990d0..0x8990e0
+            - Range: 0x899af0..0x899b00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10408,13 +10408,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testByteSliceInvalidUtf8
-      OutOfLinePCRanges: [0x899110..0x899120]
+      OutOfLinePCRanges: [0x899b30..0x899b40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0x899110..0x899120
+            - Range: 0x899b30..0x899b40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10428,13 +10428,13 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testByteSliceMultibyteUtf8
-      OutOfLinePCRanges: [0x899120..0x899130]
+      OutOfLinePCRanges: [0x899b40..0x899b50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0x899120..0x899130
+            - Range: 0x899b40..0x899b50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10448,21 +10448,21 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.stackC
-      OutOfLinePCRanges: [0x8996d0..0x899740]
+      OutOfLinePCRanges: [0x89a1d0..0x89a240]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x8996d0..0x89971c
+            - Range: 0x89a1d0..0x89a21c
               Pieces: []
-            - Range: 0x89971c..0x89971d
+            - Range: 0x89a21c..0x89a21d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89971d..0x899740
+            - Range: 0x89a21d..0x89a240
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10470,13 +10470,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x899740..0x899750]
+      OutOfLinePCRanges: [0x89a360..0x89a370]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x899740..0x899750
+            - Range: 0x89a360..0x89a370
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10488,13 +10488,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x899750..0x899760]
+      OutOfLinePCRanges: [0x89a370..0x89a380]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x899750..0x899760
+            - Range: 0x89a370..0x89a380
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10506,7 +10506,7 @@ Subprograms:
         - Name: "y"
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x899750..0x899760
+            - Range: 0x89a370..0x89a380
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10518,7 +10518,7 @@ Subprograms:
         - Name: z
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x899750..0x899760
+            - Range: 0x89a370..0x89a380
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10530,13 +10530,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x899760..0x899780]
+      OutOfLinePCRanges: [0x89a380..0x89a3a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 275 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x899760..0x899780
+            - Range: 0x89a380..0x89a3a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10556,13 +10556,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x899780..0x899790]
+      OutOfLinePCRanges: [0x89a3a0..0x89a3b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 276 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x899780..0x899790
+            - Range: 0x89a3a0..0x89a3b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10570,13 +10570,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x899790..0x8997a0]
+      OutOfLinePCRanges: [0x89a3b0..0x89a3c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 277 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x899790..0x8997a0
+            - Range: 0x89a3b0..0x89a3c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10584,13 +10584,13 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x8997a0..0x8997b0]
+      OutOfLinePCRanges: [0x89a3c0..0x89a3d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x8997a0..0x8997b0
+            - Range: 0x89a3c0..0x89a3d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10602,13 +10602,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x8997b0..0x8997c0]
+      OutOfLinePCRanges: [0x89a3d0..0x89a3e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x8997b0..0x8997c0
+            - Range: 0x89a3d0..0x89a3e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10620,13 +10620,13 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x8997c0..0x8997d0]
+      OutOfLinePCRanges: [0x89a3e0..0x89a3f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x8997c0..0x8997d0
+            - Range: 0x89a3e0..0x89a3f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10638,13 +10638,13 @@ Subprograms:
       DictRegister: null
     - ID: 161
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x8997d0..0x8997e0]
+      OutOfLinePCRanges: [0x89a3f0..0x89a400]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x8997d0..0x8997e0
+            - Range: 0x89a3f0..0x89a400
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10656,7 +10656,7 @@ Subprograms:
         - Name: b
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x8997d0..0x8997e0
+            - Range: 0x89a3f0..0x89a400
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10668,7 +10668,7 @@ Subprograms:
         - Name: c
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x8997d0..0x8997e0
+            - Range: 0x89a3f0..0x89a400
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10680,13 +10680,13 @@ Subprograms:
       DictRegister: null
     - ID: 162
       Name: main.testInvalidUtf8Strings
-      OutOfLinePCRanges: [0x8997e0..0x8997f0]
+      OutOfLinePCRanges: [0x89a400..0x89a410]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x8997e0..0x8997f0
+            - Range: 0x89a400..0x89a410
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10698,7 +10698,7 @@ Subprograms:
         - Name: b
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x8997e0..0x8997f0
+            - Range: 0x89a400..0x89a410
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10710,13 +10710,13 @@ Subprograms:
       DictRegister: null
     - ID: 163
       Name: main.testMultibyteUtf8String
-      OutOfLinePCRanges: [0x8997f0..0x899800]
+      OutOfLinePCRanges: [0x89a410..0x89a420]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x8997f0..0x899800
+            - Range: 0x89a410..0x89a420
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10728,13 +10728,13 @@ Subprograms:
       DictRegister: null
     - ID: 164
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x899990..0x8999a0]
+      OutOfLinePCRanges: [0x89a6a0..0x89a6b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 279 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x899990..0x8999a0
+            - Range: 0x89a6a0..0x89a6b0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -10742,13 +10742,13 @@ Subprograms:
       DictRegister: null
     - ID: 165
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x8999a0..0x8999c0]
+      OutOfLinePCRanges: [0x89a6b0..0x89a6d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 292 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x8999a0..0x8999c0
+            - Range: 0x89a6b0..0x89a6d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10768,13 +10768,13 @@ Subprograms:
       DictRegister: null
     - ID: 166
       Name: main.testStruct
-      OutOfLinePCRanges: [0x899a90..0x899ab0]
+      OutOfLinePCRanges: [0x89a7a0..0x89a7c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 StructureType main.aStruct
           Locations:
-            - Range: 0x899a90..0x899ab0
+            - Range: 0x89a7a0..0x89a7c0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10796,13 +10796,13 @@ Subprograms:
       DictRegister: null
     - ID: 167
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x899b30..0x899b40]
+      OutOfLinePCRanges: [0x89a840..0x89a850]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 324 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x899b30..0x899b40
+            - Range: 0x89a840..0x89a850
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10810,13 +10810,13 @@ Subprograms:
       DictRegister: null
     - ID: 168
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x899b40..0x899b50]
+      OutOfLinePCRanges: [0x89a850..0x89a860]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 326 StructureType main.tenStrings
           Locations:
-            - Range: 0x899b40..0x899b50
+            - Range: 0x89a850..0x89a860
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -10824,25 +10824,25 @@ Subprograms:
       DictRegister: null
     - ID: 169
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x899b90..0x899ba0]
+      OutOfLinePCRanges: [0x89a8a0..0x89a8b0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 327 StructureType main.emptyStruct
-          Locations: [{Range: 0x899b90..0x899ba0, Pieces: []}]
+          Locations: [{Range: 0x89a8a0..0x89a8b0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 170
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x899ba0..0x899bb0]
+      OutOfLinePCRanges: [0x89a8b0..0x89a8c0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 328 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x899ba0..0x899bb0
+            - Range: 0x89a8b0..0x89a8c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10850,13 +10850,13 @@ Subprograms:
       DictRegister: null
     - ID: 171
       Name: main.testTimeUTC
-      OutOfLinePCRanges: [0x89a6c0..0x89a6d0]
+      OutOfLinePCRanges: [0x89b4b0..0x89b4c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 GoTimeType time.Time
           Locations:
-            - Range: 0x89a6c0..0x89a6d0
+            - Range: 0x89b4b0..0x89b4c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10870,13 +10870,13 @@ Subprograms:
       DictRegister: null
     - ID: 172
       Name: main.testTimeFixedZone
-      OutOfLinePCRanges: [0x89a6d0..0x89a6e0]
+      OutOfLinePCRanges: [0x89b4c0..0x89b4d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 GoTimeType time.Time
           Locations:
-            - Range: 0x89a6d0..0x89a6e0
+            - Range: 0x89b4c0..0x89b4d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10890,13 +10890,13 @@ Subprograms:
       DictRegister: null
     - ID: 173
       Name: main.testTimeMonotonic
-      OutOfLinePCRanges: [0x89a6e0..0x89a6f0]
+      OutOfLinePCRanges: [0x89b4d0..0x89b4e0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 332 StructureType main.timeCapture
           Locations:
-            - Range: 0x89a6e0..0x89a6f0
+            - Range: 0x89b4d0..0x89b4e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10910,13 +10910,13 @@ Subprograms:
       DictRegister: null
     - ID: 174
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x89b780..0x89b790]
+      OutOfLinePCRanges: [0x89c660..0x89c670]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0x89b780..0x89b790
+            - Range: 0x89c660..0x89c670
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10924,11 +10924,11 @@ Subprograms:
         - Name: ~r0
           Type: 334 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x89b780..0x89b784
+            - Range: 0x89c660..0x89c664
               Pieces: []
-            - Range: 0x89b784..0x89b785
+            - Range: 0x89c664..0x89c665
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89b785..0x89b790
+            - Range: 0x89c665..0x89c670
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -10936,19 +10936,19 @@ Subprograms:
       DictRegister: 0
     - ID: 175
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x89b790..0x89b7a0]
+      OutOfLinePCRanges: [0x89c670..0x89c680]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89b790..0x89b79c
+            - Range: 0x89c670..0x89c67c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x89b79c..0x89b7a0
+            - Range: 0x89c67c..0x89c680
               Pieces:
                 - Size: 8
                   Op: null
@@ -10960,15 +10960,15 @@ Subprograms:
         - Name: ~r0
           Type: 336 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x89b790..0x89b79c
+            - Range: 0x89c670..0x89c67c
               Pieces: []
-            - Range: 0x89b79c..0x89b79d
+            - Range: 0x89c67c..0x89c67d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89b79d..0x89b7a0
+            - Range: 0x89c67d..0x89c680
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -10976,13 +10976,13 @@ Subprograms:
       DictRegister: 0
     - ID: 176
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x89b7a0..0x89b7b0]
+      OutOfLinePCRanges: [0x89c680..0x89c690]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 334 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x89b7a0..0x89b7b0
+            - Range: 0x89c680..0x89c690
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10990,11 +10990,11 @@ Subprograms:
         - Name: ~r0
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0x89b7a0..0x89b7a4
+            - Range: 0x89c680..0x89c684
               Pieces: []
-            - Range: 0x89b7a4..0x89b7a5
+            - Range: 0x89c684..0x89c685
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89b7a5..0x89b7b0
+            - Range: 0x89c685..0x89c690
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11002,19 +11002,19 @@ Subprograms:
       DictRegister: 0
     - ID: 177
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x89b7b0..0x89b7c0]
+      OutOfLinePCRanges: [0x89c690..0x89c6a0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 336 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x89b7b0..0x89b7bc
+            - Range: 0x89c690..0x89c69c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x89b7bc..0x89b7c0
+            - Range: 0x89c69c..0x89c6a0
               Pieces:
                 - Size: 8
                   Op: null
@@ -11026,15 +11026,15 @@ Subprograms:
         - Name: ~r0
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89b7b0..0x89b7bc
+            - Range: 0x89c690..0x89c69c
               Pieces: []
-            - Range: 0x89b7bc..0x89b7bd
+            - Range: 0x89c69c..0x89c69d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89b7bd..0x89b7c0
+            - Range: 0x89c69d..0x89c6a0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11042,13 +11042,13 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x89b830..0x89b960]
+      OutOfLinePCRanges: [0x89c710..0x89c840]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 337 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x89b830..0x89b85c
+            - Range: 0x89c710..0x89c73c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11056,7 +11056,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x89b85c..0x89b86c
+            - Range: 0x89c73c..0x89c74c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -11064,7 +11064,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x89b86c..0x89b960
+            - Range: 0x89c74c..0x89c840
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -11078,9 +11078,9 @@ Subprograms:
         - Name: pred
           Type: 339 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x89b830..0x89b86c
+            - Range: 0x89c710..0x89c74c
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x89b86c..0x89b960
+            - Range: 0x89c74c..0x89c840
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
@@ -11088,9 +11088,9 @@ Subprograms:
         - Name: ~r0
           Type: 337 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x89b830..0x89b91c
+            - Range: 0x89c710..0x89c7fc
               Pieces: []
-            - Range: 0x89b91c..0x89b91d
+            - Range: 0x89c7fc..0x89c7fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11098,7 +11098,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x89b91d..0x89b960
+            - Range: 0x89c7fd..0x89c840
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -11106,7 +11106,7 @@ Subprograms:
         - Name: result
           Type: 337 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x89b86c..0x89b888
+            - Range: 0x89c74c..0x89c768
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11114,7 +11114,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x89b888..0x89b88c
+            - Range: 0x89c768..0x89c76c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11122,7 +11122,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x89b88c..0x89b890
+            - Range: 0x89c76c..0x89c770
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11130,7 +11130,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x89b890..0x89b890
+            - Range: 0x89c770..0x89c770
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11138,7 +11138,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x89b890..0x89b8bc
+            - Range: 0x89c770..0x89c79c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -11146,7 +11146,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x89b8bc..0x89b910
+            - Range: 0x89c79c..0x89c7f0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11154,7 +11154,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x89b910..0x89b960
+            - Range: 0x89c7f0..0x89c840
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -11168,9 +11168,9 @@ Subprograms:
         - Name: item
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0x89b8ac..0x89b8bc
+            - Range: 0x89c78c..0x89c79c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89b8bc..0x89b910
+            - Range: 0x89c79c..0x89c7f0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
@@ -11178,13 +11178,13 @@ Subprograms:
       DictRegister: 0
     - ID: 179
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x89b960..0x89b9c0]
+      OutOfLinePCRanges: [0x89c840..0x89c8a0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 334 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x89b960..0x89b988
+            - Range: 0x89c840..0x89c868
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11192,7 +11192,7 @@ Subprograms:
         - Name: f
           Type: 340 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x89b960..0x89b988
+            - Range: 0x89c840..0x89c868
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11200,15 +11200,15 @@ Subprograms:
         - Name: ~r0
           Type: 336 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x89b960..0x89b988
+            - Range: 0x89c840..0x89c868
               Pieces: []
-            - Range: 0x89b988..0x89b989
+            - Range: 0x89c868..0x89c869
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89b989..0x89b9c0
+            - Range: 0x89c869..0x89c8a0
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -11216,13 +11216,13 @@ Subprograms:
       DictRegister: 0
     - ID: 180
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x89bc70..0x89bc80]
+      OutOfLinePCRanges: [0x89cb50..0x89cb60]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 338 PointerType *go.shape.int
           Locations:
-            - Range: 0x89bc70..0x89bc80
+            - Range: 0x89cb50..0x89cb60
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11230,11 +11230,11 @@ Subprograms:
         - Name: ~r0
           Type: 338 PointerType *go.shape.int
           Locations:
-            - Range: 0x89bc70..0x89bc74
+            - Range: 0x89cb50..0x89cb54
               Pieces: []
-            - Range: 0x89bc74..0x89bc75
+            - Range: 0x89cb54..0x89cb55
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89bc75..0x89bc80
+            - Range: 0x89cb55..0x89cb60
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11242,13 +11242,13 @@ Subprograms:
       DictRegister: 0
     - ID: 181
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x89bc80..0x89bc90]
+      OutOfLinePCRanges: [0x89cb60..0x89cb70]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 341 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x89bc80..0x89bc90
+            - Range: 0x89cb60..0x89cb70
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11256,11 +11256,11 @@ Subprograms:
         - Name: ~r0
           Type: 341 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x89bc80..0x89bc84
+            - Range: 0x89cb60..0x89cb64
               Pieces: []
-            - Range: 0x89bc84..0x89bc85
+            - Range: 0x89cb64..0x89cb65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89bc85..0x89bc90
+            - Range: 0x89cb65..0x89cb70
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11268,13 +11268,13 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x89bc90..0x89bca0]
+      OutOfLinePCRanges: [0x89cb70..0x89cb80]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 343 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x89bc90..0x89bca0
+            - Range: 0x89cb70..0x89cb80
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11282,11 +11282,11 @@ Subprograms:
         - Name: ~r0
           Type: 343 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x89bc90..0x89bc94
+            - Range: 0x89cb70..0x89cb74
               Pieces: []
-            - Range: 0x89bc94..0x89bc95
+            - Range: 0x89cb74..0x89cb75
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89bc95..0x89bca0
+            - Range: 0x89cb75..0x89cb80
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11294,13 +11294,13 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x89bca0..0x89bcb0]
+      OutOfLinePCRanges: [0x89cb80..0x89cb90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 345 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x89bca0..0x89bcb0
+            - Range: 0x89cb80..0x89cb90
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
@@ -11308,15 +11308,15 @@ Subprograms:
         - Name: ~r0
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89bca0..0x89bca8
+            - Range: 0x89cb80..0x89cb88
               Pieces: []
-            - Range: 0x89bca8..0x89bca9
+            - Range: 0x89cb88..0x89cb89
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89bca9..0x89bcb0
+            - Range: 0x89cb89..0x89cb90
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11324,13 +11324,13 @@ Subprograms:
       DictRegister: 0
     - ID: 184
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x89bd30..0x89bd40]
+      OutOfLinePCRanges: [0x89cc10..0x89cc20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 347 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x89bd30..0x89bd40
+            - Range: 0x89cc10..0x89cc20
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
@@ -11338,11 +11338,11 @@ Subprograms:
         - Name: ~r0
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0x89bd30..0x89bd34
+            - Range: 0x89cc10..0x89cc14
               Pieces: []
-            - Range: 0x89bd34..0x89bd35
+            - Range: 0x89cc14..0x89cc15
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89bd35..0x89bd40
+            - Range: 0x89cc15..0x89cc20
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11350,13 +11350,13 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x89bdd0..0x89bde0]
+      OutOfLinePCRanges: [0x89ccb0..0x89ccc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 348 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x89bdd0..0x89bde0
+            - Range: 0x89ccb0..0x89ccc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11364,7 +11364,7 @@ Subprograms:
         - Name: k
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0x89bdd0..0x89bde0
+            - Range: 0x89ccb0..0x89ccc0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11372,7 +11372,7 @@ Subprograms:
         - Name: v
           Type: 350 BaseType go.shape.bool
           Locations:
-            - Range: 0x89bdd0..0x89bde0
+            - Range: 0x89ccb0..0x89ccc0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11380,13 +11380,13 @@ Subprograms:
       DictRegister: 1
     - ID: 186
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x89be60..0x89bef0]
+      OutOfLinePCRanges: [0x89cd40..0x89cdd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 351 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x89be60..0x89bef0
+            - Range: 0x89cd40..0x89cdd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11394,7 +11394,7 @@ Subprograms:
         - Name: k
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89be60..0x89bef0
+            - Range: 0x89cd40..0x89cdd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -11406,7 +11406,7 @@ Subprograms:
         - Name: v
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0x89be60..0x89bef0
+            - Range: 0x89cd40..0x89cdd0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11414,13 +11414,13 @@ Subprograms:
       DictRegister: 1
     - ID: 187
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x89bf80..0x89bf90]
+      OutOfLinePCRanges: [0x89ce60..0x89ce70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89bf80..0x89bf90
+            - Range: 0x89ce60..0x89ce70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11432,7 +11432,7 @@ Subprograms:
         - Name: b
           Type: 350 BaseType go.shape.bool
           Locations:
-            - Range: 0x89bf80..0x89bf90
+            - Range: 0x89ce60..0x89ce70
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11440,11 +11440,11 @@ Subprograms:
         - Name: ~r0
           Type: 350 BaseType go.shape.bool
           Locations:
-            - Range: 0x89bf80..0x89bf88
+            - Range: 0x89ce60..0x89ce68
               Pieces: []
-            - Range: 0x89bf88..0x89bf89
+            - Range: 0x89ce68..0x89ce69
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89bf89..0x89bf90
+            - Range: 0x89ce69..0x89ce70
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11452,15 +11452,15 @@ Subprograms:
         - Name: ~r1
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89bf80..0x89bf88
+            - Range: 0x89ce60..0x89ce68
               Pieces: []
-            - Range: 0x89bf88..0x89bf89
+            - Range: 0x89ce68..0x89ce69
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x89bf89..0x89bf90
+            - Range: 0x89ce69..0x89ce70
               Pieces: []
           Role: Return
           DictIndex: 0
@@ -11468,13 +11468,13 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x89bf90..0x89bfb0]
+      OutOfLinePCRanges: [0x89ce70..0x89ce90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0x89bf90..0x89bfa0
+            - Range: 0x89ce70..0x89ce80
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11482,13 +11482,13 @@ Subprograms:
         - Name: b
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89bf90..0x89bf9c
+            - Range: 0x89ce70..0x89ce7c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x89bf9c..0x89bfb0
+            - Range: 0x89ce7c..0x89ce90
               Pieces:
                 - Size: 8
                   Op: null
@@ -11500,15 +11500,15 @@ Subprograms:
         - Name: ~r0
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89bf90..0x89bfa0
+            - Range: 0x89ce70..0x89ce80
               Pieces: []
-            - Range: 0x89bfa0..0x89bfa1
+            - Range: 0x89ce80..0x89ce81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89bfa1..0x89bfb0
+            - Range: 0x89ce81..0x89ce90
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11516,11 +11516,11 @@ Subprograms:
         - Name: ~r1
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0x89bf90..0x89bfa0
+            - Range: 0x89ce70..0x89ce80
               Pieces: []
-            - Range: 0x89bfa0..0x89bfa1
+            - Range: 0x89ce80..0x89ce81
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x89bfa1..0x89bfb0
+            - Range: 0x89ce81..0x89ce90
               Pieces: []
           Role: Return
           DictIndex: 0
@@ -11528,13 +11528,13 @@ Subprograms:
       DictRegister: 0
     - ID: 189
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x89bfb0..0x89c000]
+      OutOfLinePCRanges: [0x89ce90..0x89cee0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 353 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x89bfb0..0x89bfd8
+            - Range: 0x89ce90..0x89ceb8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11542,15 +11542,15 @@ Subprograms:
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x89bfb0..0x89bfd8
+            - Range: 0x89ce90..0x89ceb8
               Pieces: []
-            - Range: 0x89bfd8..0x89bfd9
+            - Range: 0x89ceb8..0x89ceb9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89bfd9..0x89c000
+            - Range: 0x89ceb9..0x89cee0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11558,19 +11558,19 @@ Subprograms:
       DictRegister: 0
     - ID: 190
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x89c000..0x89c060]
+      OutOfLinePCRanges: [0x89cee0..0x89cf40]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 354 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x89c000..0x89c02c
+            - Range: 0x89cee0..0x89cf0c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x89c02c..0x89c030
+            - Range: 0x89cf0c..0x89cf10
               Pieces:
                 - Size: 8
                   Op: null
@@ -11582,15 +11582,15 @@ Subprograms:
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x89c000..0x89c030
+            - Range: 0x89cee0..0x89cf10
               Pieces: []
-            - Range: 0x89c030..0x89c031
+            - Range: 0x89cf10..0x89cf11
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89c031..0x89c060
+            - Range: 0x89cf11..0x89cf40
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11598,13 +11598,13 @@ Subprograms:
       DictRegister: 0
     - ID: 191
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x89c060..0x89c070]
+      OutOfLinePCRanges: [0x89cf40..0x89cf50]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 355 PointerType *go.shape.string
           Locations:
-            - Range: 0x89c060..0x89c068
+            - Range: 0x89cf40..0x89cf48
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11612,15 +11612,15 @@ Subprograms:
         - Name: ~r0
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89c060..0x89c068
+            - Range: 0x89cf40..0x89cf48
               Pieces: []
-            - Range: 0x89c068..0x89c069
+            - Range: 0x89cf48..0x89cf49
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89c069..0x89c070
+            - Range: 0x89cf49..0x89cf50
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11628,13 +11628,13 @@ Subprograms:
       DictRegister: 0
     - ID: 192
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x89c070..0x89c0d0]
+      OutOfLinePCRanges: [0x89cf50..0x89cfb0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 356 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x89c070..0x89c0ac
+            - Range: 0x89cf50..0x89cf8c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11642,9 +11642,9 @@ Subprograms:
         - Name: ~r0
           Type: 357 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x89c070..0x89c0bc
+            - Range: 0x89cf50..0x89cf9c
               Pieces: []
-            - Range: 0x89c0bc..0x89c0bd
+            - Range: 0x89cf9c..0x89cf9d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11658,7 +11658,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x89c0bd..0x89c0d0
+            - Range: 0x89cf9d..0x89cfb0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11666,13 +11666,13 @@ Subprograms:
       DictRegister: 0
     - ID: 193
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x89c0d0..0x89c110]
+      OutOfLinePCRanges: [0x89cfb0..0x89cff0]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 337 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x89c0d0..0x89c0dc
+            - Range: 0x89cfb0..0x89cfbc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11680,7 +11680,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x89c0dc..0x89c110
+            - Range: 0x89cfbc..0x89cff0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11694,7 +11694,7 @@ Subprograms:
         - Name: needle
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0x89c0d0..0x89c110
+            - Range: 0x89cfb0..0x89cff0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11702,15 +11702,15 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x89c0d0..0x89c0f8
+            - Range: 0x89cfb0..0x89cfd8
               Pieces: []
-            - Range: 0x89c0f8..0x89c0f9
+            - Range: 0x89cfd8..0x89cfd9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89c0f9..0x89c100
+            - Range: 0x89cfd9..0x89cfe0
               Pieces: []
-            - Range: 0x89c100..0x89c101
+            - Range: 0x89cfe0..0x89cfe1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89c101..0x89c110
+            - Range: 0x89cfe1..0x89cff0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11718,7 +11718,7 @@ Subprograms:
         - Name: v
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0x89c0ec..0x89c0fc
+            - Range: 0x89cfcc..0x89cfdc
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
@@ -11726,13 +11726,13 @@ Subprograms:
       DictRegister: 0
     - ID: 194
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x89c110..0x89c1e0]
+      OutOfLinePCRanges: [0x89cff0..0x89d0c0]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 358 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x89c110..0x89c134
+            - Range: 0x89cff0..0x89d014
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11740,7 +11740,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x89c134..0x89c138
+            - Range: 0x89d014..0x89d018
               Pieces:
                 - Size: 8
                   Op: null
@@ -11754,13 +11754,13 @@ Subprograms:
         - Name: needle
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89c110..0x89c16c
+            - Range: 0x89cff0..0x89d04c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x89c16c..0x89c1e0
+            - Range: 0x89d04c..0x89d0c0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -11772,15 +11772,15 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x89c110..0x89c188
+            - Range: 0x89cff0..0x89d068
               Pieces: []
-            - Range: 0x89c188..0x89c189
+            - Range: 0x89d068..0x89d069
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89c189..0x89c198
+            - Range: 0x89d069..0x89d078
               Pieces: []
-            - Range: 0x89c198..0x89c199
+            - Range: 0x89d078..0x89d079
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89c199..0x89c1e0
+            - Range: 0x89d079..0x89d0c0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11788,13 +11788,13 @@ Subprograms:
         - Name: v
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89c14c..0x89c160
+            - Range: 0x89d02c..0x89d040
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x89c160..0x89c16c
+            - Range: 0x89d040..0x89d04c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11806,13 +11806,13 @@ Subprograms:
       DictRegister: 0
     - ID: 195
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x89c1e0..0x89c1f0]
+      OutOfLinePCRanges: [0x89d0c0..0x89d0d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 359 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x89c1e0..0x89c1e8
+            - Range: 0x89d0c0..0x89d0c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11820,7 +11820,7 @@ Subprograms:
         - Name: value
           Type: 333 BaseType go.shape.int
           Locations:
-            - Range: 0x89c1e0..0x89c1f0
+            - Range: 0x89d0c0..0x89d0d0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11828,11 +11828,11 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x89c1e0..0x89c1e8
+            - Range: 0x89d0c0..0x89d0c8
               Pieces: []
-            - Range: 0x89c1e8..0x89c1e9
+            - Range: 0x89d0c8..0x89d0c9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89c1e9..0x89c1f0
+            - Range: 0x89d0c9..0x89d0d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11840,25 +11840,25 @@ Subprograms:
       DictRegister: 1
     - ID: 196
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x89c270..0x89c2f0]
+      OutOfLinePCRanges: [0x89d150..0x89d1d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 360 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x89c270..0x89c29c
+            - Range: 0x89d150..0x89d17c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89c29c..0x89c2a8
+            - Range: 0x89d17c..0x89d188
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89c2a8..0x89c2ac
+            - Range: 0x89d188..0x89d18c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11870,7 +11870,7 @@ Subprograms:
         - Name: value
           Type: 335 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x89c270..0x89c2ac
+            - Range: 0x89d150..0x89d18c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11882,11 +11882,11 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x89c270..0x89c2ac
+            - Range: 0x89d150..0x89d18c
               Pieces: []
-            - Range: 0x89c2ac..0x89c2ad
+            - Range: 0x89d18c..0x89d18d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89c2ad..0x89c2f0
+            - Range: 0x89d18d..0x89d1d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -12106,31 +12106,31 @@ Subprograms:
       DictRegister: null
     - ID: 199
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x8939c0..0x893a30]
+      OutOfLinePCRanges: [0x893ea0..0x893f10]
       InlinePCRanges:
-        - Ranges: [0x893a4c..0x893a84]
-          RootRanges: [0x893a30..0x893ab0]
-        - Ranges: [0x893b98..0x893bd0]
-          RootRanges: [0x893b60..0x893bf0]
-        - Ranges: [0x893c14..0x893c4c]
-          RootRanges: [0x893bf0..0x893cc0]
-        - Ranges: [0x893cdc..0x893d14]
-          RootRanges: [0x893cc0..0x893d40]
+        - Ranges: [0x893f2c..0x893f64]
+          RootRanges: [0x893f10..0x893f90]
+        - Ranges: [0x894078..0x8940b0]
+          RootRanges: [0x894040..0x8940d0]
+        - Ranges: [0x8940f4..0x89412c]
+          RootRanges: [0x8940d0..0x8941a0]
+        - Ranges: [0x8941bc..0x8941f4]
+          RootRanges: [0x8941a0..0x894220]
       Variables:
         - Name: x
           Type: 11 BaseType int
           Locations:
-            - Range: 0x8939c0..0x8939e0
+            - Range: 0x893ea0..0x893ec0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893a4c..0x893a54
+            - Range: 0x893f2c..0x893f34
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893b98..0x893ba0
+            - Range: 0x894078..0x894080
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893c0c..0x893c1c
+            - Range: 0x8940ec..0x8940fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893c1c..0x893cc0
+            - Range: 0x8940fc..0x8941a0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x893cc0..0x893ce4
+            - Range: 0x8941a0..0x8941c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -12140,37 +12140,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x893c58..0x893c90]
-          RootRanges: [0x893bf0..0x893cc0]
+        - Ranges: [0x894138..0x894170]
+          RootRanges: [0x8940d0..0x8941a0]
       Variables: []
       DictRegister: null
     - ID: 201
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x893d5c..0x893da0]
-          RootRanges: [0x893d40..0x893e60]
+        - Ranges: [0x89423c..0x894280]
+          RootRanges: [0x894220..0x894340]
       Variables: []
       DictRegister: null
     - ID: 202
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x893e10..0x893e48]
-          RootRanges: [0x893d40..0x893e60]
+        - Ranges: [0x8942f0..0x894328]
+          RootRanges: [0x894220..0x894340]
       Variables: []
       DictRegister: null
     - ID: 203
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x893e64..0x893e68]
-          RootRanges: [0x893e60..0x893e70]
+        - Ranges: [0x894344..0x894348]
+          RootRanges: [0x894340..0x894350]
       Variables:
         - Name: x
           Type: 11 BaseType int
           Locations:
-            - Range: 0x893e60..0x893e68
+            - Range: 0x894340..0x894348
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -12180,39 +12180,39 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x893e94..0x893eb8]
-          RootRanges: [0x893e70..0x893ed0]
-        - Ranges: [0x893f2c..0x893f54]
-          RootRanges: [0x893ed0..0x894020]
+        - Ranges: [0x894374..0x894398]
+          RootRanges: [0x894350..0x8943b0]
+        - Ranges: [0x894458..0x894480]
+          RootRanges: [0x8943b0..0x894580]
       Variables:
         - Name: a
           Type: 165 ArrayType [5]int
           Locations:
-            - Range: 0x893e80..0x893ed0
+            - Range: 0x894360..0x8943b0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x893f18..0x894020
-              Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
+            - Range: 0x894444..0x894580
+              Pieces: [{Size: 40, Op: {CfaOffset: -144}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 205
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x894020..0x8940a0]
+      OutOfLinePCRanges: [0x8945f0..0x894670]
       InlinePCRanges:
-        - Ranges: [0x89c4cc..0x89c500]
-          RootRanges: [0x89c4a0..0x89c550]
+        - Ranges: [0x89d3ac..0x89d3e0]
+          RootRanges: [0x89d380..0x89d430]
       Variables:
         - Name: b
           Type: 365 StructureType main.firstBehavior
           Locations:
-            - Range: 0x894020..0x89404c
+            - Range: 0x8945f0..0x89461c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89404c..0x894050
+            - Range: 0x89461c..0x894620
               Pieces:
                 - Size: 8
                   Op: null
@@ -12224,15 +12224,15 @@ Subprograms:
         - Name: ~r0
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x894020..0x894070
+            - Range: 0x8945f0..0x894640
               Pieces: []
-            - Range: 0x894070..0x894071
+            - Range: 0x894640..0x894641
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x894071..0x8940a0
+            - Range: 0x894641..0x894670
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -12242,8 +12242,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x894878..0x894884, 0x894888..0x894890]
-          RootRanges: [0x8947e0..0x8948e0]
+        - Ranges: [0x894ec4..0x894ed0, 0x894ed4..0x894edc]
+          RootRanges: [0x894dd0..0x894f60]
         - Ranges: [0x88e394..0x88e398, 0x88e39c..0x88e3a4]
           RootRanges: [0x88e380..0x88e3b0]
       Variables: []
@@ -12913,7 +12913,7 @@ Types:
       ID: 2446
       Name: '*compress/gzip.Reader'
       ByteSize: 8
-      GoRuntimeType: 1442496
+      GoRuntimeType: 1441728
       GoKind: 22
       Pointee: 2447 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
@@ -12927,63 +12927,63 @@ Types:
       ID: 413
       Name: '*context.backgroundCtx'
       ByteSize: 8
-      GoRuntimeType: 1371712
+      GoRuntimeType: 1371392
       GoKind: 22
       Pointee: 414 GoContextImplementationType context.backgroundCtx
     - __kind: PointerType
       ID: 417
       Name: '*context.cancelCtx'
       ByteSize: 8
-      GoRuntimeType: 1609440
+      GoRuntimeType: 1609248
       GoKind: 22
       Pointee: 418 GoContextImplementationType context.cancelCtx
     - __kind: PointerType
       ID: 898
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1111392
+      GoRuntimeType: 1109728
       GoKind: 22
       Pointee: 899 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 400
       Name: '*context.emptyCtx'
       ByteSize: 8
-      GoRuntimeType: 1240000
+      GoRuntimeType: 1239840
       GoKind: 22
       Pointee: 401 GoContextImplementationType context.emptyCtx
     - __kind: PointerType
       ID: 402
       Name: '*context.stopCtx'
       ByteSize: 8
-      GoRuntimeType: 1240160
+      GoRuntimeType: 1240000
       GoKind: 22
       Pointee: 403 GoContextImplementationType context.stopCtx
     - __kind: PointerType
       ID: 425
       Name: '*context.timerCtx'
       ByteSize: 8
-      GoRuntimeType: 1609632
+      GoRuntimeType: 1609440
       GoKind: 22
       Pointee: 426 GoContextImplementationType context.timerCtx
     - __kind: PointerType
       ID: 415
       Name: '*context.todoCtx'
       ByteSize: 8
-      GoRuntimeType: 1371872
+      GoRuntimeType: 1371552
       GoKind: 22
       Pointee: 416 GoContextImplementationType context.todoCtx
     - __kind: PointerType
       ID: 409
       Name: '*context.valueCtx'
       ByteSize: 8
-      GoRuntimeType: 1371392
+      GoRuntimeType: 1371072
       GoKind: 22
       Pointee: 410 GoContextImplementationType context.valueCtx
     - __kind: PointerType
       ID: 411
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
-      GoRuntimeType: 1371552
+      GoRuntimeType: 1371232
       GoKind: 22
       Pointee: 412 GoContextImplementationType context.withoutCancelCtx
     - __kind: PointerType
@@ -13352,17 +13352,17 @@ Types:
       GoKind: 22
       Pointee: 793 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 691
+      ID: 689
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 842912
+      GoRuntimeType: 842144
       GoKind: 22
       Pointee: 592 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
       ID: 1037
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1004512
+      GoRuntimeType: 1004384
       GoKind: 22
       Pointee: 1038 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -13373,31 +13373,31 @@ Types:
       GoKind: 22
       Pointee: 593 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 1298
+      ID: 1296
       Name: '*encoding/json.Delim'
       ByteSize: 8
-      GoRuntimeType: 837728
+      GoRuntimeType: 836960
       GoKind: 22
-      Pointee: 1228 BaseType encoding/json.Delim
+      Pointee: 1226 BaseType encoding/json.Delim
     - __kind: PointerType
-      ID: 662
+      ID: 660
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 837632
+      GoRuntimeType: 836864
       GoKind: 22
-      Pointee: 663 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 661 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
       ID: 861
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1000160
+      GoRuntimeType: 1000032
       GoKind: 22
       Pointee: 862 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
       ID: 1470
       Name: '*encoding/json.Number'
       ByteSize: 8
-      GoRuntimeType: 1126112
+      GoRuntimeType: 1125472
       GoKind: 22
       Pointee: 1451 GoStringHeaderType encoding/json.Number
     - __kind: PointerType
@@ -13406,33 +13406,33 @@ Types:
       ByteSize: 8
       Pointee: 1452 GoStringDataType encoding/json.Number.str
     - __kind: PointerType
-      ID: 654
+      ID: 652
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 837248
+      GoRuntimeType: 836480
       GoKind: 22
-      Pointee: 655 UnresolvedPointeeType encoding/json.SyntaxError
-    - __kind: PointerType
-      ID: 660
-      Name: '*encoding/json.UnmarshalTypeError'
-      ByteSize: 8
-      GoRuntimeType: 837536
-      GoKind: 22
-      Pointee: 661 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 653 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
       ID: 658
-      Name: '*encoding/json.UnsupportedTypeError'
+      Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
-      GoRuntimeType: 837440
+      GoRuntimeType: 836768
       GoKind: 22
-      Pointee: 659 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 659 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
       ID: 656
+      Name: '*encoding/json.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 836672
+      GoKind: 22
+      Pointee: 657 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 654
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
-      GoRuntimeType: 837344
+      GoRuntimeType: 836576
       GoKind: 22
-      Pointee: 657 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 655 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
       ID: 1172
       Name: '*encoding/json.encodeState'
@@ -13441,12 +13441,12 @@ Types:
       GoKind: 22
       Pointee: 1173 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 664
+      ID: 662
       Name: '*encoding/json.jsonError'
       ByteSize: 8
-      GoRuntimeType: 838016
+      GoRuntimeType: 837248
       GoKind: 22
-      Pointee: 665 StructureType encoding/json.jsonError
+      Pointee: 663 StructureType encoding/json.jsonError
     - __kind: PointerType
       ID: 1045
       Name: '*encoding/pem.lineBreaker'
@@ -13505,14 +13505,14 @@ Types:
       ID: 632
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 828608
+      GoRuntimeType: 829472
       GoKind: 22
       Pointee: 633 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 828
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 985696
+      GoRuntimeType: 986848
       GoKind: 22
       Pointee: 829 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -13547,21 +13547,21 @@ Types:
       ID: 2343
       Name: '*fmt.stringReader'
       ByteSize: 8
-      GoRuntimeType: 828704
+      GoRuntimeType: 829568
       GoKind: 22
       Pointee: 2344 UnresolvedPointeeType fmt.stringReader
     - __kind: PointerType
       ID: 830
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 985824
+      GoRuntimeType: 986976
       GoKind: 22
       Pointee: 831 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 832
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 985952
+      GoRuntimeType: 987104
       GoKind: 22
       Pointee: 833 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -13589,7 +13589,7 @@ Types:
       ID: 2191
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AgentPayload'
       ByteSize: 8
-      GoRuntimeType: 2064384
+      GoRuntimeType: 2063552
       GoKind: 22
       Pointee: 2192 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AgentPayload
     - __kind: PointerType
@@ -13603,7 +13603,7 @@ Types:
       ID: 1872
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType'
       ByteSize: 8
-      GoRuntimeType: 1726976
+      GoRuntimeType: 1726752
       GoKind: 22
       Pointee: 1821 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
     - __kind: PointerType
@@ -13624,7 +13624,7 @@ Types:
       ID: 1873
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType'
       ByteSize: 8
-      GoRuntimeType: 1727200
+      GoRuntimeType: 1726976
       GoKind: 22
       Pointee: 1822 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
     - __kind: PointerType
@@ -13673,7 +13673,7 @@ Types:
       ID: 2189
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.StatsPayload'
       ByteSize: 8
-      GoRuntimeType: 2063552
+      GoRuntimeType: 2062720
       GoKind: 22
       Pointee: 2190 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.StatsPayload
     - __kind: PointerType
@@ -13694,7 +13694,7 @@ Types:
       ID: 2255
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.TracerPayload'
       ByteSize: 8
-      GoRuntimeType: 2112576
+      GoRuntimeType: 2111616
       GoKind: 22
       Pointee: 2256 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.TracerPayload
     - __kind: PointerType
@@ -13712,45 +13712,45 @@ Types:
       GoKind: 22
       Pointee: 1528 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/version.Version
     - __kind: PointerType
-      ID: 673
+      ID: 671
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
-      GoRuntimeType: 840416
+      GoRuntimeType: 839648
       GoKind: 22
-      Pointee: 674 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 672 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 675
+      ID: 673
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
-      GoRuntimeType: 840512
+      GoRuntimeType: 839744
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 674 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
       ID: 989
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
-      GoRuntimeType: 840224
+      GoRuntimeType: 839456
       GoKind: 22
       Pointee: 990 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 679
+      ID: 677
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
-      GoRuntimeType: 840800
+      GoRuntimeType: 840032
       GoKind: 22
-      Pointee: 680 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 678 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
       ID: 991
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
-      GoRuntimeType: 840320
+      GoRuntimeType: 839552
       GoKind: 22
       Pointee: 992 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 677
+      ID: 675
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
-      GoRuntimeType: 840608
+      GoRuntimeType: 839840
       GoKind: 22
       Pointee: 586 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
@@ -13759,10 +13759,10 @@ Types:
       ByteSize: 8
       Pointee: 587 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 672
+      ID: 670
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
-      GoRuntimeType: 840128
+      GoRuntimeType: 839360
       GoKind: 22
       Pointee: 583 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
@@ -13771,10 +13771,10 @@ Types:
       ByteSize: 8
       Pointee: 584 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 678
+      ID: 676
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
-      GoRuntimeType: 840704
+      GoRuntimeType: 839936
       GoKind: 22
       Pointee: 589 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
@@ -13786,7 +13786,7 @@ Types:
       ID: 1059
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1129696
+      GoRuntimeType: 1129056
       GoKind: 22
       Pointee: 1060 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
@@ -13807,14 +13807,14 @@ Types:
       ID: 1584
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule'
       ByteSize: 8
-      GoRuntimeType: 1372032
+      GoRuntimeType: 1371712
       GoKind: 22
       Pointee: 1585 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule
     - __kind: PointerType
       ID: 1281
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType'
       ByteSize: 8
-      GoRuntimeType: 829184
+      GoRuntimeType: 828704
       GoKind: 22
       Pointee: 1219 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType
     - __kind: PointerType
@@ -13835,14 +13835,14 @@ Types:
       ID: 387
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
-      GoRuntimeType: 1111648
+      GoRuntimeType: 1109984
       GoKind: 22
       Pointee: 388 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
       ID: 1284
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate'
       ByteSize: 8
-      GoRuntimeType: 829472
+      GoRuntimeType: 828992
       GoKind: 22
       Pointee: 1285 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate
     - __kind: PointerType
@@ -13856,7 +13856,7 @@ Types:
       ID: 1282
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule'
       ByteSize: 8
-      GoRuntimeType: 829376
+      GoRuntimeType: 828896
       GoKind: 22
       Pointee: 1283 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule
     - __kind: PointerType
@@ -13870,35 +13870,35 @@ Types:
       ID: 1468
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance'
       ByteSize: 8
-      GoRuntimeType: 1113056
+      GoRuntimeType: 1111392
       GoKind: 22
       Pointee: 1376 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance
     - __kind: PointerType
       ID: 2147
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter'
       ByteSize: 8
-      GoRuntimeType: 829280
+      GoRuntimeType: 828800
       GoKind: 22
       Pointee: 2148 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter
     - __kind: PointerType
       ID: 390
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
-      GoRuntimeType: 1111776
+      GoRuntimeType: 1110112
       GoKind: 22
       Pointee: 391 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
       ID: 2501
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
-      GoRuntimeType: 1112416
+      GoRuntimeType: 1110752
       GoKind: 22
       Pointee: 2502 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
       ID: 558
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      GoRuntimeType: 1112544
+      GoRuntimeType: 1110880
       GoKind: 22
       Pointee: 559 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
@@ -13926,7 +13926,7 @@ Types:
       ID: 1547
       Name: '*github.com/DataDog/dd-trace-go/v2/internal.TraceSource'
       ByteSize: 8
-      GoRuntimeType: 1245120
+      GoRuntimeType: 1244960
       GoKind: 22
       Pointee: 1377 BaseType github.com/DataDog/dd-trace-go/v2/internal.TraceSource
     - __kind: PointerType
@@ -14010,7 +14010,7 @@ Types:
       ID: 405
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
-      GoRuntimeType: 1245440
+      GoRuntimeType: 1245280
       GoKind: 22
       Pointee: 406 GoContextImplementationType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
@@ -14024,21 +14024,21 @@ Types:
       ID: 1408
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource'
       ByteSize: 8
-      GoRuntimeType: 1002592
+      GoRuntimeType: 1002464
       GoKind: 22
       Pointee: 1409 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource
     - __kind: PointerType
       ID: 1410
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource'
       ByteSize: 8
-      GoRuntimeType: 1002720
+      GoRuntimeType: 1002592
       GoKind: 22
       Pointee: 1411 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource
     - __kind: PointerType
       ID: 1402
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey'
       ByteSize: 8
-      GoRuntimeType: 999776
+      GoRuntimeType: 999648
       GoKind: 22
       Pointee: 1403 StructureType github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey
     - __kind: PointerType
@@ -14253,47 +14253,47 @@ Types:
       GoKind: 22
       Pointee: 2258 StructureType github.com/Masterminds/semver/v3.Version
     - __kind: PointerType
-      ID: 1310
+      ID: 1308
       Name: '*github.com/cihub/seelog.CfgParseParams'
       ByteSize: 8
-      GoRuntimeType: 842624
+      GoRuntimeType: 841856
       GoKind: 22
-      Pointee: 1311 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
+      Pointee: 1309 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
     - __kind: PointerType
-      ID: 1309
+      ID: 1307
       Name: '*github.com/cihub/seelog.LogLevel'
       ByteSize: 8
-      GoRuntimeType: 841760
+      GoRuntimeType: 840992
       GoKind: 22
-      Pointee: 1231 BaseType github.com/cihub/seelog.LogLevel
+      Pointee: 1229 BaseType github.com/cihub/seelog.LogLevel
     - __kind: PointerType
       ID: 1830
       Name: '*github.com/cihub/seelog.LogLevelException'
       ByteSize: 8
-      GoRuntimeType: 1687552
+      GoRuntimeType: 1687104
       GoKind: 22
       Pointee: 1831 UnresolvedPointeeType github.com/cihub/seelog.LogLevelException
     - __kind: PointerType
-      ID: 681
+      ID: 679
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
-      GoRuntimeType: 841952
+      GoRuntimeType: 841184
       GoKind: 22
-      Pointee: 682 StructureType github.com/cihub/seelog.baseError
+      Pointee: 680 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 1098
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1688000
+      GoRuntimeType: 1687552
       GoKind: 22
       Pointee: 1099 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 683
+      ID: 681
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
-      GoRuntimeType: 842048
+      GoRuntimeType: 841280
       GoKind: 22
-      Pointee: 684 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 682 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 1077
       Name: '*github.com/cihub/seelog.connWriter'
@@ -14305,42 +14305,42 @@ Types:
       ID: 1033
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1003488
+      GoRuntimeType: 1003360
       GoKind: 22
       Pointee: 1034 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1552
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1249600
+      GoRuntimeType: 1249440
       GoKind: 22
       Pointee: 1553 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
       ID: 1656
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
-      GoRuntimeType: 1453632
+      GoRuntimeType: 1452864
       GoKind: 22
       Pointee: 1657 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
       ID: 1067
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1249120
+      GoRuntimeType: 1248960
       GoKind: 22
       Pointee: 1068 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
       ID: 1660
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1454400
+      GoRuntimeType: 1453632
       GoKind: 22
       Pointee: 1661 UnresolvedPointeeType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
       ID: 1548
       Name: '*github.com/cihub/seelog.formattedWriter'
       ByteSize: 8
-      GoRuntimeType: 1249280
+      GoRuntimeType: 1249120
       GoKind: 22
       Pointee: 1549 UnresolvedPointeeType github.com/cihub/seelog.formattedWriter
     - __kind: PointerType
@@ -14354,42 +14354,42 @@ Types:
       ID: 1475
       Name: '*github.com/cihub/seelog.listConstraints'
       ByteSize: 8
-      GoRuntimeType: 1132000
+      GoRuntimeType: 1131360
       GoKind: 22
       Pointee: 1476 UnresolvedPointeeType github.com/cihub/seelog.listConstraints
     - __kind: PointerType
-      ID: 1307
+      ID: 1305
       Name: '*github.com/cihub/seelog.logFormattedMessage'
       ByteSize: 8
-      GoRuntimeType: 841664
+      GoRuntimeType: 840896
       GoKind: 22
-      Pointee: 1308 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
+      Pointee: 1306 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
     - __kind: PointerType
-      ID: 1305
+      ID: 1303
       Name: '*github.com/cihub/seelog.logMessage'
       ByteSize: 8
-      GoRuntimeType: 841568
+      GoRuntimeType: 840800
       GoKind: 22
-      Pointee: 1306 UnresolvedPointeeType github.com/cihub/seelog.logMessage
+      Pointee: 1304 UnresolvedPointeeType github.com/cihub/seelog.logMessage
     - __kind: PointerType
       ID: 1414
       Name: '*github.com/cihub/seelog.minMaxConstraints'
       ByteSize: 8
-      GoRuntimeType: 1004000
+      GoRuntimeType: 1003872
       GoKind: 22
       Pointee: 1415 UnresolvedPointeeType github.com/cihub/seelog.minMaxConstraints
     - __kind: PointerType
-      ID: 687
+      ID: 685
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
-      GoRuntimeType: 842240
+      GoRuntimeType: 841472
       GoKind: 22
-      Pointee: 688 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 686 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 1412
       Name: '*github.com/cihub/seelog.offConstraints'
       ByteSize: 8
-      GoRuntimeType: 1003872
+      GoRuntimeType: 1003744
       GoKind: 22
       Pointee: 1413 UnresolvedPointeeType github.com/cihub/seelog.offConstraints
     - __kind: PointerType
@@ -14417,35 +14417,35 @@ Types:
       ID: 1035
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1003616
+      GoRuntimeType: 1003488
       GoKind: 22
       Pointee: 1036 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
       ID: 1658
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1453824
+      GoRuntimeType: 1453056
       GoKind: 22
       Pointee: 1659 UnresolvedPointeeType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 685
+      ID: 683
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
-      GoRuntimeType: 842144
+      GoRuntimeType: 841376
       GoKind: 22
-      Pointee: 686 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 684 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 689
+      ID: 687
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
-      GoRuntimeType: 842336
+      GoRuntimeType: 841568
       GoKind: 22
-      Pointee: 690 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 688 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 1550
       Name: '*github.com/cihub/seelog.xmlNode'
       ByteSize: 8
-      GoRuntimeType: 1249440
+      GoRuntimeType: 1249280
       GoKind: 22
       Pointee: 1551 UnresolvedPointeeType github.com/cihub/seelog.xmlNode
     - __kind: PointerType
@@ -15297,42 +15297,42 @@ Types:
       ID: 910
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1120224
+      GoRuntimeType: 1119584
       GoKind: 22
       Pointee: 911 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 904
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1119840
+      GoRuntimeType: 1119200
       GoKind: 22
       Pointee: 905 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 847
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 994272
+      GoRuntimeType: 994144
       GoKind: 22
       Pointee: 848 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 916
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1120608
+      GoRuntimeType: 1119968
       GoKind: 22
       Pointee: 917 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 846
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 994144
+      GoRuntimeType: 994016
       GoKind: 22
       Pointee: 825 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 908
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1120096
+      GoRuntimeType: 1119456
       GoKind: 22
       Pointee: 909 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
@@ -15343,31 +15343,31 @@ Types:
       GoKind: 22
       Pointee: 2483 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Reader
     - __kind: PointerType
-      ID: 1291
+      ID: 1289
       Name: '*github.com/tinylib/msgp/msgp.Type'
       ByteSize: 8
-      GoRuntimeType: 833792
+      GoRuntimeType: 833024
       GoKind: 22
       Pointee: 997 BaseType github.com/tinylib/msgp/msgp.Type
     - __kind: PointerType
       ID: 906
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1119968
+      GoRuntimeType: 1119328
       GoKind: 22
       Pointee: 907 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 914
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1120480
+      GoRuntimeType: 1119840
       GoKind: 22
       Pointee: 915 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 912
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1120352
+      GoRuntimeType: 1119712
       GoKind: 22
       Pointee: 913 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
@@ -15381,28 +15381,28 @@ Types:
       ID: 920
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1120992
+      GoRuntimeType: 1120352
       GoKind: 22
       Pointee: 921 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 851
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 994528
+      GoRuntimeType: 994400
       GoKind: 22
       Pointee: 852 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 849
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 994400
+      GoRuntimeType: 994272
       GoKind: 22
       Pointee: 850 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 918
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1120864
+      GoRuntimeType: 1120224
       GoKind: 22
       Pointee: 919 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -17597,77 +17597,77 @@ Types:
       ID: 2347
       Name: '*io.LimitedReader'
       ByteSize: 8
-      GoRuntimeType: 828896
+      GoRuntimeType: 829760
       GoKind: 22
       Pointee: 2348 UnresolvedPointeeType io.LimitedReader
     - __kind: PointerType
       ID: 2459
       Name: '*io.PipeReader'
       ByteSize: 8
-      GoRuntimeType: 1718464
+      GoRuntimeType: 1720704
       GoKind: 22
       Pointee: 2460 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
       ID: 1055
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1111136
+      GoRuntimeType: 1114336
       GoKind: 22
       Pointee: 1056 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 2439
       Name: '*io.SectionReader'
       ByteSize: 8
-      GoRuntimeType: 1371232
+      GoRuntimeType: 1372832
       GoKind: 22
       Pointee: 2440 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
       ID: 1053
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1110752
+      GoRuntimeType: 1113952
       GoKind: 22
       Pointee: 1054 StructureType io.discard
     - __kind: PointerType
       ID: 2349
       Name: '*io.eofReader'
       ByteSize: 8
-      GoRuntimeType: 828992
+      GoRuntimeType: 829856
       GoKind: 22
       Pointee: 2350 StructureType io.eofReader
     - __kind: PointerType
       ID: 2413
       Name: '*io.multiReader'
       ByteSize: 8
-      GoRuntimeType: 1110496
+      GoRuntimeType: 1113696
       GoKind: 22
       Pointee: 2414 UnresolvedPointeeType io.multiReader
     - __kind: PointerType
       ID: 1027
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 986720
+      GoRuntimeType: 987872
       GoKind: 22
       Pointee: 1028 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 2383
       Name: '*io.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 986976
+      GoRuntimeType: 988128
       GoKind: 22
       Pointee: 2384 StructureType io.nopCloser
     - __kind: PointerType
       ID: 2415
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
-      GoRuntimeType: 1110624
+      GoRuntimeType: 1113824
       GoKind: 22
       Pointee: 2416 StructureType io.nopCloserWriterTo
     - __kind: PointerType
       ID: 2345
       Name: '*io.teeReader'
       ByteSize: 8
-      GoRuntimeType: 828800
+      GoRuntimeType: 829664
       GoKind: 22
       Pointee: 2346 UnresolvedPointeeType io.teeReader
     - __kind: PointerType
@@ -17695,16 +17695,16 @@ Types:
       ID: 1477
       Name: '*log/slog.Attr'
       ByteSize: 8
-      GoRuntimeType: 1132640
+      GoRuntimeType: 1132000
       GoKind: 22
       Pointee: 1478 StructureType log/slog.Attr
     - __kind: PointerType
-      ID: 1312
+      ID: 1310
       Name: '*log/slog.Kind'
       ByteSize: 8
-      GoRuntimeType: 842720
+      GoRuntimeType: 841952
       GoKind: 22
-      Pointee: 1232 BaseType log/slog.Kind
+      Pointee: 1230 BaseType log/slog.Kind
     - __kind: PointerType
       ID: 1752
       Name: '*log/slog.Level'
@@ -17716,7 +17716,7 @@ Types:
       ID: 2193
       Name: '*log/slog.Value'
       ByteSize: 8
-      GoRuntimeType: 2064800
+      GoRuntimeType: 2063968
       GoKind: 22
       Pointee: 1823 StructureType log/slog.Value
     - __kind: PointerType
@@ -18117,21 +18117,21 @@ Types:
       ID: 927
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1127264
+      GoRuntimeType: 1126624
       GoKind: 22
       Pointee: 928 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 958
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1247360
+      GoRuntimeType: 1247200
       GoKind: 22
       Pointee: 959 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1303
+      ID: 1301
       Name: '*net.HardwareAddr.array'
       ByteSize: 8
-      Pointee: 1302 GoSliceDataType net.HardwareAddr.array
+      Pointee: 1300 GoSliceDataType net.HardwareAddr.array
     - __kind: PointerType
       ID: 2088
       Name: '*net.IP'
@@ -18155,14 +18155,14 @@ Types:
       ID: 1154
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2099648
+      GoRuntimeType: 2098688
       GoKind: 22
       Pointee: 1155 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 1404
       Name: '*net.IPMask'
       ByteSize: 8
-      GoRuntimeType: 1000672
+      GoRuntimeType: 1000544
       GoKind: 22
       Pointee: 1405 GoSliceHeaderType net.IPMask
     - __kind: PointerType
@@ -18174,28 +18174,28 @@ Types:
       ID: 1471
       Name: '*net.IPNet'
       ByteSize: 8
-      GoRuntimeType: 1127008
+      GoRuntimeType: 1126368
       GoKind: 22
       Pointee: 1472 UnresolvedPointeeType net.IPNet
     - __kind: PointerType
       ID: 956
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1247040
+      GoRuntimeType: 1246880
       GoKind: 22
       Pointee: 957 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 929
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1127392
+      GoRuntimeType: 1126752
       GoKind: 22
       Pointee: 930 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 1828
       Name: '*net.TCPAddr'
       ByteSize: 8
-      GoRuntimeType: 1686656
+      GoRuntimeType: 1686208
       GoKind: 22
       Pointee: 1829 UnresolvedPointeeType net.TCPAddr
     - __kind: PointerType
@@ -18209,7 +18209,7 @@ Types:
       ID: 1826
       Name: '*net.UDPAddr'
       ByteSize: 8
-      GoRuntimeType: 1686432
+      GoRuntimeType: 1685984
       GoKind: 22
       Pointee: 1827 UnresolvedPointeeType net.UDPAddr
     - __kind: PointerType
@@ -18237,7 +18237,7 @@ Types:
       ID: 926
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1126496
+      GoRuntimeType: 1125856
       GoKind: 22
       Pointee: 895 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -18256,30 +18256,30 @@ Types:
       ID: 863
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1000928
+      GoRuntimeType: 1000800
       GoKind: 22
       Pointee: 864 StructureType net.canceledError
     - __kind: PointerType
       ID: 1132
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 1885408
+      GoRuntimeType: 1885120
       GoKind: 22
       Pointee: 1133 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 998
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1728768
+      GoRuntimeType: 1728544
       GoKind: 22
       Pointee: 999 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1304
+      ID: 1302
       Name: '*net.hostLookupOrder'
       ByteSize: 8
-      GoRuntimeType: 839360
+      GoRuntimeType: 838592
       GoKind: 22
-      Pointee: 1230 BaseType net.hostLookupOrder
+      Pointee: 1228 BaseType net.hostLookupOrder
     - __kind: PointerType
       ID: 1176
       Name: '*net.netFD'
@@ -18288,150 +18288,150 @@ Types:
       GoKind: 22
       Pointee: 1177 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 666
+      ID: 664
       Name: '*net.notFoundError'
       ByteSize: 8
-      GoRuntimeType: 838976
+      GoRuntimeType: 838208
       GoKind: 22
-      Pointee: 667 UnresolvedPointeeType net.notFoundError
+      Pointee: 665 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 407
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
-      GoRuntimeType: 1247200
+      GoRuntimeType: 1247040
       GoKind: 22
       Pointee: 408 GoContextImplementationType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 668
+      ID: 666
       Name: '*net.result·2'
       ByteSize: 8
-      GoRuntimeType: 839648
+      GoRuntimeType: 838880
       GoKind: 22
-      Pointee: 669 StructureType net.result·2
+      Pointee: 667 StructureType net.result·2
     - __kind: PointerType
       ID: 1158
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2113536
+      GoRuntimeType: 2112576
       GoKind: 22
       Pointee: 1159 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1156
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2113056
+      GoRuntimeType: 2112096
       GoKind: 22
       Pointee: 1157 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 931
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1128032
+      GoRuntimeType: 1127392
       GoKind: 22
       Pointee: 932 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 960
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1247520
+      GoRuntimeType: 1247360
       GoKind: 22
       Pointee: 961 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 1398
       Name: '*net/http.Cookie'
       ByteSize: 8
-      GoRuntimeType: 995296
+      GoRuntimeType: 995168
       GoKind: 22
       Pointee: 1399 UnresolvedPointeeType net/http.Cookie
     - __kind: PointerType
       ID: 853
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 996960
+      GoRuntimeType: 996832
       GoKind: 22
       Pointee: 854 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 2427
       Name: '*net/http.body'
       ByteSize: 8
-      GoRuntimeType: 1686208
+      GoRuntimeType: 1685760
       GoKind: 22
       Pointee: 2428 UnresolvedPointeeType net/http.body
     - __kind: PointerType
       ID: 2417
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
-      GoRuntimeType: 1122016
+      GoRuntimeType: 1121376
       GoKind: 22
       Pointee: 2418 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
       ID: 2351
       Name: '*net/http.bodyLocked'
       ByteSize: 8
-      GoRuntimeType: 834656
+      GoRuntimeType: 833888
       GoKind: 22
       Pointee: 2352 StructureType net/http.bodyLocked
     - __kind: PointerType
       ID: 1009
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
-      GoRuntimeType: 834848
+      GoRuntimeType: 834080
       GoKind: 22
       Pointee: 1010 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
       ID: 2353
       Name: '*net/http.byteReader'
       ByteSize: 8
-      GoRuntimeType: 834944
+      GoRuntimeType: 834176
       GoKind: 22
       Pointee: 2354 UnresolvedPointeeType net/http.byteReader
     - __kind: PointerType
       ID: 2395
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
-      GoRuntimeType: 996832
+      GoRuntimeType: 996704
       GoKind: 22
       Pointee: 2396 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 1294
+      ID: 1292
       Name: '*net/http.connectMethodKey'
       ByteSize: 8
-      GoRuntimeType: 835424
+      GoRuntimeType: 834656
       GoKind: 22
-      Pointee: 1295 StructureType net/http.connectMethodKey
+      Pointee: 1293 StructureType net/http.connectMethodKey
     - __kind: PointerType
-      ID: 1296
+      ID: 1294
       Name: '*net/http.contextKey'
       ByteSize: 8
-      GoRuntimeType: 836672
+      GoRuntimeType: 835904
       GoKind: 22
-      Pointee: 1297 UnresolvedPointeeType net/http.contextKey
+      Pointee: 1295 UnresolvedPointeeType net/http.contextKey
     - __kind: PointerType
       ID: 2355
       Name: '*net/http.errorReader'
       ByteSize: 8
-      GoRuntimeType: 835040
+      GoRuntimeType: 834272
       GoKind: 22
       Pointee: 2356 StructureType net/http.errorReader
     - __kind: PointerType
       ID: 2357
       Name: '*net/http.finishAsyncByteRead'
       ByteSize: 8
-      GoRuntimeType: 835136
+      GoRuntimeType: 834368
       GoKind: 22
       Pointee: 2358 StructureType net/http.finishAsyncByteRead
     - __kind: PointerType
       ID: 2397
       Name: '*net/http.gzipReader'
       ByteSize: 8
-      GoRuntimeType: 997472
+      GoRuntimeType: 997344
       GoKind: 22
       Pointee: 2398 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 643
+      ID: 641
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 835520
+      GoRuntimeType: 834752
       GoKind: 22
       Pointee: 564 BaseType net/http.http2ConnectionError
     - __kind: PointerType
@@ -18452,7 +18452,7 @@ Types:
       ID: 1395
       Name: '*net/http.http2ErrCode'
       ByteSize: 8
-      GoRuntimeType: 995040
+      GoRuntimeType: 994912
       GoKind: 22
       Pointee: 971 BaseType net/http.http2ErrCode
     - __kind: PointerType
@@ -18463,52 +18463,52 @@ Types:
       GoKind: 22
       Pointee: 1589 StructureType net/http.http2FrameHeader
     - __kind: PointerType
-      ID: 1292
+      ID: 1290
       Name: '*net/http.http2FrameType'
       ByteSize: 8
-      GoRuntimeType: 833984
+      GoRuntimeType: 833216
       GoKind: 22
-      Pointee: 1225 BaseType net/http.http2FrameType
+      Pointee: 1223 BaseType net/http.http2FrameType
     - __kind: PointerType
-      ID: 644
+      ID: 642
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
-      GoRuntimeType: 835616
+      GoRuntimeType: 834848
       GoKind: 22
-      Pointee: 645 StructureType net/http.http2GoAwayError
+      Pointee: 643 StructureType net/http.http2GoAwayError
     - __kind: PointerType
       ID: 1648
       Name: '*net/http.http2GoAwayFrame'
       ByteSize: 8
-      GoRuntimeType: 1443264
+      GoRuntimeType: 1442496
       GoKind: 22
       Pointee: 1649 StructureType net/http.http2GoAwayFrame
     - __kind: PointerType
       ID: 1871
       Name: '*net/http.http2HeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 1725408
+      GoRuntimeType: 1725184
       GoKind: 22
       Pointee: 1870 StructureType net/http.http2HeadersFrame
     - __kind: PointerType
       ID: 1975
       Name: '*net/http.http2MetaHeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 1884544
+      GoRuntimeType: 1884256
       GoKind: 22
       Pointee: 1976 StructureType net/http.http2MetaHeadersFrame
     - __kind: PointerType
       ID: 1650
       Name: '*net/http.http2PingFrame'
       ByteSize: 8
-      GoRuntimeType: 1443456
+      GoRuntimeType: 1442688
       GoKind: 22
       Pointee: 1651 StructureType net/http.http2PingFrame
     - __kind: PointerType
       ID: 1652
       Name: '*net/http.http2PriorityFrame'
       ByteSize: 8
-      GoRuntimeType: 1443648
+      GoRuntimeType: 1442880
       GoKind: 22
       Pointee: 1653 StructureType net/http.http2PriorityFrame
     - __kind: PointerType
@@ -18529,16 +18529,16 @@ Types:
       ID: 1396
       Name: '*net/http.http2Setting'
       ByteSize: 8
-      GoRuntimeType: 995168
+      GoRuntimeType: 995040
       GoKind: 22
       Pointee: 1397 StructureType net/http.http2Setting
     - __kind: PointerType
-      ID: 1293
+      ID: 1291
       Name: '*net/http.http2SettingID'
       ByteSize: 8
-      GoRuntimeType: 834272
+      GoRuntimeType: 833504
       GoKind: 22
-      Pointee: 1226 BaseType net/http.http2SettingID
+      Pointee: 1224 BaseType net/http.http2SettingID
     - __kind: PointerType
       ID: 1932
       Name: '*net/http.http2SettingsFrame'
@@ -18550,14 +18550,14 @@ Types:
       ID: 952
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1243520
+      GoRuntimeType: 1243360
       GoKind: 22
       Pointee: 953 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 1654
       Name: '*net/http.http2UnknownFrame'
       ByteSize: 8
-      GoRuntimeType: 1444992
+      GoRuntimeType: 1444224
       GoKind: 22
       Pointee: 1655 StructureType net/http.http2UnknownFrame
     - __kind: PointerType
@@ -18571,16 +18571,16 @@ Types:
       ID: 2441
       Name: '*net/http.http2clientStream'
       ByteSize: 8
-      GoRuntimeType: 1884832
+      GoRuntimeType: 1884544
       GoKind: 22
       Pointee: 2442 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 648
+      ID: 646
       Name: '*net/http.http2connError'
       ByteSize: 8
-      GoRuntimeType: 836096
+      GoRuntimeType: 835328
       GoKind: 22
-      Pointee: 649 StructureType net/http.http2connError
+      Pointee: 647 StructureType net/http.http2connError
     - __kind: PointerType
       ID: 1073
       Name: '*net/http.http2dataBuffer'
@@ -18589,10 +18589,10 @@ Types:
       GoKind: 22
       Pointee: 1074 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 647
+      ID: 645
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 836000
+      GoRuntimeType: 835232
       GoKind: 22
       Pointee: 568 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
@@ -18604,14 +18604,14 @@ Types:
       ID: 2393
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
-      GoRuntimeType: 996576
+      GoRuntimeType: 996448
       GoKind: 22
       Pointee: 2394 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 651
+      ID: 649
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 836288
+      GoRuntimeType: 835520
       GoKind: 22
       Pointee: 574 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
@@ -18620,10 +18620,10 @@ Types:
       ByteSize: 8
       Pointee: 575 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 650
+      ID: 648
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 836192
+      GoRuntimeType: 835424
       GoKind: 22
       Pointee: 571 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
@@ -18635,28 +18635,28 @@ Types:
       ID: 924
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1123168
+      GoRuntimeType: 1122528
       GoKind: 22
       Pointee: 925 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 2389
       Name: '*net/http.http2missingBody'
       ByteSize: 8
-      GoRuntimeType: 996320
+      GoRuntimeType: 996192
       GoKind: 22
       Pointee: 2390 StructureType net/http.http2missingBody
     - __kind: PointerType
       ID: 2399
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
-      GoRuntimeType: 997728
+      GoRuntimeType: 997600
       GoKind: 22
       Pointee: 2400 StructureType net/http.http2noBodyReader
     - __kind: PointerType
       ID: 859
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 997600
+      GoRuntimeType: 997472
       GoKind: 22
       Pointee: 860 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
@@ -18667,10 +18667,10 @@ Types:
       GoKind: 22
       Pointee: 1125 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 646
+      ID: 644
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 835904
+      GoRuntimeType: 835136
       GoKind: 22
       Pointee: 565 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
@@ -18682,98 +18682,98 @@ Types:
       ID: 1011
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
-      GoRuntimeType: 836384
+      GoRuntimeType: 835616
       GoKind: 22
       Pointee: 1012 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
       ID: 2391
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
-      GoRuntimeType: 996448
+      GoRuntimeType: 996320
       GoKind: 22
       Pointee: 2392 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
       ID: 2387
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
-      GoRuntimeType: 995936
+      GoRuntimeType: 995808
       GoKind: 22
       Pointee: 2388 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
       ID: 2419
       Name: '*net/http.noBody'
       ByteSize: 8
-      GoRuntimeType: 1122272
+      GoRuntimeType: 1121632
       GoKind: 22
       Pointee: 2420 StructureType net/http.noBody
     - __kind: PointerType
       ID: 855
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 997216
+      GoRuntimeType: 997088
       GoKind: 22
       Pointee: 856 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1646
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1442880
+      GoRuntimeType: 1442112
       GoKind: 22
       Pointee: 1647 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 1075
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2044416
+      GoRuntimeType: 2044000
       GoKind: 22
       Pointee: 1076 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1031
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 997088
+      GoRuntimeType: 996960
       GoKind: 22
       Pointee: 1032 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 2385
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
-      GoRuntimeType: 995552
+      GoRuntimeType: 995424
       GoKind: 22
       Pointee: 2386 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
       ID: 1057
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1122144
+      GoRuntimeType: 1121504
       GoKind: 22
       Pointee: 1058 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 652
+      ID: 650
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
-      GoRuntimeType: 836480
+      GoRuntimeType: 835712
       GoKind: 22
-      Pointee: 653 StructureType net/http.requestBodyReadError
+      Pointee: 651 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 1400
       Name: '*net/http.socksAddr'
       ByteSize: 8
-      GoRuntimeType: 995680
+      GoRuntimeType: 995552
       GoKind: 22
       Pointee: 1401 UnresolvedPointeeType net/http.socksAddr
     - __kind: PointerType
       ID: 954
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1244640
+      GoRuntimeType: 1244480
       GoKind: 22
       Pointee: 955 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 922
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1123040
+      GoRuntimeType: 1122400
       GoKind: 22
       Pointee: 923 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
@@ -18787,16 +18787,16 @@ Types:
       ID: 857
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 997344
+      GoRuntimeType: 997216
       GoKind: 22
       Pointee: 858 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 641
+      ID: 639
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
-      GoRuntimeType: 834752
+      GoRuntimeType: 833984
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 640 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 2407
       Name: '*net/http/httputil.failureToReadBody'
@@ -18918,14 +18918,14 @@ Types:
       ID: 962
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1247840
+      GoRuntimeType: 1247680
       GoKind: 22
       Pointee: 963 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 670
+      ID: 668
       Name: '*net/url.EscapeError'
       ByteSize: 8
-      GoRuntimeType: 839744
+      GoRuntimeType: 838976
       GoKind: 22
       Pointee: 577 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
@@ -18934,10 +18934,10 @@ Types:
       ByteSize: 8
       Pointee: 578 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 671
+      ID: 669
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
-      GoRuntimeType: 839840
+      GoRuntimeType: 839072
       GoKind: 22
       Pointee: 580 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
@@ -18956,7 +18956,7 @@ Types:
       ID: 1473
       Name: '*net/url.Userinfo'
       ByteSize: 8
-      GoRuntimeType: 1128928
+      GoRuntimeType: 1128288
       GoKind: 22
       Pointee: 1474 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
@@ -19063,19 +19063,19 @@ Types:
       GoKind: 22
       Pointee: 611 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 1289
+      ID: 1311
       Name: '*reflect.ChanDir'
       ByteSize: 8
-      GoRuntimeType: 832832
+      GoRuntimeType: 842240
       GoKind: 22
-      Pointee: 1222 BaseType reflect.ChanDir
+      Pointee: 1231 BaseType reflect.ChanDir
     - __kind: PointerType
-      ID: 1290
+      ID: 1312
       Name: '*reflect.Kind'
       ByteSize: 8
-      GoRuntimeType: 833024
+      GoRuntimeType: 842432
       GoKind: 22
-      Pointee: 1223 BaseType reflect.Kind
+      Pointee: 1232 BaseType reflect.Kind
     - __kind: PointerType
       ID: 2322
       Name: '*reflect.Value'
@@ -19084,12 +19084,12 @@ Types:
       GoKind: 22
       Pointee: 2323 StructureType reflect.Value
     - __kind: PointerType
-      ID: 639
+      ID: 690
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 833504
+      GoRuntimeType: 842912
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType reflect.ValueError
+      Pointee: 691 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 2306
       Name: '*reflect.rtype'
@@ -19302,12 +19302,12 @@ Types:
       GoKind: 22
       Pointee: 36 BaseType runtime.waitReason
     - __kind: PointerType
-      ID: 1299
+      ID: 1297
       Name: '*runtime/debug.BuildInfo'
       ByteSize: 8
-      GoRuntimeType: 838688
+      GoRuntimeType: 837920
       GoKind: 22
-      Pointee: 1300 UnresolvedPointeeType runtime/debug.BuildInfo
+      Pointee: 1298 UnresolvedPointeeType runtime/debug.BuildInfo
     - __kind: PointerType
       ID: 1313
       Name: '*runtime/pprof.labelMap'
@@ -31239,7 +31239,7 @@ Types:
     - __kind: ArrayType
       ID: 1739
       Name: '[0]func()'
-      GoRuntimeType: 673024
+      GoRuntimeType: 671104
       GoKind: 17
       HasCount: true
       Element: 60 GoSubroutineType func()
@@ -31561,7 +31561,7 @@ Types:
       ID: 1214
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
-      GoRuntimeType: 452704
+      GoRuntimeType: 452512
       GoKind: 23
       RawFields:
         - Name: array
@@ -32098,7 +32098,7 @@ Types:
       ID: 386
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
-      GoRuntimeType: 452256
+      GoRuntimeType: 452064
       GoKind: 23
       RawFields:
         - Name: array
@@ -32121,7 +32121,7 @@ Types:
       ID: 389
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
-      GoRuntimeType: 452448
+      GoRuntimeType: 452256
       GoKind: 23
       RawFields:
         - Name: array
@@ -32167,7 +32167,7 @@ Types:
       ID: 361
       Name: '[]go.shape.float64'
       ByteSize: 24
-      GoRuntimeType: 454688
+      GoRuntimeType: 454496
       GoKind: 23
       RawFields:
         - Name: array
@@ -32787,7 +32787,7 @@ Types:
       ID: 2001
       Name: '[]vendor/golang.org/x/net/http2/hpack.HeaderField'
       ByteSize: 24
-      GoRuntimeType: 461664
+      GoRuntimeType: 461024
       GoKind: 23
       RawFields:
         - Name: array
@@ -33657,7 +33657,7 @@ Types:
       ID: 153
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1201824
+      GoRuntimeType: 1201696
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33709,7 +33709,7 @@ Types:
       ID: 549
       Name: context.canceler
       ByteSize: 16
-      GoRuntimeType: 1075808
+      GoRuntimeType: 1074912
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33721,7 +33721,7 @@ Types:
     - __kind: StructureType
       ID: 899
       Name: context.deadlineExceededError
-      GoRuntimeType: 1290048
+      GoRuntimeType: 1288928
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
@@ -33752,7 +33752,7 @@ Types:
       ID: 426
       Name: context.timerCtx
       ByteSize: 112
-      GoRuntimeType: 1431936
+      GoRuntimeType: 1431552
       GoKind: 25
       RawFields:
         - Name: cancelCtx
@@ -33782,7 +33782,7 @@ Types:
       ID: 410
       Name: context.valueCtx
       ByteSize: 48
-      GoRuntimeType: 1718688
+      GoRuntimeType: 1717568
       GoKind: 25
       RawFields:
         - Name: Context
@@ -34249,7 +34249,7 @@ Types:
       ID: 592
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 768224
+      GoRuntimeType: 768032
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1038
@@ -34262,13 +34262,13 @@ Types:
       GoRuntimeType: 768416
       GoKind: 8
     - __kind: BaseType
-      ID: 1228
+      ID: 1226
       Name: encoding/json.Delim
       ByteSize: 4
-      GoRuntimeType: 766880
+      GoRuntimeType: 766688
       GoKind: 5
     - __kind: UnresolvedPointeeType
-      ID: 663
+      ID: 661
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34295,19 +34295,19 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 655
+      ID: 653
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 661
+      ID: 659
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 659
+      ID: 657
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 657
+      ID: 655
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34315,10 +34315,10 @@ Types:
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 665
+      ID: 663
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1246080
+      GoRuntimeType: 1245920
       GoKind: 25
       RawFields:
         - Name: error
@@ -34400,7 +34400,7 @@ Types:
       ID: 2473
       Name: fmt.ScanState
       ByteSize: 16
-      GoRuntimeType: 1289248
+      GoRuntimeType: 1291328
       GoKind: 20
       RawFields:
         - Name: tab
@@ -34413,7 +34413,7 @@ Types:
       ID: 398
       Name: fmt.Stringer
       ByteSize: 16
-      GoRuntimeType: 986464
+      GoRuntimeType: 987616
       GoKind: 20
       RawFields:
         - Name: tab
@@ -34521,7 +34521,7 @@ Types:
       ID: 1821
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
       ByteSize: 4
-      GoRuntimeType: 1643968
+      GoRuntimeType: 1643392
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 1989
@@ -34535,7 +34535,7 @@ Types:
       ID: 1822
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
       ByteSize: 4
-      GoRuntimeType: 1644160
+      GoRuntimeType: 1643584
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 2286
@@ -34596,7 +34596,7 @@ Types:
       Name: github.com/DataDog/datadog-agent/pkg/version.Version
       ByteSize: 8
     - __kind: StructureType
-      ID: 674
+      ID: 672
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1615008
@@ -34612,7 +34612,7 @@ Types:
           Offset: 200
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 674
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34620,7 +34620,7 @@ Types:
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 680
+      ID: 678
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1078624
       GoKind: 25
@@ -34633,7 +34633,7 @@ Types:
       ID: 586
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
-      GoRuntimeType: 767648
+      GoRuntimeType: 767456
       GoKind: 24
       RawFields:
         - Name: str
@@ -34701,13 +34701,13 @@ Types:
       ID: 987
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
-      GoRuntimeType: 536960
+      GoRuntimeType: 536896
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 583
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
-      GoRuntimeType: 767552
+      GoRuntimeType: 767360
       GoKind: 24
       RawFields:
         - Name: str
@@ -34726,7 +34726,7 @@ Types:
       ID: 589
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
-      GoRuntimeType: 767744
+      GoRuntimeType: 767552
       GoKind: 24
       RawFields:
         - Name: str
@@ -34937,7 +34937,7 @@ Types:
       ID: 388
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
-      GoRuntimeType: 1791776
+      GoRuntimeType: 1791520
       GoKind: 25
       RawFields:
         - Name: TraceID
@@ -35010,7 +35010,7 @@ Types:
       ID: 376
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 988512
+      GoRuntimeType: 985952
       GoKind: 21
       HeaderType: 378 GoHMapHeaderType hash<string,interface {}>
     - __kind: UnresolvedPointeeType
@@ -35031,7 +35031,7 @@ Types:
       ID: 1216
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
-      GoRuntimeType: 534080
+      GoRuntimeType: 534016
       GoKind: 10
     - __kind: StructureType
       ID: 391
@@ -35060,7 +35060,7 @@ Types:
       ID: 559
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
-      GoRuntimeType: 1792032
+      GoRuntimeType: 1791776
       GoKind: 25
       RawFields:
         - Name: Type
@@ -35091,7 +35091,7 @@ Types:
       ID: 396
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
-      GoRuntimeType: 1980032
+      GoRuntimeType: 1979680
       GoKind: 25
       RawFields:
         - Name: mu
@@ -35128,7 +35128,7 @@ Types:
       ID: 397
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
-      GoRuntimeType: 829568
+      GoRuntimeType: 829088
       GoKind: 17
       Count: 16
       HasCount: true
@@ -35147,7 +35147,7 @@ Types:
       ID: 1377
       Name: github.com/DataDog/dd-trace-go/v2/internal.TraceSource
       ByteSize: 1
-      GoRuntimeType: 954880
+      GoRuntimeType: 954784
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1169
@@ -35194,16 +35194,16 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/waf.Feature
       ByteSize: 8
     - __kind: BaseType
-      ID: 1224
+      ID: 1222
       Name: github.com/DataDog/dd-trace-go/v2/internal/log.Level
       ByteSize: 8
-      GoRuntimeType: 765824
+      GoRuntimeType: 765632
       GoKind: 2
     - __kind: GoContextImplementationType
       ID: 406
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
-      GoRuntimeType: 1446144
+      GoRuntimeType: 1445376
       GoKind: 25
       RawFields:
         - Name: Context
@@ -35595,24 +35595,24 @@ Types:
           Offset: 56
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1311
+      ID: 1309
       Name: github.com/cihub/seelog.CfgParseParams
       ByteSize: 8
     - __kind: BaseType
-      ID: 1231
+      ID: 1229
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
-      GoRuntimeType: 768032
+      GoRuntimeType: 767840
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1831
       Name: github.com/cihub/seelog.LogLevelException
       ByteSize: 8
     - __kind: StructureType
-      ID: 682
+      ID: 680
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1248320
+      GoRuntimeType: 1248160
       GoKind: 25
       RawFields:
         - Name: message
@@ -35623,15 +35623,15 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 684
+      ID: 682
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1248480
+      GoRuntimeType: 1248320
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 682 StructureType github.com/cihub/seelog.baseError
+          Type: 680 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1078
       Name: github.com/cihub/seelog.connWriter
@@ -35669,11 +35669,11 @@ Types:
       Name: github.com/cihub/seelog.listConstraints
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1308
+      ID: 1306
       Name: github.com/cihub/seelog.logFormattedMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1306
+      ID: 1304
       Name: github.com/cihub/seelog.logMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -35681,15 +35681,15 @@ Types:
       Name: github.com/cihub/seelog.minMaxConstraints
       ByteSize: 8
     - __kind: StructureType
-      ID: 688
+      ID: 686
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1248800
+      GoRuntimeType: 1248640
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 682 StructureType github.com/cihub/seelog.baseError
+          Type: 680 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1413
       Name: github.com/cihub/seelog.offConstraints
@@ -35736,25 +35736,25 @@ Types:
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 686
+      ID: 684
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1248640
+      GoRuntimeType: 1248480
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 682 StructureType github.com/cihub/seelog.baseError
+          Type: 680 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 690
+      ID: 688
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1248960
+      GoRuntimeType: 1248800
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 682 StructureType github.com/cihub/seelog.baseError
+          Type: 680 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1551
       Name: github.com/cihub/seelog.xmlNode
@@ -36379,7 +36379,7 @@ Types:
       ID: 911
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1724064
+      GoRuntimeType: 1723840
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -36412,7 +36412,7 @@ Types:
       ID: 917
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1724512
+      GoRuntimeType: 1724288
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36428,13 +36428,13 @@ Types:
       ID: 825
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 954304
+      GoRuntimeType: 954208
       GoKind: 8
     - __kind: StructureType
       ID: 909
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1723840
+      GoRuntimeType: 1723616
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -36454,13 +36454,13 @@ Types:
       ID: 997
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
-      GoRuntimeType: 765920
+      GoRuntimeType: 765728
       GoKind: 8
     - __kind: StructureType
       ID: 907
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1723616
+      GoRuntimeType: 1723392
       GoKind: 25
       RawFields:
         - Name: Method
@@ -36476,7 +36476,7 @@ Types:
       ID: 915
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1641280
+      GoRuntimeType: 1640704
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36489,7 +36489,7 @@ Types:
       ID: 913
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1724288
+      GoRuntimeType: 1724064
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36509,7 +36509,7 @@ Types:
       ID: 921
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1441920
+      GoRuntimeType: 1441152
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -36531,7 +36531,7 @@ Types:
       ID: 919
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1641472
+      GoRuntimeType: 1640896
       GoKind: 25
       RawFields:
         - Name: cause
@@ -39811,7 +39811,7 @@ Types:
       ID: 2452
       Name: io.Closer
       ByteSize: 16
-      GoRuntimeType: 987488
+      GoRuntimeType: 988640
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39836,7 +39836,7 @@ Types:
       ID: 1097
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1110880
+      GoRuntimeType: 1114080
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39849,7 +39849,7 @@ Types:
       ID: 399
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 986848
+      GoRuntimeType: 988000
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39866,7 +39866,7 @@ Types:
       ID: 1085
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1075296
+      GoRuntimeType: 1075552
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39879,7 +39879,7 @@ Types:
       ID: 127
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 986592
+      GoRuntimeType: 987744
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39892,7 +39892,7 @@ Types:
       ID: 2451
       Name: io.WriterTo
       ByteSize: 16
-      GoRuntimeType: 987360
+      GoRuntimeType: 988512
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39904,13 +39904,13 @@ Types:
     - __kind: StructureType
       ID: 1054
       Name: io.discard
-      GoRuntimeType: 1289728
+      GoRuntimeType: 1291808
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 2350
       Name: io.eofReader
-      GoRuntimeType: 1075040
+      GoRuntimeType: 1075296
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -39925,7 +39925,7 @@ Types:
       ID: 2384
       Name: io.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1371072
+      GoRuntimeType: 1372672
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -39935,7 +39935,7 @@ Types:
       ID: 2416
       Name: io.nopCloserWriterTo
       ByteSize: 16
-      GoRuntimeType: 1431552
+      GoRuntimeType: 1432704
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -39982,7 +39982,7 @@ Types:
       ID: 1478
       Name: log/slog.Attr
       ByteSize: 40
-      GoRuntimeType: 1649344
+      GoRuntimeType: 1648768
       GoKind: 25
       RawFields:
         - Name: Key
@@ -39992,10 +39992,10 @@ Types:
           Offset: 16
           Type: 1823 StructureType log/slog.Value
     - __kind: BaseType
-      ID: 1232
+      ID: 1230
       Name: log/slog.Kind
       ByteSize: 8
-      GoRuntimeType: 768128
+      GoRuntimeType: 767936
       GoKind: 2
     - __kind: BaseType
       ID: 1544
@@ -41099,7 +41099,7 @@ Types:
       ID: 420
       Name: map[context.canceler]struct {}
       ByteSize: 8
-      GoRuntimeType: 887456
+      GoRuntimeType: 886784
       GoKind: 21
       HeaderType: 422 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: GoMapType
@@ -41162,14 +41162,14 @@ Types:
       ID: 540
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
-      GoRuntimeType: 887648
+      GoRuntimeType: 886976
       GoKind: 21
       HeaderType: 542 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 2142
       Name: map[string]*regexp.Regexp
       ByteSize: 8
-      GoRuntimeType: 887936
+      GoRuntimeType: 887264
       GoKind: 21
       HeaderType: 2144 GoHMapHeaderType hash<string,*regexp.Regexp>
     - __kind: GoMapType
@@ -41190,7 +41190,7 @@ Types:
       ID: 381
       Name: map[string]float64
       ByteSize: 8
-      GoRuntimeType: 887552
+      GoRuntimeType: 886880
       GoKind: 21
       HeaderType: 383 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
@@ -41429,16 +41429,16 @@ Types:
       Name: net.DNSError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1229
+      ID: 1227
       Name: net.Flags
       ByteSize: 8
-      GoRuntimeType: 767072
+      GoRuntimeType: 766880
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 1301
+      ID: 1299
       Name: net.HardwareAddr
       ByteSize: 24
-      GoRuntimeType: 839168
+      GoRuntimeType: 838400
       GoKind: 23
       RawFields:
         - Name: array
@@ -41450,9 +41450,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1302 GoSliceDataType net.HardwareAddr.array
+      Data: 1300 GoSliceDataType net.HardwareAddr.array
     - __kind: GoSliceDataType
-      ID: 1302
+      ID: 1300
       Name: net.HardwareAddr.array
       DynamicSizeClass: slice
       ByteSize: 1
@@ -41492,7 +41492,7 @@ Types:
       ID: 1405
       Name: net.IPMask
       ByteSize: 24
-      GoRuntimeType: 1000800
+      GoRuntimeType: 1000672
       GoKind: 23
       RawFields:
         - Name: array
@@ -41606,10 +41606,10 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: BaseType
-      ID: 1230
+      ID: 1228
       Name: net.hostLookupOrder
       ByteSize: 8
-      GoRuntimeType: 767168
+      GoRuntimeType: 766976
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1177
@@ -41628,14 +41628,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 667
+      ID: 665
       Name: net.notFoundError
       ByteSize: 8
     - __kind: GoContextImplementationType
       ID: 408
       Name: net.onlyValuesCtx
       ByteSize: 32
-      GoRuntimeType: 1646272
+      GoRuntimeType: 1645696
       GoKind: 25
       RawFields:
         - Name: Context
@@ -41647,7 +41647,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: StructureType
-      ID: 669
+      ID: 667
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1614816
@@ -41697,10 +41697,10 @@ Types:
       Name: net.timeoutError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1227
+      ID: 1225
       Name: net/http.ConnState
       ByteSize: 8
-      GoRuntimeType: 766304
+      GoRuntimeType: 766112
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1399
@@ -41722,7 +41722,7 @@ Types:
       ID: 2352
       Name: net/http.bodyLocked
       ByteSize: 8
-      GoRuntimeType: 1243680
+      GoRuntimeType: 1243520
       GoKind: 25
       RawFields:
         - Name: b
@@ -41732,7 +41732,7 @@ Types:
       ID: 1010
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1243840
+      GoRuntimeType: 1243680
       GoKind: 25
       RawFields:
         - Name: w
@@ -41747,7 +41747,7 @@ Types:
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 1295
+      ID: 1293
       Name: net/http.connectMethodKey
       ByteSize: 56
       GoRuntimeType: 1707872
@@ -41766,14 +41766,14 @@ Types:
           Offset: 48
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1297
+      ID: 1295
       Name: net/http.contextKey
       ByteSize: 8
     - __kind: StructureType
       ID: 2356
       Name: net/http.errorReader
       ByteSize: 16
-      GoRuntimeType: 1244000
+      GoRuntimeType: 1243840
       GoKind: 25
       RawFields:
         - Name: err
@@ -41783,7 +41783,7 @@ Types:
       ID: 2358
       Name: net/http.finishAsyncByteRead
       ByteSize: 8
-      GoRuntimeType: 1244160
+      GoRuntimeType: 1244000
       GoKind: 25
       RawFields:
         - Name: tw
@@ -41797,13 +41797,13 @@ Types:
       ID: 564
       Name: net/http.http2ConnectionError
       ByteSize: 4
-      GoRuntimeType: 766400
+      GoRuntimeType: 766208
       GoKind: 10
     - __kind: StructureType
       ID: 1745
       Name: net/http.http2ContinuationFrame
       ByteSize: 40
-      GoRuntimeType: 1643392
+      GoRuntimeType: 1642816
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41816,7 +41816,7 @@ Types:
       ID: 1741
       Name: net/http.http2DataFrame
       ByteSize: 40
-      GoRuntimeType: 1641664
+      GoRuntimeType: 1641088
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41829,13 +41829,13 @@ Types:
       ID: 971
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 954400
+      GoRuntimeType: 954304
       GoKind: 10
     - __kind: BaseType
       ID: 1819
       Name: net/http.http2Flags
       ByteSize: 1
-      GoRuntimeType: 766112
+      GoRuntimeType: 765920
       GoKind: 8
     - __kind: StructureType
       ID: 1589
@@ -41849,7 +41849,7 @@ Types:
           Type: 6 BaseType bool
         - Name: Type
           Offset: 1
-          Type: 1225 BaseType net/http.http2FrameType
+          Type: 1223 BaseType net/http.http2FrameType
         - Name: Flags
           Offset: 2
           Type: 1819 BaseType net/http.http2Flags
@@ -41860,13 +41860,13 @@ Types:
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1225
+      ID: 1223
       Name: net/http.http2FrameType
       ByteSize: 1
-      GoRuntimeType: 766016
+      GoRuntimeType: 765824
       GoKind: 8
     - __kind: StructureType
-      ID: 645
+      ID: 643
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1613280
@@ -41885,7 +41885,7 @@ Types:
       ID: 1649
       Name: net/http.http2GoAwayFrame
       ByteSize: 48
-      GoRuntimeType: 1795616
+      GoRuntimeType: 1795360
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41904,7 +41904,7 @@ Types:
       ID: 1870
       Name: net/http.http2HeadersFrame
       ByteSize: 48
-      GoRuntimeType: 1725184
+      GoRuntimeType: 1724960
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41936,7 +41936,7 @@ Types:
       ID: 1651
       Name: net/http.http2PingFrame
       ByteSize: 20
-      GoRuntimeType: 1641856
+      GoRuntimeType: 1641280
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41978,7 +41978,7 @@ Types:
       ID: 1743
       Name: net/http.http2PushPromiseFrame
       ByteSize: 40
-      GoRuntimeType: 1726752
+      GoRuntimeType: 1726528
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41994,7 +41994,7 @@ Types:
       ID: 1591
       Name: net/http.http2RSTStreamFrame
       ByteSize: 16
-      GoRuntimeType: 1642048
+      GoRuntimeType: 1641472
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42012,21 +42012,21 @@ Types:
       RawFields:
         - Name: ID
           Offset: 0
-          Type: 1226 BaseType net/http.http2SettingID
+          Type: 1224 BaseType net/http.http2SettingID
         - Name: Val
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1226
+      ID: 1224
       Name: net/http.http2SettingID
       ByteSize: 2
-      GoRuntimeType: 766208
+      GoRuntimeType: 766016
       GoKind: 9
     - __kind: StructureType
       ID: 1820
       Name: net/http.http2SettingsFrame
       ByteSize: 40
-      GoRuntimeType: 1642240
+      GoRuntimeType: 1641664
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42039,7 +42039,7 @@ Types:
       ID: 953
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1779520
+      GoRuntimeType: 1779264
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -42055,7 +42055,7 @@ Types:
       ID: 1655
       Name: net/http.http2UnknownFrame
       ByteSize: 40
-      GoRuntimeType: 1643200
+      GoRuntimeType: 1642624
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42068,7 +42068,7 @@ Types:
       ID: 1593
       Name: net/http.http2WindowUpdateFrame
       ByteSize: 16
-      GoRuntimeType: 1642432
+      GoRuntimeType: 1641856
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42082,7 +42082,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 649
+      ID: 647
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1414304
@@ -42102,7 +42102,7 @@ Types:
       ID: 568
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 766592
+      GoRuntimeType: 766400
       GoKind: 24
       RawFields:
         - Name: str
@@ -42125,7 +42125,7 @@ Types:
       ID: 574
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 766784
+      GoRuntimeType: 766592
       GoKind: 24
       RawFields:
         - Name: str
@@ -42144,7 +42144,7 @@ Types:
       ID: 571
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 766688
+      GoRuntimeType: 766496
       GoKind: 24
       RawFields:
         - Name: str
@@ -42189,7 +42189,7 @@ Types:
       ID: 565
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 766496
+      GoRuntimeType: 766304
       GoKind: 24
       RawFields:
         - Name: str
@@ -42233,7 +42233,7 @@ Types:
     - __kind: ArrayType
       ID: 1094
       Name: net/http.incomparable
-      GoRuntimeType: 834560
+      GoRuntimeType: 833792
       GoKind: 17
       HasCount: true
       Element: 60 GoSubroutineType func()
@@ -42244,7 +42244,7 @@ Types:
     - __kind: StructureType
       ID: 2420
       Name: net/http.noBody
-      GoRuntimeType: 1300928
+      GoRuntimeType: 1299808
       GoKind: 25
       RawFields: []
     - __kind: StructureType
@@ -42283,7 +42283,7 @@ Types:
       ID: 1058
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1685984
+      GoRuntimeType: 1685536
       GoKind: 25
       RawFields:
         - Name: _
@@ -42296,10 +42296,10 @@ Types:
           Offset: 8
           Type: 1097 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 653
+      ID: 651
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1244800
+      GoRuntimeType: 1244640
       GoKind: 25
       RawFields:
         - Name: error
@@ -42316,7 +42316,7 @@ Types:
     - __kind: StructureType
       ID: 923
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1302048
+      GoRuntimeType: 1300928
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -42334,7 +42334,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 640
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -42502,7 +42502,7 @@ Types:
       ID: 577
       Name: net/url.EscapeError
       ByteSize: 16
-      GoRuntimeType: 767264
+      GoRuntimeType: 767072
       GoKind: 24
       RawFields:
         - Name: str
@@ -42521,7 +42521,7 @@ Types:
       ID: 580
       Name: net/url.InvalidHostError
       ByteSize: 16
-      GoRuntimeType: 767360
+      GoRuntimeType: 767168
       GoKind: 24
       RawFields:
         - Name: str
@@ -42702,16 +42702,16 @@ Types:
       GoRuntimeType: 772352
       GoKind: 2
     - __kind: BaseType
-      ID: 1222
+      ID: 1231
       Name: reflect.ChanDir
       ByteSize: 8
-      GoRuntimeType: 765632
+      GoRuntimeType: 768128
       GoKind: 2
     - __kind: BaseType
-      ID: 1223
+      ID: 1232
       Name: reflect.Kind
       ByteSize: 8
-      GoRuntimeType: 765728
+      GoRuntimeType: 768224
       GoKind: 7
     - __kind: StructureType
       ID: 2323
@@ -42730,14 +42730,14 @@ Types:
           Offset: 16
           Type: 2324 BaseType reflect.flag
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 691
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: BaseType
       ID: 2324
       Name: reflect.flag
       ByteSize: 8
-      GoRuntimeType: 1640320
+      GoRuntimeType: 1648960
       GoKind: 12
     - __kind: UnresolvedPointeeType
       ID: 2307
@@ -43648,7 +43648,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1300
+      ID: 1298
       Name: runtime/debug.BuildInfo
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -43704,7 +43704,7 @@ Types:
       ID: 2412
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
-      GoRuntimeType: 1541664
+      GoRuntimeType: 1540128
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -43717,7 +43717,7 @@ Types:
       ID: 2410
       Name: struct { io.Reader; io.WriterTo }
       ByteSize: 32
-      GoRuntimeType: 1538592
+      GoRuntimeType: 1537056
       GoKind: 25
       RawFields:
         - Name: Reader

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -20,11 +20,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2989 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x856e08", Frameless: false}]
+              InjectionPoints: [{PC: "0x8578c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2990 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x856e3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8578fc", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -40,11 +40,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2824 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x851978", Frameless: false}]
+              InjectionPoints: [{PC: "0x851ef8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2825 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x8519a4", Frameless: false}]
+              InjectionPoints: [{PC: "0x851f24", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -66,11 +66,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2827 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x8519f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851f78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2828 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x851a24", Frameless: false}]
+              InjectionPoints: [{PC: "0x851fa4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -91,11 +91,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2958 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x85592c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8562fc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2959 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8559c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x856394", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -183,7 +183,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2836 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x852180", Frameless: true}]
+              InjectionPoints: [{PC: "0x8527a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -248,11 +248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2860 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x853b80", Frameless: true}]
+              InjectionPoints: [{PC: "0x854380", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2861 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x853bbc", Frameless: true}]
+              InjectionPoints: [{PC: "0x8543bc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -274,11 +274,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2788 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x84d610", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d7d0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2789 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0x84d628", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d7e8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -344,7 +344,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2987 EventRootType Probe[main.testByteSliceInvalidUtf8]
-              InjectionPoints: [{PC: "0x856840", Frameless: true}]
+              InjectionPoints: [{PC: "0x857210", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -366,7 +366,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2988 EventRootType Probe[main.testByteSliceMultibyteUtf8]
-              InjectionPoints: [{PC: "0x856850", Frameless: true}]
+              InjectionPoints: [{PC: "0x857220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -387,7 +387,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2803 EventRootType Probe[main.testCaptureContextImpl]
-              InjectionPoints: [{PC: "0x84e2a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84e540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -414,11 +414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3011 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x8571b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857e80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3012 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x8571cc", Frameless: true}]
+              InjectionPoints: [{PC: "0x857e9c", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -426,7 +426,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: ""
       segments: []
@@ -438,15 +438,15 @@ Probes:
             - Kind: Line
               Type: 3075 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x851238"
+                - PC: "0x8516c8"
                   Frameless: false
-                - PC: "0x8512ac"
+                - PC: "0x85173c"
                   Frameless: false
-                - PC: "0x8513f8"
+                - PC: "0x851888"
                   Frameless: false
-                - PC: "0x851474"
+                - PC: "0x851904"
                   Frameless: false
-                - PC: "0x85152c"
+                - PC: "0x8519bc"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -455,7 +455,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       when: {dsl: x == 3, json: {eq: [{ref: x}, 3]}}
       sampling: {snapshotsPerSecond: 100}
       template: ""
@@ -468,15 +468,15 @@ Probes:
             - Kind: Line
               Type: 3076 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x851238"
+                - PC: "0x8516c8"
                   Frameless: false
-                - PC: "0x8512ac"
+                - PC: "0x85173c"
                   Frameless: false
-                - PC: "0x8513f8"
+                - PC: "0x851888"
                   Frameless: false
-                - PC: "0x851474"
+                - PC: "0x851904"
                   Frameless: false
-                - PC: "0x85152c"
+                - PC: "0x8519bc"
                   Frameless: false
               Condition:
                 Type: 6 BaseType bool
@@ -502,7 +502,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: x={x}
       segments: [x=, {json: {ref: x}, dsl: x}]
@@ -514,15 +514,15 @@ Probes:
             - Kind: Line
               Type: 3077 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x851238"
+                - PC: "0x8516c8"
                   Frameless: false
-                - PC: "0x8512ac"
+                - PC: "0x85173c"
                   Frameless: false
-                - PC: "0x8513f8"
+                - PC: "0x851888"
                   Frameless: false
-                - PC: "0x851474"
+                - PC: "0x851904"
                   Frameless: false
-                - PC: "0x85152c"
+                - PC: "0x8519bc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -550,7 +550,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2855 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x8536c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853ce0", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -569,7 +569,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2856 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x8536c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853ce0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -595,7 +595,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3019 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x857260", Frameless: true}]
+              InjectionPoints: [{PC: "0x857f30", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -633,7 +633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2862 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x853bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8543c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -663,7 +663,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2854 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x8536a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x853cc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -692,11 +692,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2923 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x854b48", Frameless: false}]
+              InjectionPoints: [{PC: "0x855518", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2924 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x854bf4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8555c4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -718,7 +718,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2870 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x853e70", Frameless: true}]
+              InjectionPoints: [{PC: "0x854750", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -740,7 +740,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2795 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x84db10", Frameless: true}]
+              InjectionPoints: [{PC: "0x84dcd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -762,7 +762,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2796 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x84db20", Frameless: true}]
+              InjectionPoints: [{PC: "0x84dce0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -784,7 +784,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2791 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x84d800", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d9c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -806,7 +806,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2792 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x84d810", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d9d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -828,7 +828,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2793 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x84d9b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84db70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -850,7 +850,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2794 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x84d9c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84db80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -872,7 +872,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2975 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x856760", Frameless: true}]
+              InjectionPoints: [{PC: "0x857130", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -899,7 +899,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2978 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x856790", Frameless: true}]
+              InjectionPoints: [{PC: "0x857160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -927,7 +927,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3003 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x856ee0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -949,7 +949,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3020 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x8572b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857f80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -970,7 +970,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3021 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x8572c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857f90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -992,7 +992,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2826 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x8519d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851f50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1007,7 +1007,7 @@ Probes:
       where:
         methodName: main.testErrorAtLine
         sourceFile: complex.go
-        lines: ["108"]
+        lines: ["111"]
       tags:
         - config_diff:arch=amd64,toolchain=go1.26rc1
         - skip_integration:arch=arm64,toolchain=go1.25.0
@@ -1026,7 +1026,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2790 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x84d69c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84d85c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -1054,11 +1054,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2808 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x850248", Frameless: false}]
+              InjectionPoints: [{PC: "0x8506d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2809 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x850284", Frameless: false}]
+              InjectionPoints: [{PC: "0x850714", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1080,11 +1080,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2806 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x85017c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85060c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2807 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x8501ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x85067c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1106,11 +1106,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2818 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x8516b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x851b40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2819 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x8516b8", Frameless: true}]
+              InjectionPoints: [{PC: "0x851b48", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1132,11 +1132,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2820 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x8516cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b5c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2821 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x851708", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b98", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1151,7 +1151,7 @@ Probes:
       where:
         methodName: main.testFramelessArray
         sourceFile: inlined.go
-        lines: ["93"]
+        lines: ["96"]
       sampling: {snapshotsPerSecond: 100}
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
@@ -1161,7 +1161,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2822 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x8516cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b5c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1183,11 +1183,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3061 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x859570", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a410", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3062 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x859578", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a418", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1201,11 +1201,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3063 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x859590", Frameless: false}]
+              InjectionPoints: [{PC: "0x85a430", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3064 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x8595cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x85a46c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1228,11 +1228,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3057 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x8594d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x85a378", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3058 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x8594e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x85a388", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1246,11 +1246,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3059 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x859528", Frameless: false}]
+              InjectionPoints: [{PC: "0x85a3c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3060 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x859540", Frameless: false}]
+              InjectionPoints: [{PC: "0x85a3e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1273,14 +1273,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 3065 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x8595e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a480", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3066 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x859608"
+                - PC: "0x85a4a8"
                   Frameless: true
-                - PC: "0x859610"
+                - PC: "0x85a4b0"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1295,14 +1295,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 3067 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x859638", Frameless: false}]
+              InjectionPoints: [{PC: "0x85a4d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3068 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x859698"
+                - PC: "0x85a538"
                   Frameless: false
-                - PC: "0x8596a8"
+                - PC: "0x85a548"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1329,7 +1329,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3069 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x8595e4", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a484", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1341,7 +1341,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3070 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x859648", Frameless: false}]
+              InjectionPoints: [{PC: "0x85a4e8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1362,11 +1362,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3045 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x8591d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a070", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3046 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x8591d8", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a078", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1380,11 +1380,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3047 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x859260", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a100", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3048 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x859264", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a104", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1408,11 +1408,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3033 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x858dd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x859c78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3034 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x858eac", Frameless: false}]
+              InjectionPoints: [{PC: "0x859d4c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1454,11 +1454,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3037 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x858ef8", Frameless: false}]
+              InjectionPoints: [{PC: "0x859d98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3038 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x858f08", Frameless: false}]
+              InjectionPoints: [{PC: "0x859da8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1481,11 +1481,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3071 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x8596e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a580", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3072 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x8596e8", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a588", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1499,11 +1499,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3073 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x859778", Frameless: false}]
+              InjectionPoints: [{PC: "0x85a618", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3074 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x85979c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85a63c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1526,11 +1526,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3029 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x858d40", Frameless: true}]
+              InjectionPoints: [{PC: "0x859be0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3030 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x858d44", Frameless: true}]
+              InjectionPoints: [{PC: "0x859be4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1544,11 +1544,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3031 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x858d50", Frameless: true}]
+              InjectionPoints: [{PC: "0x859bf0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3032 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x858d5c", Frameless: true}]
+              InjectionPoints: [{PC: "0x859bfc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1571,11 +1571,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3049 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x859300", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a1a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3050 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x859308", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a1a8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1589,11 +1589,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3051 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x8593a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x85a248", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3052 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x8593d4", Frameless: false}]
+              InjectionPoints: [{PC: "0x85a274", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1616,11 +1616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3039 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x8591a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a040", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3040 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8591a4", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a044", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1634,11 +1634,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3041 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x8591b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a050", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3042 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x8591b4", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a054", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1652,11 +1652,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3043 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x8591c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a060", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3044 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x8591c4", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a064", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1679,11 +1679,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3053 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x859490", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a330", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3054 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x859498", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a338", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1697,11 +1697,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3055 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x8594a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a340", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3056 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8594b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x85a350", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1724,11 +1724,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3025 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x858d20", Frameless: true}]
+              InjectionPoints: [{PC: "0x859bc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3026 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x858d24", Frameless: true}]
+              InjectionPoints: [{PC: "0x859bc4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1742,11 +1742,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3027 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x858d30", Frameless: true}]
+              InjectionPoints: [{PC: "0x859bd0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3028 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x858d3c", Frameless: true}]
+              InjectionPoints: [{PC: "0x859bdc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1769,14 +1769,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2858 EventRootType Probe[main.(*Server).handleOrder]
-              InjectionPoints: [{PC: "0x85393c", Frameless: false}]
+              InjectionPoints: [{PC: "0x85404c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2859 EventRootType Probe[main.(*Server).handleOrder]Return
               InjectionPoints:
-                - PC: "0x8539f4"
+                - PC: "0x854104"
                   Frameless: false
-                - PC: "0x853aa8"
+                - PC: "0x8541b8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1799,11 +1799,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2810 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x8513d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851868", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2811 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x851430", Frameless: false}]
+              InjectionPoints: [{PC: "0x8518c0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1830,11 +1830,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2812 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x851468", Frameless: false}]
+              InjectionPoints: [{PC: "0x8518f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2813 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x8514f0", Frameless: false}]
+              InjectionPoints: [{PC: "0x851980", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1861,11 +1861,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2814 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x851528", Frameless: false}]
+              InjectionPoints: [{PC: "0x8519b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2815 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x851564", Frameless: false}]
+              InjectionPoints: [{PC: "0x8519f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1887,7 +1887,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3081 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x8514b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851948", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1905,11 +1905,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2816 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x8515a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x851a38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2817 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x851698", Frameless: false}]
+              InjectionPoints: [{PC: "0x851b28", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1927,7 +1927,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3082 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x8515ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x851a3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1938,7 +1938,7 @@ Probes:
       where:
         methodName: main.testInlinedBCA
         sourceFile: inlined.go
-        lines: ["63"]
+        lines: ["66"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCA
       segments: [testInlinedBCA]
@@ -1948,7 +1948,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3083 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x8515ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x851a3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1966,7 +1966,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3084 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x851660", Frameless: false}]
+              InjectionPoints: [{PC: "0x851af0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1977,7 +1977,7 @@ Probes:
       where:
         methodName: main.testInlinedBCB
         sourceFile: inlined.go
-        lines: ["67"]
+        lines: ["70"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCB
       segments: [testInlinedBCB]
@@ -1987,7 +1987,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3085 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x851660", Frameless: false}]
+              InjectionPoints: [{PC: "0x851af0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -2008,7 +2008,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x84bcb8"
                   Frameless: true
-                - PC: "0x8520b8"
+                - PC: "0x8526b4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2029,20 +2029,20 @@ Probes:
             - Kind: Entry
               Type: 3078 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x851238"
+                - PC: "0x8516c8"
                   Frameless: false
-                - PC: "0x8512ac"
+                - PC: "0x85173c"
                   Frameless: false
-                - PC: "0x8513f8"
+                - PC: "0x851888"
                   Frameless: false
-                - PC: "0x851474"
+                - PC: "0x851904"
                   Frameless: false
-                - PC: "0x85152c"
+                - PC: "0x8519bc"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 3079 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x851270", Frameless: false}]
+              InjectionPoints: [{PC: "0x851700", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2057,7 +2057,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2068,15 +2068,15 @@ Probes:
             - Kind: Line
               Type: 3080 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x851238"
+                - PC: "0x8516c8"
                   Frameless: false
-                - PC: "0x8512ac"
+                - PC: "0x85173c"
                   Frameless: false
-                - PC: "0x8513f8"
+                - PC: "0x851888"
                   Frameless: false
-                - PC: "0x851474"
+                - PC: "0x851904"
                   Frameless: false
-                - PC: "0x85152c"
+                - PC: "0x8519bc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2099,7 +2099,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3086 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x8516b4", Frameless: true}]
+              InjectionPoints: [{PC: "0x851b44", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2114,7 +2114,7 @@ Probes:
       where:
         methodName: main.testInlinedSq
         sourceFile: inlined.go
-        lines: ["75"]
+        lines: ["78"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2124,7 +2124,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3087 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x8516b4", Frameless: true}]
+              InjectionPoints: [{PC: "0x851b44", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2148,9 +2148,9 @@ Probes:
             - Kind: Entry
               Type: 3088 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x8516e4"
+                - PC: "0x851b74"
                   Frameless: false
-                - PC: "0x85177c"
+                - PC: "0x851c58"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2283,7 +2283,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2823 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x851950", Frameless: true}]
+              InjectionPoints: [{PC: "0x851ed0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2310,7 +2310,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3005 EventRootType Probe[main.testInvalidUtf8Strings]
-              InjectionPoints: [{PC: "0x856f00", Frameless: true}]
+              InjectionPoints: [{PC: "0x857ae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2956 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x855770", Frameless: false}]
+              InjectionPoints: [{PC: "0x856140", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2957 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8558c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x856298", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2362,7 +2362,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2864 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x853d80", Frameless: true}]
+              InjectionPoints: [{PC: "0x854660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2377,7 +2377,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["230"]
+        lines: ["233"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
@@ -2387,7 +2387,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2799 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x84db6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x84dd2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2398,7 +2398,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["237"]
+        lines: ["240"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2409,7 +2409,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2800 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x84dbfc", Frameless: false}]
+              InjectionPoints: [{PC: "0x84ddbc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2420,7 +2420,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["242"]
+        lines: ["245"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2431,7 +2431,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2801 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x84dca4", Frameless: false}]
+              InjectionPoints: [{PC: "0x84de64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2474,11 +2474,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2962 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x855c2c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8565fc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2963 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x855d98", Frameless: false}]
+              InjectionPoints: [{PC: "0x856768", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2541,7 +2541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2804 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0x84e550", Frameless: true}]
+              InjectionPoints: [{PC: "0x84e7f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2565,7 +2565,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2805 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0x84fec0", Frameless: true}]
+              InjectionPoints: [{PC: "0x850260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2587,7 +2587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2834 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x852160", Frameless: true}]
+              InjectionPoints: [{PC: "0x852780", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2609,7 +2609,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2841 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x8521c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8527e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2631,7 +2631,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2851 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x852260", Frameless: true}]
+              InjectionPoints: [{PC: "0x852880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2653,7 +2653,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2853 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x852280", Frameless: true}]
+              InjectionPoints: [{PC: "0x8528a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2675,7 +2675,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2852 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x852270", Frameless: true}]
+              InjectionPoints: [{PC: "0x852890", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2697,7 +2697,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2838 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x8521a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8527c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2719,7 +2719,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2850 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x852250", Frameless: true}]
+              InjectionPoints: [{PC: "0x852870", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2741,7 +2741,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2849 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x852240", Frameless: true}]
+              InjectionPoints: [{PC: "0x852860", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2765,7 +2765,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2839 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x8521b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8527d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2789,7 +2789,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2840 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x8521b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8527d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2811,7 +2811,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2848 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x852230", Frameless: true}]
+              InjectionPoints: [{PC: "0x852850", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2833,7 +2833,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2847 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x852220", Frameless: true}]
+              InjectionPoints: [{PC: "0x852840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2855,7 +2855,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2832 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x852140", Frameless: true}]
+              InjectionPoints: [{PC: "0x852760", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2877,7 +2877,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2833 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x852150", Frameless: true}]
+              InjectionPoints: [{PC: "0x852770", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2899,7 +2899,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2831 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x852130", Frameless: true}]
+              InjectionPoints: [{PC: "0x852750", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2921,7 +2921,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2842 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x8521d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8527f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2943,7 +2943,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2845 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x852200", Frameless: true}]
+              InjectionPoints: [{PC: "0x852820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2965,7 +2965,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2846 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x852210", Frameless: true}]
+              InjectionPoints: [{PC: "0x852830", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2987,7 +2987,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2843 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x8521e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x852800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3011,7 +3011,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2844 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x8521f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x852810", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -3033,7 +3033,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3000 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x856ec0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3056,7 +3056,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3001 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x856ec0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857aa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3103,11 +3103,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2964 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x855e00", Frameless: false}]
+              InjectionPoints: [{PC: "0x8567d0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2965 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x855fac", Frameless: false}]
+              InjectionPoints: [{PC: "0x85697c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3169,7 +3169,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3006 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0x856f10", Frameless: true}]
+              InjectionPoints: [{PC: "0x857af0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3192,7 +3192,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3007 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0x856f10", Frameless: true}]
+              InjectionPoints: [{PC: "0x857af0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3218,11 +3218,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2968 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x8560ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x856a7c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2969 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x856154", Frameless: false}]
+              InjectionPoints: [{PC: "0x856b24", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3253,11 +3253,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2960 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x855a00", Frameless: false}]
+              InjectionPoints: [{PC: "0x8563d0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2961 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x855bd0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8565a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3283,11 +3283,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2901 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8549b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x855388", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2902 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x854a44", Frameless: false}]
+              InjectionPoints: [{PC: "0x855414", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3323,7 +3323,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2857 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x853780", Frameless: true}]
+              InjectionPoints: [{PC: "0x853da0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3364,11 +3364,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2895 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x854918", Frameless: false}]
+              InjectionPoints: [{PC: "0x8552e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2896 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x854978", Frameless: false}]
+              InjectionPoints: [{PC: "0x855348", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3392,11 +3392,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2897 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x854918", Frameless: false}]
+              InjectionPoints: [{PC: "0x8552e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2898 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x854978", Frameless: false}]
+              InjectionPoints: [{PC: "0x855348", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3415,11 +3415,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2903 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8549b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x855388", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2904 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x854a44", Frameless: false}]
+              InjectionPoints: [{PC: "0x855414", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3439,11 +3439,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2905 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8549b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x855388", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2906 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x854a44", Frameless: false}]
+              InjectionPoints: [{PC: "0x855414", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3476,11 +3476,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2899 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x854918", Frameless: false}]
+              InjectionPoints: [{PC: "0x8552e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2900 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x854978", Frameless: false}]
+              InjectionPoints: [{PC: "0x855348", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3508,7 +3508,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3015 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x857250", Frameless: true}]
+              InjectionPoints: [{PC: "0x857f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3533,7 +3533,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3016 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x857250", Frameless: true}]
+              InjectionPoints: [{PC: "0x857f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3564,7 +3564,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3017 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x857250", Frameless: true}]
+              InjectionPoints: [{PC: "0x857f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3589,7 +3589,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3018 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x857250", Frameless: true}]
+              InjectionPoints: [{PC: "0x857f20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3616,7 +3616,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2869 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x853e50", Frameless: true}]
+              InjectionPoints: [{PC: "0x854730", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3643,7 +3643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2982 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x8567d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8571a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3670,7 +3670,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2979 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x8567a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857170", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3705,7 +3705,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2981 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x8567c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857190", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3737,7 +3737,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2999 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x856eb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857a90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3759,7 +3759,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2865 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x853d90", Frameless: true}]
+              InjectionPoints: [{PC: "0x854670", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3781,7 +3781,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2837 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x852190", Frameless: true}]
+              InjectionPoints: [{PC: "0x8527b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3803,7 +3803,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2863 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x853d70", Frameless: true}]
+              InjectionPoints: [{PC: "0x854650", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3827,11 +3827,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2871 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x8541c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x854b98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2872 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x85420c", Frameless: false}]
+              InjectionPoints: [{PC: "0x854bdc", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3851,11 +3851,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2915 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x854a88", Frameless: false}]
+              InjectionPoints: [{PC: "0x855458", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2916 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x854b10", Frameless: false}]
+              InjectionPoints: [{PC: "0x8554e0", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3900,11 +3900,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2881 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x8542e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x854cb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2882 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x854380", Frameless: false}]
+              InjectionPoints: [{PC: "0x854d50", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3946,11 +3946,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2873 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x8541c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x854b98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2874 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x85420c", Frameless: false}]
+              InjectionPoints: [{PC: "0x854bdc", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3995,11 +3995,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2883 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x8542e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x854cb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2884 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x854380", Frameless: false}]
+              InjectionPoints: [{PC: "0x854d50", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -4043,11 +4043,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2917 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x854a88", Frameless: false}]
+              InjectionPoints: [{PC: "0x855458", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2918 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x854b10", Frameless: false}]
+              InjectionPoints: [{PC: "0x8554e0", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -4064,11 +4064,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2919 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x854a88", Frameless: false}]
+              InjectionPoints: [{PC: "0x855458", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2920 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x854b10", Frameless: false}]
+              InjectionPoints: [{PC: "0x8554e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -4090,11 +4090,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2875 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x8541c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x854b98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2876 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x85420c", Frameless: false}]
+              InjectionPoints: [{PC: "0x854bdc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -4117,18 +4117,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2891 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x8545b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x854f88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2892 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x854654"
+                - PC: "0x855024"
                   Frameless: false
-                - PC: "0x85469c"
+                - PC: "0x85506c"
                   Frameless: false
-                - PC: "0x854760"
+                - PC: "0x855130"
                   Frameless: false
-                - PC: "0x854774"
+                - PC: "0x855144"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4156,18 +4156,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2889 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x854438", Frameless: false}]
+              InjectionPoints: [{PC: "0x854e08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2890 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x85448c"
+                - PC: "0x854e5c"
                   Frameless: false
-                - PC: "0x8544f0"
+                - PC: "0x854ec0"
                   Frameless: false
-                - PC: "0x854530"
+                - PC: "0x854f00"
                   Frameless: false
-                - PC: "0x854570"
+                - PC: "0x854f40"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4194,11 +4194,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2934 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x85517c", Frameless: false}]
+              InjectionPoints: [{PC: "0x855b4c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2935 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x8551d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x855ba0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4215,11 +4215,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2936 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x855208", Frameless: false}]
+              InjectionPoints: [{PC: "0x855bd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2937 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x855244", Frameless: false}]
+              InjectionPoints: [{PC: "0x855c14", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4236,11 +4236,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2938 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x855278", Frameless: false}]
+              InjectionPoints: [{PC: "0x855c48", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2939 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x8552b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x855c80", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4257,11 +4257,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2942 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x855368", Frameless: false}]
+              InjectionPoints: [{PC: "0x855d38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2943 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x8553cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x855d9c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4278,11 +4278,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2954 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x8556f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8560c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2955 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x855738", Frameless: false}]
+              InjectionPoints: [{PC: "0x856108", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4299,11 +4299,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2930 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x855028", Frameless: false}]
+              InjectionPoints: [{PC: "0x8559f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2931 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x855074", Frameless: false}]
+              InjectionPoints: [{PC: "0x855a44", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4321,14 +4321,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2887 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x8543b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x854d88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2888 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x8543e8"
+                - PC: "0x854db8"
                   Frameless: false
-                - PC: "0x8543fc"
+                - PC: "0x854dcc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4350,11 +4350,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2877 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x8541c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x854b98", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2878 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x85420c", Frameless: false}]
+              InjectionPoints: [{PC: "0x854bdc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4375,11 +4375,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2885 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x8542e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x854cb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2886 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x854380", Frameless: false}]
+              InjectionPoints: [{PC: "0x854d50", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4400,11 +4400,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2879 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x854248", Frameless: false}]
+              InjectionPoints: [{PC: "0x854c18", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2880 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x8542a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x854c78", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4426,14 +4426,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2893 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x8547b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x855188", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2894 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x854884"
+                - PC: "0x855254"
                   Frameless: false
-                - PC: "0x854898"
+                - PC: "0x855268"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4455,11 +4455,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2932 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x8550b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x855a80", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2933 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x855144", Frameless: false}]
+              InjectionPoints: [{PC: "0x855b14", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4476,11 +4476,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2928 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x854f68", Frameless: false}]
+              InjectionPoints: [{PC: "0x855938", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2929 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x854fec", Frameless: false}]
+              InjectionPoints: [{PC: "0x8559bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4497,11 +4497,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2946 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x8554e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x855eb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2947 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x855540", Frameless: false}]
+              InjectionPoints: [{PC: "0x855f10", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4518,11 +4518,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2940 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x8552e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x855cb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2941 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x855330", Frameless: false}]
+              InjectionPoints: [{PC: "0x855d00", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4539,11 +4539,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2952 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x855678", Frameless: false}]
+              InjectionPoints: [{PC: "0x856048", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2953 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x8556bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x85608c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4563,7 +4563,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2925 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x854cf8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8556c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4584,11 +4584,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2950 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x855608", Frameless: false}]
+              InjectionPoints: [{PC: "0x855fd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2951 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x855648", Frameless: false}]
+              InjectionPoints: [{PC: "0x856018", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4605,11 +4605,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2926 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x854ed8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8558a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2927 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x854f30", Frameless: false}]
+              InjectionPoints: [{PC: "0x855900", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4626,11 +4626,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2948 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x85557c", Frameless: false}]
+              InjectionPoints: [{PC: "0x855f4c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2949 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x8555d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x855fa0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4647,11 +4647,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2944 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x855410", Frameless: false}]
+              InjectionPoints: [{PC: "0x855de0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2945 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x8554b4", Frameless: false}]
+              InjectionPoints: [{PC: "0x855e84", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4704,11 +4704,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2907 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8549b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x855388", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2908 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x854a44", Frameless: false}]
+              InjectionPoints: [{PC: "0x855414", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4754,7 +4754,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2774 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x84d430", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d510", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4776,7 +4776,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2772 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x84d410", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d4f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4798,7 +4798,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2785 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x84d4e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4816,7 +4816,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2786 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x84d4f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d5d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4834,7 +4834,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2775 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x84d440", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4856,7 +4856,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2777 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x84d460", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4879,7 +4879,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2778 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x84d470", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d550", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4901,7 +4901,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2779 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x84d480", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4930,7 +4930,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2776 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x84d450", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d530", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4961,7 +4961,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2773 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x84d420", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4983,7 +4983,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2991 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x856e60", Frameless: true}]
+              InjectionPoints: [{PC: "0x857a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5005,7 +5005,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2780 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x84d490", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d570", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5027,7 +5027,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2782 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x84d4b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5049,7 +5049,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2783 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x84d4c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5071,7 +5071,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2784 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x84d4d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d5b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5093,7 +5093,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2781 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x84d4a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5115,7 +5115,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2985 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x8567f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8571c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5137,7 +5137,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2976 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x856770", Frameless: true}]
+              InjectionPoints: [{PC: "0x857140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5159,7 +5159,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2835 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x852170", Frameless: true}]
+              InjectionPoints: [{PC: "0x852790", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -5180,11 +5180,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2921 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x854a88", Frameless: false}]
+              InjectionPoints: [{PC: "0x855458", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2922 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x854b10", Frameless: false}]
+              InjectionPoints: [{PC: "0x8554e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5205,11 +5205,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2966 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x856008", Frameless: false}]
+              InjectionPoints: [{PC: "0x8569d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2967 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x85606c", Frameless: false}]
+              InjectionPoints: [{PC: "0x856a3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5253,7 +5253,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2868 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x853e30", Frameless: true}]
+              InjectionPoints: [{PC: "0x854710", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5275,7 +5275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2980 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x8567b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5297,7 +5297,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2797 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x84db30", Frameless: true}]
+              InjectionPoints: [{PC: "0x84dcf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5319,7 +5319,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2798 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x84db40", Frameless: true}]
+              InjectionPoints: [{PC: "0x84dd00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5341,11 +5341,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3013 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x8571b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857e80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3014 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x8571cc", Frameless: true}]
+              InjectionPoints: [{PC: "0x857e9c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5372,7 +5372,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2977 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x856780", Frameless: true}]
+              InjectionPoints: [{PC: "0x857150", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5399,7 +5399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2829 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x851a50", Frameless: true}]
+              InjectionPoints: [{PC: "0x851fd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5420,11 +5420,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2970 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x85618c", Frameless: false}]
+              InjectionPoints: [{PC: "0x856b5c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2971 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x85621c", Frameless: false}]
+              InjectionPoints: [{PC: "0x856bec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5446,11 +5446,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3009 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x8570c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857d90", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3010 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x8570d8", Frameless: true}]
+              InjectionPoints: [{PC: "0x857da8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5471,7 +5471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3008 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x8570b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857d80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5498,7 +5498,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2830 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x852120", Frameless: true}]
+              InjectionPoints: [{PC: "0x852740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5531,7 +5531,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2986 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x856800", Frameless: true}]
+              InjectionPoints: [{PC: "0x8571d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5571,7 +5571,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3004 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x856ef0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857ad0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2802 EventRootType Probe[main.testTakeContext]
-              InjectionPoints: [{PC: "0x84e0d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x84e370", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
       version: 0
@@ -5619,11 +5619,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2909 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8549b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x855388", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2910 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x854a44", Frameless: false}]
+              InjectionPoints: [{PC: "0x855414", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5644,11 +5644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2911 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8549b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x855388", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2912 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x854a44", Frameless: false}]
+              InjectionPoints: [{PC: "0x855414", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5671,11 +5671,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2913 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x8549b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x855388", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2914 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x854a44", Frameless: false}]
+              InjectionPoints: [{PC: "0x855414", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5707,7 +5707,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2992 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x856e70", Frameless: true}]
+              InjectionPoints: [{PC: "0x857a50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5739,11 +5739,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2993 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x856e80", Frameless: true}]
+              InjectionPoints: [{PC: "0x857a60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2994 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x856e98", Frameless: true}]
+              InjectionPoints: [{PC: "0x857a78", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5773,11 +5773,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2995 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x856e80", Frameless: true}]
+              InjectionPoints: [{PC: "0x857a60", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2996 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x856e98", Frameless: true}]
+              InjectionPoints: [{PC: "0x857a78", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5809,7 +5809,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2997 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x856ea0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5839,7 +5839,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2998 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x856ea0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857a80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5871,7 +5871,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3023 EventRootType Probe[main.testTimeFixedZone]
-              InjectionPoints: [{PC: "0x857de0", Frameless: true}]
+              InjectionPoints: [{PC: "0x858b90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5893,7 +5893,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3024 EventRootType Probe[main.testTimeMonotonic]
-              InjectionPoints: [{PC: "0x857df0", Frameless: true}]
+              InjectionPoints: [{PC: "0x858ba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -5915,7 +5915,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3022 EventRootType Probe[main.testTimeUTC]
-              InjectionPoints: [{PC: "0x857dd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x858b80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5937,7 +5937,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2787 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x84d500", Frameless: true}]
+              InjectionPoints: [{PC: "0x84d5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6069,7 +6069,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2867 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x853dc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8546a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6091,7 +6091,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2974 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x856750", Frameless: true}]
+              InjectionPoints: [{PC: "0x857120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -6113,7 +6113,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3002 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x856ed0", Frameless: true}]
+              InjectionPoints: [{PC: "0x857ab0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6135,7 +6135,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2866 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x853da0", Frameless: true}]
+              InjectionPoints: [{PC: "0x854680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6179,7 +6179,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2983 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x8567e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8571b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6201,7 +6201,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2984 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x8567e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8571b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6224,14 +6224,14 @@ Probes:
             - Kind: Entry
               Type: 3089 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x851888"
+                - PC: "0x851e08"
                   Frameless: false
-                - PC: "0x85999c"
+                - PC: "0x85a83c"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 3090 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x8518c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x851e40", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -6253,11 +6253,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2972 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x856258", Frameless: false}]
+              InjectionPoints: [{PC: "0x856c28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2973 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8562c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x856c90", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -6554,13 +6554,13 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x84d410..0x84d420]
+      OutOfLinePCRanges: [0x84d4f0..0x84d500]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x84d410..0x84d420
+            - Range: 0x84d4f0..0x84d500
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6568,13 +6568,13 @@ Subprograms:
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x84d420..0x84d430]
+      OutOfLinePCRanges: [0x84d500..0x84d510]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x84d420..0x84d430
+            - Range: 0x84d500..0x84d510
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6582,13 +6582,13 @@ Subprograms:
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x84d430..0x84d440]
+      OutOfLinePCRanges: [0x84d510..0x84d520]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x84d430..0x84d440
+            - Range: 0x84d510..0x84d520
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6596,13 +6596,13 @@ Subprograms:
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x84d440..0x84d450]
+      OutOfLinePCRanges: [0x84d520..0x84d530]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x84d440..0x84d450
+            - Range: 0x84d520..0x84d530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6610,13 +6610,13 @@ Subprograms:
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x84d450..0x84d460]
+      OutOfLinePCRanges: [0x84d530..0x84d540]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType int8
           Locations:
-            - Range: 0x84d450..0x84d460
+            - Range: 0x84d530..0x84d540
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6624,13 +6624,13 @@ Subprograms:
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x84d460..0x84d470]
+      OutOfLinePCRanges: [0x84d540..0x84d550]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 97 BaseType int16
           Locations:
-            - Range: 0x84d460..0x84d470
+            - Range: 0x84d540..0x84d550
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6638,13 +6638,13 @@ Subprograms:
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x84d470..0x84d480]
+      OutOfLinePCRanges: [0x84d550..0x84d560]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x84d470..0x84d480
+            - Range: 0x84d550..0x84d560
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6652,13 +6652,13 @@ Subprograms:
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x84d480..0x84d490]
+      OutOfLinePCRanges: [0x84d560..0x84d570]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int64
           Locations:
-            - Range: 0x84d480..0x84d490
+            - Range: 0x84d560..0x84d570
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6666,13 +6666,13 @@ Subprograms:
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x84d490..0x84d4a0]
+      OutOfLinePCRanges: [0x84d570..0x84d580]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x84d490..0x84d4a0
+            - Range: 0x84d570..0x84d580
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6680,13 +6680,13 @@ Subprograms:
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x84d4a0..0x84d4b0]
+      OutOfLinePCRanges: [0x84d580..0x84d590]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x84d4a0..0x84d4b0
+            - Range: 0x84d580..0x84d590
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6694,13 +6694,13 @@ Subprograms:
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x84d4b0..0x84d4c0]
+      OutOfLinePCRanges: [0x84d590..0x84d5a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0x84d4b0..0x84d4c0
+            - Range: 0x84d590..0x84d5a0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6708,13 +6708,13 @@ Subprograms:
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x84d4c0..0x84d4d0]
+      OutOfLinePCRanges: [0x84d5a0..0x84d5b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint32
           Locations:
-            - Range: 0x84d4c0..0x84d4d0
+            - Range: 0x84d5a0..0x84d5b0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6722,13 +6722,13 @@ Subprograms:
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x84d4d0..0x84d4e0]
+      OutOfLinePCRanges: [0x84d5b0..0x84d5c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x84d4d0..0x84d4e0
+            - Range: 0x84d5b0..0x84d5c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6736,13 +6736,13 @@ Subprograms:
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x84d4e0..0x84d4f0]
+      OutOfLinePCRanges: [0x84d5c0..0x84d5d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 BaseType float32
           Locations:
-            - Range: 0x84d4e0..0x84d4f0
+            - Range: 0x84d5c0..0x84d5d0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6750,13 +6750,13 @@ Subprograms:
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x84d4f0..0x84d500]
+      OutOfLinePCRanges: [0x84d5d0..0x84d5e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 20 BaseType float64
           Locations:
-            - Range: 0x84d4f0..0x84d500
+            - Range: 0x84d5d0..0x84d5e0
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6764,13 +6764,13 @@ Subprograms:
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x84d500..0x84d510]
+      OutOfLinePCRanges: [0x84d5e0..0x84d5f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 128 BaseType main.typeAlias
           Locations:
-            - Range: 0x84d500..0x84d510
+            - Range: 0x84d5e0..0x84d5f0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6778,13 +6778,13 @@ Subprograms:
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x84d610..0x84d630]
+      OutOfLinePCRanges: [0x84d7d0..0x84d7f0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 129 StructureType main.bigStruct
           Locations:
-            - Range: 0x84d610..0x84d630
+            - Range: 0x84d7d0..0x84d7f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6804,51 +6804,51 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x84d650..0x84d770]
+      OutOfLinePCRanges: [0x84d810..0x84d930]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x84d650..0x84d670
+            - Range: 0x84d810..0x84d830
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x84d650..0x84d770, Pieces: []}]
+          Locations: [{Range: 0x84d810..0x84d930, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: x
           Type: 9 BaseType int
-          Locations: [{Range: 0x84d650..0x84d770, Pieces: []}]
+          Locations: [{Range: 0x84d810..0x84d930, Pieces: []}]
           Role: Local
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: err
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x84d688..0x84d6a8
+            - Range: 0x84d848..0x84d868
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x84d6a8..0x84d6c4
+            - Range: 0x84d868..0x84d884
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84d6c4..0x84d6d8
+            - Range: 0x84d884..0x84d898
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: -64}
-            - Range: 0x84d6d8..0x84d770
+            - Range: 0x84d898..0x84d930
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
@@ -6860,13 +6860,13 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x84d800..0x84d810]
+      OutOfLinePCRanges: [0x84d9c0..0x84d9d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 133 StructureType main.deepPtr1
           Locations:
-            - Range: 0x84d800..0x84d810
+            - Range: 0x84d9c0..0x84d9d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6874,13 +6874,13 @@ Subprograms:
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x84d810..0x84d820]
+      OutOfLinePCRanges: [0x84d9d0..0x84d9e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 136 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x84d810..0x84d820
+            - Range: 0x84d9d0..0x84d9e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6888,13 +6888,13 @@ Subprograms:
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x84d9b0..0x84d9c0]
+      OutOfLinePCRanges: [0x84db70..0x84db80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 138 StructureType main.deepSlice1
           Locations:
-            - Range: 0x84d9b0..0x84d9c0
+            - Range: 0x84db70..0x84db80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6908,13 +6908,13 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x84d9c0..0x84d9d0]
+      OutOfLinePCRanges: [0x84db80..0x84db90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 142 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x84d9c0..0x84d9d0
+            - Range: 0x84db80..0x84db90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6922,13 +6922,13 @@ Subprograms:
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x84db10..0x84db20]
+      OutOfLinePCRanges: [0x84dcd0..0x84dce0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 144 StructureType main.deepMap1
           Locations:
-            - Range: 0x84db10..0x84db20
+            - Range: 0x84dcd0..0x84dce0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6936,13 +6936,13 @@ Subprograms:
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x84db20..0x84db30]
+      OutOfLinePCRanges: [0x84dce0..0x84dcf0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 150 PointerType *main.deepMap7
           Locations:
-            - Range: 0x84db20..0x84db30
+            - Range: 0x84dce0..0x84dcf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6950,13 +6950,13 @@ Subprograms:
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x84db30..0x84db40]
+      OutOfLinePCRanges: [0x84dcf0..0x84dd00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 152 PointerType *main.stringType1
           Locations:
-            - Range: 0x84db30..0x84db40
+            - Range: 0x84dcf0..0x84dd00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6964,13 +6964,13 @@ Subprograms:
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x84db40..0x84db50]
+      OutOfLinePCRanges: [0x84dd00..0x84dd10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 154 PointerType **main.stringType2
           Locations:
-            - Range: 0x84db40..0x84db50
+            - Range: 0x84dd00..0x84dd10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6978,15 +6978,15 @@ Subprograms:
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x84db50..0x84dd50]
+      OutOfLinePCRanges: [0x84dd10..0x84df10]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x84dc14..0x84dc24
+            - Range: 0x84ddd4..0x84dde4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84dcc0..0x84dcd0
+            - Range: 0x84de80..0x84de90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -6994,15 +6994,15 @@ Subprograms:
         - Name: aPerArch
           Type: 9 BaseType int
           Locations:
-            - Range: 0x84dbfc..0x84dc00
+            - Range: 0x84ddbc..0x84ddc0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84dc00..0x84dc24
+            - Range: 0x84ddc0..0x84dde4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84dc24..0x84dcb4
+            - Range: 0x84dde4..0x84de74
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x84dcb4..0x84dcbc
+            - Range: 0x84de74..0x84de7c
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x84dcbc..0x84dd50
+            - Range: 0x84de7c..0x84df10
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
           DictIndex: -1
@@ -7010,21 +7010,21 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x84dbf8..0x84dc00
+            - Range: 0x84ddb8..0x84ddc0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84dc00..0x84dc00
+            - Range: 0x84ddc0..0x84ddc0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x84dc00..0x84dc24
+            - Range: 0x84ddc0..0x84dde4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84dc24..0x84dcb4
+            - Range: 0x84dde4..0x84de74
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x84dcb4..0x84dcb8
+            - Range: 0x84de74..0x84de78
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x84dcb8..0x84dcbc
+            - Range: 0x84de78..0x84de7c
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x84dcbc..0x84dcd0
+            - Range: 0x84de7c..0x84de90
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x84dcd0..0x84dd50
+            - Range: 0x84de90..0x84df10
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
@@ -7032,13 +7032,13 @@ Subprograms:
       DictRegister: null
     - ID: 48
       Name: main.testTakeContext
-      OutOfLinePCRanges: [0x84e0d0..0x84e0e0]
+      OutOfLinePCRanges: [0x84e370..0x84e380]
       InlinePCRanges: []
       Variables:
         - Name: ctx
           Type: 156 GoInterfaceType context.Context
           Locations:
-            - Range: 0x84e0d0..0x84e0e0
+            - Range: 0x84e370..0x84e380
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7050,13 +7050,13 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testCaptureContextImpl
-      OutOfLinePCRanges: [0x84e2a0..0x84e2b0]
+      OutOfLinePCRanges: [0x84e540..0x84e550]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 157 PointerType *main.contextImpl
           Locations:
-            - Range: 0x84e2a0..0x84e2b0
+            - Range: 0x84e540..0x84e550
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7064,13 +7064,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0x84e550..0x84e560]
+      OutOfLinePCRanges: [0x84e7f0..0x84e800]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 159 StructureType main.manyPointers
           Locations:
-            - Range: 0x84e550..0x84e560
+            - Range: 0x84e7f0..0x84e800
               Pieces: [{Size: 560, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7078,13 +7078,13 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0x84fec0..0x84fed0]
+      OutOfLinePCRanges: [0x850260..0x850270]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 162 GoSliceHeaderType []string
           Locations:
-            - Range: 0x84fec0..0x84fed0
+            - Range: 0x850260..0x850270
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7098,13 +7098,13 @@ Subprograms:
       DictRegister: null
     - ID: 52
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x850160..0x850230]
+      OutOfLinePCRanges: [0x8505f0..0x8506c0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 163 StructureType main.esotericStack
           Locations:
-            - Range: 0x850160..0x8501a8
+            - Range: 0x8505f0..0x850638
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -7124,7 +7124,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x8501a8..0x8501ac
+            - Range: 0x850638..0x85063c
               Pieces:
                 - Size: 4
                   Op: null
@@ -7144,7 +7144,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x8501ac..0x8501b0
+            - Range: 0x85063c..0x850640
               Pieces:
                 - Size: 4
                   Op: null
@@ -7170,13 +7170,13 @@ Subprograms:
       DictRegister: null
     - ID: 53
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x850230..0x8502b0]
+      OutOfLinePCRanges: [0x8506c0..0x850740]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 166 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x850230..0x850268
+            - Range: 0x8506c0..0x8506f8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7184,13 +7184,13 @@ Subprograms:
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x8513c0..0x851450]
+      OutOfLinePCRanges: [0x851850..0x8518e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8513c0..0x8513f8
+            - Range: 0x851850..0x851888
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7198,13 +7198,13 @@ Subprograms:
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x851450..0x851510]
+      OutOfLinePCRanges: [0x8518e0..0x8519a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x851450..0x85146c
+            - Range: 0x8518e0..0x8518fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7212,7 +7212,7 @@ Subprograms:
         - Name: "y"
           Type: 9 BaseType int
           Locations:
-            - Range: 0x851450..0x85147c
+            - Range: 0x8518e0..0x85190c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7220,9 +7220,9 @@ Subprograms:
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0x85146c..0x85147c
+            - Range: 0x8518fc..0x85190c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85147c..0x851510
+            - Range: 0x85190c..0x8519a0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
@@ -7230,13 +7230,13 @@ Subprograms:
       DictRegister: null
     - ID: 56
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x851510..0x851590]
+      OutOfLinePCRanges: [0x8519a0..0x851a20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x851510..0x851534
+            - Range: 0x8519a0..0x8519c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7244,17 +7244,17 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x851590..0x8516b0]
+      OutOfLinePCRanges: [0x851a20..0x851b40]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8515f8..0x851600
+            - Range: 0x851a88..0x851a90
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x851600..0x851618
+            - Range: 0x851a90..0x851aa8
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x851618..0x85162c
+            - Range: 0x851aa8..0x851abc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7262,11 +7262,11 @@ Subprograms:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8515f4..0x8515fc
+            - Range: 0x851a84..0x851a8c
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x8515fc..0x851618
+            - Range: 0x851a8c..0x851aa8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x851618..0x851628
+            - Range: 0x851aa8..0x851ab8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7274,13 +7274,13 @@ Subprograms:
       DictRegister: null
     - ID: 58
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x8516b0..0x8516c0]
+      OutOfLinePCRanges: [0x851b40..0x851b50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8516b0..0x8516b8
+            - Range: 0x851b40..0x851b48
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7288,11 +7288,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8516b0..0x8516b8
+            - Range: 0x851b40..0x851b48
               Pieces: []
-            - Range: 0x8516b8..0x8516b9
+            - Range: 0x851b48..0x851b49
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8516b9..0x8516c0
+            - Range: 0x851b49..0x851b50
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7300,13 +7300,13 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x8516c0..0x851720]
+      OutOfLinePCRanges: [0x851b50..0x851bb0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 168 ArrayType [5]int
           Locations:
-            - Range: 0x8516c0..0x851720
+            - Range: 0x851b50..0x851bb0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7314,11 +7314,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8516c0..0x851708
+            - Range: 0x851b50..0x851b98
               Pieces: []
-            - Range: 0x851708..0x851709
+            - Range: 0x851b98..0x851b99
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851709..0x851720
+            - Range: 0x851b99..0x851bb0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7326,13 +7326,13 @@ Subprograms:
       DictRegister: null
     - ID: 60
       Name: main.testInterface
-      OutOfLinePCRanges: [0x851950..0x851960]
+      OutOfLinePCRanges: [0x851ed0..0x851ee0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 169 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x851950..0x851960
+            - Range: 0x851ed0..0x851ee0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7344,19 +7344,19 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testAny
-      OutOfLinePCRanges: [0x851960..0x8519d0]
+      OutOfLinePCRanges: [0x851ee0..0x851f50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x851960..0x851990
+            - Range: 0x851ee0..0x851f10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851990..0x851994
+            - Range: 0x851f10..0x851f14
               Pieces:
                 - Size: 8
                   Op: null
@@ -7368,15 +7368,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x851960..0x8519a4
+            - Range: 0x851ee0..0x851f24
               Pieces: []
-            - Range: 0x8519a4..0x8519a5
+            - Range: 0x851f24..0x851f25
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8519a5..0x8519d0
+            - Range: 0x851f25..0x851f50
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7384,13 +7384,13 @@ Subprograms:
       DictRegister: null
     - ID: 62
       Name: main.testError
-      OutOfLinePCRanges: [0x8519d0..0x8519e0]
+      OutOfLinePCRanges: [0x851f50..0x851f60]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x8519d0..0x8519e0
+            - Range: 0x851f50..0x851f60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7402,13 +7402,13 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x8519e0..0x851a50]
+      OutOfLinePCRanges: [0x851f60..0x851fd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 170 PointerType *interface {}
           Locations:
-            - Range: 0x8519e0..0x851a10
+            - Range: 0x851f60..0x851f90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7416,15 +7416,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8519e0..0x851a24
+            - Range: 0x851f60..0x851fa4
               Pieces: []
-            - Range: 0x851a24..0x851a25
+            - Range: 0x851fa4..0x851fa5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851a25..0x851a50
+            - Range: 0x851fa5..0x851fd0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7432,13 +7432,13 @@ Subprograms:
       DictRegister: null
     - ID: 64
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x851a50..0x851a60]
+      OutOfLinePCRanges: [0x851fd0..0x851fe0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 171 StructureType main.structWithAny
           Locations:
-            - Range: 0x851a50..0x851a60
+            - Range: 0x851fd0..0x851fe0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7450,13 +7450,13 @@ Subprograms:
       DictRegister: null
     - ID: 65
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x852120..0x852130]
+      OutOfLinePCRanges: [0x852740..0x852750]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 172 StructureType main.structWithMap
           Locations:
-            - Range: 0x852120..0x852130
+            - Range: 0x852740..0x852750
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7464,13 +7464,13 @@ Subprograms:
       DictRegister: null
     - ID: 66
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x852130..0x852140]
+      OutOfLinePCRanges: [0x852750..0x852760]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 178 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x852130..0x852140
+            - Range: 0x852750..0x852760
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7478,13 +7478,13 @@ Subprograms:
       DictRegister: null
     - ID: 67
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x852140..0x852150]
+      OutOfLinePCRanges: [0x852760..0x852770]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 183 GoMapType map[string]int
           Locations:
-            - Range: 0x852140..0x852150
+            - Range: 0x852760..0x852770
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7492,13 +7492,13 @@ Subprograms:
       DictRegister: null
     - ID: 68
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x852150..0x852160]
+      OutOfLinePCRanges: [0x852770..0x852780]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 188 GoMapType map[string][]string
           Locations:
-            - Range: 0x852150..0x852160
+            - Range: 0x852770..0x852780
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7506,13 +7506,13 @@ Subprograms:
       DictRegister: null
     - ID: 69
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x852160..0x852170]
+      OutOfLinePCRanges: [0x852780..0x852790]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 193 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x852160..0x852170
+            - Range: 0x852780..0x852790
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7520,13 +7520,13 @@ Subprograms:
       DictRegister: null
     - ID: 70
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x852170..0x852180]
+      OutOfLinePCRanges: [0x852790..0x8527a0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 183 GoMapType map[string]int
           Locations:
-            - Range: 0x852170..0x852180
+            - Range: 0x852790..0x8527a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7534,13 +7534,13 @@ Subprograms:
       DictRegister: null
     - ID: 71
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x852180..0x852190]
+      OutOfLinePCRanges: [0x8527a0..0x8527b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 198 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x852180..0x852190
+            - Range: 0x8527a0..0x8527b0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7548,13 +7548,13 @@ Subprograms:
       DictRegister: null
     - ID: 72
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x852190..0x8521a0]
+      OutOfLinePCRanges: [0x8527b0..0x8527c0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 199 PointerType *map[string]int
           Locations:
-            - Range: 0x852190..0x8521a0
+            - Range: 0x8527b0..0x8527c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7562,13 +7562,13 @@ Subprograms:
       DictRegister: null
     - ID: 73
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x8521a0..0x8521b0]
+      OutOfLinePCRanges: [0x8527c0..0x8527d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 173 GoMapType map[int]int
           Locations:
-            - Range: 0x8521a0..0x8521b0
+            - Range: 0x8527c0..0x8527d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7576,13 +7576,13 @@ Subprograms:
       DictRegister: null
     - ID: 74
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x8521b0..0x8521c0]
+      OutOfLinePCRanges: [0x8527d0..0x8527e0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 200 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x8521b0..0x8521c0
+            - Range: 0x8527d0..0x8527e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7590,13 +7590,13 @@ Subprograms:
       DictRegister: null
     - ID: 75
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x8521c0..0x8521d0]
+      OutOfLinePCRanges: [0x8527e0..0x8527f0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 200 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x8521c0..0x8521d0
+            - Range: 0x8527e0..0x8527f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7604,13 +7604,13 @@ Subprograms:
       DictRegister: null
     - ID: 76
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x8521d0..0x8521e0]
+      OutOfLinePCRanges: [0x8527f0..0x852800]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 205 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x8521d0..0x8521e0
+            - Range: 0x8527f0..0x852800
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7618,13 +7618,13 @@ Subprograms:
       DictRegister: null
     - ID: 77
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x8521e0..0x8521f0]
+      OutOfLinePCRanges: [0x852800..0x852810]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 210 GoMapType map[int]uint8
           Locations:
-            - Range: 0x8521e0..0x8521f0
+            - Range: 0x852800..0x852810
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7632,13 +7632,13 @@ Subprograms:
       DictRegister: null
     - ID: 78
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x8521f0..0x852200]
+      OutOfLinePCRanges: [0x852810..0x852820]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 210 GoMapType map[int]uint8
           Locations:
-            - Range: 0x8521f0..0x852200
+            - Range: 0x852810..0x852820
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7646,13 +7646,13 @@ Subprograms:
       DictRegister: null
     - ID: 79
       Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x852200..0x852210]
+      OutOfLinePCRanges: [0x852820..0x852830]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 215 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x852200..0x852210
+            - Range: 0x852820..0x852830
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7660,13 +7660,13 @@ Subprograms:
       DictRegister: null
     - ID: 80
       Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x852210..0x852220]
+      OutOfLinePCRanges: [0x852830..0x852840]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 215 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x852210..0x852220
+            - Range: 0x852830..0x852840
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7674,13 +7674,13 @@ Subprograms:
       DictRegister: null
     - ID: 81
       Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x852220..0x852230]
+      OutOfLinePCRanges: [0x852840..0x852850]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 215 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x852220..0x852230
+            - Range: 0x852840..0x852850
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7688,13 +7688,13 @@ Subprograms:
       DictRegister: null
     - ID: 82
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x852230..0x852240]
+      OutOfLinePCRanges: [0x852850..0x852860]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 220 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x852230..0x852240
+            - Range: 0x852850..0x852860
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7702,13 +7702,13 @@ Subprograms:
       DictRegister: null
     - ID: 83
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x852240..0x852250]
+      OutOfLinePCRanges: [0x852860..0x852870]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 225 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x852240..0x852250
+            - Range: 0x852860..0x852870
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7716,13 +7716,13 @@ Subprograms:
       DictRegister: null
     - ID: 84
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x852250..0x852260]
+      OutOfLinePCRanges: [0x852870..0x852880]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 230 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x852250..0x852260
+            - Range: 0x852870..0x852880
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7730,13 +7730,13 @@ Subprograms:
       DictRegister: null
     - ID: 85
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x852260..0x852270]
+      OutOfLinePCRanges: [0x852880..0x852890]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 235 GoMapType map[struct {}]int
           Locations:
-            - Range: 0x852260..0x852270
+            - Range: 0x852880..0x852890
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7744,13 +7744,13 @@ Subprograms:
       DictRegister: null
     - ID: 86
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x852270..0x852280]
+      OutOfLinePCRanges: [0x852890..0x8528a0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 240 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x852270..0x852280
+            - Range: 0x852890..0x8528a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7758,13 +7758,13 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0x852280..0x852290]
+      OutOfLinePCRanges: [0x8528a0..0x8528b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 245 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0x852280..0x852290
+            - Range: 0x8528a0..0x8528b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7772,13 +7772,13 @@ Subprograms:
       DictRegister: null
     - ID: 88
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x8536a0..0x8536b0]
+      OutOfLinePCRanges: [0x853cc0..0x853cd0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x8536a0..0x8536b0
+            - Range: 0x853cc0..0x853cd0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7786,7 +7786,7 @@ Subprograms:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x8536a0..0x8536b0
+            - Range: 0x853cc0..0x853cd0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7794,7 +7794,7 @@ Subprograms:
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0x8536a0..0x8536b0
+            - Range: 0x853cc0..0x853cd0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7802,13 +7802,13 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x8536c0..0x8536d0]
+      OutOfLinePCRanges: [0x853ce0..0x853cf0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x8536c0..0x8536d0
+            - Range: 0x853ce0..0x853cf0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7816,7 +7816,7 @@ Subprograms:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8536c0..0x8536d0
+            - Range: 0x853ce0..0x853cf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7828,7 +7828,7 @@ Subprograms:
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0x8536c0..0x8536d0
+            - Range: 0x853ce0..0x853cf0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7836,13 +7836,13 @@ Subprograms:
       DictRegister: null
     - ID: 90
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x853780..0x853790]
+      OutOfLinePCRanges: [0x853da0..0x853db0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x853780..0x853790
+            - Range: 0x853da0..0x853db0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7850,7 +7850,7 @@ Subprograms:
         - Name: b
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x853780..0x853790
+            - Range: 0x853da0..0x853db0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7858,7 +7858,7 @@ Subprograms:
         - Name: c
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x853780..0x853790
+            - Range: 0x853da0..0x853db0
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7866,7 +7866,7 @@ Subprograms:
         - Name: d
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x853780..0x853790
+            - Range: 0x853da0..0x853db0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7874,7 +7874,7 @@ Subprograms:
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x853780..0x853790
+            - Range: 0x853da0..0x853db0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7886,13 +7886,13 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.(*Server).handleOrder
-      OutOfLinePCRanges: [0x853920..0x853ad0]
+      OutOfLinePCRanges: [0x854030..0x8541e0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 250 PointerType *main.Server
           Locations:
-            - Range: 0x853920..0x853968
+            - Range: 0x854030..0x854078
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7900,9 +7900,9 @@ Subprograms:
         - Name: req
           Type: 252 PointerType *main.Request
           Locations:
-            - Range: 0x853920..0x853964
+            - Range: 0x854030..0x854074
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x853964..0x853ad0
+            - Range: 0x854074..0x8541e0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -7910,23 +7910,23 @@ Subprograms:
         - Name: ~r0
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x853920..0x8539f4
+            - Range: 0x854030..0x854104
               Pieces: []
-            - Range: 0x8539f4..0x8539f5
+            - Range: 0x854104..0x854105
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8539f5..0x853aa8
+            - Range: 0x854105..0x8541b8
               Pieces: []
-            - Range: 0x853aa8..0x853aa9
+            - Range: 0x8541b8..0x8541b9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x853aa9..0x853ad0
+            - Range: 0x8541b9..0x8541e0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7934,13 +7934,13 @@ Subprograms:
       DictRegister: null
     - ID: 92
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x853b80..0x853bc0]
+      OutOfLinePCRanges: [0x854380..0x8543c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x853b80..0x853bbc
+            - Range: 0x854380..0x8543bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7948,11 +7948,11 @@ Subprograms:
         - Name: ~r0
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x853b80..0x853bbc
+            - Range: 0x854380..0x8543bc
               Pieces: []
-            - Range: 0x853bbc..0x853bbd
+            - Range: 0x8543bc..0x8543bd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853bbd..0x853bc0
+            - Range: 0x8543bd..0x8543c0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7960,13 +7960,13 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testChannel
-      OutOfLinePCRanges: [0x853bc0..0x853bd0]
+      OutOfLinePCRanges: [0x8543c0..0x8543d0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 254 GoChannelType chan bool
           Locations:
-            - Range: 0x853bc0..0x853bd0
+            - Range: 0x8543c0..0x8543d0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7974,13 +7974,13 @@ Subprograms:
       DictRegister: null
     - ID: 94
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x853d70..0x853d80]
+      OutOfLinePCRanges: [0x854650..0x854660]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 255 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x853d70..0x853d80
+            - Range: 0x854650..0x854660
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7988,13 +7988,13 @@ Subprograms:
       DictRegister: null
     - ID: 95
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x853d80..0x853d90]
+      OutOfLinePCRanges: [0x854660..0x854670]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 257 StructureType main.node
           Locations:
-            - Range: 0x853d80..0x853d90
+            - Range: 0x854660..0x854670
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8006,13 +8006,13 @@ Subprograms:
       DictRegister: null
     - ID: 96
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x853d90..0x853da0]
+      OutOfLinePCRanges: [0x854670..0x854680]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 258 PointerType *main.node
           Locations:
-            - Range: 0x853d90..0x853da0
+            - Range: 0x854670..0x854680
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8020,13 +8020,13 @@ Subprograms:
       DictRegister: null
     - ID: 97
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x853da0..0x853db0]
+      OutOfLinePCRanges: [0x854680..0x854690]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x853da0..0x853db0
+            - Range: 0x854680..0x854690
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8034,13 +8034,13 @@ Subprograms:
       DictRegister: null
     - ID: 98
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x853dc0..0x853dd0]
+      OutOfLinePCRanges: [0x8546a0..0x8546b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 PointerType *uint
           Locations:
-            - Range: 0x853dc0..0x853dd0
+            - Range: 0x8546a0..0x8546b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8048,13 +8048,13 @@ Subprograms:
       DictRegister: null
     - ID: 99
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x853e30..0x853e40]
+      OutOfLinePCRanges: [0x854710..0x854720]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 96 PointerType *string
           Locations:
-            - Range: 0x853e30..0x853e40
+            - Range: 0x854710..0x854720
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8062,13 +8062,13 @@ Subprograms:
       DictRegister: null
     - ID: 100
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x853e50..0x853e60]
+      OutOfLinePCRanges: [0x854730..0x854740]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 13 PointerType *bool
           Locations:
-            - Range: 0x853e50..0x853e60
+            - Range: 0x854730..0x854740
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8076,7 +8076,7 @@ Subprograms:
         - Name: a
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x853e50..0x853e60
+            - Range: 0x854730..0x854740
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8084,13 +8084,13 @@ Subprograms:
       DictRegister: null
     - ID: 101
       Name: main.testCycle
-      OutOfLinePCRanges: [0x853e70..0x853e80]
+      OutOfLinePCRanges: [0x854750..0x854760]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 259 PointerType *main.t
           Locations:
-            - Range: 0x853e70..0x853e80
+            - Range: 0x854750..0x854760
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8098,13 +8098,13 @@ Subprograms:
       DictRegister: null
     - ID: 102
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x8541b0..0x854230]
+      OutOfLinePCRanges: [0x854b80..0x854c00]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8541b0..0x8541cc
+            - Range: 0x854b80..0x854b9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8112,11 +8112,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8541b0..0x85420c
+            - Range: 0x854b80..0x854bdc
               Pieces: []
-            - Range: 0x85420c..0x85420d
+            - Range: 0x854bdc..0x854bdd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85420d..0x854230
+            - Range: 0x854bdd..0x854c00
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8124,9 +8124,9 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8541cc..0x8541d8
+            - Range: 0x854b9c..0x854ba8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8541d8..0x854230
+            - Range: 0x854ba8..0x854c00
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
@@ -8134,15 +8134,15 @@ Subprograms:
       DictRegister: null
     - ID: 103
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x854230..0x8542d0]
+      OutOfLinePCRanges: [0x854c00..0x854ca0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x854230..0x854254
+            - Range: 0x854c00..0x854c24
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854254..0x8542d0
+            - Range: 0x854c24..0x854ca0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8150,11 +8150,11 @@ Subprograms:
         - Name: ~r0
           Type: 102 PointerType *int
           Locations:
-            - Range: 0x854230..0x8542a8
+            - Range: 0x854c00..0x854c78
               Pieces: []
-            - Range: 0x8542a8..0x8542a9
+            - Range: 0x854c78..0x854c79
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8542a9..0x8542d0
+            - Range: 0x854c79..0x854ca0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8162,9 +8162,9 @@ Subprograms:
         - Name: '&result'
           Type: 102 PointerType *int
           Locations:
-            - Range: 0x854258..0x854270
+            - Range: 0x854c28..0x854c40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854270..0x8542d0
+            - Range: 0x854c40..0x854ca0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
@@ -8172,13 +8172,13 @@ Subprograms:
       DictRegister: null
     - ID: 104
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x8542d0..0x8543a0]
+      OutOfLinePCRanges: [0x854ca0..0x854d70]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8542d0..0x854328
+            - Range: 0x854ca0..0x854cf8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8186,27 +8186,27 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8542d0..0x854380
+            - Range: 0x854ca0..0x854d50
               Pieces: []
-            - Range: 0x854380..0x854381
+            - Range: 0x854d50..0x854d51
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854381..0x8543a0
+            - Range: 0x854d51..0x854d70
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 20 BaseType float64
-          Locations: [{Range: 0x8542d0..0x8543a0, Pieces: []}]
+          Locations: [{Range: 0x854ca0..0x854d70, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8542ec..0x85432c
+            - Range: 0x854cbc..0x854cfc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x85432c..0x8543a0
+            - Range: 0x854cfc..0x854d70
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
@@ -8214,9 +8214,9 @@ Subprograms:
         - Name: resultFloat
           Type: 20 BaseType float64
           Locations:
-            - Range: 0x8542fc..0x85432c
+            - Range: 0x854ccc..0x854cfc
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x85432c..0x8543a0
+            - Range: 0x854cfc..0x854d70
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
@@ -8224,13 +8224,13 @@ Subprograms:
       DictRegister: null
     - ID: 105
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x8543a0..0x854420]
+      OutOfLinePCRanges: [0x854d70..0x854df0]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x8543a0..0x8543c4
+            - Range: 0x854d70..0x854d94
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8238,23 +8238,23 @@ Subprograms:
         - Name: ~r0
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x8543a0..0x8543e8
+            - Range: 0x854d70..0x854db8
               Pieces: []
-            - Range: 0x8543e8..0x8543e9
+            - Range: 0x854db8..0x854db9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8543e9..0x8543fc
+            - Range: 0x854db9..0x854dcc
               Pieces: []
-            - Range: 0x8543fc..0x8543fd
+            - Range: 0x854dcc..0x854dcd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8543fd..0x854420
+            - Range: 0x854dcd..0x854df0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8262,37 +8262,37 @@ Subprograms:
       DictRegister: null
     - ID: 106
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x854420..0x8545a0]
+      OutOfLinePCRanges: [0x854df0..0x854f70]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x854420..0x854470
+            - Range: 0x854df0..0x854e40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854470..0x854474
+            - Range: 0x854e40..0x854e44
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x8544c4..0x8544c8
+            - Range: 0x854e94..0x854e98
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854504..0x854508
+            - Range: 0x854ed4..0x854ed8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854544..0x854548
+            - Range: 0x854f14..0x854f18
               Pieces:
                 - Size: 8
                   Op: null
@@ -8304,7 +8304,7 @@ Subprograms:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x854420..0x854464
+            - Range: 0x854df0..0x854e34
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8312,39 +8312,39 @@ Subprograms:
         - Name: ~r0
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x854420..0x85448c
+            - Range: 0x854df0..0x854e5c
               Pieces: []
-            - Range: 0x85448c..0x85448d
+            - Range: 0x854e5c..0x854e5d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85448d..0x8544f0
+            - Range: 0x854e5d..0x854ec0
               Pieces: []
-            - Range: 0x8544f0..0x8544f1
+            - Range: 0x854ec0..0x854ec1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8544f1..0x854530
+            - Range: 0x854ec1..0x854f00
               Pieces: []
-            - Range: 0x854530..0x854531
+            - Range: 0x854f00..0x854f01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854531..0x854570
+            - Range: 0x854f01..0x854f40
               Pieces: []
-            - Range: 0x854570..0x854571
+            - Range: 0x854f40..0x854f41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854571..0x8545a0
+            - Range: 0x854f41..0x854f70
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8352,39 +8352,39 @@ Subprograms:
         - Name: ~r1
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x854420..0x85448c
+            - Range: 0x854df0..0x854e5c
               Pieces: []
-            - Range: 0x85448c..0x85448d
+            - Range: 0x854e5c..0x854e5d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x85448d..0x8544f0
+            - Range: 0x854e5d..0x854ec0
               Pieces: []
-            - Range: 0x8544f0..0x8544f1
+            - Range: 0x854ec0..0x854ec1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8544f1..0x854530
+            - Range: 0x854ec1..0x854f00
               Pieces: []
-            - Range: 0x854530..0x854531
+            - Range: 0x854f00..0x854f01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x854531..0x854570
+            - Range: 0x854f01..0x854f40
               Pieces: []
-            - Range: 0x854570..0x854571
+            - Range: 0x854f40..0x854f41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x854571..0x8545a0
+            - Range: 0x854f41..0x854f70
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8392,7 +8392,7 @@ Subprograms:
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x854470..0x854478
+            - Range: 0x854e40..0x854e48
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8400,25 +8400,25 @@ Subprograms:
       DictRegister: null
     - ID: 107
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x8545a0..0x8547a0]
+      OutOfLinePCRanges: [0x854f70..0x855170]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8545a0..0x8545e8
+            - Range: 0x854f70..0x854fb8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8545e8..0x8545f0
+            - Range: 0x854fb8..0x854fc0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8545f0..0x8547a0
+            - Range: 0x854fc0..0x855170
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -8430,39 +8430,39 @@ Subprograms:
         - Name: ~r0
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8545a0..0x854654
+            - Range: 0x854f70..0x855024
               Pieces: []
-            - Range: 0x854654..0x854655
+            - Range: 0x855024..0x855025
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854655..0x85469c
+            - Range: 0x855025..0x85506c
               Pieces: []
-            - Range: 0x85469c..0x85469d
+            - Range: 0x85506c..0x85506d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85469d..0x854760
+            - Range: 0x85506d..0x855130
               Pieces: []
-            - Range: 0x854760..0x854761
+            - Range: 0x855130..0x855131
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854761..0x854774
+            - Range: 0x855131..0x855144
               Pieces: []
-            - Range: 0x854774..0x854775
+            - Range: 0x855144..0x855145
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854775..0x8547a0
+            - Range: 0x855145..0x855170
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8470,7 +8470,7 @@ Subprograms:
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x854688..0x854690
+            - Range: 0x855058..0x855060
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8478,7 +8478,7 @@ Subprograms:
         - Name: '&result'
           Type: 102 PointerType *int
           Locations:
-            - Range: 0x854638..0x854654
+            - Range: 0x855008..0x855024
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8486,35 +8486,35 @@ Subprograms:
       DictRegister: null
     - ID: 108
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x8547a0..0x854900]
+      OutOfLinePCRanges: [0x855170..0x8552d0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8547a0..0x8547dc
+            - Range: 0x855170..0x8551ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8547dc..0x854824
+            - Range: 0x8551ac..0x8551f4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x854824..0x8548a4
+            - Range: 0x8551f4..0x855274
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8548a4..0x8548cc
+            - Range: 0x855274..0x85529c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8548cc..0x8548d0
+            - Range: 0x85529c..0x8552a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8548d0..0x854900
+            - Range: 0x8552a0..0x8552d0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -8522,23 +8522,23 @@ Subprograms:
         - Name: ~r0
           Type: 169 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8547a0..0x854884
+            - Range: 0x855170..0x855254
               Pieces: []
-            - Range: 0x854884..0x854885
+            - Range: 0x855254..0x855255
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854885..0x854898
+            - Range: 0x855255..0x855268
               Pieces: []
-            - Range: 0x854898..0x854899
+            - Range: 0x855268..0x855269
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854899..0x854900
+            - Range: 0x855269..0x8552d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8546,39 +8546,39 @@ Subprograms:
         - Name: b
           Type: 169 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8547a0..0x8547dc
+            - Range: 0x855170..0x8551ac
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8547dc..0x854824
+            - Range: 0x8551ac..0x8551f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x854824..0x85482c
+            - Range: 0x8551f4..0x8551fc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x85482c..0x854890
+            - Range: 0x8551fc..0x855260
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x854890..0x854894
+            - Range: 0x855260..0x855264
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x854894..0x854898
+            - Range: 0x855264..0x855268
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x854898..0x854900
+            - Range: 0x855268..0x8552d0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
@@ -8586,13 +8586,13 @@ Subprograms:
       DictRegister: null
     - ID: 109
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x854900..0x8549a0]
+      OutOfLinePCRanges: [0x8552d0..0x855370]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x854900..0x85491c
+            - Range: 0x8552d0..0x8552ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8600,11 +8600,11 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x854900..0x854978
+            - Range: 0x8552d0..0x855348
               Pieces: []
-            - Range: 0x854978..0x854979
+            - Range: 0x855348..0x855349
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854979..0x8549a0
+            - Range: 0x855349..0x855370
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8612,13 +8612,13 @@ Subprograms:
       DictRegister: null
     - ID: 110
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x8549a0..0x854a70]
+      OutOfLinePCRanges: [0x855370..0x855440]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8549a0..0x8549f0
+            - Range: 0x855370..0x8553c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8626,11 +8626,11 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8549a0..0x854a44
+            - Range: 0x855370..0x855414
               Pieces: []
-            - Range: 0x854a44..0x854a45
+            - Range: 0x855414..0x855415
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854a45..0x854a70
+            - Range: 0x855415..0x855440
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8638,11 +8638,11 @@ Subprograms:
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8549a0..0x854a44
+            - Range: 0x855370..0x855414
               Pieces: []
-            - Range: 0x854a44..0x854a45
+            - Range: 0x855414..0x855415
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x854a45..0x854a70
+            - Range: 0x855415..0x855440
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8650,15 +8650,15 @@ Subprograms:
       DictRegister: null
     - ID: 111
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x854a70..0x854b30]
+      OutOfLinePCRanges: [0x855440..0x855500]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x854a70..0x854ab0
+            - Range: 0x855440..0x855480
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854ab0..0x854b30
+            - Range: 0x855480..0x855500
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8666,11 +8666,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x854a70..0x854b10
+            - Range: 0x855440..0x8554e0
               Pieces: []
-            - Range: 0x854b10..0x854b11
+            - Range: 0x8554e0..0x8554e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854b11..0x854b30
+            - Range: 0x8554e1..0x855500
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8678,11 +8678,11 @@ Subprograms:
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x854a70..0x854b10
+            - Range: 0x855440..0x8554e0
               Pieces: []
-            - Range: 0x854b10..0x854b11
+            - Range: 0x8554e0..0x8554e1
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x854b11..0x854b30
+            - Range: 0x8554e1..0x855500
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8690,11 +8690,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x854a70..0x854b10
+            - Range: 0x855440..0x8554e0
               Pieces: []
-            - Range: 0x854b10..0x854b11
+            - Range: 0x8554e0..0x8554e1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x854b11..0x854b30
+            - Range: 0x8554e1..0x855500
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8702,15 +8702,15 @@ Subprograms:
       DictRegister: null
     - ID: 112
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x854b30..0x854c20]
+      OutOfLinePCRanges: [0x855500..0x8555f0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x854b30..0x854b70
+            - Range: 0x855500..0x855540
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854b70..0x854c20
+            - Range: 0x855540..0x8555f0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8718,11 +8718,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x854b30..0x854bf4
+            - Range: 0x855500..0x8555c4
               Pieces: []
-            - Range: 0x854bf4..0x854bf5
+            - Range: 0x8555c4..0x8555c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854bf5..0x854c20
+            - Range: 0x8555c5..0x8555f0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8730,15 +8730,15 @@ Subprograms:
         - Name: r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x854b30..0x854bf4
+            - Range: 0x855500..0x8555c4
               Pieces: []
-            - Range: 0x854bf4..0x854bf5
+            - Range: 0x8555c4..0x8555c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x854bf5..0x854c20
+            - Range: 0x8555c5..0x8555f0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8746,15 +8746,15 @@ Subprograms:
       DictRegister: null
     - ID: 113
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x854c20..0x854de0]
+      OutOfLinePCRanges: [0x8555f0..0x8557b0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x854c20..0x854c84
+            - Range: 0x8555f0..0x855654
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854c84..0x854de0
+            - Range: 0x855654..0x8557b0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8762,7 +8762,7 @@ Subprograms:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x854c4c..0x854de0
+            - Range: 0x85561c..0x8557b0
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
@@ -8770,7 +8770,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x854c50..0x854de0
+            - Range: 0x855620..0x8557b0
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
@@ -8778,17 +8778,17 @@ Subprograms:
       DictRegister: null
     - ID: 114
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x854ec0..0x854f50]
+      OutOfLinePCRanges: [0x855890..0x855920]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType int8
           Locations:
-            - Range: 0x854ec0..0x854f30
+            - Range: 0x855890..0x855900
               Pieces: []
-            - Range: 0x854f30..0x854f31
+            - Range: 0x855900..0x855901
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854f31..0x854f50
+            - Range: 0x855901..0x855920
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8796,11 +8796,11 @@ Subprograms:
         - Name: ~r1
           Type: 97 BaseType int16
           Locations:
-            - Range: 0x854ec0..0x854f30
+            - Range: 0x855890..0x855900
               Pieces: []
-            - Range: 0x854f30..0x854f31
+            - Range: 0x855900..0x855901
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x854f31..0x854f50
+            - Range: 0x855901..0x855920
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8808,11 +8808,11 @@ Subprograms:
         - Name: ~r2
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x854ec0..0x854f30
+            - Range: 0x855890..0x855900
               Pieces: []
-            - Range: 0x854f30..0x854f31
+            - Range: 0x855900..0x855901
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x854f31..0x854f50
+            - Range: 0x855901..0x855920
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8820,11 +8820,11 @@ Subprograms:
         - Name: ~r3
           Type: 15 BaseType int64
           Locations:
-            - Range: 0x854ec0..0x854f30
+            - Range: 0x855890..0x855900
               Pieces: []
-            - Range: 0x854f30..0x854f31
+            - Range: 0x855900..0x855901
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x854f31..0x854f50
+            - Range: 0x855901..0x855920
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8832,11 +8832,11 @@ Subprograms:
         - Name: ~r4
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x854ec0..0x854f30
+            - Range: 0x855890..0x855900
               Pieces: []
-            - Range: 0x854f30..0x854f31
+            - Range: 0x855900..0x855901
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x854f31..0x854f50
+            - Range: 0x855901..0x855920
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8844,11 +8844,11 @@ Subprograms:
         - Name: ~r5
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0x854ec0..0x854f30
+            - Range: 0x855890..0x855900
               Pieces: []
-            - Range: 0x854f30..0x854f31
+            - Range: 0x855900..0x855901
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x854f31..0x854f50
+            - Range: 0x855901..0x855920
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8856,11 +8856,11 @@ Subprograms:
         - Name: ~r6
           Type: 4 BaseType uint32
           Locations:
-            - Range: 0x854ec0..0x854f30
+            - Range: 0x855890..0x855900
               Pieces: []
-            - Range: 0x854f30..0x854f31
+            - Range: 0x855900..0x855901
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x854f31..0x854f50
+            - Range: 0x855901..0x855920
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8868,11 +8868,11 @@ Subprograms:
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x854ec0..0x854f30
+            - Range: 0x855890..0x855900
               Pieces: []
-            - Range: 0x854f30..0x854f31
+            - Range: 0x855900..0x855901
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x854f31..0x854f50
+            - Range: 0x855901..0x855920
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8880,113 +8880,113 @@ Subprograms:
       DictRegister: null
     - ID: 115
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x854f50..0x855010]
+      OutOfLinePCRanges: [0x855920..0x8559e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r5
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r6
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r7
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r8
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r9
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r10
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r11
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r12
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r13
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r14
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: onlyOnAmd64_16
           Type: 20 BaseType float64
-          Locations: [{Range: 0x854f50..0x855010, Pieces: []}]
+          Locations: [{Range: 0x855920..0x8559e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: bothArmAndAmd64
           Type: 20 BaseType float64
           Locations:
-            - Range: 0x854f50..0x854fec
+            - Range: 0x855920..0x8559bc
               Pieces: []
-            - Range: 0x854fec..0x854fed
+            - Range: 0x8559bc..0x8559bd
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x854fed..0x855010
+            - Range: 0x8559bd..0x8559e0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8994,33 +8994,33 @@ Subprograms:
       DictRegister: null
     - ID: 116
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x855010..0x855090]
+      OutOfLinePCRanges: [0x8559e0..0x855a60]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 98 BaseType complex64
-          Locations: [{Range: 0x855010..0x855090, Pieces: []}]
+          Locations: [{Range: 0x8559e0..0x855a60, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 99 BaseType complex128
-          Locations: [{Range: 0x855010..0x855090, Pieces: []}]
+          Locations: [{Range: 0x8559e0..0x855a60, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 117
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x855090..0x855160]
+      OutOfLinePCRanges: [0x855a60..0x855b30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x855090..0x855144
+            - Range: 0x855a60..0x855b14
               Pieces: []
-            - Range: 0x855144..0x855145
+            - Range: 0x855b14..0x855b15
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9042,7 +9042,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x855145..0x855160
+            - Range: 0x855b15..0x855b30
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9050,17 +9050,17 @@ Subprograms:
       DictRegister: null
     - ID: 118
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x855160..0x8551f0]
+      OutOfLinePCRanges: [0x855b30..0x855bc0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0x855160..0x8551d0
+            - Range: 0x855b30..0x855ba0
               Pieces: []
-            - Range: 0x8551d0..0x8551d1
+            - Range: 0x855ba0..0x855ba1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x8551d1..0x8551f0
+            - Range: 0x855ba1..0x855bc0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9068,17 +9068,17 @@ Subprograms:
       DictRegister: null
     - ID: 119
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x8551f0..0x855260]
+      OutOfLinePCRanges: [0x855bc0..0x855c30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 263 ArrayType [1]int
           Locations:
-            - Range: 0x8551f0..0x855244
+            - Range: 0x855bc0..0x855c14
               Pieces: []
-            - Range: 0x855244..0x855245
+            - Range: 0x855c14..0x855c15
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x855245..0x855260
+            - Range: 0x855c15..0x855c30
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9086,17 +9086,17 @@ Subprograms:
       DictRegister: null
     - ID: 120
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x855260..0x8552d0]
+      OutOfLinePCRanges: [0x855c30..0x855ca0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 264 ArrayType [0]int
           Locations:
-            - Range: 0x855260..0x8552b0
+            - Range: 0x855c30..0x855c80
               Pieces: []
-            - Range: 0x8552b0..0x8552b1
+            - Range: 0x855c80..0x855c81
               Pieces: []
-            - Range: 0x8552b1..0x8552d0
+            - Range: 0x855c81..0x855ca0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9104,29 +9104,29 @@ Subprograms:
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x8552d0..0x855350]
+      OutOfLinePCRanges: [0x855ca0..0x855d20]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 265 StructureType main.mixedStruct
-          Locations: [{Range: 0x8552d0..0x855350, Pieces: []}]
+          Locations: [{Range: 0x855ca0..0x855d20, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 122
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x855350..0x8553f0]
+      OutOfLinePCRanges: [0x855d20..0x855dc0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855350..0x8553cc
+            - Range: 0x855d20..0x855d9c
               Pieces: []
-            - Range: 0x8553cc..0x8553cd
+            - Range: 0x855d9c..0x855d9d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8553cd..0x8553f0
+            - Range: 0x855d9d..0x855dc0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9134,11 +9134,11 @@ Subprograms:
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855350..0x8553cc
+            - Range: 0x855d20..0x855d9c
               Pieces: []
-            - Range: 0x8553cc..0x8553cd
+            - Range: 0x855d9c..0x855d9d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8553cd..0x8553f0
+            - Range: 0x855d9d..0x855dc0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9146,11 +9146,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855350..0x8553cc
+            - Range: 0x855d20..0x855d9c
               Pieces: []
-            - Range: 0x8553cc..0x8553cd
+            - Range: 0x855d9c..0x855d9d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8553cd..0x8553f0
+            - Range: 0x855d9d..0x855dc0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9158,11 +9158,11 @@ Subprograms:
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855350..0x8553cc
+            - Range: 0x855d20..0x855d9c
               Pieces: []
-            - Range: 0x8553cc..0x8553cd
+            - Range: 0x855d9c..0x855d9d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8553cd..0x8553f0
+            - Range: 0x855d9d..0x855dc0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9170,11 +9170,11 @@ Subprograms:
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855350..0x8553cc
+            - Range: 0x855d20..0x855d9c
               Pieces: []
-            - Range: 0x8553cc..0x8553cd
+            - Range: 0x855d9c..0x855d9d
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8553cd..0x8553f0
+            - Range: 0x855d9d..0x855dc0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9182,11 +9182,11 @@ Subprograms:
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855350..0x8553cc
+            - Range: 0x855d20..0x855d9c
               Pieces: []
-            - Range: 0x8553cc..0x8553cd
+            - Range: 0x855d9c..0x855d9d
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8553cd..0x8553f0
+            - Range: 0x855d9d..0x855dc0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9194,11 +9194,11 @@ Subprograms:
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855350..0x8553cc
+            - Range: 0x855d20..0x855d9c
               Pieces: []
-            - Range: 0x8553cc..0x8553cd
+            - Range: 0x855d9c..0x855d9d
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8553cd..0x8553f0
+            - Range: 0x855d9d..0x855dc0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9206,11 +9206,11 @@ Subprograms:
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855350..0x8553cc
+            - Range: 0x855d20..0x855d9c
               Pieces: []
-            - Range: 0x8553cc..0x8553cd
+            - Range: 0x855d9c..0x855d9d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8553cd..0x8553f0
+            - Range: 0x855d9d..0x855dc0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9218,15 +9218,15 @@ Subprograms:
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x855350..0x8553cc
+            - Range: 0x855d20..0x855d9c
               Pieces: []
-            - Range: 0x8553cc..0x8553cd
+            - Range: 0x855d9c..0x855d9d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8553cd..0x8553f0
+            - Range: 0x855d9d..0x855dc0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9234,15 +9234,15 @@ Subprograms:
       DictRegister: null
     - ID: 123
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x8553f0..0x8554d0]
+      OutOfLinePCRanges: [0x855dc0..0x855ea0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 266 StructureType main.wideStruct
           Locations:
-            - Range: 0x8553f0..0x8554b4
+            - Range: 0x855dc0..0x855e84
               Pieces: []
-            - Range: 0x8554b4..0x8554b5
+            - Range: 0x855e84..0x855e85
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9266,7 +9266,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x8554b5..0x8554d0
+            - Range: 0x855e85..0x855ea0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9274,57 +9274,57 @@ Subprograms:
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x8554d0..0x855560]
+      OutOfLinePCRanges: [0x855ea0..0x855f30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8554d0..0x855540
+            - Range: 0x855ea0..0x855f10
               Pieces: []
-            - Range: 0x855540..0x855541
+            - Range: 0x855f10..0x855f11
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x855541..0x855560
+            - Range: 0x855f11..0x855f30
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 20 BaseType float64
-          Locations: [{Range: 0x8554d0..0x855560, Pieces: []}]
+          Locations: [{Range: 0x855ea0..0x855f30, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8554d0..0x855540
+            - Range: 0x855ea0..0x855f10
               Pieces: []
-            - Range: 0x855540..0x855541
+            - Range: 0x855f10..0x855f11
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x855541..0x855560
+            - Range: 0x855f11..0x855f30
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 20 BaseType float64
-          Locations: [{Range: 0x8554d0..0x855560, Pieces: []}]
+          Locations: [{Range: 0x855ea0..0x855f30, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8554d0..0x855540
+            - Range: 0x855ea0..0x855f10
               Pieces: []
-            - Range: 0x855540..0x855541
+            - Range: 0x855f10..0x855f11
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x855541..0x855560
+            - Range: 0x855f11..0x855f30
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9332,17 +9332,17 @@ Subprograms:
       DictRegister: null
     - ID: 125
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x855560..0x8555f0]
+      OutOfLinePCRanges: [0x855f30..0x855fc0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0x855560..0x8555d0
+            - Range: 0x855f30..0x855fa0
               Pieces: []
-            - Range: 0x8555d0..0x8555d1
+            - Range: 0x855fa0..0x855fa1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x8555d1..0x8555f0
+            - Range: 0x855fa1..0x855fc0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9350,47 +9350,47 @@ Subprograms:
       DictRegister: null
     - ID: 126
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x8555f0..0x855660]
+      OutOfLinePCRanges: [0x855fc0..0x856030]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 20 BaseType float64
-          Locations: [{Range: 0x8555f0..0x855660, Pieces: []}]
+          Locations: [{Range: 0x855fc0..0x856030, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 127
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x855660..0x8556e0]
+      OutOfLinePCRanges: [0x856030..0x8560b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float32
-          Locations: [{Range: 0x855660..0x8556e0, Pieces: []}]
+          Locations: [{Range: 0x856030..0x8560b0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 20 BaseType float64
-          Locations: [{Range: 0x855660..0x8556e0, Pieces: []}]
+          Locations: [{Range: 0x856030..0x8560b0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 128
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x8556e0..0x855750]
+      OutOfLinePCRanges: [0x8560b0..0x856120]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x8556e0..0x855738
+            - Range: 0x8560b0..0x856108
               Pieces: []
-            - Range: 0x855738..0x855739
+            - Range: 0x856108..0x856109
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x855739..0x855750
+            - Range: 0x856109..0x856120
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9398,11 +9398,11 @@ Subprograms:
         - Name: ~r1
           Type: 3 BaseType uintptr
           Locations:
-            - Range: 0x8556e0..0x855738
+            - Range: 0x8560b0..0x856108
               Pieces: []
-            - Range: 0x855738..0x855739
+            - Range: 0x856108..0x856109
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x855739..0x855750
+            - Range: 0x856109..0x856120
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9410,13 +9410,13 @@ Subprograms:
       DictRegister: null
     - ID: 129
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x855750..0x855910]
+      OutOfLinePCRanges: [0x856120..0x8562e0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x855750..0x8557bc
+            - Range: 0x856120..0x85618c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9438,7 +9438,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8557bc..0x8557d0
+            - Range: 0x85618c..0x8561a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9460,7 +9460,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8557d0..0x8557d4
+            - Range: 0x8561a0..0x8561a4
               Pieces:
                 - Size: 8
                   Op: null
@@ -9488,9 +9488,9 @@ Subprograms:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x855750..0x8558c8
+            - Range: 0x856120..0x856298
               Pieces: []
-            - Range: 0x8558c8..0x8558c9
+            - Range: 0x856298..0x856299
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9512,7 +9512,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8558c9..0x855910
+            - Range: 0x856299..0x8562e0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9520,13 +9520,13 @@ Subprograms:
       DictRegister: null
     - ID: 130
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x855910..0x8559e0]
+      OutOfLinePCRanges: [0x8562e0..0x8563b0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0x855910..0x8559e0
+            - Range: 0x8562e0..0x8563b0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9534,11 +9534,11 @@ Subprograms:
         - Name: ~r0
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0x855910..0x8559c4
+            - Range: 0x8562e0..0x856394
               Pieces: []
-            - Range: 0x8559c4..0x8559c5
+            - Range: 0x856394..0x856395
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x8559c5..0x8559e0
+            - Range: 0x856395..0x8563b0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9546,13 +9546,13 @@ Subprograms:
       DictRegister: null
     - ID: 131
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x8559e0..0x855c10]
+      OutOfLinePCRanges: [0x8563b0..0x8565e0]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x8559e0..0x855a50
+            - Range: 0x8563b0..0x856420
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9574,7 +9574,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x855a50..0x855a64
+            - Range: 0x856420..0x856434
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9596,7 +9596,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x855a64..0x855a68
+            - Range: 0x856434..0x856438
               Pieces:
                 - Size: 8
                   Op: null
@@ -9624,7 +9624,7 @@ Subprograms:
         - Name: s2
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x8559e0..0x855c10
+            - Range: 0x8563b0..0x8565e0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9632,9 +9632,9 @@ Subprograms:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x8559e0..0x855bd0
+            - Range: 0x8563b0..0x8565a0
               Pieces: []
-            - Range: 0x855bd0..0x855bd1
+            - Range: 0x8565a0..0x8565a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9656,7 +9656,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x855bd1..0x855c10
+            - Range: 0x8565a1..0x8565e0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9664,15 +9664,15 @@ Subprograms:
       DictRegister: null
     - ID: 132
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x855c10..0x855de0]
+      OutOfLinePCRanges: [0x8565e0..0x8567b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855c10..0x855c88
+            - Range: 0x8565e0..0x856658
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x855c88..0x855de0
+            - Range: 0x856658..0x8567b0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -9680,9 +9680,9 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855c10..0x855c74
+            - Range: 0x8565e0..0x856644
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x855c74..0x855de0
+            - Range: 0x856644..0x8567b0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
@@ -9690,9 +9690,9 @@ Subprograms:
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855c10..0x855c88
+            - Range: 0x8565e0..0x856658
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x855c88..0x855de0
+            - Range: 0x856658..0x8567b0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
@@ -9700,9 +9700,9 @@ Subprograms:
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855c10..0x855c88
+            - Range: 0x8565e0..0x856658
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x855c88..0x855de0
+            - Range: 0x856658..0x8567b0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
@@ -9710,9 +9710,9 @@ Subprograms:
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855c10..0x855c88
+            - Range: 0x8565e0..0x856658
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x855c88..0x855de0
+            - Range: 0x856658..0x8567b0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
@@ -9720,9 +9720,9 @@ Subprograms:
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855c10..0x855c88
+            - Range: 0x8565e0..0x856658
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x855c88..0x855de0
+            - Range: 0x856658..0x8567b0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
@@ -9730,9 +9730,9 @@ Subprograms:
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855c10..0x855c88
+            - Range: 0x8565e0..0x856658
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x855c88..0x855de0
+            - Range: 0x856658..0x8567b0
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
@@ -9740,9 +9740,9 @@ Subprograms:
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855c10..0x855c88
+            - Range: 0x8565e0..0x856658
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x855c88..0x855de0
+            - Range: 0x856658..0x8567b0
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
@@ -9750,9 +9750,9 @@ Subprograms:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855c10..0x855c88
+            - Range: 0x8565e0..0x856658
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x855c88..0x855de0
+            - Range: 0x856658..0x8567b0
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
@@ -9760,11 +9760,11 @@ Subprograms:
         - Name: ~r0
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0x855c10..0x855d98
+            - Range: 0x8565e0..0x856768
               Pieces: []
-            - Range: 0x855d98..0x855d99
+            - Range: 0x856768..0x856769
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x855d99..0x855de0
+            - Range: 0x856769..0x8567b0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9772,15 +9772,15 @@ Subprograms:
       DictRegister: null
     - ID: 133
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x855de0..0x855ff0]
+      OutOfLinePCRanges: [0x8567b0..0x8569c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855de0..0x855e68
+            - Range: 0x8567b0..0x856838
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x855e68..0x855ff0
+            - Range: 0x856838..0x8569c0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9788,9 +9788,9 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855de0..0x855e54
+            - Range: 0x8567b0..0x856824
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x855e54..0x855ff0
+            - Range: 0x856824..0x8569c0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -9798,9 +9798,9 @@ Subprograms:
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855de0..0x855e68
+            - Range: 0x8567b0..0x856838
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x855e68..0x855ff0
+            - Range: 0x856838..0x8569c0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -9808,9 +9808,9 @@ Subprograms:
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855de0..0x855e68
+            - Range: 0x8567b0..0x856838
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x855e68..0x855ff0
+            - Range: 0x856838..0x8569c0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
@@ -9818,9 +9818,9 @@ Subprograms:
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855de0..0x855e68
+            - Range: 0x8567b0..0x856838
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x855e68..0x855ff0
+            - Range: 0x856838..0x8569c0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
@@ -9828,9 +9828,9 @@ Subprograms:
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855de0..0x855e68
+            - Range: 0x8567b0..0x856838
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x855e68..0x855ff0
+            - Range: 0x856838..0x8569c0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
@@ -9838,9 +9838,9 @@ Subprograms:
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855de0..0x855e68
+            - Range: 0x8567b0..0x856838
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x855e68..0x855ff0
+            - Range: 0x856838..0x8569c0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
@@ -9848,9 +9848,9 @@ Subprograms:
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855de0..0x855e68
+            - Range: 0x8567b0..0x856838
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x855e68..0x855ff0
+            - Range: 0x856838..0x8569c0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
@@ -9858,13 +9858,13 @@ Subprograms:
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x855de0..0x855e68
+            - Range: 0x8567b0..0x856838
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x855e68..0x855ff0
+            - Range: 0x856838..0x8569c0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9876,9 +9876,9 @@ Subprograms:
         - Name: ~r0
           Type: 261 StructureType main.largeStruct
           Locations:
-            - Range: 0x855de0..0x855fac
+            - Range: 0x8567b0..0x85697c
               Pieces: []
-            - Range: 0x855fac..0x855fad
+            - Range: 0x85697c..0x85697d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9900,7 +9900,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x855fad..0x855ff0
+            - Range: 0x85697d..0x8569c0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9908,13 +9908,13 @@ Subprograms:
       DictRegister: null
     - ID: 134
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x855ff0..0x856090]
+      OutOfLinePCRanges: [0x8569c0..0x856a60]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 168 ArrayType [5]int
           Locations:
-            - Range: 0x855ff0..0x856090
+            - Range: 0x8569c0..0x856a60
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9922,11 +9922,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855ff0..0x85606c
+            - Range: 0x8569c0..0x856a3c
               Pieces: []
-            - Range: 0x85606c..0x85606d
+            - Range: 0x856a3c..0x856a3d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85606d..0x856090
+            - Range: 0x856a3d..0x856a60
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9934,11 +9934,11 @@ Subprograms:
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855ff0..0x85606c
+            - Range: 0x8569c0..0x856a3c
               Pieces: []
-            - Range: 0x85606c..0x85606d
+            - Range: 0x856a3c..0x856a3d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x85606d..0x856090
+            - Range: 0x856a3d..0x856a60
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9946,11 +9946,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x855ff0..0x85606c
+            - Range: 0x8569c0..0x856a3c
               Pieces: []
-            - Range: 0x85606c..0x85606d
+            - Range: 0x856a3c..0x856a3d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x85606d..0x856090
+            - Range: 0x856a3d..0x856a60
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9958,13 +9958,13 @@ Subprograms:
       DictRegister: null
     - ID: 135
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x856090..0x856170]
+      OutOfLinePCRanges: [0x856a60..0x856b40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0x856090..0x856170
+            - Range: 0x856a60..0x856b40
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9972,7 +9972,7 @@ Subprograms:
         - Name: b
           Type: 262 ArrayType [3]int
           Locations:
-            - Range: 0x856090..0x856170
+            - Range: 0x856a60..0x856b40
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -9980,11 +9980,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x856090..0x856154
+            - Range: 0x856a60..0x856b24
               Pieces: []
-            - Range: 0x856154..0x856155
+            - Range: 0x856b24..0x856b25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856155..0x856170
+            - Range: 0x856b25..0x856b40
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9992,11 +9992,11 @@ Subprograms:
         - Name: ~r1
           Type: 114 ArrayType [2]int
           Locations:
-            - Range: 0x856090..0x856154
+            - Range: 0x856a60..0x856b24
               Pieces: []
-            - Range: 0x856154..0x856155
+            - Range: 0x856b24..0x856b25
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x856155..0x856170
+            - Range: 0x856b25..0x856b40
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10004,13 +10004,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x856170..0x856240]
+      OutOfLinePCRanges: [0x856b40..0x856c10]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0x856170..0x856240
+            - Range: 0x856b40..0x856c10
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -10018,11 +10018,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x856170..0x85621c
+            - Range: 0x856b40..0x856bec
               Pieces: []
-            - Range: 0x85621c..0x85621d
+            - Range: 0x856bec..0x856bed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85621d..0x856240
+            - Range: 0x856bed..0x856c10
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10030,11 +10030,11 @@ Subprograms:
         - Name: ~r1
           Type: 267 StructureType main.structWithArray
           Locations:
-            - Range: 0x856170..0x85621c
+            - Range: 0x856b40..0x856bec
               Pieces: []
-            - Range: 0x85621c..0x85621d
+            - Range: 0x856bec..0x856bed
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x85621d..0x856240
+            - Range: 0x856bed..0x856c10
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10042,7 +10042,7 @@ Subprograms:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8561f0..0x856240
+            - Range: 0x856bc0..0x856c10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -10050,25 +10050,25 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x856240..0x8562e0]
+      OutOfLinePCRanges: [0x856c10..0x856cb0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 264 ArrayType [0]int
-          Locations: [{Range: 0x856240..0x8562e0, Pieces: []}]
+          Locations: [{Range: 0x856c10..0x856cb0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x856240..0x856280
+            - Range: 0x856c10..0x856c50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856280..0x85629c
+            - Range: 0x856c50..0x856c6c
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x85629c..0x8562a4
+            - Range: 0x856c6c..0x856c74
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x8562a4..0x8562e0
+            - Range: 0x856c74..0x856cb0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
@@ -10076,11 +10076,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x856240..0x8562c0
+            - Range: 0x856c10..0x856c90
               Pieces: []
-            - Range: 0x8562c0..0x8562c1
+            - Range: 0x856c90..0x856c91
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8562c1..0x8562e0
+            - Range: 0x856c91..0x856cb0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10088,11 +10088,11 @@ Subprograms:
         - Name: ~r1
           Type: 264 ArrayType [0]int
           Locations:
-            - Range: 0x856240..0x8562c0
+            - Range: 0x856c10..0x856c90
               Pieces: []
-            - Range: 0x8562c0..0x8562c1
+            - Range: 0x856c90..0x856c91
               Pieces: []
-            - Range: 0x8562c1..0x8562e0
+            - Range: 0x856c91..0x856cb0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10100,13 +10100,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x856750..0x856760]
+      OutOfLinePCRanges: [0x857120..0x857130]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x856750..0x856760
+            - Range: 0x857120..0x857130
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10120,13 +10120,13 @@ Subprograms:
       DictRegister: null
     - ID: 139
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x856760..0x856770]
+      OutOfLinePCRanges: [0x857130..0x857140]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x856760..0x856770
+            - Range: 0x857130..0x857140
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10140,13 +10140,13 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x856770..0x856780]
+      OutOfLinePCRanges: [0x857140..0x857150]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 269 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x856770..0x856780
+            - Range: 0x857140..0x857150
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10160,13 +10160,13 @@ Subprograms:
       DictRegister: null
     - ID: 141
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x856780..0x856790]
+      OutOfLinePCRanges: [0x857150..0x857160]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x856780..0x856790
+            - Range: 0x857150..0x857160
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10180,7 +10180,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x856780..0x856790
+            - Range: 0x857150..0x857160
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10188,13 +10188,13 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x856790..0x8567a0]
+      OutOfLinePCRanges: [0x857160..0x857170]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x856790..0x8567a0
+            - Range: 0x857160..0x857170
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10208,7 +10208,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x856790..0x8567a0
+            - Range: 0x857160..0x857170
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10216,13 +10216,13 @@ Subprograms:
       DictRegister: null
     - ID: 143
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x8567a0..0x8567b0]
+      OutOfLinePCRanges: [0x857170..0x857180]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x8567a0..0x8567b0
+            - Range: 0x857170..0x857180
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10236,7 +10236,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8567a0..0x8567b0
+            - Range: 0x857170..0x857180
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10244,13 +10244,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x8567b0..0x8567c0]
+      OutOfLinePCRanges: [0x857180..0x857190]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 162 GoSliceHeaderType []string
           Locations:
-            - Range: 0x8567b0..0x8567c0
+            - Range: 0x857180..0x857190
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10264,13 +10264,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x8567c0..0x8567d0]
+      OutOfLinePCRanges: [0x857190..0x8571a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 18 BaseType int8
           Locations:
-            - Range: 0x8567c0..0x8567d0
+            - Range: 0x857190..0x8571a0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10278,7 +10278,7 @@ Subprograms:
         - Name: s
           Type: 274 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x8567c0..0x8567d0
+            - Range: 0x857190..0x8571a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10292,7 +10292,7 @@ Subprograms:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x8567c0..0x8567d0
+            - Range: 0x857190..0x8571a0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10300,13 +10300,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x8567d0..0x8567e0]
+      OutOfLinePCRanges: [0x8571a0..0x8571b0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 275 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x8567d0..0x8567e0
+            - Range: 0x8571a0..0x8571b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10320,13 +10320,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x8567e0..0x8567f0]
+      OutOfLinePCRanges: [0x8571b0..0x8571c0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8567e0..0x8567f0
+            - Range: 0x8571b0..0x8571c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10340,13 +10340,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x8567f0..0x856800]
+      OutOfLinePCRanges: [0x8571c0..0x8571d0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 276 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0x8567f0..0x856800
+            - Range: 0x8571c0..0x8571d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10360,13 +10360,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x856800..0x856810]
+      OutOfLinePCRanges: [0x8571d0..0x8571e0]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x856800..0x856810
+            - Range: 0x8571d0..0x8571e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10380,7 +10380,7 @@ Subprograms:
         - Name: bs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x856800..0x856810
+            - Range: 0x8571d0..0x8571e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10394,7 +10394,7 @@ Subprograms:
         - Name: cs
           Type: 268 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x856800..0x856810
+            - Range: 0x8571d0..0x8571e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10408,13 +10408,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testByteSliceInvalidUtf8
-      OutOfLinePCRanges: [0x856840..0x856850]
+      OutOfLinePCRanges: [0x857210..0x857220]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0x856840..0x856850
+            - Range: 0x857210..0x857220
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10428,13 +10428,13 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testByteSliceMultibyteUtf8
-      OutOfLinePCRanges: [0x856850..0x856860]
+      OutOfLinePCRanges: [0x857220..0x857230]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0x856850..0x856860
+            - Range: 0x857220..0x857230
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10448,21 +10448,21 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.stackC
-      OutOfLinePCRanges: [0x856df0..0x856e60]
+      OutOfLinePCRanges: [0x8578b0..0x857920]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x856df0..0x856e3c
+            - Range: 0x8578b0..0x8578fc
               Pieces: []
-            - Range: 0x856e3c..0x856e3d
+            - Range: 0x8578fc..0x8578fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x856e3d..0x856e60
+            - Range: 0x8578fd..0x857920
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10470,13 +10470,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x856e60..0x856e70]
+      OutOfLinePCRanges: [0x857a40..0x857a50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x856e60..0x856e70
+            - Range: 0x857a40..0x857a50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10488,13 +10488,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x856e70..0x856e80]
+      OutOfLinePCRanges: [0x857a50..0x857a60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x856e70..0x856e80
+            - Range: 0x857a50..0x857a60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10506,7 +10506,7 @@ Subprograms:
         - Name: "y"
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x856e70..0x856e80
+            - Range: 0x857a50..0x857a60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10518,7 +10518,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x856e70..0x856e80
+            - Range: 0x857a50..0x857a60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10530,13 +10530,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x856e80..0x856ea0]
+      OutOfLinePCRanges: [0x857a60..0x857a80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x856e80..0x856ea0
+            - Range: 0x857a60..0x857a80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10556,13 +10556,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x856ea0..0x856eb0]
+      OutOfLinePCRanges: [0x857a80..0x857a90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 279 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x856ea0..0x856eb0
+            - Range: 0x857a80..0x857a90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10570,13 +10570,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x856eb0..0x856ec0]
+      OutOfLinePCRanges: [0x857a90..0x857aa0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x856eb0..0x856ec0
+            - Range: 0x857a90..0x857aa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10584,13 +10584,13 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x856ec0..0x856ed0]
+      OutOfLinePCRanges: [0x857aa0..0x857ab0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x856ec0..0x856ed0
+            - Range: 0x857aa0..0x857ab0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10602,13 +10602,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x856ed0..0x856ee0]
+      OutOfLinePCRanges: [0x857ab0..0x857ac0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x856ed0..0x856ee0
+            - Range: 0x857ab0..0x857ac0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10620,13 +10620,13 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x856ee0..0x856ef0]
+      OutOfLinePCRanges: [0x857ac0..0x857ad0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x856ee0..0x856ef0
+            - Range: 0x857ac0..0x857ad0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10638,13 +10638,13 @@ Subprograms:
       DictRegister: null
     - ID: 161
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x856ef0..0x856f00]
+      OutOfLinePCRanges: [0x857ad0..0x857ae0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x856ef0..0x856f00
+            - Range: 0x857ad0..0x857ae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10656,7 +10656,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x856ef0..0x856f00
+            - Range: 0x857ad0..0x857ae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10668,7 +10668,7 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x856ef0..0x856f00
+            - Range: 0x857ad0..0x857ae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10680,13 +10680,13 @@ Subprograms:
       DictRegister: null
     - ID: 162
       Name: main.testInvalidUtf8Strings
-      OutOfLinePCRanges: [0x856f00..0x856f10]
+      OutOfLinePCRanges: [0x857ae0..0x857af0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x856f00..0x856f10
+            - Range: 0x857ae0..0x857af0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10698,7 +10698,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x856f00..0x856f10
+            - Range: 0x857ae0..0x857af0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10710,13 +10710,13 @@ Subprograms:
       DictRegister: null
     - ID: 163
       Name: main.testMultibyteUtf8String
-      OutOfLinePCRanges: [0x856f10..0x856f20]
+      OutOfLinePCRanges: [0x857af0..0x857b00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x856f10..0x856f20
+            - Range: 0x857af0..0x857b00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10728,13 +10728,13 @@ Subprograms:
       DictRegister: null
     - ID: 164
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x8570b0..0x8570c0]
+      OutOfLinePCRanges: [0x857d80..0x857d90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 282 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x8570b0..0x8570c0
+            - Range: 0x857d80..0x857d90
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -10742,13 +10742,13 @@ Subprograms:
       DictRegister: null
     - ID: 165
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x8570c0..0x8570e0]
+      OutOfLinePCRanges: [0x857d90..0x857db0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 295 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x8570c0..0x8570e0
+            - Range: 0x857d90..0x857db0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10768,13 +10768,13 @@ Subprograms:
       DictRegister: null
     - ID: 166
       Name: main.testStruct
-      OutOfLinePCRanges: [0x8571b0..0x8571d0]
+      OutOfLinePCRanges: [0x857e80..0x857ea0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 326 StructureType main.aStruct
           Locations:
-            - Range: 0x8571b0..0x8571d0
+            - Range: 0x857e80..0x857ea0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10796,13 +10796,13 @@ Subprograms:
       DictRegister: null
     - ID: 167
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x857250..0x857260]
+      OutOfLinePCRanges: [0x857f20..0x857f30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 327 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x857250..0x857260
+            - Range: 0x857f20..0x857f30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10810,13 +10810,13 @@ Subprograms:
       DictRegister: null
     - ID: 168
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x857260..0x857270]
+      OutOfLinePCRanges: [0x857f30..0x857f40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 StructureType main.tenStrings
           Locations:
-            - Range: 0x857260..0x857270
+            - Range: 0x857f30..0x857f40
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -10824,25 +10824,25 @@ Subprograms:
       DictRegister: null
     - ID: 169
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x8572b0..0x8572c0]
+      OutOfLinePCRanges: [0x857f80..0x857f90]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 330 StructureType main.emptyStruct
-          Locations: [{Range: 0x8572b0..0x8572c0, Pieces: []}]
+          Locations: [{Range: 0x857f80..0x857f90, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 170
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x8572c0..0x8572d0]
+      OutOfLinePCRanges: [0x857f90..0x857fa0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 331 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x8572c0..0x8572d0
+            - Range: 0x857f90..0x857fa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10850,13 +10850,13 @@ Subprograms:
       DictRegister: null
     - ID: 171
       Name: main.testTimeUTC
-      OutOfLinePCRanges: [0x857dd0..0x857de0]
+      OutOfLinePCRanges: [0x858b80..0x858b90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 332 GoTimeType time.Time
           Locations:
-            - Range: 0x857dd0..0x857de0
+            - Range: 0x858b80..0x858b90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10870,13 +10870,13 @@ Subprograms:
       DictRegister: null
     - ID: 172
       Name: main.testTimeFixedZone
-      OutOfLinePCRanges: [0x857de0..0x857df0]
+      OutOfLinePCRanges: [0x858b90..0x858ba0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 332 GoTimeType time.Time
           Locations:
-            - Range: 0x857de0..0x857df0
+            - Range: 0x858b90..0x858ba0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10890,13 +10890,13 @@ Subprograms:
       DictRegister: null
     - ID: 173
       Name: main.testTimeMonotonic
-      OutOfLinePCRanges: [0x857df0..0x857e00]
+      OutOfLinePCRanges: [0x858ba0..0x858bb0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 335 StructureType main.timeCapture
           Locations:
-            - Range: 0x857df0..0x857e00
+            - Range: 0x858ba0..0x858bb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10910,13 +10910,13 @@ Subprograms:
       DictRegister: null
     - ID: 174
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x858d20..0x858d30]
+      OutOfLinePCRanges: [0x859bc0..0x859bd0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0x858d20..0x858d30
+            - Range: 0x859bc0..0x859bd0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10924,11 +10924,11 @@ Subprograms:
         - Name: ~r0
           Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x858d20..0x858d24
+            - Range: 0x859bc0..0x859bc4
               Pieces: []
-            - Range: 0x858d24..0x858d25
+            - Range: 0x859bc4..0x859bc5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x858d25..0x858d30
+            - Range: 0x859bc5..0x859bd0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -10936,19 +10936,19 @@ Subprograms:
       DictRegister: 0
     - ID: 175
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x858d30..0x858d40]
+      OutOfLinePCRanges: [0x859bd0..0x859be0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x858d30..0x858d3c
+            - Range: 0x859bd0..0x859bdc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x858d3c..0x858d40
+            - Range: 0x859bdc..0x859be0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10960,15 +10960,15 @@ Subprograms:
         - Name: ~r0
           Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x858d30..0x858d3c
+            - Range: 0x859bd0..0x859bdc
               Pieces: []
-            - Range: 0x858d3c..0x858d3d
+            - Range: 0x859bdc..0x859bdd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x858d3d..0x858d40
+            - Range: 0x859bdd..0x859be0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -10976,13 +10976,13 @@ Subprograms:
       DictRegister: 0
     - ID: 176
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x858d40..0x858d50]
+      OutOfLinePCRanges: [0x859be0..0x859bf0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x858d40..0x858d50
+            - Range: 0x859be0..0x859bf0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10990,11 +10990,11 @@ Subprograms:
         - Name: ~r0
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0x858d40..0x858d44
+            - Range: 0x859be0..0x859be4
               Pieces: []
-            - Range: 0x858d44..0x858d45
+            - Range: 0x859be4..0x859be5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x858d45..0x858d50
+            - Range: 0x859be5..0x859bf0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11002,19 +11002,19 @@ Subprograms:
       DictRegister: 0
     - ID: 177
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x858d50..0x858d60]
+      OutOfLinePCRanges: [0x859bf0..0x859c00]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x858d50..0x858d5c
+            - Range: 0x859bf0..0x859bfc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x858d5c..0x858d60
+            - Range: 0x859bfc..0x859c00
               Pieces:
                 - Size: 8
                   Op: null
@@ -11026,15 +11026,15 @@ Subprograms:
         - Name: ~r0
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x858d50..0x858d5c
+            - Range: 0x859bf0..0x859bfc
               Pieces: []
-            - Range: 0x858d5c..0x858d5d
+            - Range: 0x859bfc..0x859bfd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x858d5d..0x858d60
+            - Range: 0x859bfd..0x859c00
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11042,13 +11042,13 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x858dc0..0x858ee0]
+      OutOfLinePCRanges: [0x859c60..0x859d80]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 340 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x858dc0..0x858dec
+            - Range: 0x859c60..0x859c8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11056,7 +11056,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x858dec..0x858dfc
+            - Range: 0x859c8c..0x859c9c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -11064,7 +11064,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x858dfc..0x858ee0
+            - Range: 0x859c9c..0x859d80
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -11078,9 +11078,9 @@ Subprograms:
         - Name: pred
           Type: 342 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x858dc0..0x858dfc
+            - Range: 0x859c60..0x859c9c
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x858dfc..0x858ee0
+            - Range: 0x859c9c..0x859d80
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
@@ -11088,9 +11088,9 @@ Subprograms:
         - Name: ~r0
           Type: 340 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x858dc0..0x858eac
+            - Range: 0x859c60..0x859d4c
               Pieces: []
-            - Range: 0x858eac..0x858ead
+            - Range: 0x859d4c..0x859d4d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11098,7 +11098,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x858ead..0x858ee0
+            - Range: 0x859d4d..0x859d80
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -11106,7 +11106,7 @@ Subprograms:
         - Name: result
           Type: 340 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x858dfc..0x858e18
+            - Range: 0x859c9c..0x859cb8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11114,7 +11114,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x858e18..0x858e1c
+            - Range: 0x859cb8..0x859cbc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11122,7 +11122,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x858e1c..0x858e20
+            - Range: 0x859cbc..0x859cc0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11130,7 +11130,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x858e20..0x858e20
+            - Range: 0x859cc0..0x859cc0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11138,7 +11138,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x858e20..0x858e4c
+            - Range: 0x859cc0..0x859cec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -11146,7 +11146,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x858e4c..0x858ea0
+            - Range: 0x859cec..0x859d40
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11154,7 +11154,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x858ea0..0x858ee0
+            - Range: 0x859d40..0x859d80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -11168,9 +11168,9 @@ Subprograms:
         - Name: item
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0x858e3c..0x858e4c
+            - Range: 0x859cdc..0x859cec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x858e4c..0x858ea0
+            - Range: 0x859cec..0x859d40
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
@@ -11178,13 +11178,13 @@ Subprograms:
       DictRegister: 0
     - ID: 179
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x858ee0..0x858f30]
+      OutOfLinePCRanges: [0x859d80..0x859dd0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 337 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x858ee0..0x858f08
+            - Range: 0x859d80..0x859da8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11192,7 +11192,7 @@ Subprograms:
         - Name: f
           Type: 343 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x858ee0..0x858f08
+            - Range: 0x859d80..0x859da8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11200,15 +11200,15 @@ Subprograms:
         - Name: ~r0
           Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x858ee0..0x858f08
+            - Range: 0x859d80..0x859da8
               Pieces: []
-            - Range: 0x858f08..0x858f09
+            - Range: 0x859da8..0x859da9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x858f09..0x858f30
+            - Range: 0x859da9..0x859dd0
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -11216,13 +11216,13 @@ Subprograms:
       DictRegister: 0
     - ID: 180
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x8591a0..0x8591b0]
+      OutOfLinePCRanges: [0x85a040..0x85a050]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 341 PointerType *go.shape.int
           Locations:
-            - Range: 0x8591a0..0x8591b0
+            - Range: 0x85a040..0x85a050
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11230,11 +11230,11 @@ Subprograms:
         - Name: ~r0
           Type: 341 PointerType *go.shape.int
           Locations:
-            - Range: 0x8591a0..0x8591a4
+            - Range: 0x85a040..0x85a044
               Pieces: []
-            - Range: 0x8591a4..0x8591a5
+            - Range: 0x85a044..0x85a045
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8591a5..0x8591b0
+            - Range: 0x85a045..0x85a050
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11242,13 +11242,13 @@ Subprograms:
       DictRegister: 0
     - ID: 181
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x8591b0..0x8591c0]
+      OutOfLinePCRanges: [0x85a050..0x85a060]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 344 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x8591b0..0x8591c0
+            - Range: 0x85a050..0x85a060
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11256,11 +11256,11 @@ Subprograms:
         - Name: ~r0
           Type: 344 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x8591b0..0x8591b4
+            - Range: 0x85a050..0x85a054
               Pieces: []
-            - Range: 0x8591b4..0x8591b5
+            - Range: 0x85a054..0x85a055
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8591b5..0x8591c0
+            - Range: 0x85a055..0x85a060
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11268,13 +11268,13 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x8591c0..0x8591d0]
+      OutOfLinePCRanges: [0x85a060..0x85a070]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 346 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x8591c0..0x8591d0
+            - Range: 0x85a060..0x85a070
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11282,11 +11282,11 @@ Subprograms:
         - Name: ~r0
           Type: 346 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x8591c0..0x8591c4
+            - Range: 0x85a060..0x85a064
               Pieces: []
-            - Range: 0x8591c4..0x8591c5
+            - Range: 0x85a064..0x85a065
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8591c5..0x8591d0
+            - Range: 0x85a065..0x85a070
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11294,13 +11294,13 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x8591d0..0x8591e0]
+      OutOfLinePCRanges: [0x85a070..0x85a080]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 348 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x8591d0..0x8591e0
+            - Range: 0x85a070..0x85a080
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
@@ -11308,15 +11308,15 @@ Subprograms:
         - Name: ~r0
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8591d0..0x8591d8
+            - Range: 0x85a070..0x85a078
               Pieces: []
-            - Range: 0x8591d8..0x8591d9
+            - Range: 0x85a078..0x85a079
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8591d9..0x8591e0
+            - Range: 0x85a079..0x85a080
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11324,13 +11324,13 @@ Subprograms:
       DictRegister: 0
     - ID: 184
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x859260..0x859270]
+      OutOfLinePCRanges: [0x85a100..0x85a110]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 350 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x859260..0x859270
+            - Range: 0x85a100..0x85a110
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
@@ -11338,11 +11338,11 @@ Subprograms:
         - Name: ~r0
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0x859260..0x859264
+            - Range: 0x85a100..0x85a104
               Pieces: []
-            - Range: 0x859264..0x859265
+            - Range: 0x85a104..0x85a105
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x859265..0x859270
+            - Range: 0x85a105..0x85a110
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11350,13 +11350,13 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x859300..0x859310]
+      OutOfLinePCRanges: [0x85a1a0..0x85a1b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 351 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x859300..0x859310
+            - Range: 0x85a1a0..0x85a1b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11364,7 +11364,7 @@ Subprograms:
         - Name: k
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0x859300..0x859310
+            - Range: 0x85a1a0..0x85a1b0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11372,7 +11372,7 @@ Subprograms:
         - Name: v
           Type: 353 BaseType go.shape.bool
           Locations:
-            - Range: 0x859300..0x859310
+            - Range: 0x85a1a0..0x85a1b0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11380,13 +11380,13 @@ Subprograms:
       DictRegister: 1
     - ID: 186
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x859390..0x859410]
+      OutOfLinePCRanges: [0x85a230..0x85a2b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 354 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x859390..0x859410
+            - Range: 0x85a230..0x85a2b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11394,7 +11394,7 @@ Subprograms:
         - Name: k
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x859390..0x859410
+            - Range: 0x85a230..0x85a2b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -11406,7 +11406,7 @@ Subprograms:
         - Name: v
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0x859390..0x859410
+            - Range: 0x85a230..0x85a2b0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11414,13 +11414,13 @@ Subprograms:
       DictRegister: 1
     - ID: 187
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x859490..0x8594a0]
+      OutOfLinePCRanges: [0x85a330..0x85a340]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x859490..0x8594a0
+            - Range: 0x85a330..0x85a340
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11432,7 +11432,7 @@ Subprograms:
         - Name: b
           Type: 353 BaseType go.shape.bool
           Locations:
-            - Range: 0x859490..0x8594a0
+            - Range: 0x85a330..0x85a340
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11440,11 +11440,11 @@ Subprograms:
         - Name: ~r0
           Type: 353 BaseType go.shape.bool
           Locations:
-            - Range: 0x859490..0x859498
+            - Range: 0x85a330..0x85a338
               Pieces: []
-            - Range: 0x859498..0x859499
+            - Range: 0x85a338..0x85a339
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x859499..0x8594a0
+            - Range: 0x85a339..0x85a340
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11452,15 +11452,15 @@ Subprograms:
         - Name: ~r1
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x859490..0x859498
+            - Range: 0x85a330..0x85a338
               Pieces: []
-            - Range: 0x859498..0x859499
+            - Range: 0x85a338..0x85a339
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x859499..0x8594a0
+            - Range: 0x85a339..0x85a340
               Pieces: []
           Role: Return
           DictIndex: 0
@@ -11468,13 +11468,13 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x8594a0..0x8594c0]
+      OutOfLinePCRanges: [0x85a340..0x85a360]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0x8594a0..0x8594b0
+            - Range: 0x85a340..0x85a350
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11482,13 +11482,13 @@ Subprograms:
         - Name: b
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8594a0..0x8594ac
+            - Range: 0x85a340..0x85a34c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8594ac..0x8594c0
+            - Range: 0x85a34c..0x85a360
               Pieces:
                 - Size: 8
                   Op: null
@@ -11500,15 +11500,15 @@ Subprograms:
         - Name: ~r0
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8594a0..0x8594b0
+            - Range: 0x85a340..0x85a350
               Pieces: []
-            - Range: 0x8594b0..0x8594b1
+            - Range: 0x85a350..0x85a351
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8594b1..0x8594c0
+            - Range: 0x85a351..0x85a360
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11516,11 +11516,11 @@ Subprograms:
         - Name: ~r1
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0x8594a0..0x8594b0
+            - Range: 0x85a340..0x85a350
               Pieces: []
-            - Range: 0x8594b0..0x8594b1
+            - Range: 0x85a350..0x85a351
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8594b1..0x8594c0
+            - Range: 0x85a351..0x85a360
               Pieces: []
           Role: Return
           DictIndex: 0
@@ -11528,13 +11528,13 @@ Subprograms:
       DictRegister: 0
     - ID: 189
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x8594c0..0x859510]
+      OutOfLinePCRanges: [0x85a360..0x85a3b0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 356 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x8594c0..0x8594e8
+            - Range: 0x85a360..0x85a388
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11542,15 +11542,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8594c0..0x8594e8
+            - Range: 0x85a360..0x85a388
               Pieces: []
-            - Range: 0x8594e8..0x8594e9
+            - Range: 0x85a388..0x85a389
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8594e9..0x859510
+            - Range: 0x85a389..0x85a3b0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11558,19 +11558,19 @@ Subprograms:
       DictRegister: 0
     - ID: 190
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x859510..0x859570]
+      OutOfLinePCRanges: [0x85a3b0..0x85a410]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 357 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x859510..0x85953c
+            - Range: 0x85a3b0..0x85a3dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x85953c..0x859540
+            - Range: 0x85a3dc..0x85a3e0
               Pieces:
                 - Size: 8
                   Op: null
@@ -11582,15 +11582,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x859510..0x859540
+            - Range: 0x85a3b0..0x85a3e0
               Pieces: []
-            - Range: 0x859540..0x859541
+            - Range: 0x85a3e0..0x85a3e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x859541..0x859570
+            - Range: 0x85a3e1..0x85a410
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11598,13 +11598,13 @@ Subprograms:
       DictRegister: 0
     - ID: 191
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x859570..0x859580]
+      OutOfLinePCRanges: [0x85a410..0x85a420]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 358 PointerType *go.shape.string
           Locations:
-            - Range: 0x859570..0x859578
+            - Range: 0x85a410..0x85a418
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11612,15 +11612,15 @@ Subprograms:
         - Name: ~r0
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x859570..0x859578
+            - Range: 0x85a410..0x85a418
               Pieces: []
-            - Range: 0x859578..0x859579
+            - Range: 0x85a418..0x85a419
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x859579..0x859580
+            - Range: 0x85a419..0x85a420
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11628,13 +11628,13 @@ Subprograms:
       DictRegister: 0
     - ID: 192
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x859580..0x8595e0]
+      OutOfLinePCRanges: [0x85a420..0x85a480]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 359 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x859580..0x8595bc
+            - Range: 0x85a420..0x85a45c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11642,9 +11642,9 @@ Subprograms:
         - Name: ~r0
           Type: 360 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x859580..0x8595cc
+            - Range: 0x85a420..0x85a46c
               Pieces: []
-            - Range: 0x8595cc..0x8595cd
+            - Range: 0x85a46c..0x85a46d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11658,7 +11658,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x8595cd..0x8595e0
+            - Range: 0x85a46d..0x85a480
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11666,13 +11666,13 @@ Subprograms:
       DictRegister: 0
     - ID: 193
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x8595e0..0x859620]
+      OutOfLinePCRanges: [0x85a480..0x85a4c0]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 340 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8595e0..0x8595ec
+            - Range: 0x85a480..0x85a48c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11680,7 +11680,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8595ec..0x859620
+            - Range: 0x85a48c..0x85a4c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11694,7 +11694,7 @@ Subprograms:
         - Name: needle
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0x8595e0..0x859620
+            - Range: 0x85a480..0x85a4c0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11702,15 +11702,15 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x8595e0..0x859608
+            - Range: 0x85a480..0x85a4a8
               Pieces: []
-            - Range: 0x859608..0x859609
+            - Range: 0x85a4a8..0x85a4a9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x859609..0x859610
+            - Range: 0x85a4a9..0x85a4b0
               Pieces: []
-            - Range: 0x859610..0x859611
+            - Range: 0x85a4b0..0x85a4b1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x859611..0x859620
+            - Range: 0x85a4b1..0x85a4c0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11718,7 +11718,7 @@ Subprograms:
         - Name: v
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0x8595fc..0x85960c
+            - Range: 0x85a49c..0x85a4ac
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
@@ -11726,13 +11726,13 @@ Subprograms:
       DictRegister: 0
     - ID: 194
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x859620..0x8596e0]
+      OutOfLinePCRanges: [0x85a4c0..0x85a580]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 361 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x859620..0x859644
+            - Range: 0x85a4c0..0x85a4e4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11740,7 +11740,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x859644..0x859648
+            - Range: 0x85a4e4..0x85a4e8
               Pieces:
                 - Size: 8
                   Op: null
@@ -11754,13 +11754,13 @@ Subprograms:
         - Name: needle
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x859620..0x85967c
+            - Range: 0x85a4c0..0x85a51c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x85967c..0x8596e0
+            - Range: 0x85a51c..0x85a580
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -11772,15 +11772,15 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x859620..0x859698
+            - Range: 0x85a4c0..0x85a538
               Pieces: []
-            - Range: 0x859698..0x859699
+            - Range: 0x85a538..0x85a539
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x859699..0x8596a8
+            - Range: 0x85a539..0x85a548
               Pieces: []
-            - Range: 0x8596a8..0x8596a9
+            - Range: 0x85a548..0x85a549
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8596a9..0x8596e0
+            - Range: 0x85a549..0x85a580
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11788,13 +11788,13 @@ Subprograms:
         - Name: v
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x85965c..0x859670
+            - Range: 0x85a4fc..0x85a510
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x859670..0x85967c
+            - Range: 0x85a510..0x85a51c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11806,13 +11806,13 @@ Subprograms:
       DictRegister: 0
     - ID: 195
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x8596e0..0x8596f0]
+      OutOfLinePCRanges: [0x85a580..0x85a590]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 362 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x8596e0..0x8596e8
+            - Range: 0x85a580..0x85a588
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11820,7 +11820,7 @@ Subprograms:
         - Name: value
           Type: 336 BaseType go.shape.int
           Locations:
-            - Range: 0x8596e0..0x8596f0
+            - Range: 0x85a580..0x85a590
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11828,11 +11828,11 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x8596e0..0x8596e8
+            - Range: 0x85a580..0x85a588
               Pieces: []
-            - Range: 0x8596e8..0x8596e9
+            - Range: 0x85a588..0x85a589
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8596e9..0x8596f0
+            - Range: 0x85a589..0x85a590
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11840,25 +11840,25 @@ Subprograms:
       DictRegister: 1
     - ID: 196
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x859760..0x8597d0]
+      OutOfLinePCRanges: [0x85a600..0x85a670]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 363 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x859760..0x85978c
+            - Range: 0x85a600..0x85a62c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85978c..0x859798
+            - Range: 0x85a62c..0x85a638
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x859798..0x85979c
+            - Range: 0x85a638..0x85a63c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11870,7 +11870,7 @@ Subprograms:
         - Name: value
           Type: 338 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x859760..0x85979c
+            - Range: 0x85a600..0x85a63c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11882,11 +11882,11 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x859760..0x85979c
+            - Range: 0x85a600..0x85a63c
               Pieces: []
-            - Range: 0x85979c..0x85979d
+            - Range: 0x85a63c..0x85a63d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85979d..0x8597d0
+            - Range: 0x85a63d..0x85a670
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -12106,31 +12106,31 @@ Subprograms:
       DictRegister: null
     - ID: 199
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x851220..0x851290]
+      OutOfLinePCRanges: [0x8516b0..0x851720]
       InlinePCRanges:
-        - Ranges: [0x8512ac..0x8512e4]
-          RootRanges: [0x851290..0x851310]
-        - Ranges: [0x8513f8..0x851430]
-          RootRanges: [0x8513c0..0x851450]
-        - Ranges: [0x851474..0x8514ac]
-          RootRanges: [0x851450..0x851510]
-        - Ranges: [0x85152c..0x851564]
-          RootRanges: [0x851510..0x851590]
+        - Ranges: [0x85173c..0x851774]
+          RootRanges: [0x851720..0x8517a0]
+        - Ranges: [0x851888..0x8518c0]
+          RootRanges: [0x851850..0x8518e0]
+        - Ranges: [0x851904..0x85193c]
+          RootRanges: [0x8518e0..0x8519a0]
+        - Ranges: [0x8519bc..0x8519f4]
+          RootRanges: [0x8519a0..0x851a20]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x851220..0x851240
+            - Range: 0x8516b0..0x8516d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8512ac..0x8512b4
+            - Range: 0x85173c..0x851744
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8513f8..0x851400
+            - Range: 0x851888..0x851890
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85146c..0x85147c
+            - Range: 0x8518fc..0x85190c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85147c..0x851510
+            - Range: 0x85190c..0x8519a0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x851510..0x851534
+            - Range: 0x8519a0..0x8519c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -12140,37 +12140,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8514b8..0x8514f0]
-          RootRanges: [0x851450..0x851510]
+        - Ranges: [0x851948..0x851980]
+          RootRanges: [0x8518e0..0x8519a0]
       Variables: []
       DictRegister: null
     - ID: 201
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8515ac..0x8515f0]
-          RootRanges: [0x851590..0x8516b0]
+        - Ranges: [0x851a3c..0x851a80]
+          RootRanges: [0x851a20..0x851b40]
       Variables: []
       DictRegister: null
     - ID: 202
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x851660..0x851698]
-          RootRanges: [0x851590..0x8516b0]
+        - Ranges: [0x851af0..0x851b28]
+          RootRanges: [0x851a20..0x851b40]
       Variables: []
       DictRegister: null
     - ID: 203
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8516b4..0x8516b8]
-          RootRanges: [0x8516b0..0x8516c0]
+        - Ranges: [0x851b44..0x851b48]
+          RootRanges: [0x851b40..0x851b50]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8516b0..0x8516b8
+            - Range: 0x851b40..0x851b48
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -12180,39 +12180,39 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8516e4..0x851708]
-          RootRanges: [0x8516c0..0x851720]
-        - Ranges: [0x85177c..0x8517a4]
-          RootRanges: [0x851720..0x851870]
+        - Ranges: [0x851b74..0x851b98]
+          RootRanges: [0x851b50..0x851bb0]
+        - Ranges: [0x851c58..0x851c80]
+          RootRanges: [0x851bb0..0x851d80]
       Variables:
         - Name: a
           Type: 168 ArrayType [5]int
           Locations:
-            - Range: 0x8516d0..0x851720
+            - Range: 0x851b60..0x851bb0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x851768..0x851870
-              Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
+            - Range: 0x851c44..0x851d80
+              Pieces: [{Size: 40, Op: {CfaOffset: -144}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 205
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x851870..0x8518e0]
+      OutOfLinePCRanges: [0x851df0..0x851e60]
       InlinePCRanges:
-        - Ranges: [0x85999c..0x8599d0]
-          RootRanges: [0x859970..0x859a20]
+        - Ranges: [0x85a83c..0x85a870]
+          RootRanges: [0x85a810..0x85a8c0]
       Variables:
         - Name: b
           Type: 368 StructureType main.firstBehavior
           Locations:
-            - Range: 0x851870..0x85189c
+            - Range: 0x851df0..0x851e1c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85189c..0x8518a0
+            - Range: 0x851e1c..0x851e20
               Pieces:
                 - Size: 8
                   Op: null
@@ -12224,15 +12224,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x851870..0x8518c0
+            - Range: 0x851df0..0x851e40
               Pieces: []
-            - Range: 0x8518c0..0x8518c1
+            - Range: 0x851e40..0x851e41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8518c1..0x8518e0
+            - Range: 0x851e41..0x851e60
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -12242,8 +12242,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8520b8..0x8520c4, 0x8520c8..0x8520d0]
-          RootRanges: [0x852020..0x852120]
+        - Ranges: [0x8526b4..0x8526c0, 0x8526c4..0x8526cc]
+          RootRanges: [0x8525c0..0x852740]
         - Ranges: [0x84bcb8..0x84bcbc, 0x84bcc0..0x84bcc8]
           RootRanges: [0x84bcb0..0x84bcd0]
       Variables: []
@@ -12913,7 +12913,7 @@ Types:
       ID: 2622
       Name: '*compress/gzip.Reader'
       ByteSize: 8
-      GoRuntimeType: 1629504
+      GoRuntimeType: 1628736
       GoKind: 22
       Pointee: 2623 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
@@ -12927,7 +12927,7 @@ Types:
       ID: 418
       Name: '*context.backgroundCtx'
       ByteSize: 8
-      GoRuntimeType: 1555616
+      GoRuntimeType: 1555136
       GoKind: 22
       Pointee: 419 GoContextImplementationType context.backgroundCtx
     - __kind: PointerType
@@ -12941,21 +12941,21 @@ Types:
       ID: 1067
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1193920
+      GoRuntimeType: 1192256
       GoKind: 22
       Pointee: 1068 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 405
       Name: '*context.emptyCtx'
       ByteSize: 8
-      GoRuntimeType: 1418016
+      GoRuntimeType: 1417856
       GoKind: 22
       Pointee: 406 GoContextImplementationType context.emptyCtx
     - __kind: PointerType
       ID: 407
       Name: '*context.stopCtx'
       ByteSize: 8
-      GoRuntimeType: 1418176
+      GoRuntimeType: 1418016
       GoKind: 22
       Pointee: 408 GoContextImplementationType context.stopCtx
     - __kind: PointerType
@@ -12969,21 +12969,21 @@ Types:
       ID: 420
       Name: '*context.todoCtx'
       ByteSize: 8
-      GoRuntimeType: 1555776
+      GoRuntimeType: 1555296
       GoKind: 22
       Pointee: 421 GoContextImplementationType context.todoCtx
     - __kind: PointerType
       ID: 414
       Name: '*context.valueCtx'
       ByteSize: 8
-      GoRuntimeType: 1555296
+      GoRuntimeType: 1554816
       GoKind: 22
       Pointee: 415 GoContextImplementationType context.valueCtx
     - __kind: PointerType
       ID: 416
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
-      GoRuntimeType: 1555456
+      GoRuntimeType: 1554976
       GoKind: 22
       Pointee: 417 GoContextImplementationType context.withoutCancelCtx
     - __kind: PointerType
@@ -13345,17 +13345,17 @@ Types:
       GoKind: 22
       Pointee: 962 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 857
+      ID: 855
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 911136
+      GoRuntimeType: 910464
       GoKind: 22
       Pointee: 757 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
       ID: 1212
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1042112
+      GoRuntimeType: 1041984
       GoKind: 22
       Pointee: 1213 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -13366,31 +13366,31 @@ Types:
       GoKind: 22
       Pointee: 758 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 1479
+      ID: 1477
       Name: '*encoding/json.Delim'
       ByteSize: 8
-      GoRuntimeType: 905952
+      GoRuntimeType: 905280
       GoKind: 22
-      Pointee: 1409 BaseType encoding/json.Delim
+      Pointee: 1407 BaseType encoding/json.Delim
     - __kind: PointerType
-      ID: 828
+      ID: 826
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 905856
+      GoRuntimeType: 905184
       GoKind: 22
-      Pointee: 829 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 827 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
       ID: 1030
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1038400
+      GoRuntimeType: 1038272
       GoKind: 22
       Pointee: 1031 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
       ID: 1649
       Name: '*encoding/json.Number'
       ByteSize: 8
-      GoRuntimeType: 1208128
+      GoRuntimeType: 1207616
       GoKind: 22
       Pointee: 1631 GoStringHeaderType encoding/json.Number
     - __kind: PointerType
@@ -13399,33 +13399,33 @@ Types:
       ByteSize: 8
       Pointee: 1632 GoStringDataType encoding/json.Number.str
     - __kind: PointerType
-      ID: 820
+      ID: 818
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 905472
+      GoRuntimeType: 904800
       GoKind: 22
-      Pointee: 821 UnresolvedPointeeType encoding/json.SyntaxError
-    - __kind: PointerType
-      ID: 826
-      Name: '*encoding/json.UnmarshalTypeError'
-      ByteSize: 8
-      GoRuntimeType: 905760
-      GoKind: 22
-      Pointee: 827 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 819 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
       ID: 824
-      Name: '*encoding/json.UnsupportedTypeError'
+      Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
-      GoRuntimeType: 905664
+      GoRuntimeType: 905088
       GoKind: 22
-      Pointee: 825 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 825 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
       ID: 822
+      Name: '*encoding/json.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 904992
+      GoKind: 22
+      Pointee: 823 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 820
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
-      GoRuntimeType: 905568
+      GoRuntimeType: 904896
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 821 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
       ID: 1354
       Name: '*encoding/json.encodeState'
@@ -13434,12 +13434,12 @@ Types:
       GoKind: 22
       Pointee: 1355 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 830
+      ID: 828
       Name: '*encoding/json.jsonError'
       ByteSize: 8
-      GoRuntimeType: 906240
+      GoRuntimeType: 905568
       GoKind: 22
-      Pointee: 831 StructureType encoding/json.jsonError
+      Pointee: 829 StructureType encoding/json.jsonError
     - __kind: PointerType
       ID: 1220
       Name: '*encoding/pem.lineBreaker'
@@ -13498,14 +13498,14 @@ Types:
       ID: 798
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 896832
+      GoRuntimeType: 897696
       GoKind: 22
       Pointee: 799 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 997
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1024192
+      GoRuntimeType: 1025216
       GoKind: 22
       Pointee: 998 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -13540,21 +13540,21 @@ Types:
       ID: 2528
       Name: '*fmt.stringReader'
       ByteSize: 8
-      GoRuntimeType: 896928
+      GoRuntimeType: 897792
       GoKind: 22
       Pointee: 2529 UnresolvedPointeeType fmt.stringReader
     - __kind: PointerType
       ID: 999
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1024320
+      GoRuntimeType: 1025344
       GoKind: 22
       Pointee: 1000 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 1001
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1024448
+      GoRuntimeType: 1025472
       GoKind: 22
       Pointee: 1002 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -13582,7 +13582,7 @@ Types:
       ID: 2370
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AgentPayload'
       ByteSize: 8
-      GoRuntimeType: 2200928
+      GoRuntimeType: 2200096
       GoKind: 22
       Pointee: 2371 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AgentPayload
     - __kind: PointerType
@@ -13596,7 +13596,7 @@ Types:
       ID: 2051
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType'
       ByteSize: 8
-      GoRuntimeType: 1849024
+      GoRuntimeType: 1848800
       GoKind: 22
       Pointee: 1998 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
     - __kind: PointerType
@@ -13617,7 +13617,7 @@ Types:
       ID: 2052
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType'
       ByteSize: 8
-      GoRuntimeType: 1849248
+      GoRuntimeType: 1849024
       GoKind: 22
       Pointee: 1999 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
     - __kind: PointerType
@@ -13666,7 +13666,7 @@ Types:
       ID: 2368
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.StatsPayload'
       ByteSize: 8
-      GoRuntimeType: 2200096
+      GoRuntimeType: 2199264
       GoKind: 22
       Pointee: 2369 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.StatsPayload
     - __kind: PointerType
@@ -13687,7 +13687,7 @@ Types:
       ID: 2434
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.TracerPayload'
       ByteSize: 8
-      GoRuntimeType: 2254560
+      GoRuntimeType: 2253600
       GoKind: 22
       Pointee: 2435 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.TracerPayload
     - __kind: PointerType
@@ -13705,45 +13705,45 @@ Types:
       GoKind: 22
       Pointee: 1707 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/version.Version
     - __kind: PointerType
-      ID: 839
+      ID: 837
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
-      GoRuntimeType: 908640
+      GoRuntimeType: 907968
       GoKind: 22
-      Pointee: 840 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 838 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 841
+      ID: 839
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
-      GoRuntimeType: 908736
+      GoRuntimeType: 908064
       GoKind: 22
-      Pointee: 842 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 840 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
       ID: 1158
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
-      GoRuntimeType: 908448
+      GoRuntimeType: 907776
       GoKind: 22
       Pointee: 1159 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 845
+      ID: 843
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
-      GoRuntimeType: 909024
+      GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 846 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 844 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
       ID: 1160
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
-      GoRuntimeType: 908544
+      GoRuntimeType: 907872
       GoKind: 22
       Pointee: 1161 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 843
+      ID: 841
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
-      GoRuntimeType: 908832
+      GoRuntimeType: 908160
       GoKind: 22
       Pointee: 751 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
@@ -13752,10 +13752,10 @@ Types:
       ByteSize: 8
       Pointee: 752 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 838
+      ID: 836
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
-      GoRuntimeType: 908352
+      GoRuntimeType: 907680
       GoKind: 22
       Pointee: 748 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
@@ -13764,10 +13764,10 @@ Types:
       ByteSize: 8
       Pointee: 749 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 844
+      ID: 842
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
-      GoRuntimeType: 908928
+      GoRuntimeType: 908256
       GoKind: 22
       Pointee: 754 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
@@ -13779,7 +13779,7 @@ Types:
       ID: 1234
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1211456
+      GoRuntimeType: 1210944
       GoKind: 22
       Pointee: 1235 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
@@ -13800,14 +13800,14 @@ Types:
       ID: 1764
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule'
       ByteSize: 8
-      GoRuntimeType: 1555936
+      GoRuntimeType: 1555456
       GoKind: 22
       Pointee: 1765 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule
     - __kind: PointerType
       ID: 1462
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType'
       ByteSize: 8
-      GoRuntimeType: 897408
+      GoRuntimeType: 896928
       GoKind: 22
       Pointee: 1400 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType
     - __kind: PointerType
@@ -13828,14 +13828,14 @@ Types:
       ID: 392
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
-      GoRuntimeType: 1194176
+      GoRuntimeType: 1192512
       GoKind: 22
       Pointee: 393 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
       ID: 1465
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate'
       ByteSize: 8
-      GoRuntimeType: 897696
+      GoRuntimeType: 897216
       GoKind: 22
       Pointee: 1466 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate
     - __kind: PointerType
@@ -13849,7 +13849,7 @@ Types:
       ID: 1463
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule'
       ByteSize: 8
-      GoRuntimeType: 897600
+      GoRuntimeType: 897120
       GoKind: 22
       Pointee: 1464 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule
     - __kind: PointerType
@@ -13863,35 +13863,35 @@ Types:
       ID: 1648
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance'
       ByteSize: 8
-      GoRuntimeType: 1195584
+      GoRuntimeType: 1193920
       GoKind: 22
       Pointee: 1556 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance
     - __kind: PointerType
       ID: 2325
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter'
       ByteSize: 8
-      GoRuntimeType: 897504
+      GoRuntimeType: 897024
       GoKind: 22
       Pointee: 2326 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter
     - __kind: PointerType
       ID: 395
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
-      GoRuntimeType: 1194304
+      GoRuntimeType: 1192640
       GoKind: 22
       Pointee: 396 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
       ID: 2685
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
-      GoRuntimeType: 1194944
+      GoRuntimeType: 1193280
       GoKind: 22
       Pointee: 2686 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
       ID: 722
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      GoRuntimeType: 1195072
+      GoRuntimeType: 1193408
       GoKind: 22
       Pointee: 723 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
@@ -13919,7 +13919,7 @@ Types:
       ID: 1726
       Name: '*github.com/DataDog/dd-trace-go/v2/internal.TraceSource'
       ByteSize: 8
-      GoRuntimeType: 1423296
+      GoRuntimeType: 1423136
       GoKind: 22
       Pointee: 1557 BaseType github.com/DataDog/dd-trace-go/v2/internal.TraceSource
     - __kind: PointerType
@@ -14003,7 +14003,7 @@ Types:
       ID: 410
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
-      GoRuntimeType: 1423616
+      GoRuntimeType: 1423456
       GoKind: 22
       Pointee: 411 GoContextImplementationType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
@@ -14017,21 +14017,21 @@ Types:
       ID: 1588
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource'
       ByteSize: 8
-      GoRuntimeType: 1040448
+      GoRuntimeType: 1040320
       GoKind: 22
       Pointee: 1589 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource
     - __kind: PointerType
       ID: 1590
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource'
       ByteSize: 8
-      GoRuntimeType: 1040576
+      GoRuntimeType: 1040448
       GoKind: 22
       Pointee: 1591 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource
     - __kind: PointerType
       ID: 1582
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey'
       ByteSize: 8
-      GoRuntimeType: 1038016
+      GoRuntimeType: 1037888
       GoKind: 22
       Pointee: 1583 StructureType github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey
     - __kind: PointerType
@@ -14246,47 +14246,47 @@ Types:
       GoKind: 22
       Pointee: 2437 StructureType github.com/Masterminds/semver/v3.Version
     - __kind: PointerType
-      ID: 1491
+      ID: 1489
       Name: '*github.com/cihub/seelog.CfgParseParams'
       ByteSize: 8
-      GoRuntimeType: 910848
+      GoRuntimeType: 910176
       GoKind: 22
-      Pointee: 1492 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
+      Pointee: 1490 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
     - __kind: PointerType
-      ID: 1490
+      ID: 1488
       Name: '*github.com/cihub/seelog.LogLevel'
       ByteSize: 8
-      GoRuntimeType: 909984
+      GoRuntimeType: 909312
       GoKind: 22
-      Pointee: 1412 BaseType github.com/cihub/seelog.LogLevel
+      Pointee: 1410 BaseType github.com/cihub/seelog.LogLevel
     - __kind: PointerType
       ID: 2008
       Name: '*github.com/cihub/seelog.LogLevelException'
       ByteSize: 8
-      GoRuntimeType: 1806816
+      GoRuntimeType: 1806368
       GoKind: 22
       Pointee: 2009 UnresolvedPointeeType github.com/cihub/seelog.LogLevelException
     - __kind: PointerType
-      ID: 847
+      ID: 845
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
-      GoRuntimeType: 910176
+      GoRuntimeType: 909504
       GoKind: 22
-      Pointee: 848 StructureType github.com/cihub/seelog.baseError
+      Pointee: 846 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 1272
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1807264
+      GoRuntimeType: 1806816
       GoKind: 22
       Pointee: 1273 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 849
+      ID: 847
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
-      GoRuntimeType: 910272
+      GoRuntimeType: 909600
       GoKind: 22
-      Pointee: 850 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 848 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 1252
       Name: '*github.com/cihub/seelog.connWriter'
@@ -14298,42 +14298,42 @@ Types:
       ID: 1208
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1041088
+      GoRuntimeType: 1040960
       GoKind: 22
       Pointee: 1209 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1731
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1427776
+      GoRuntimeType: 1427616
       GoKind: 22
       Pointee: 1732 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
       ID: 1840
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
-      GoRuntimeType: 1641024
+      GoRuntimeType: 1640256
       GoKind: 22
       Pointee: 1841 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
       ID: 1242
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1427296
+      GoRuntimeType: 1427136
       GoKind: 22
       Pointee: 1243 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
       ID: 1844
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1641792
+      GoRuntimeType: 1641024
       GoKind: 22
       Pointee: 1845 UnresolvedPointeeType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
       ID: 1727
       Name: '*github.com/cihub/seelog.formattedWriter'
       ByteSize: 8
-      GoRuntimeType: 1427456
+      GoRuntimeType: 1427296
       GoKind: 22
       Pointee: 1728 UnresolvedPointeeType github.com/cihub/seelog.formattedWriter
     - __kind: PointerType
@@ -14347,42 +14347,42 @@ Types:
       ID: 1654
       Name: '*github.com/cihub/seelog.listConstraints'
       ByteSize: 8
-      GoRuntimeType: 1213760
+      GoRuntimeType: 1213248
       GoKind: 22
       Pointee: 1655 UnresolvedPointeeType github.com/cihub/seelog.listConstraints
     - __kind: PointerType
-      ID: 1488
+      ID: 1486
       Name: '*github.com/cihub/seelog.logFormattedMessage'
       ByteSize: 8
-      GoRuntimeType: 909888
+      GoRuntimeType: 909216
       GoKind: 22
-      Pointee: 1489 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
+      Pointee: 1487 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
     - __kind: PointerType
-      ID: 1486
+      ID: 1484
       Name: '*github.com/cihub/seelog.logMessage'
       ByteSize: 8
-      GoRuntimeType: 909792
+      GoRuntimeType: 909120
       GoKind: 22
-      Pointee: 1487 UnresolvedPointeeType github.com/cihub/seelog.logMessage
+      Pointee: 1485 UnresolvedPointeeType github.com/cihub/seelog.logMessage
     - __kind: PointerType
       ID: 1594
       Name: '*github.com/cihub/seelog.minMaxConstraints'
       ByteSize: 8
-      GoRuntimeType: 1041600
+      GoRuntimeType: 1041472
       GoKind: 22
       Pointee: 1595 UnresolvedPointeeType github.com/cihub/seelog.minMaxConstraints
     - __kind: PointerType
-      ID: 853
+      ID: 851
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
-      GoRuntimeType: 910464
+      GoRuntimeType: 909792
       GoKind: 22
-      Pointee: 854 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 852 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 1592
       Name: '*github.com/cihub/seelog.offConstraints'
       ByteSize: 8
-      GoRuntimeType: 1041472
+      GoRuntimeType: 1041344
       GoKind: 22
       Pointee: 1593 UnresolvedPointeeType github.com/cihub/seelog.offConstraints
     - __kind: PointerType
@@ -14410,35 +14410,35 @@ Types:
       ID: 1210
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1041216
+      GoRuntimeType: 1041088
       GoKind: 22
       Pointee: 1211 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
       ID: 1842
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1641216
+      GoRuntimeType: 1640448
       GoKind: 22
       Pointee: 1843 UnresolvedPointeeType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 851
+      ID: 849
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
-      GoRuntimeType: 910368
+      GoRuntimeType: 909696
       GoKind: 22
-      Pointee: 852 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 850 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 855
+      ID: 853
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
-      GoRuntimeType: 910560
+      GoRuntimeType: 909888
       GoKind: 22
-      Pointee: 856 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 854 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 1729
       Name: '*github.com/cihub/seelog.xmlNode'
       ByteSize: 8
-      GoRuntimeType: 1427616
+      GoRuntimeType: 1427456
       GoKind: 22
       Pointee: 1730 UnresolvedPointeeType github.com/cihub/seelog.xmlNode
     - __kind: PointerType
@@ -15290,42 +15290,42 @@ Types:
       ID: 1079
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1202368
+      GoRuntimeType: 1201856
       GoKind: 22
       Pointee: 1080 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 1073
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1201984
+      GoRuntimeType: 1201472
       GoKind: 22
       Pointee: 1074 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 1016
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1032640
+      GoRuntimeType: 1032512
       GoKind: 22
       Pointee: 1017 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 1085
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1202752
+      GoRuntimeType: 1202240
       GoKind: 22
       Pointee: 1086 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 1015
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1032512
+      GoRuntimeType: 1032384
       GoKind: 22
       Pointee: 994 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 1077
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1202240
+      GoRuntimeType: 1201728
       GoKind: 22
       Pointee: 1078 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
@@ -15336,31 +15336,31 @@ Types:
       GoKind: 22
       Pointee: 2661 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Reader
     - __kind: PointerType
-      ID: 1472
+      ID: 1470
       Name: '*github.com/tinylib/msgp/msgp.Type'
       ByteSize: 8
-      GoRuntimeType: 901920
+      GoRuntimeType: 901248
       GoKind: 22
       Pointee: 1166 BaseType github.com/tinylib/msgp/msgp.Type
     - __kind: PointerType
       ID: 1075
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1202112
+      GoRuntimeType: 1201600
       GoKind: 22
       Pointee: 1076 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 1083
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1202624
+      GoRuntimeType: 1202112
       GoKind: 22
       Pointee: 1084 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 1081
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1202496
+      GoRuntimeType: 1201984
       GoKind: 22
       Pointee: 1082 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
@@ -15374,28 +15374,28 @@ Types:
       ID: 1089
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1203136
+      GoRuntimeType: 1202624
       GoKind: 22
       Pointee: 1090 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 1020
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1032896
+      GoRuntimeType: 1032768
       GoKind: 22
       Pointee: 1021 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 1018
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1032768
+      GoRuntimeType: 1032640
       GoKind: 22
       Pointee: 1019 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 1087
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1203008
+      GoRuntimeType: 1202496
       GoKind: 22
       Pointee: 1088 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -17432,77 +17432,77 @@ Types:
       ID: 2532
       Name: '*io.LimitedReader'
       ByteSize: 8
-      GoRuntimeType: 897120
+      GoRuntimeType: 897984
       GoKind: 22
       Pointee: 2533 UnresolvedPointeeType io.LimitedReader
     - __kind: PointerType
       ID: 2637
       Name: '*io.PipeReader'
       ByteSize: 8
-      GoRuntimeType: 1839840
+      GoRuntimeType: 1842080
       GoKind: 22
       Pointee: 2638 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
       ID: 1230
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1193664
+      GoRuntimeType: 1196864
       GoKind: 22
       Pointee: 1231 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 2616
       Name: '*io.SectionReader'
       ByteSize: 8
-      GoRuntimeType: 1554976
+      GoRuntimeType: 1556576
       GoKind: 22
       Pointee: 2617 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
       ID: 1228
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1193280
+      GoRuntimeType: 1196480
       GoKind: 22
       Pointee: 1229 StructureType io.discard
     - __kind: PointerType
       ID: 2534
       Name: '*io.eofReader'
       ByteSize: 8
-      GoRuntimeType: 897216
+      GoRuntimeType: 898080
       GoKind: 22
       Pointee: 2535 StructureType io.eofReader
     - __kind: PointerType
       ID: 2590
       Name: '*io.multiReader'
       ByteSize: 8
-      GoRuntimeType: 1193024
+      GoRuntimeType: 1196224
       GoKind: 22
       Pointee: 2591 UnresolvedPointeeType io.multiReader
     - __kind: PointerType
       ID: 1202
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1025216
+      GoRuntimeType: 1026240
       GoKind: 22
       Pointee: 1203 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 2558
       Name: '*io.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1025472
+      GoRuntimeType: 1026496
       GoKind: 22
       Pointee: 2559 StructureType io.nopCloser
     - __kind: PointerType
       ID: 2592
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
-      GoRuntimeType: 1193152
+      GoRuntimeType: 1196352
       GoKind: 22
       Pointee: 2593 StructureType io.nopCloserWriterTo
     - __kind: PointerType
       ID: 2530
       Name: '*io.teeReader'
       ByteSize: 8
-      GoRuntimeType: 897024
+      GoRuntimeType: 897888
       GoKind: 22
       Pointee: 2531 UnresolvedPointeeType io.teeReader
     - __kind: PointerType
@@ -17530,28 +17530,28 @@ Types:
       ID: 1656
       Name: '*log/slog.Attr'
       ByteSize: 8
-      GoRuntimeType: 1214400
+      GoRuntimeType: 1213888
       GoKind: 22
       Pointee: 1657 StructureType log/slog.Attr
     - __kind: PointerType
-      ID: 1493
+      ID: 1491
       Name: '*log/slog.Kind'
       ByteSize: 8
-      GoRuntimeType: 910944
+      GoRuntimeType: 910272
       GoKind: 22
-      Pointee: 1413 BaseType log/slog.Kind
+      Pointee: 1411 BaseType log/slog.Kind
     - __kind: PointerType
       ID: 2010
       Name: '*log/slog.Level'
       ByteSize: 8
-      GoRuntimeType: 1807712
+      GoRuntimeType: 1807264
       GoKind: 22
       Pointee: 1760 BaseType log/slog.Level
     - __kind: PointerType
       ID: 2372
       Name: '*log/slog.Value'
       ByteSize: 8
-      GoRuntimeType: 2201344
+      GoRuntimeType: 2200512
       GoKind: 22
       Pointee: 2000 StructureType log/slog.Value
     - __kind: PointerType
@@ -18075,7 +18075,7 @@ Types:
       ID: 2624
       Name: '*math/rand/v2.ChaCha8'
       ByteSize: 8
-      GoRuntimeType: 1638144
+      GoRuntimeType: 1637376
       GoKind: 22
       Pointee: 2625 UnresolvedPointeeType math/rand/v2.ChaCha8
     - __kind: PointerType
@@ -18124,21 +18124,21 @@ Types:
       ID: 1096
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1209280
+      GoRuntimeType: 1208768
       GoKind: 22
       Pointee: 1097 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 1127
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1425536
+      GoRuntimeType: 1425376
       GoKind: 22
       Pointee: 1128 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1484
+      ID: 1482
       Name: '*net.HardwareAddr.array'
       ByteSize: 8
-      Pointee: 1483 GoSliceDataType net.HardwareAddr.array
+      Pointee: 1481 GoSliceDataType net.HardwareAddr.array
     - __kind: PointerType
       ID: 2335
       Name: '*net.IP'
@@ -18169,7 +18169,7 @@ Types:
       ID: 1584
       Name: '*net.IPMask'
       ByteSize: 8
-      GoRuntimeType: 1039040
+      GoRuntimeType: 1038912
       GoKind: 22
       Pointee: 1585 GoSliceHeaderType net.IPMask
     - __kind: PointerType
@@ -18181,28 +18181,28 @@ Types:
       ID: 1650
       Name: '*net.IPNet'
       ByteSize: 8
-      GoRuntimeType: 1209024
+      GoRuntimeType: 1208512
       GoKind: 22
       Pointee: 1651 UnresolvedPointeeType net.IPNet
     - __kind: PointerType
       ID: 1125
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1425216
+      GoRuntimeType: 1425056
       GoKind: 22
       Pointee: 1126 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 1098
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1209408
+      GoRuntimeType: 1208896
       GoKind: 22
       Pointee: 1099 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 2006
       Name: '*net.TCPAddr'
       ByteSize: 8
-      GoRuntimeType: 1805920
+      GoRuntimeType: 1805472
       GoKind: 22
       Pointee: 2007 UnresolvedPointeeType net.TCPAddr
     - __kind: PointerType
@@ -18216,7 +18216,7 @@ Types:
       ID: 2004
       Name: '*net.UDPAddr'
       ByteSize: 8
-      GoRuntimeType: 1805696
+      GoRuntimeType: 1805248
       GoKind: 22
       Pointee: 2005 UnresolvedPointeeType net.UDPAddr
     - __kind: PointerType
@@ -18244,7 +18244,7 @@ Types:
       ID: 1095
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1208512
+      GoRuntimeType: 1208000
       GoKind: 22
       Pointee: 1064 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -18256,37 +18256,37 @@ Types:
       ID: 2149
       Name: '*net.addrPortUDPAddr'
       ByteSize: 8
-      GoRuntimeType: 2014208
+      GoRuntimeType: 2013920
       GoKind: 22
       Pointee: 2150 StructureType net.addrPortUDPAddr
     - __kind: PointerType
       ID: 1032
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1039296
+      GoRuntimeType: 1039168
       GoKind: 22
       Pointee: 1033 StructureType net.canceledError
     - __kind: PointerType
       ID: 1312
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2013920
+      GoRuntimeType: 2013632
       GoKind: 22
       Pointee: 1313 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1167
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1850816
+      GoRuntimeType: 1850592
       GoKind: 22
       Pointee: 1168 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1485
+      ID: 1483
       Name: '*net.hostLookupOrder'
       ByteSize: 8
-      GoRuntimeType: 907584
+      GoRuntimeType: 906912
       GoKind: 22
-      Pointee: 1411 BaseType net.hostLookupOrder
+      Pointee: 1409 BaseType net.hostLookupOrder
     - __kind: PointerType
       ID: 1358
       Name: '*net.netFD'
@@ -18295,157 +18295,157 @@ Types:
       GoKind: 22
       Pointee: 1359 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 832
+      ID: 830
       Name: '*net.notFoundError'
       ByteSize: 8
-      GoRuntimeType: 907200
+      GoRuntimeType: 906528
       GoKind: 22
-      Pointee: 833 UnresolvedPointeeType net.notFoundError
+      Pointee: 831 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 412
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
-      GoRuntimeType: 1425376
+      GoRuntimeType: 1425216
       GoKind: 22
       Pointee: 413 GoContextImplementationType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 834
+      ID: 832
       Name: '*net.result·2'
       ByteSize: 8
-      GoRuntimeType: 907872
+      GoRuntimeType: 907200
       GoKind: 22
-      Pointee: 835 StructureType net.result·2
+      Pointee: 833 StructureType net.result·2
     - __kind: PointerType
       ID: 1340
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2255520
+      GoRuntimeType: 2254560
       GoKind: 22
       Pointee: 1341 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1338
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2255040
+      GoRuntimeType: 2254080
       GoKind: 22
       Pointee: 1339 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 1100
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1210048
+      GoRuntimeType: 1209536
       GoKind: 22
       Pointee: 1101 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 1129
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1425696
+      GoRuntimeType: 1425536
       GoKind: 22
       Pointee: 1130 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 1578
       Name: '*net/http.Cookie'
       ByteSize: 8
-      GoRuntimeType: 1033664
+      GoRuntimeType: 1033536
       GoKind: 22
       Pointee: 1579 UnresolvedPointeeType net/http.Cookie
     - __kind: PointerType
       ID: 1022
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1035328
+      GoRuntimeType: 1035200
       GoKind: 22
       Pointee: 1023 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 2003
       Name: '*net/http.Protocols'
       ByteSize: 8
-      GoRuntimeType: 1805024
+      GoRuntimeType: 1804576
       GoKind: 22
       Pointee: 1918 StructureType net/http.Protocols
     - __kind: PointerType
       ID: 2604
       Name: '*net/http.body'
       ByteSize: 8
-      GoRuntimeType: 1805472
+      GoRuntimeType: 1805024
       GoKind: 22
       Pointee: 2605 UnresolvedPointeeType net/http.body
     - __kind: PointerType
       ID: 2594
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
-      GoRuntimeType: 1204160
+      GoRuntimeType: 1203648
       GoKind: 22
       Pointee: 2595 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
       ID: 2536
       Name: '*net/http.bodyLocked'
       ByteSize: 8
-      GoRuntimeType: 902784
+      GoRuntimeType: 902112
       GoKind: 22
       Pointee: 2537 StructureType net/http.bodyLocked
     - __kind: PointerType
       ID: 1184
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
-      GoRuntimeType: 902976
+      GoRuntimeType: 902304
       GoKind: 22
       Pointee: 1185 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
       ID: 2538
       Name: '*net/http.byteReader'
       ByteSize: 8
-      GoRuntimeType: 903072
+      GoRuntimeType: 902400
       GoKind: 22
       Pointee: 2539 UnresolvedPointeeType net/http.byteReader
     - __kind: PointerType
       ID: 2570
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
-      GoRuntimeType: 1035200
+      GoRuntimeType: 1035072
       GoKind: 22
       Pointee: 2571 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 1475
+      ID: 1473
       Name: '*net/http.connectMethodKey'
       ByteSize: 8
-      GoRuntimeType: 903552
+      GoRuntimeType: 902880
       GoKind: 22
-      Pointee: 1476 StructureType net/http.connectMethodKey
+      Pointee: 1474 StructureType net/http.connectMethodKey
     - __kind: PointerType
-      ID: 1477
+      ID: 1475
       Name: '*net/http.contextKey'
       ByteSize: 8
-      GoRuntimeType: 904896
+      GoRuntimeType: 904224
       GoKind: 22
-      Pointee: 1478 UnresolvedPointeeType net/http.contextKey
+      Pointee: 1476 UnresolvedPointeeType net/http.contextKey
     - __kind: PointerType
       ID: 2540
       Name: '*net/http.errorReader'
       ByteSize: 8
-      GoRuntimeType: 903168
+      GoRuntimeType: 902496
       GoKind: 22
       Pointee: 2541 StructureType net/http.errorReader
     - __kind: PointerType
       ID: 2542
       Name: '*net/http.finishAsyncByteRead'
       ByteSize: 8
-      GoRuntimeType: 903264
+      GoRuntimeType: 902592
       GoKind: 22
       Pointee: 2543 StructureType net/http.finishAsyncByteRead
     - __kind: PointerType
       ID: 2572
       Name: '*net/http.gzipReader'
       ByteSize: 8
-      GoRuntimeType: 1035840
+      GoRuntimeType: 1035712
       GoKind: 22
       Pointee: 2573 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 809
+      ID: 807
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 903648
+      GoRuntimeType: 902976
       GoKind: 22
       Pointee: 729 BaseType net/http.http2ConnectionError
     - __kind: PointerType
@@ -18466,7 +18466,7 @@ Types:
       ID: 1575
       Name: '*net/http.http2ErrCode'
       ByteSize: 8
-      GoRuntimeType: 1033408
+      GoRuntimeType: 1033280
       GoKind: 22
       Pointee: 1140 BaseType net/http.http2ErrCode
     - __kind: PointerType
@@ -18477,52 +18477,52 @@ Types:
       GoKind: 22
       Pointee: 1769 StructureType net/http.http2FrameHeader
     - __kind: PointerType
-      ID: 1473
+      ID: 1471
       Name: '*net/http.http2FrameType'
       ByteSize: 8
-      GoRuntimeType: 902112
+      GoRuntimeType: 901440
       GoKind: 22
-      Pointee: 1406 BaseType net/http.http2FrameType
+      Pointee: 1404 BaseType net/http.http2FrameType
     - __kind: PointerType
-      ID: 810
+      ID: 808
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
-      GoRuntimeType: 903744
+      GoRuntimeType: 903072
       GoKind: 22
-      Pointee: 811 StructureType net/http.http2GoAwayError
+      Pointee: 809 StructureType net/http.http2GoAwayError
     - __kind: PointerType
       ID: 1832
       Name: '*net/http.http2GoAwayFrame'
       ByteSize: 8
-      GoRuntimeType: 1630272
+      GoRuntimeType: 1629504
       GoKind: 22
       Pointee: 1833 StructureType net/http.http2GoAwayFrame
     - __kind: PointerType
       ID: 2050
       Name: '*net/http.http2HeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 1847232
+      GoRuntimeType: 1847008
       GoKind: 22
       Pointee: 2049 StructureType net/http.http2HeadersFrame
     - __kind: PointerType
       ID: 2147
       Name: '*net/http.http2MetaHeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 2013056
+      GoRuntimeType: 2012768
       GoKind: 22
       Pointee: 2148 StructureType net/http.http2MetaHeadersFrame
     - __kind: PointerType
       ID: 1834
       Name: '*net/http.http2PingFrame'
       ByteSize: 8
-      GoRuntimeType: 1630464
+      GoRuntimeType: 1629696
       GoKind: 22
       Pointee: 1835 StructureType net/http.http2PingFrame
     - __kind: PointerType
       ID: 1836
       Name: '*net/http.http2PriorityFrame'
       ByteSize: 8
-      GoRuntimeType: 1630656
+      GoRuntimeType: 1629888
       GoKind: 22
       Pointee: 1837 StructureType net/http.http2PriorityFrame
     - __kind: PointerType
@@ -18543,16 +18543,16 @@ Types:
       ID: 1576
       Name: '*net/http.http2Setting'
       ByteSize: 8
-      GoRuntimeType: 1033536
+      GoRuntimeType: 1033408
       GoKind: 22
       Pointee: 1577 StructureType net/http.http2Setting
     - __kind: PointerType
-      ID: 1474
+      ID: 1472
       Name: '*net/http.http2SettingID'
       ByteSize: 8
-      GoRuntimeType: 902400
+      GoRuntimeType: 901728
       GoKind: 22
-      Pointee: 1407 BaseType net/http.http2SettingID
+      Pointee: 1405 BaseType net/http.http2SettingID
     - __kind: PointerType
       ID: 2107
       Name: '*net/http.http2SettingsFrame'
@@ -18564,14 +18564,14 @@ Types:
       ID: 1121
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1421696
+      GoRuntimeType: 1421536
       GoKind: 22
       Pointee: 1122 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 1838
       Name: '*net/http.http2UnknownFrame'
       ByteSize: 8
-      GoRuntimeType: 1632000
+      GoRuntimeType: 1631232
       GoKind: 22
       Pointee: 1839 StructureType net/http.http2UnknownFrame
     - __kind: PointerType
@@ -18585,16 +18585,16 @@ Types:
       ID: 2618
       Name: '*net/http.http2clientStream'
       ByteSize: 8
-      GoRuntimeType: 2013344
+      GoRuntimeType: 2013056
       GoKind: 22
       Pointee: 2619 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 814
+      ID: 812
       Name: '*net/http.http2connError'
       ByteSize: 8
-      GoRuntimeType: 904320
+      GoRuntimeType: 903648
       GoKind: 22
-      Pointee: 815 StructureType net/http.http2connError
+      Pointee: 813 StructureType net/http.http2connError
     - __kind: PointerType
       ID: 1248
       Name: '*net/http.http2dataBuffer'
@@ -18603,10 +18603,10 @@ Types:
       GoKind: 22
       Pointee: 1249 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 813
+      ID: 811
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 904224
+      GoRuntimeType: 903552
       GoKind: 22
       Pointee: 733 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
@@ -18618,14 +18618,14 @@ Types:
       ID: 2568
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
-      GoRuntimeType: 1034944
+      GoRuntimeType: 1034816
       GoKind: 22
       Pointee: 2569 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 817
+      ID: 815
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 904512
+      GoRuntimeType: 903840
       GoKind: 22
       Pointee: 739 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
@@ -18634,10 +18634,10 @@ Types:
       ByteSize: 8
       Pointee: 740 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 816
+      ID: 814
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 904416
+      GoRuntimeType: 903744
       GoKind: 22
       Pointee: 736 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
@@ -18649,28 +18649,28 @@ Types:
       ID: 1093
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1205184
+      GoRuntimeType: 1204672
       GoKind: 22
       Pointee: 1094 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 2564
       Name: '*net/http.http2missingBody'
       ByteSize: 8
-      GoRuntimeType: 1034688
+      GoRuntimeType: 1034560
       GoKind: 22
       Pointee: 2565 StructureType net/http.http2missingBody
     - __kind: PointerType
       ID: 2574
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
-      GoRuntimeType: 1036096
+      GoRuntimeType: 1035968
       GoKind: 22
       Pointee: 2575 StructureType net/http.http2noBodyReader
     - __kind: PointerType
       ID: 1028
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1035968
+      GoRuntimeType: 1035840
       GoKind: 22
       Pointee: 1029 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
@@ -18681,10 +18681,10 @@ Types:
       GoKind: 22
       Pointee: 1303 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 812
+      ID: 810
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 904128
+      GoRuntimeType: 903456
       GoKind: 22
       Pointee: 730 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
@@ -18696,98 +18696,98 @@ Types:
       ID: 1186
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
-      GoRuntimeType: 904608
+      GoRuntimeType: 903936
       GoKind: 22
       Pointee: 1187 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
       ID: 2566
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
-      GoRuntimeType: 1034816
+      GoRuntimeType: 1034688
       GoKind: 22
       Pointee: 2567 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
       ID: 2562
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
-      GoRuntimeType: 1034304
+      GoRuntimeType: 1034176
       GoKind: 22
       Pointee: 2563 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
       ID: 2596
       Name: '*net/http.noBody'
       ByteSize: 8
-      GoRuntimeType: 1204416
+      GoRuntimeType: 1203904
       GoKind: 22
       Pointee: 2597 StructureType net/http.noBody
     - __kind: PointerType
       ID: 1024
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1035584
+      GoRuntimeType: 1035456
       GoKind: 22
       Pointee: 1025 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1830
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1629888
+      GoRuntimeType: 1629120
       GoKind: 22
       Pointee: 1831 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 1250
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2180576
+      GoRuntimeType: 2180160
       GoKind: 22
       Pointee: 1251 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1206
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1035456
+      GoRuntimeType: 1035328
       GoKind: 22
       Pointee: 1207 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 2560
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
-      GoRuntimeType: 1033920
+      GoRuntimeType: 1033792
       GoKind: 22
       Pointee: 2561 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
       ID: 1232
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1204288
+      GoRuntimeType: 1203776
       GoKind: 22
       Pointee: 1233 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 818
+      ID: 816
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
-      GoRuntimeType: 904704
+      GoRuntimeType: 904032
       GoKind: 22
-      Pointee: 819 StructureType net/http.requestBodyReadError
+      Pointee: 817 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 1580
       Name: '*net/http.socksAddr'
       ByteSize: 8
-      GoRuntimeType: 1034048
+      GoRuntimeType: 1033920
       GoKind: 22
       Pointee: 1581 UnresolvedPointeeType net/http.socksAddr
     - __kind: PointerType
       ID: 1123
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1422816
+      GoRuntimeType: 1422656
       GoKind: 22
       Pointee: 1124 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 1091
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1205056
+      GoRuntimeType: 1204544
       GoKind: 22
       Pointee: 1092 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
@@ -18801,23 +18801,23 @@ Types:
       ID: 1026
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1035712
+      GoRuntimeType: 1035584
       GoKind: 22
       Pointee: 1027 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1284
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1847680
+      GoRuntimeType: 1847456
       GoKind: 22
       Pointee: 1285 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 807
+      ID: 805
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
-      GoRuntimeType: 902880
+      GoRuntimeType: 902208
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 806 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 2584
       Name: '*net/http/httputil.failureToReadBody'
@@ -18939,14 +18939,14 @@ Types:
       ID: 1131
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1426016
+      GoRuntimeType: 1425856
       GoKind: 22
       Pointee: 1132 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 836
+      ID: 834
       Name: '*net/url.EscapeError'
       ByteSize: 8
-      GoRuntimeType: 907968
+      GoRuntimeType: 907296
       GoKind: 22
       Pointee: 742 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
@@ -18955,10 +18955,10 @@ Types:
       ByteSize: 8
       Pointee: 743 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 837
+      ID: 835
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
-      GoRuntimeType: 908064
+      GoRuntimeType: 907392
       GoKind: 22
       Pointee: 745 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
@@ -18977,7 +18977,7 @@ Types:
       ID: 1652
       Name: '*net/url.Userinfo'
       ByteSize: 8
-      GoRuntimeType: 1210816
+      GoRuntimeType: 1210304
       GoKind: 22
       Pointee: 1653 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
@@ -19249,19 +19249,19 @@ Types:
       GoKind: 22
       Pointee: 777 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 1470
+      ID: 1492
       Name: '*reflect.ChanDir'
       ByteSize: 8
-      GoRuntimeType: 901056
+      GoRuntimeType: 910560
       GoKind: 22
-      Pointee: 1403 BaseType reflect.ChanDir
+      Pointee: 1412 BaseType reflect.ChanDir
     - __kind: PointerType
-      ID: 1471
+      ID: 1493
       Name: '*reflect.Kind'
       ByteSize: 8
-      GoRuntimeType: 901248
+      GoRuntimeType: 910752
       GoKind: 22
-      Pointee: 1404 BaseType reflect.Kind
+      Pointee: 1413 BaseType reflect.Kind
     - __kind: PointerType
       ID: 2501
       Name: '*reflect.Value'
@@ -19270,12 +19270,12 @@ Types:
       GoKind: 22
       Pointee: 2502 StructureType reflect.Value
     - __kind: PointerType
-      ID: 805
+      ID: 856
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 901632
+      GoRuntimeType: 911136
       GoKind: 22
-      Pointee: 806 UnresolvedPointeeType reflect.ValueError
+      Pointee: 857 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 2485
       Name: '*reflect.rtype'
@@ -19481,12 +19481,12 @@ Types:
       GoKind: 22
       Pointee: 36 BaseType runtime.waitReason
     - __kind: PointerType
-      ID: 1480
+      ID: 1478
       Name: '*runtime/debug.BuildInfo'
       ByteSize: 8
-      GoRuntimeType: 906912
+      GoRuntimeType: 906240
       GoKind: 22
-      Pointee: 1481 UnresolvedPointeeType runtime/debug.BuildInfo
+      Pointee: 1479 UnresolvedPointeeType runtime/debug.BuildInfo
     - __kind: PointerType
       ID: 1494
       Name: '*runtime/pprof.labelMap'
@@ -31569,7 +31569,7 @@ Types:
     - __kind: ArrayType
       ID: 1915
       Name: '[0]func()'
-      GoRuntimeType: 732320
+      GoRuntimeType: 730304
       GoKind: 17
       HasCount: true
       Element: 62 GoSubroutineType func()
@@ -31898,7 +31898,7 @@ Types:
       ID: 1996
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 695104
+      GoRuntimeType: 694240
       GoKind: 17
       Count: 8
       HasCount: true
@@ -31907,7 +31907,7 @@ Types:
       ID: 1395
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
-      GoRuntimeType: 481600
+      GoRuntimeType: 481408
       GoKind: 23
       RawFields:
         - Name: array
@@ -32444,7 +32444,7 @@ Types:
       ID: 391
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
-      GoRuntimeType: 481152
+      GoRuntimeType: 480960
       GoKind: 23
       RawFields:
         - Name: array
@@ -32467,7 +32467,7 @@ Types:
       ID: 394
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
-      GoRuntimeType: 481344
+      GoRuntimeType: 481152
       GoKind: 23
       RawFields:
         - Name: array
@@ -32513,7 +32513,7 @@ Types:
       ID: 364
       Name: '[]go.shape.float64'
       ByteSize: 24
-      GoRuntimeType: 483712
+      GoRuntimeType: 483520
       GoKind: 23
       RawFields:
         - Name: array
@@ -33100,7 +33100,7 @@ Types:
       ID: 2180
       Name: '[]vendor/golang.org/x/net/http2/hpack.HeaderField'
       ByteSize: 24
-      GoRuntimeType: 492576
+      GoRuntimeType: 491744
       GoKind: 23
       RawFields:
         - Name: array
@@ -33343,7 +33343,7 @@ Types:
       ID: 156
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1285632
+      GoRuntimeType: 1285504
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33395,7 +33395,7 @@ Types:
       ID: 707
       Name: context.canceler
       ByteSize: 16
-      GoRuntimeType: 1112672
+      GoRuntimeType: 1111776
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33407,7 +33407,7 @@ Types:
     - __kind: StructureType
       ID: 1068
       Name: context.deadlineExceededError
-      GoRuntimeType: 1468896
+      GoRuntimeType: 1467776
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
@@ -33438,7 +33438,7 @@ Types:
       ID: 431
       Name: context.timerCtx
       ByteSize: 112
-      GoRuntimeType: 1619328
+      GoRuntimeType: 1618944
       GoKind: 25
       RawFields:
         - Name: cancelCtx
@@ -33468,7 +33468,7 @@ Types:
       ID: 415
       Name: context.valueCtx
       ByteSize: 48
-      GoRuntimeType: 1840064
+      GoRuntimeType: 1838944
       GoKind: 25
       RawFields:
         - Name: Context
@@ -33903,7 +33903,7 @@ Types:
       ID: 757
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 835040
+      GoRuntimeType: 834848
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1213
@@ -33916,13 +33916,13 @@ Types:
       GoRuntimeType: 835232
       GoKind: 8
     - __kind: BaseType
-      ID: 1409
+      ID: 1407
       Name: encoding/json.Delim
       ByteSize: 4
-      GoRuntimeType: 833696
+      GoRuntimeType: 833504
       GoKind: 5
     - __kind: UnresolvedPointeeType
-      ID: 829
+      ID: 827
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -33949,19 +33949,19 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 821
+      ID: 819
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 827
+      ID: 825
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 825
+      ID: 823
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 821
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -33969,10 +33969,10 @@ Types:
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 831
+      ID: 829
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1424256
+      GoRuntimeType: 1424096
       GoKind: 25
       RawFields:
         - Name: error
@@ -34054,7 +34054,7 @@ Types:
       ID: 2651
       Name: fmt.ScanState
       ByteSize: 16
-      GoRuntimeType: 1468096
+      GoRuntimeType: 1470176
       GoKind: 20
       RawFields:
         - Name: tab
@@ -34067,7 +34067,7 @@ Types:
       ID: 403
       Name: fmt.Stringer
       ByteSize: 16
-      GoRuntimeType: 1024960
+      GoRuntimeType: 1025984
       GoKind: 20
       RawFields:
         - Name: tab
@@ -34175,7 +34175,7 @@ Types:
       ID: 1998
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
       ByteSize: 4
-      GoRuntimeType: 1761888
+      GoRuntimeType: 1761312
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 2163
@@ -34189,7 +34189,7 @@ Types:
       ID: 1999
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
       ByteSize: 4
-      GoRuntimeType: 1762080
+      GoRuntimeType: 1761504
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 2465
@@ -34250,7 +34250,7 @@ Types:
       Name: github.com/DataDog/datadog-agent/pkg/version.Version
       ByteSize: 8
     - __kind: StructureType
-      ID: 840
+      ID: 838
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1734272
@@ -34266,7 +34266,7 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 842
+      ID: 840
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34274,7 +34274,7 @@ Types:
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 846
+      ID: 844
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1115360
       GoKind: 25
@@ -34287,7 +34287,7 @@ Types:
       ID: 751
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
-      GoRuntimeType: 834464
+      GoRuntimeType: 834272
       GoKind: 24
       RawFields:
         - Name: str
@@ -34355,13 +34355,13 @@ Types:
       ID: 1156
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
-      GoRuntimeType: 586272
+      GoRuntimeType: 586208
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 748
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
-      GoRuntimeType: 834368
+      GoRuntimeType: 834176
       GoKind: 24
       RawFields:
         - Name: str
@@ -34380,7 +34380,7 @@ Types:
       ID: 754
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
-      GoRuntimeType: 834560
+      GoRuntimeType: 834368
       GoKind: 24
       RawFields:
         - Name: str
@@ -34591,7 +34591,7 @@ Types:
       ID: 393
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
-      GoRuntimeType: 1916192
+      GoRuntimeType: 1915936
       GoKind: 25
       RawFields:
         - Name: TraceID
@@ -34664,7 +34664,7 @@ Types:
       ID: 381
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 1285760
+      GoRuntimeType: 1285632
       GoKind: 21
       HeaderType: 383 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
@@ -34685,7 +34685,7 @@ Types:
       ID: 1397
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
-      GoRuntimeType: 583392
+      GoRuntimeType: 583328
       GoKind: 10
     - __kind: StructureType
       ID: 396
@@ -34714,7 +34714,7 @@ Types:
       ID: 723
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
-      GoRuntimeType: 1916448
+      GoRuntimeType: 1916192
       GoKind: 25
       RawFields:
         - Name: Type
@@ -34745,7 +34745,7 @@ Types:
       ID: 401
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
-      GoRuntimeType: 2111200
+      GoRuntimeType: 2110848
       GoKind: 25
       RawFields:
         - Name: mu
@@ -34782,7 +34782,7 @@ Types:
       ID: 402
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
-      GoRuntimeType: 897792
+      GoRuntimeType: 897312
       GoKind: 17
       Count: 16
       HasCount: true
@@ -34801,7 +34801,7 @@ Types:
       ID: 1557
       Name: github.com/DataDog/dd-trace-go/v2/internal.TraceSource
       ByteSize: 1
-      GoRuntimeType: 991904
+      GoRuntimeType: 991808
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1351
@@ -34848,16 +34848,16 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/waf.Feature
       ByteSize: 8
     - __kind: BaseType
-      ID: 1405
+      ID: 1403
       Name: github.com/DataDog/dd-trace-go/v2/internal/log.Level
       ByteSize: 8
-      GoRuntimeType: 832640
+      GoRuntimeType: 832448
       GoKind: 2
     - __kind: GoContextImplementationType
       ID: 411
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
-      GoRuntimeType: 1633152
+      GoRuntimeType: 1632384
       GoKind: 25
       RawFields:
         - Name: Context
@@ -35249,24 +35249,24 @@ Types:
           Offset: 56
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1492
+      ID: 1490
       Name: github.com/cihub/seelog.CfgParseParams
       ByteSize: 8
     - __kind: BaseType
-      ID: 1412
+      ID: 1410
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
-      GoRuntimeType: 834848
+      GoRuntimeType: 834656
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 2009
       Name: github.com/cihub/seelog.LogLevelException
       ByteSize: 8
     - __kind: StructureType
-      ID: 848
+      ID: 846
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1426496
+      GoRuntimeType: 1426336
       GoKind: 25
       RawFields:
         - Name: message
@@ -35277,15 +35277,15 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 850
+      ID: 848
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1426656
+      GoRuntimeType: 1426496
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 848 StructureType github.com/cihub/seelog.baseError
+          Type: 846 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1253
       Name: github.com/cihub/seelog.connWriter
@@ -35323,11 +35323,11 @@ Types:
       Name: github.com/cihub/seelog.listConstraints
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1489
+      ID: 1487
       Name: github.com/cihub/seelog.logFormattedMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1487
+      ID: 1485
       Name: github.com/cihub/seelog.logMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -35335,15 +35335,15 @@ Types:
       Name: github.com/cihub/seelog.minMaxConstraints
       ByteSize: 8
     - __kind: StructureType
-      ID: 854
+      ID: 852
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1426976
+      GoRuntimeType: 1426816
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 848 StructureType github.com/cihub/seelog.baseError
+          Type: 846 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1593
       Name: github.com/cihub/seelog.offConstraints
@@ -35390,25 +35390,25 @@ Types:
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 852
+      ID: 850
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1426816
+      GoRuntimeType: 1426656
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 848 StructureType github.com/cihub/seelog.baseError
+          Type: 846 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 856
+      ID: 854
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1427136
+      GoRuntimeType: 1426976
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 848 StructureType github.com/cihub/seelog.baseError
+          Type: 846 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1730
       Name: github.com/cihub/seelog.xmlNode
@@ -36033,7 +36033,7 @@ Types:
       ID: 1080
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1845888
+      GoRuntimeType: 1845664
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -36066,7 +36066,7 @@ Types:
       ID: 1086
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1846336
+      GoRuntimeType: 1846112
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36082,13 +36082,13 @@ Types:
       ID: 994
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 991328
+      GoRuntimeType: 991232
       GoKind: 8
     - __kind: StructureType
       ID: 1078
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1845664
+      GoRuntimeType: 1845440
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -36108,13 +36108,13 @@ Types:
       ID: 1166
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
-      GoRuntimeType: 832736
+      GoRuntimeType: 832544
       GoKind: 8
     - __kind: StructureType
       ID: 1076
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1845440
+      GoRuntimeType: 1845216
       GoKind: 25
       RawFields:
         - Name: Method
@@ -36130,7 +36130,7 @@ Types:
       ID: 1084
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1759200
+      GoRuntimeType: 1758624
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36143,7 +36143,7 @@ Types:
       ID: 1082
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1846112
+      GoRuntimeType: 1845888
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36163,7 +36163,7 @@ Types:
       ID: 1090
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1628928
+      GoRuntimeType: 1628160
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -36185,7 +36185,7 @@ Types:
       ID: 1088
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1759392
+      GoRuntimeType: 1758816
       GoKind: 25
       RawFields:
         - Name: cause
@@ -38822,7 +38822,7 @@ Types:
       ID: 2630
       Name: io.Closer
       ByteSize: 16
-      GoRuntimeType: 1025984
+      GoRuntimeType: 1027008
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38847,7 +38847,7 @@ Types:
       ID: 1271
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1193408
+      GoRuntimeType: 1196608
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38860,7 +38860,7 @@ Types:
       ID: 404
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1025344
+      GoRuntimeType: 1026368
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38877,7 +38877,7 @@ Types:
       ID: 1260
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1112160
+      GoRuntimeType: 1112416
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38890,7 +38890,7 @@ Types:
       ID: 132
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1025088
+      GoRuntimeType: 1026112
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38903,7 +38903,7 @@ Types:
       ID: 2629
       Name: io.WriterTo
       ByteSize: 16
-      GoRuntimeType: 1025856
+      GoRuntimeType: 1026880
       GoKind: 20
       RawFields:
         - Name: tab
@@ -38915,13 +38915,13 @@ Types:
     - __kind: StructureType
       ID: 1229
       Name: io.discard
-      GoRuntimeType: 1468576
+      GoRuntimeType: 1470656
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 2535
       Name: io.eofReader
-      GoRuntimeType: 1111904
+      GoRuntimeType: 1112160
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -38936,7 +38936,7 @@ Types:
       ID: 2559
       Name: io.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1554816
+      GoRuntimeType: 1556416
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -38946,7 +38946,7 @@ Types:
       ID: 2593
       Name: io.nopCloserWriterTo
       ByteSize: 16
-      GoRuntimeType: 1618944
+      GoRuntimeType: 1620096
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -38993,7 +38993,7 @@ Types:
       ID: 1657
       Name: log/slog.Attr
       ByteSize: 40
-      GoRuntimeType: 1767264
+      GoRuntimeType: 1766688
       GoKind: 25
       RawFields:
         - Name: Key
@@ -39003,16 +39003,16 @@ Types:
           Offset: 16
           Type: 2000 StructureType log/slog.Value
     - __kind: BaseType
-      ID: 1413
+      ID: 1411
       Name: log/slog.Kind
       ByteSize: 8
-      GoRuntimeType: 834944
+      GoRuntimeType: 834752
       GoKind: 2
     - __kind: BaseType
       ID: 1760
       Name: log/slog.Level
       ByteSize: 8
-      GoRuntimeType: 1489216
+      GoRuntimeType: 1488096
       GoKind: 2
     - __kind: StructureType
       ID: 2000
@@ -41500,16 +41500,16 @@ Types:
       Name: net.DNSError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1410
+      ID: 1408
       Name: net.Flags
       ByteSize: 8
-      GoRuntimeType: 833888
+      GoRuntimeType: 833696
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 1482
+      ID: 1480
       Name: net.HardwareAddr
       ByteSize: 24
-      GoRuntimeType: 907392
+      GoRuntimeType: 906720
       GoKind: 23
       RawFields:
         - Name: array
@@ -41521,9 +41521,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1483 GoSliceDataType net.HardwareAddr.array
+      Data: 1481 GoSliceDataType net.HardwareAddr.array
     - __kind: GoSliceDataType
-      ID: 1483
+      ID: 1481
       Name: net.HardwareAddr.array
       DynamicSizeClass: slice
       ByteSize: 1
@@ -41563,7 +41563,7 @@ Types:
       ID: 1585
       Name: net.IPMask
       ByteSize: 24
-      GoRuntimeType: 1039168
+      GoRuntimeType: 1039040
       GoKind: 23
       RawFields:
         - Name: array
@@ -41677,10 +41677,10 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: BaseType
-      ID: 1411
+      ID: 1409
       Name: net.hostLookupOrder
       ByteSize: 8
-      GoRuntimeType: 833984
+      GoRuntimeType: 833792
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1359
@@ -41699,14 +41699,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 833
+      ID: 831
       Name: net.notFoundError
       ByteSize: 8
     - __kind: GoContextImplementationType
       ID: 413
       Name: net.onlyValuesCtx
       ByteSize: 32
-      GoRuntimeType: 1764192
+      GoRuntimeType: 1763616
       GoKind: 25
       RawFields:
         - Name: Context
@@ -41718,7 +41718,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: StructureType
-      ID: 835
+      ID: 833
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1734080
@@ -41768,10 +41768,10 @@ Types:
       Name: net.timeoutError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1408
+      ID: 1406
       Name: net/http.ConnState
       ByteSize: 8
-      GoRuntimeType: 833120
+      GoRuntimeType: 832928
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1579
@@ -41800,7 +41800,7 @@ Types:
       ID: 2537
       Name: net/http.bodyLocked
       ByteSize: 8
-      GoRuntimeType: 1421856
+      GoRuntimeType: 1421696
       GoKind: 25
       RawFields:
         - Name: b
@@ -41810,7 +41810,7 @@ Types:
       ID: 1185
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1422016
+      GoRuntimeType: 1421856
       GoKind: 25
       RawFields:
         - Name: w
@@ -41825,7 +41825,7 @@ Types:
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 1476
+      ID: 1474
       Name: net/http.connectMethodKey
       ByteSize: 56
       GoRuntimeType: 1828800
@@ -41844,14 +41844,14 @@ Types:
           Offset: 48
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1478
+      ID: 1476
       Name: net/http.contextKey
       ByteSize: 8
     - __kind: StructureType
       ID: 2541
       Name: net/http.errorReader
       ByteSize: 16
-      GoRuntimeType: 1422176
+      GoRuntimeType: 1422016
       GoKind: 25
       RawFields:
         - Name: err
@@ -41861,7 +41861,7 @@ Types:
       ID: 2543
       Name: net/http.finishAsyncByteRead
       ByteSize: 8
-      GoRuntimeType: 1422336
+      GoRuntimeType: 1422176
       GoKind: 25
       RawFields:
         - Name: tw
@@ -41875,13 +41875,13 @@ Types:
       ID: 729
       Name: net/http.http2ConnectionError
       ByteSize: 4
-      GoRuntimeType: 833216
+      GoRuntimeType: 833024
       GoKind: 10
     - __kind: StructureType
       ID: 1922
       Name: net/http.http2ContinuationFrame
       ByteSize: 40
-      GoRuntimeType: 1761312
+      GoRuntimeType: 1760736
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41894,7 +41894,7 @@ Types:
       ID: 1917
       Name: net/http.http2DataFrame
       ByteSize: 40
-      GoRuntimeType: 1759584
+      GoRuntimeType: 1759008
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41907,13 +41907,13 @@ Types:
       ID: 1140
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 991424
+      GoRuntimeType: 991328
       GoKind: 10
     - __kind: BaseType
       ID: 1995
       Name: net/http.http2Flags
       ByteSize: 1
-      GoRuntimeType: 832928
+      GoRuntimeType: 832736
       GoKind: 8
     - __kind: StructureType
       ID: 1769
@@ -41927,7 +41927,7 @@ Types:
           Type: 6 BaseType bool
         - Name: Type
           Offset: 1
-          Type: 1406 BaseType net/http.http2FrameType
+          Type: 1404 BaseType net/http.http2FrameType
         - Name: Flags
           Offset: 2
           Type: 1995 BaseType net/http.http2Flags
@@ -41938,13 +41938,13 @@ Types:
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1406
+      ID: 1404
       Name: net/http.http2FrameType
       ByteSize: 1
-      GoRuntimeType: 832832
+      GoRuntimeType: 832640
       GoKind: 8
     - __kind: StructureType
-      ID: 811
+      ID: 809
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1732736
@@ -41963,7 +41963,7 @@ Types:
       ID: 1833
       Name: net/http.http2GoAwayFrame
       ByteSize: 48
-      GoRuntimeType: 1919776
+      GoRuntimeType: 1919520
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -41982,7 +41982,7 @@ Types:
       ID: 2049
       Name: net/http.http2HeadersFrame
       ByteSize: 48
-      GoRuntimeType: 1847008
+      GoRuntimeType: 1846784
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42014,7 +42014,7 @@ Types:
       ID: 1835
       Name: net/http.http2PingFrame
       ByteSize: 20
-      GoRuntimeType: 1759776
+      GoRuntimeType: 1759200
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42056,7 +42056,7 @@ Types:
       ID: 1920
       Name: net/http.http2PushPromiseFrame
       ByteSize: 40
-      GoRuntimeType: 1848800
+      GoRuntimeType: 1848576
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42072,7 +42072,7 @@ Types:
       ID: 1771
       Name: net/http.http2RSTStreamFrame
       ByteSize: 16
-      GoRuntimeType: 1759968
+      GoRuntimeType: 1759392
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42090,21 +42090,21 @@ Types:
       RawFields:
         - Name: ID
           Offset: 0
-          Type: 1407 BaseType net/http.http2SettingID
+          Type: 1405 BaseType net/http.http2SettingID
         - Name: Val
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1407
+      ID: 1405
       Name: net/http.http2SettingID
       ByteSize: 2
-      GoRuntimeType: 833024
+      GoRuntimeType: 832832
       GoKind: 9
     - __kind: StructureType
       ID: 1997
       Name: net/http.http2SettingsFrame
       ByteSize: 40
-      GoRuntimeType: 1760160
+      GoRuntimeType: 1759584
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42117,7 +42117,7 @@ Types:
       ID: 1122
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1904960
+      GoRuntimeType: 1904704
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -42133,7 +42133,7 @@ Types:
       ID: 1839
       Name: net/http.http2UnknownFrame
       ByteSize: 40
-      GoRuntimeType: 1761120
+      GoRuntimeType: 1760544
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42146,7 +42146,7 @@ Types:
       ID: 1773
       Name: net/http.http2WindowUpdateFrame
       ByteSize: 16
-      GoRuntimeType: 1760352
+      GoRuntimeType: 1759776
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42160,7 +42160,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 815
+      ID: 813
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1601216
@@ -42180,7 +42180,7 @@ Types:
       ID: 733
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 833408
+      GoRuntimeType: 833216
       GoKind: 24
       RawFields:
         - Name: str
@@ -42203,7 +42203,7 @@ Types:
       ID: 739
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 833600
+      GoRuntimeType: 833408
       GoKind: 24
       RawFields:
         - Name: str
@@ -42222,7 +42222,7 @@ Types:
       ID: 736
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 833504
+      GoRuntimeType: 833312
       GoKind: 24
       RawFields:
         - Name: str
@@ -42267,7 +42267,7 @@ Types:
       ID: 730
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 833312
+      GoRuntimeType: 833120
       GoKind: 24
       RawFields:
         - Name: str
@@ -42305,7 +42305,7 @@ Types:
       ID: 1282
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
-      GoRuntimeType: 1421376
+      GoRuntimeType: 1421216
       GoKind: 20
       RawFields:
         - Name: tab
@@ -42327,7 +42327,7 @@ Types:
     - __kind: ArrayType
       ID: 1268
       Name: net/http.incomparable
-      GoRuntimeType: 902688
+      GoRuntimeType: 902016
       GoKind: 17
       HasCount: true
       Element: 62 GoSubroutineType func()
@@ -42338,7 +42338,7 @@ Types:
     - __kind: StructureType
       ID: 2597
       Name: net/http.noBody
-      GoRuntimeType: 1479616
+      GoRuntimeType: 1478496
       GoKind: 25
       RawFields: []
     - __kind: StructureType
@@ -42377,7 +42377,7 @@ Types:
       ID: 1233
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1805248
+      GoRuntimeType: 1804800
       GoKind: 25
       RawFields:
         - Name: _
@@ -42390,10 +42390,10 @@ Types:
           Offset: 8
           Type: 1271 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 819
+      ID: 817
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1422976
+      GoRuntimeType: 1422816
       GoKind: 25
       RawFields:
         - Name: error
@@ -42410,7 +42410,7 @@ Types:
     - __kind: StructureType
       ID: 1092
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1480896
+      GoRuntimeType: 1479776
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -42431,7 +42431,7 @@ Types:
       ID: 1285
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2031168
+      GoRuntimeType: 2030880
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -42441,7 +42441,7 @@ Types:
           Offset: 16
           Type: 1163 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 806
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -42609,7 +42609,7 @@ Types:
       ID: 742
       Name: net/url.EscapeError
       ByteSize: 16
-      GoRuntimeType: 834080
+      GoRuntimeType: 833888
       GoKind: 24
       RawFields:
         - Name: str
@@ -42628,7 +42628,7 @@ Types:
       ID: 745
       Name: net/url.InvalidHostError
       ByteSize: 16
-      GoRuntimeType: 834176
+      GoRuntimeType: 833984
       GoKind: 24
       RawFields:
         - Name: str
@@ -42727,7 +42727,7 @@ Types:
       ID: 705
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
-      GoRuntimeType: 689760
+      GoRuntimeType: 688224
       GoKind: 17
       Count: 8
       HasCount: true
@@ -42808,7 +42808,7 @@ Types:
       ID: 720
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
-      GoRuntimeType: 690400
+      GoRuntimeType: 688960
       GoKind: 17
       Count: 8
       HasCount: true
@@ -42817,7 +42817,7 @@ Types:
       ID: 2522
       Name: noalg.[8]struct { key string; elem *regexp.Regexp }
       ByteSize: 192
-      GoRuntimeType: 691552
+      GoRuntimeType: 690400
       GoKind: 17
       Count: 8
       HasCount: true
@@ -42844,7 +42844,7 @@ Types:
       ID: 687
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
-      GoRuntimeType: 690304
+      GoRuntimeType: 688864
       GoKind: 17
       Count: 8
       HasCount: true
@@ -43033,7 +43033,7 @@ Types:
       ID: 704
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
-      GoRuntimeType: 1303680
+      GoRuntimeType: 1303552
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43150,7 +43150,7 @@ Types:
       ID: 719
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
-      GoRuntimeType: 1304576
+      GoRuntimeType: 1304448
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43163,7 +43163,7 @@ Types:
       ID: 2521
       Name: noalg.map.group[string]*regexp.Regexp
       ByteSize: 200
-      GoRuntimeType: 1305344
+      GoRuntimeType: 1305216
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43202,7 +43202,7 @@ Types:
       ID: 686
       Name: noalg.map.group[string]float64
       ByteSize: 200
-      GoRuntimeType: 1304320
+      GoRuntimeType: 1304192
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43456,7 +43456,7 @@ Types:
       ID: 706
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
-      GoRuntimeType: 1303552
+      GoRuntimeType: 1303424
       GoKind: 25
       RawFields:
         - Name: key
@@ -43573,7 +43573,7 @@ Types:
       ID: 721
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
-      GoRuntimeType: 1304448
+      GoRuntimeType: 1304320
       GoKind: 25
       RawFields:
         - Name: key
@@ -43586,7 +43586,7 @@ Types:
       ID: 2523
       Name: noalg.struct { key string; elem *regexp.Regexp }
       ByteSize: 24
-      GoRuntimeType: 1305216
+      GoRuntimeType: 1305088
       GoKind: 25
       RawFields:
         - Name: key
@@ -43625,7 +43625,7 @@ Types:
       ID: 688
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
-      GoRuntimeType: 1304192
+      GoRuntimeType: 1304064
       GoKind: 25
       RawFields:
         - Name: key
@@ -43944,16 +43944,16 @@ Types:
       GoRuntimeType: 839264
       GoKind: 2
     - __kind: BaseType
-      ID: 1403
+      ID: 1412
       Name: reflect.ChanDir
       ByteSize: 8
-      GoRuntimeType: 832448
+      GoRuntimeType: 834944
       GoKind: 2
     - __kind: BaseType
-      ID: 1404
+      ID: 1413
       Name: reflect.Kind
       ByteSize: 8
-      GoRuntimeType: 832544
+      GoRuntimeType: 835040
       GoKind: 7
     - __kind: StructureType
       ID: 2502
@@ -43972,14 +43972,14 @@ Types:
           Offset: 16
           Type: 2503 BaseType reflect.flag
     - __kind: UnresolvedPointeeType
-      ID: 806
+      ID: 857
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: BaseType
       ID: 2503
       Name: reflect.flag
       ByteSize: 8
-      GoRuntimeType: 1758240
+      GoRuntimeType: 1766880
       GoKind: 12
     - __kind: UnresolvedPointeeType
       ID: 2486
@@ -44924,7 +44924,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1481
+      ID: 1479
       Name: runtime/debug.BuildInfo
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -44980,7 +44980,7 @@ Types:
       ID: 2589
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
-      GoRuntimeType: 1714848
+      GoRuntimeType: 1714272
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -44993,7 +44993,7 @@ Types:
       ID: 2587
       Name: struct { io.Reader; io.WriterTo }
       ByteSize: 32
-      GoRuntimeType: 1714656
+      GoRuntimeType: 1714080
       GoKind: 25
       RawFields:
         - Name: Reader

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -20,11 +20,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3006 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x812ef8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8139e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3007 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x812f28", Frameless: false}]
+              InjectionPoints: [{PC: "0x813a18", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -40,11 +40,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2841 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x80de18", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e3c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2842 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x80de40", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e3f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -66,11 +66,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2844 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x80de88", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e438", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2845 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x80deb0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e460", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -91,11 +91,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2975 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x811b2c", Frameless: false}]
+              InjectionPoints: [{PC: "0x81252c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2976 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x811bb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8125b8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -183,7 +183,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2853 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x80e590", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ebf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -248,11 +248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2877 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x80ff10", Frameless: true}]
+              InjectionPoints: [{PC: "0x810750", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2878 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x80ff4c", Frameless: true}]
+              InjectionPoints: [{PC: "0x81078c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -274,11 +274,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2805 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x809cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e80", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2806 EventRootType Probe[main.testBigStruct]Return
-              InjectionPoints: [{PC: "0x809ccc", Frameless: true}]
+              InjectionPoints: [{PC: "0x809e8c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -344,7 +344,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3004 EventRootType Probe[main.testByteSliceInvalidUtf8]
-              InjectionPoints: [{PC: "0x812960", Frameless: true}]
+              InjectionPoints: [{PC: "0x813360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -366,7 +366,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3005 EventRootType Probe[main.testByteSliceMultibyteUtf8]
-              InjectionPoints: [{PC: "0x812970", Frameless: true}]
+              InjectionPoints: [{PC: "0x813370", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -387,7 +387,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2820 EventRootType Probe[main.testCaptureContextImpl]
-              InjectionPoints: [{PC: "0x80a860", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ab30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -414,11 +414,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3028 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x813230", Frameless: true}]
+              InjectionPoints: [{PC: "0x813f40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3029 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x813240", Frameless: true}]
+              InjectionPoints: [{PC: "0x813f50", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -426,7 +426,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: ""
       segments: []
@@ -438,15 +438,15 @@ Probes:
             - Kind: Line
               Type: 3092 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x80d738"
+                - PC: "0x80dbe8"
                   Frameless: false
-                - PC: "0x80d7ac"
+                - PC: "0x80dc5c"
                   Frameless: false
-                - PC: "0x80d8e8"
+                - PC: "0x80dd98"
                   Frameless: false
-                - PC: "0x80d964"
+                - PC: "0x80de14"
                   Frameless: false
-                - PC: "0x80da1c"
+                - PC: "0x80decc"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -455,7 +455,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       when: {dsl: x == 3, json: {eq: [{ref: x}, 3]}}
       sampling: {snapshotsPerSecond: 100}
       template: ""
@@ -468,15 +468,15 @@ Probes:
             - Kind: Line
               Type: 3093 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x80d738"
+                - PC: "0x80dbe8"
                   Frameless: false
-                - PC: "0x80d7ac"
+                - PC: "0x80dc5c"
                   Frameless: false
-                - PC: "0x80d8e8"
+                - PC: "0x80dd98"
                   Frameless: false
-                - PC: "0x80d964"
+                - PC: "0x80de14"
                   Frameless: false
-                - PC: "0x80da1c"
+                - PC: "0x80decc"
                   Frameless: false
               Condition:
                 Type: 6 BaseType bool
@@ -502,7 +502,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: x={x}
       segments: [x=, {json: {ref: x}, dsl: x}]
@@ -514,15 +514,15 @@ Probes:
             - Kind: Line
               Type: 3094 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x80d738"
+                - PC: "0x80dbe8"
                   Frameless: false
-                - PC: "0x80d7ac"
+                - PC: "0x80dc5c"
                   Frameless: false
-                - PC: "0x80d8e8"
+                - PC: "0x80dd98"
                   Frameless: false
-                - PC: "0x80d964"
+                - PC: "0x80de14"
                   Frameless: false
-                - PC: "0x80da1c"
+                - PC: "0x80decc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -550,7 +550,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2872 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80fa80", Frameless: true}]
+              InjectionPoints: [{PC: "0x8100e0", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -569,7 +569,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2873 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80fa80", Frameless: true}]
+              InjectionPoints: [{PC: "0x8100e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -595,7 +595,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3036 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x8132d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x813fe0", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -633,7 +633,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2879 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x80ff50", Frameless: true}]
+              InjectionPoints: [{PC: "0x810790", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -663,7 +663,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2871 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x80fa60", Frameless: true}]
+              InjectionPoints: [{PC: "0x8100c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -692,11 +692,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2940 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x810e28", Frameless: false}]
+              InjectionPoints: [{PC: "0x811828", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2941 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x810ec8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8118c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -718,7 +718,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2887 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x8101e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -740,7 +740,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2812 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x80a160", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -762,7 +762,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2813 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x80a170", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a330", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -784,7 +784,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2808 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x809e80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -806,7 +806,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2809 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x809e90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a050", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -828,7 +828,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2810 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x80a000", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a1c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -850,7 +850,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2811 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x80a010", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a1d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -872,7 +872,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2992 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x812880", Frameless: true}]
+              InjectionPoints: [{PC: "0x813280", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -899,7 +899,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2995 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x8128b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8132b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -927,7 +927,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3020 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x812fb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x813bc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -949,7 +949,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3037 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x813300", Frameless: true}]
+              InjectionPoints: [{PC: "0x814010", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -970,7 +970,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3038 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x813310", Frameless: true}]
+              InjectionPoints: [{PC: "0x814020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -992,7 +992,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2843 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x80de60", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e410", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1007,7 +1007,7 @@ Probes:
       where:
         methodName: main.testErrorAtLine
         sourceFile: complex.go
-        lines: ["108"]
+        lines: ["111"]
       tags:
         - config_diff:arch=amd64,toolchain=go1.26rc1
         - skip_integration:arch=arm64,toolchain=go1.25.0
@@ -1026,7 +1026,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2807 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x809d0c", Frameless: false}]
+              InjectionPoints: [{PC: "0x809ecc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -1054,11 +1054,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2825 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x80c818", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ccc8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2826 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x80c850", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cd00", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1080,11 +1080,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2823 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x80c75c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cc0c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2824 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x80c7b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cc68", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1106,11 +1106,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2835 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x80db80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e030", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2836 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x80db88", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e038", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1132,11 +1132,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2837 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x80db9c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e04c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2838 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x80dbd0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e080", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1151,7 +1151,7 @@ Probes:
       where:
         methodName: main.testFramelessArray
         sourceFile: inlined.go
-        lines: ["93"]
+        lines: ["96"]
       sampling: {snapshotsPerSecond: 100}
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
@@ -1161,7 +1161,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2839 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x80db9c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e04c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1183,11 +1183,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3078 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x815460", Frameless: true}]
+              InjectionPoints: [{PC: "0x816360", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3079 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x815464", Frameless: true}]
+              InjectionPoints: [{PC: "0x816364", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1201,11 +1201,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3080 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x815480", Frameless: false}]
+              InjectionPoints: [{PC: "0x816380", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3081 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x8154b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8163b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1228,11 +1228,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3074 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x8153c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8162c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3075 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x8153d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8162d8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1246,11 +1246,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3076 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x815418", Frameless: false}]
+              InjectionPoints: [{PC: "0x816318", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3077 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x815430", Frameless: false}]
+              InjectionPoints: [{PC: "0x816330", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1273,14 +1273,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 3082 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x8154c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8163c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3083 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x8154e8"
+                - PC: "0x8163e8"
                   Frameless: true
-                - PC: "0x8154f0"
+                - PC: "0x8163f0"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1295,14 +1295,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 3084 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x815518", Frameless: false}]
+              InjectionPoints: [{PC: "0x816418", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3085 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x815574"
+                - PC: "0x816474"
                   Frameless: false
-                - PC: "0x815584"
+                - PC: "0x816484"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1329,7 +1329,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3086 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x8154c4", Frameless: true}]
+              InjectionPoints: [{PC: "0x8163c4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1341,7 +1341,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3087 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x815528", Frameless: false}]
+              InjectionPoints: [{PC: "0x816428", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1362,11 +1362,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3062 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x8150d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x815fd0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3063 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x8150d4", Frameless: true}]
+              InjectionPoints: [{PC: "0x815fd4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1380,11 +1380,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3064 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x815160", Frameless: true}]
+              InjectionPoints: [{PC: "0x816060", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3065 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x815164", Frameless: true}]
+              InjectionPoints: [{PC: "0x816064", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1408,11 +1408,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3050 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x814cd8", Frameless: false}]
+              InjectionPoints: [{PC: "0x815bd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3051 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x814dac", Frameless: false}]
+              InjectionPoints: [{PC: "0x815cac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1454,11 +1454,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3054 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x814df8", Frameless: false}]
+              InjectionPoints: [{PC: "0x815cf8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3055 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x814e08", Frameless: false}]
+              InjectionPoints: [{PC: "0x815d08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1481,11 +1481,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3088 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x8155c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8164c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3089 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x8155c8", Frameless: true}]
+              InjectionPoints: [{PC: "0x8164c8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1499,11 +1499,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3090 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x815658", Frameless: false}]
+              InjectionPoints: [{PC: "0x816558", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3091 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x81567c", Frameless: false}]
+              InjectionPoints: [{PC: "0x81657c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1526,11 +1526,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3046 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x814c40", Frameless: true}]
+              InjectionPoints: [{PC: "0x815b40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3047 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x814c44", Frameless: true}]
+              InjectionPoints: [{PC: "0x815b44", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1544,11 +1544,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3048 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x814c50", Frameless: true}]
+              InjectionPoints: [{PC: "0x815b50", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3049 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x814c5c", Frameless: true}]
+              InjectionPoints: [{PC: "0x815b5c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1571,11 +1571,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3066 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x815200", Frameless: true}]
+              InjectionPoints: [{PC: "0x816100", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3067 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x815208", Frameless: true}]
+              InjectionPoints: [{PC: "0x816108", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1589,11 +1589,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3068 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x8152a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8161a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3069 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x8152d0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8161d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1616,11 +1616,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3056 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x8150a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x815fa0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3057 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8150a4", Frameless: true}]
+              InjectionPoints: [{PC: "0x815fa4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1634,11 +1634,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3058 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x8150b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x815fb0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3059 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x8150b4", Frameless: true}]
+              InjectionPoints: [{PC: "0x815fb4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1652,11 +1652,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3060 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x8150c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x815fc0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3061 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x8150c4", Frameless: true}]
+              InjectionPoints: [{PC: "0x815fc4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1679,11 +1679,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3070 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x815380", Frameless: true}]
+              InjectionPoints: [{PC: "0x816280", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3071 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x815388", Frameless: true}]
+              InjectionPoints: [{PC: "0x816288", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1697,11 +1697,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3072 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x815390", Frameless: true}]
+              InjectionPoints: [{PC: "0x816290", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3073 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8153a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8162a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1724,11 +1724,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3042 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x814c20", Frameless: true}]
+              InjectionPoints: [{PC: "0x815b20", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3043 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x814c24", Frameless: true}]
+              InjectionPoints: [{PC: "0x815b24", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1742,11 +1742,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3044 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x814c30", Frameless: true}]
+              InjectionPoints: [{PC: "0x815b30", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3045 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x814c3c", Frameless: true}]
+              InjectionPoints: [{PC: "0x815b3c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1769,14 +1769,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2875 EventRootType Probe[main.(*Server).handleOrder]
-              InjectionPoints: [{PC: "0x80fcfc", Frameless: false}]
+              InjectionPoints: [{PC: "0x81044c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2876 EventRootType Probe[main.(*Server).handleOrder]Return
               InjectionPoints:
-                - PC: "0x80fd98"
+                - PC: "0x8104e8"
                   Frameless: false
-                - PC: "0x80fe38"
+                - PC: "0x810588"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1799,11 +1799,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2827 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x80d8c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dd78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2828 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x80d91c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ddcc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1830,11 +1830,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2829 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x80d958", Frameless: false}]
+              InjectionPoints: [{PC: "0x80de08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2830 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x80d9d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80de88", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1861,11 +1861,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2831 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x80da18", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dec8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2832 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x80da50", Frameless: false}]
+              InjectionPoints: [{PC: "0x80df00", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1887,7 +1887,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3098 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x80d9a4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80de54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1905,11 +1905,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2833 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x80da88", Frameless: false}]
+              InjectionPoints: [{PC: "0x80df38", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2834 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x80db64", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e014", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1927,7 +1927,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3099 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x80da8c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80df3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1938,7 +1938,7 @@ Probes:
       where:
         methodName: main.testInlinedBCA
         sourceFile: inlined.go
-        lines: ["63"]
+        lines: ["66"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCA
       segments: [testInlinedBCA]
@@ -1948,7 +1948,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3100 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x80da8c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80df3c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1966,7 +1966,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3101 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x80db30", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dfe0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1977,7 +1977,7 @@ Probes:
       where:
         methodName: main.testInlinedBCB
         sourceFile: inlined.go
-        lines: ["67"]
+        lines: ["70"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCB
       segments: [testInlinedBCB]
@@ -1987,7 +1987,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3102 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x80db30", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dfe0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -2008,7 +2008,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x8083a8"
                   Frameless: true
-                - PC: "0x80e4c4"
+                - PC: "0x80eb00"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2029,20 +2029,20 @@ Probes:
             - Kind: Entry
               Type: 3095 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x80d738"
+                - PC: "0x80dbe8"
                   Frameless: false
-                - PC: "0x80d7ac"
+                - PC: "0x80dc5c"
                   Frameless: false
-                - PC: "0x80d8e8"
+                - PC: "0x80dd98"
                   Frameless: false
-                - PC: "0x80d964"
+                - PC: "0x80de14"
                   Frameless: false
-                - PC: "0x80da1c"
+                - PC: "0x80decc"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 3096 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x80d76c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dc1c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2057,7 +2057,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2068,15 +2068,15 @@ Probes:
             - Kind: Line
               Type: 3097 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x80d738"
+                - PC: "0x80dbe8"
                   Frameless: false
-                - PC: "0x80d7ac"
+                - PC: "0x80dc5c"
                   Frameless: false
-                - PC: "0x80d8e8"
+                - PC: "0x80dd98"
                   Frameless: false
-                - PC: "0x80d964"
+                - PC: "0x80de14"
                   Frameless: false
-                - PC: "0x80da1c"
+                - PC: "0x80decc"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2099,7 +2099,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3103 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x80db84", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e034", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2114,7 +2114,7 @@ Probes:
       where:
         methodName: main.testInlinedSq
         sourceFile: inlined.go
-        lines: ["75"]
+        lines: ["78"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2124,7 +2124,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3104 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x80db84", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e034", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2148,9 +2148,9 @@ Probes:
             - Kind: Entry
               Type: 3105 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x80dbb4"
+                - PC: "0x80e064"
                   Frameless: false
-                - PC: "0x80dc3c"
+                - PC: "0x80e138"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2283,7 +2283,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2840 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x80ddf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e3a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2310,7 +2310,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3022 EventRootType Probe[main.testInvalidUtf8Strings]
-              InjectionPoints: [{PC: "0x812fd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x813be0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -2336,11 +2336,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2973 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x8119a0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8123a0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2974 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x811ac8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8124c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2362,7 +2362,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2881 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x8100f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810a10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2377,7 +2377,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["230"]
+        lines: ["233"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
@@ -2387,7 +2387,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2816 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x80a1bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a37c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2398,7 +2398,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["237"]
+        lines: ["240"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2409,7 +2409,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2817 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x80a240", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a400", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2420,7 +2420,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["242"]
+        lines: ["245"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2431,7 +2431,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2818 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x80a2dc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a49c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2474,11 +2474,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2979 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x811dfc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8127fc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2980 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x811f3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x81293c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2541,7 +2541,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2821 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0x80aae0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80adb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2565,7 +2565,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2822 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0x80c450", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2587,7 +2587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2851 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x80e570", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ebd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2609,7 +2609,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2858 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x80e5d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ec30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2631,7 +2631,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2868 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x80e670", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ecd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2653,7 +2653,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2870 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x80e690", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ecf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2675,7 +2675,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2869 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x80e680", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ece0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2697,7 +2697,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2855 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x80e5b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ec10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2719,7 +2719,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2867 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x80e660", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ecc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2741,7 +2741,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2866 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x80e650", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ecb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2765,7 +2765,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2856 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x80e5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ec20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2789,7 +2789,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2857 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x80e5c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ec20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2811,7 +2811,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2865 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x80e640", Frameless: true}]
+              InjectionPoints: [{PC: "0x80eca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2833,7 +2833,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2864 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x80e630", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ec90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2855,7 +2855,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2849 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x80e550", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ebb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2877,7 +2877,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2850 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x80e560", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ebc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2899,7 +2899,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2848 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x80e540", Frameless: true}]
+              InjectionPoints: [{PC: "0x80eba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2921,7 +2921,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2859 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x80e5e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ec40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2943,7 +2943,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2862 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x80e610", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ec70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2965,7 +2965,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2863 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x80e620", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ec80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2987,7 +2987,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2860 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x80e5f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ec50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3011,7 +3011,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2861 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x80e600", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ec60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -3033,7 +3033,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3017 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x812f90", Frameless: true}]
+              InjectionPoints: [{PC: "0x813ba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3056,7 +3056,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3018 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x812f90", Frameless: true}]
+              InjectionPoints: [{PC: "0x813ba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3103,11 +3103,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2981 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x811fa0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8129a0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2982 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x812128", Frameless: false}]
+              InjectionPoints: [{PC: "0x812b28", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3169,7 +3169,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3023 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0x812fe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x813bf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3192,7 +3192,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3024 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0x812fe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x813bf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3218,11 +3218,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2985 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x81221c", Frameless: false}]
+              InjectionPoints: [{PC: "0x812c1c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2986 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x8122b4", Frameless: false}]
+              InjectionPoints: [{PC: "0x812cb4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3253,11 +3253,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2977 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x811bf0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8125f0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2978 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x811d94", Frameless: false}]
+              InjectionPoints: [{PC: "0x812794", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3283,11 +3283,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2918 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x810ca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8116a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2919 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x810d28", Frameless: false}]
+              InjectionPoints: [{PC: "0x811728", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3323,7 +3323,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2874 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x80fb40", Frameless: true}]
+              InjectionPoints: [{PC: "0x8101a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3364,11 +3364,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2912 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x810c18", Frameless: false}]
+              InjectionPoints: [{PC: "0x811618", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2913 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x810c70", Frameless: false}]
+              InjectionPoints: [{PC: "0x811670", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3392,11 +3392,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2914 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x810c18", Frameless: false}]
+              InjectionPoints: [{PC: "0x811618", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2915 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x810c70", Frameless: false}]
+              InjectionPoints: [{PC: "0x811670", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3415,11 +3415,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2920 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x810ca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8116a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2921 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x810d28", Frameless: false}]
+              InjectionPoints: [{PC: "0x811728", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3439,11 +3439,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2922 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x810ca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8116a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2923 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x810d28", Frameless: false}]
+              InjectionPoints: [{PC: "0x811728", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3476,11 +3476,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2916 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x810c18", Frameless: false}]
+              InjectionPoints: [{PC: "0x811618", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2917 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x810c70", Frameless: false}]
+              InjectionPoints: [{PC: "0x811670", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3508,7 +3508,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3032 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x8132c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x813fd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3533,7 +3533,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3033 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x8132c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x813fd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3564,7 +3564,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3034 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x8132c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x813fd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3589,7 +3589,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3035 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x8132c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x813fd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3616,7 +3616,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2886 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x8101c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810ae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3643,7 +3643,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2999 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x8128f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8132f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3670,7 +3670,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2996 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x8128c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8132c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3705,7 +3705,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2998 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x8128e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8132e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3737,7 +3737,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3016 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x812f80", Frameless: true}]
+              InjectionPoints: [{PC: "0x813b90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3759,7 +3759,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2882 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x810100", Frameless: true}]
+              InjectionPoints: [{PC: "0x810a20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3781,7 +3781,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2854 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x80e5a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ec00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3803,7 +3803,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2880 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x8100e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3827,11 +3827,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2888 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x810508", Frameless: false}]
+              InjectionPoints: [{PC: "0x810f08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2889 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x810548", Frameless: false}]
+              InjectionPoints: [{PC: "0x810f48", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3851,11 +3851,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2932 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x810d68", Frameless: false}]
+              InjectionPoints: [{PC: "0x811768", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2933 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x810dec", Frameless: false}]
+              InjectionPoints: [{PC: "0x8117ec", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3900,11 +3900,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2898 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x810628", Frameless: false}]
+              InjectionPoints: [{PC: "0x811028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2899 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x8106b4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8110b4", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3946,11 +3946,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2890 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x810508", Frameless: false}]
+              InjectionPoints: [{PC: "0x810f08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2891 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x810548", Frameless: false}]
+              InjectionPoints: [{PC: "0x810f48", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3995,11 +3995,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2900 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x810628", Frameless: false}]
+              InjectionPoints: [{PC: "0x811028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2901 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x8106b4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8110b4", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -4043,11 +4043,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2934 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x810d68", Frameless: false}]
+              InjectionPoints: [{PC: "0x811768", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2935 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x810dec", Frameless: false}]
+              InjectionPoints: [{PC: "0x8117ec", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -4064,11 +4064,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2936 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x810d68", Frameless: false}]
+              InjectionPoints: [{PC: "0x811768", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2937 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x810dec", Frameless: false}]
+              InjectionPoints: [{PC: "0x8117ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -4090,11 +4090,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2892 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x810508", Frameless: false}]
+              InjectionPoints: [{PC: "0x810f08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2893 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x810548", Frameless: false}]
+              InjectionPoints: [{PC: "0x810f48", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -4117,18 +4117,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2908 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x8108e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8112e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2909 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x810970"
+                - PC: "0x811370"
                   Frameless: false
-                - PC: "0x8109c4"
+                - PC: "0x8113c4"
                   Frameless: false
-                - PC: "0x810a74"
+                - PC: "0x811474"
                   Frameless: false
-                - PC: "0x810a88"
+                - PC: "0x811488"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4156,18 +4156,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2906 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x810778", Frameless: false}]
+              InjectionPoints: [{PC: "0x811178", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2907 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x8107cc"
+                - PC: "0x8111cc"
                   Frameless: false
-                - PC: "0x810828"
+                - PC: "0x811228"
                   Frameless: false
-                - PC: "0x810868"
+                - PC: "0x811268"
                   Frameless: false
-                - PC: "0x8108a4"
+                - PC: "0x8112a4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4194,11 +4194,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2951 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x8113fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x811dfc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2952 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x811448", Frameless: false}]
+              InjectionPoints: [{PC: "0x811e48", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4215,11 +4215,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2953 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x811478", Frameless: false}]
+              InjectionPoints: [{PC: "0x811e78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2954 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x8114b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x811eb0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4236,11 +4236,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2955 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x8114e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x811ee8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2956 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x81151c", Frameless: false}]
+              InjectionPoints: [{PC: "0x811f1c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4257,11 +4257,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2959 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x8115d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x811fd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2960 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x811638", Frameless: false}]
+              InjectionPoints: [{PC: "0x812038", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4278,11 +4278,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2971 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x811928", Frameless: false}]
+              InjectionPoints: [{PC: "0x812328", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2972 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x811964", Frameless: false}]
+              InjectionPoints: [{PC: "0x812364", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4299,11 +4299,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2947 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x8112b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x811cb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2948 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x811300", Frameless: false}]
+              InjectionPoints: [{PC: "0x811d00", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4321,14 +4321,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2904 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x8106f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8110f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2905 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x810724"
+                - PC: "0x811124"
                   Frameless: false
-                - PC: "0x810738"
+                - PC: "0x811138"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4350,11 +4350,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2894 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x810508", Frameless: false}]
+              InjectionPoints: [{PC: "0x810f08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2895 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x810548", Frameless: false}]
+              InjectionPoints: [{PC: "0x810f48", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4375,11 +4375,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2902 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x810628", Frameless: false}]
+              InjectionPoints: [{PC: "0x811028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2903 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x8106b4", Frameless: false}]
+              InjectionPoints: [{PC: "0x8110b4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4400,11 +4400,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2896 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x810588", Frameless: false}]
+              InjectionPoints: [{PC: "0x810f88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2897 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x8105e4", Frameless: false}]
+              InjectionPoints: [{PC: "0x810fe4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4426,14 +4426,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2910 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x810ac8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8114c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2911 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x810b80"
+                - PC: "0x811580"
                   Frameless: false
-                - PC: "0x810b94"
+                - PC: "0x811594"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4455,11 +4455,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2949 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x811340", Frameless: false}]
+              InjectionPoints: [{PC: "0x811d40", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2950 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x8113bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x811dbc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4476,11 +4476,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2945 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x811208", Frameless: false}]
+              InjectionPoints: [{PC: "0x811c08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2946 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x811288", Frameless: false}]
+              InjectionPoints: [{PC: "0x811c88", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4497,11 +4497,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2963 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x811738", Frameless: false}]
+              InjectionPoints: [{PC: "0x812138", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2964 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x81178c", Frameless: false}]
+              InjectionPoints: [{PC: "0x81218c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4518,11 +4518,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2957 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x811558", Frameless: false}]
+              InjectionPoints: [{PC: "0x811f58", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2958 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x81159c", Frameless: false}]
+              InjectionPoints: [{PC: "0x811f9c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4539,11 +4539,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2969 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x8118b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8122b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2970 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x8118f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8122f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4563,7 +4563,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2942 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x810fd0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8119d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4584,11 +4584,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2967 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x811848", Frameless: false}]
+              InjectionPoints: [{PC: "0x812248", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2968 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x811884", Frameless: false}]
+              InjectionPoints: [{PC: "0x812284", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4605,11 +4605,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2943 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x811178", Frameless: false}]
+              InjectionPoints: [{PC: "0x811b78", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2944 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x8111cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x811bcc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4626,11 +4626,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2965 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x8117cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8121cc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2966 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x811818", Frameless: false}]
+              InjectionPoints: [{PC: "0x812218", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4647,11 +4647,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2961 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x811670", Frameless: false}]
+              InjectionPoints: [{PC: "0x812070", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2962 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x8116fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8120fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4704,11 +4704,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2924 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x810ca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8116a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2925 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x810d28", Frameless: false}]
+              InjectionPoints: [{PC: "0x811728", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4754,7 +4754,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2791 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x809af0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809bd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4776,7 +4776,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2789 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x809ad0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809bb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4798,7 +4798,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2802 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x809ba0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4816,7 +4816,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2803 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x809bb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4834,7 +4834,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2792 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x809b00", Frameless: true}]
+              InjectionPoints: [{PC: "0x809be0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4856,7 +4856,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2794 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x809b20", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4879,7 +4879,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2795 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x809b30", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4901,7 +4901,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2796 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x809b40", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4930,7 +4930,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2793 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x809b10", Frameless: true}]
+              InjectionPoints: [{PC: "0x809bf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4961,7 +4961,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2790 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x809ae0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809bc0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4983,7 +4983,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3008 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x812f40", Frameless: true}]
+              InjectionPoints: [{PC: "0x813b50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5005,7 +5005,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2797 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x809b50", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5027,7 +5027,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2799 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x809b70", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5049,7 +5049,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2800 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x809b80", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5071,7 +5071,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2801 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x809b90", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5093,7 +5093,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2798 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x809b60", Frameless: true}]
+              InjectionPoints: [{PC: "0x809c40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5115,7 +5115,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3002 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x812910", Frameless: true}]
+              InjectionPoints: [{PC: "0x813310", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5137,7 +5137,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2993 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x812890", Frameless: true}]
+              InjectionPoints: [{PC: "0x813290", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5159,7 +5159,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2852 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x80e580", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ebe0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -5180,11 +5180,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2938 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x810d68", Frameless: false}]
+              InjectionPoints: [{PC: "0x811768", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2939 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x810dec", Frameless: false}]
+              InjectionPoints: [{PC: "0x8117ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5205,11 +5205,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2983 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x812188", Frameless: false}]
+              InjectionPoints: [{PC: "0x812b88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2984 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x8121e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x812be0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5253,7 +5253,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2885 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x8101a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5275,7 +5275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2997 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x8128d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8132d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5297,7 +5297,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2814 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x80a180", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5319,7 +5319,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2815 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x80a190", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a350", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5341,11 +5341,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3030 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x813230", Frameless: true}]
+              InjectionPoints: [{PC: "0x813f40", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3031 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x813240", Frameless: true}]
+              InjectionPoints: [{PC: "0x813f50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5372,7 +5372,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2994 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x8128a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8132a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5399,7 +5399,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2846 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x80ded0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80e480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5420,11 +5420,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2987 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x8122ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x812cec", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2988 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x812370", Frameless: false}]
+              InjectionPoints: [{PC: "0x812d70", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5446,11 +5446,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3026 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x813180", Frameless: true}]
+              InjectionPoints: [{PC: "0x813e90", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3027 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x81318c", Frameless: true}]
+              InjectionPoints: [{PC: "0x813e9c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5471,7 +5471,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3025 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x813170", Frameless: true}]
+              InjectionPoints: [{PC: "0x813e80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5498,7 +5498,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2847 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x80e530", Frameless: true}]
+              InjectionPoints: [{PC: "0x80eb90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5531,7 +5531,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3003 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x812920", Frameless: true}]
+              InjectionPoints: [{PC: "0x813320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5571,7 +5571,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3021 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x812fc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x813bd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5603,7 +5603,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2819 EventRootType Probe[main.testTakeContext]
-              InjectionPoints: [{PC: "0x80a6a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a970", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
       version: 0
@@ -5619,11 +5619,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2926 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x810ca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8116a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2927 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x810d28", Frameless: false}]
+              InjectionPoints: [{PC: "0x811728", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5644,11 +5644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2928 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x810ca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8116a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2929 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x810d28", Frameless: false}]
+              InjectionPoints: [{PC: "0x811728", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5671,11 +5671,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2930 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x810ca8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8116a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2931 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x810d28", Frameless: false}]
+              InjectionPoints: [{PC: "0x811728", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5707,7 +5707,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3009 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x812f50", Frameless: true}]
+              InjectionPoints: [{PC: "0x813b60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5739,11 +5739,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3010 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x812f60", Frameless: true}]
+              InjectionPoints: [{PC: "0x813b70", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3011 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x812f6c", Frameless: true}]
+              InjectionPoints: [{PC: "0x813b7c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5773,11 +5773,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3012 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x812f60", Frameless: true}]
+              InjectionPoints: [{PC: "0x813b70", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3013 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x812f6c", Frameless: true}]
+              InjectionPoints: [{PC: "0x813b7c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5809,7 +5809,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3014 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x812f70", Frameless: true}]
+              InjectionPoints: [{PC: "0x813b80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5839,7 +5839,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3015 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x812f70", Frameless: true}]
+              InjectionPoints: [{PC: "0x813b80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5871,7 +5871,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3040 EventRootType Probe[main.testTimeFixedZone]
-              InjectionPoints: [{PC: "0x813cb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x814ac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5893,7 +5893,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3041 EventRootType Probe[main.testTimeMonotonic]
-              InjectionPoints: [{PC: "0x813cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x814ad0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -5915,7 +5915,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3039 EventRootType Probe[main.testTimeUTC]
-              InjectionPoints: [{PC: "0x813ca0", Frameless: true}]
+              InjectionPoints: [{PC: "0x814ab0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5937,7 +5937,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2804 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x809bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809ca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6069,7 +6069,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2884 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x810130", Frameless: true}]
+              InjectionPoints: [{PC: "0x810a50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6091,7 +6091,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2991 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x812870", Frameless: true}]
+              InjectionPoints: [{PC: "0x813270", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -6113,7 +6113,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3019 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x812fa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x813bb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6135,7 +6135,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2883 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x810110", Frameless: true}]
+              InjectionPoints: [{PC: "0x810a30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6179,7 +6179,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3000 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x812900", Frameless: true}]
+              InjectionPoints: [{PC: "0x813300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6201,7 +6201,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3001 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x812900", Frameless: true}]
+              InjectionPoints: [{PC: "0x813300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6224,14 +6224,14 @@ Probes:
             - Kind: Entry
               Type: 3106 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x80dd38"
+                - PC: "0x80e2e8"
                   Frameless: false
-                - PC: "0x815848"
+                - PC: "0x816748"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 3107 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x80dd60", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e310", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -6253,11 +6253,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2989 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x8123a8", Frameless: false}]
+              InjectionPoints: [{PC: "0x812da8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2990 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x812408", Frameless: false}]
+              InjectionPoints: [{PC: "0x812e08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -6554,13 +6554,13 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x809ad0..0x809ae0]
+      OutOfLinePCRanges: [0x809bb0..0x809bc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x809ad0..0x809ae0
+            - Range: 0x809bb0..0x809bc0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6568,13 +6568,13 @@ Subprograms:
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x809ae0..0x809af0]
+      OutOfLinePCRanges: [0x809bc0..0x809bd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x809ae0..0x809af0
+            - Range: 0x809bc0..0x809bd0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6582,13 +6582,13 @@ Subprograms:
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x809af0..0x809b00]
+      OutOfLinePCRanges: [0x809bd0..0x809be0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x809af0..0x809b00
+            - Range: 0x809bd0..0x809be0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6596,13 +6596,13 @@ Subprograms:
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x809b00..0x809b10]
+      OutOfLinePCRanges: [0x809be0..0x809bf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x809b00..0x809b10
+            - Range: 0x809be0..0x809bf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6610,13 +6610,13 @@ Subprograms:
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x809b10..0x809b20]
+      OutOfLinePCRanges: [0x809bf0..0x809c00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x809b10..0x809b20
+            - Range: 0x809bf0..0x809c00
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6624,13 +6624,13 @@ Subprograms:
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x809b20..0x809b30]
+      OutOfLinePCRanges: [0x809c00..0x809c10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 99 BaseType int16
           Locations:
-            - Range: 0x809b20..0x809b30
+            - Range: 0x809c00..0x809c10
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6638,13 +6638,13 @@ Subprograms:
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x809b30..0x809b40]
+      OutOfLinePCRanges: [0x809c10..0x809c20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x809b30..0x809b40
+            - Range: 0x809c10..0x809c20
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6652,13 +6652,13 @@ Subprograms:
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x809b40..0x809b50]
+      OutOfLinePCRanges: [0x809c20..0x809c30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int64
           Locations:
-            - Range: 0x809b40..0x809b50
+            - Range: 0x809c20..0x809c30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6666,13 +6666,13 @@ Subprograms:
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x809b50..0x809b60]
+      OutOfLinePCRanges: [0x809c30..0x809c40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x809b50..0x809b60
+            - Range: 0x809c30..0x809c40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6680,13 +6680,13 @@ Subprograms:
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x809b60..0x809b70]
+      OutOfLinePCRanges: [0x809c40..0x809c50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x809b60..0x809b70
+            - Range: 0x809c40..0x809c50
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6694,13 +6694,13 @@ Subprograms:
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x809b70..0x809b80]
+      OutOfLinePCRanges: [0x809c50..0x809c60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0x809b70..0x809b80
+            - Range: 0x809c50..0x809c60
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6708,13 +6708,13 @@ Subprograms:
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x809b80..0x809b90]
+      OutOfLinePCRanges: [0x809c60..0x809c70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint32
           Locations:
-            - Range: 0x809b80..0x809b90
+            - Range: 0x809c60..0x809c70
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6722,13 +6722,13 @@ Subprograms:
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x809b90..0x809ba0]
+      OutOfLinePCRanges: [0x809c70..0x809c80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x809b90..0x809ba0
+            - Range: 0x809c70..0x809c80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6736,13 +6736,13 @@ Subprograms:
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x809ba0..0x809bb0]
+      OutOfLinePCRanges: [0x809c80..0x809c90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 20 BaseType float32
           Locations:
-            - Range: 0x809ba0..0x809bb0
+            - Range: 0x809c80..0x809c90
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6750,13 +6750,13 @@ Subprograms:
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x809bb0..0x809bc0]
+      OutOfLinePCRanges: [0x809c90..0x809ca0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x809bb0..0x809bc0
+            - Range: 0x809c90..0x809ca0
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6764,13 +6764,13 @@ Subprograms:
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x809bc0..0x809bd0]
+      OutOfLinePCRanges: [0x809ca0..0x809cb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 130 BaseType main.typeAlias
           Locations:
-            - Range: 0x809bc0..0x809bd0
+            - Range: 0x809ca0..0x809cb0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6778,13 +6778,13 @@ Subprograms:
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x809cc0..0x809cd0]
+      OutOfLinePCRanges: [0x809e80..0x809e90]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 131 StructureType main.bigStruct
           Locations:
-            - Range: 0x809cc0..0x809cd0
+            - Range: 0x809e80..0x809e90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6804,53 +6804,53 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x809cf0..0x809df0]
+      OutOfLinePCRanges: [0x809eb0..0x809fb0]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x809cf0..0x809d10
+            - Range: 0x809eb0..0x809ed0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x809cf0..0x809df0, Pieces: []}]
+          Locations: [{Range: 0x809eb0..0x809fb0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: x
           Type: 9 BaseType int
-          Locations: [{Range: 0x809cf0..0x809df0, Pieces: []}]
+          Locations: [{Range: 0x809eb0..0x809fb0, Pieces: []}]
           Role: Local
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: err
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x809d08..0x809d44
+            - Range: 0x809ec8..0x809f04
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x809d44..0x809d4c
+            - Range: 0x809f04..0x809f0c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x809d4c..0x809d98
+            - Range: 0x809f0c..0x809f58
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x809d98..0x809da0
+            - Range: 0x809f58..0x809f60
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}, {Size: 8, Op: null}]
-            - Range: 0x809da0..0x809df0
+            - Range: 0x809f60..0x809fb0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}, {Size: 8, Op: null}]
           Role: Local
           DictIndex: -1
@@ -6858,13 +6858,13 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x809e80..0x809e90]
+      OutOfLinePCRanges: [0x80a040..0x80a050]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 135 StructureType main.deepPtr1
           Locations:
-            - Range: 0x809e80..0x809e90
+            - Range: 0x80a040..0x80a050
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6872,13 +6872,13 @@ Subprograms:
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x809e90..0x809ea0]
+      OutOfLinePCRanges: [0x80a050..0x80a060]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 138 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x809e90..0x809ea0
+            - Range: 0x80a050..0x80a060
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6886,13 +6886,13 @@ Subprograms:
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x80a000..0x80a010]
+      OutOfLinePCRanges: [0x80a1c0..0x80a1d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 140 StructureType main.deepSlice1
           Locations:
-            - Range: 0x80a000..0x80a010
+            - Range: 0x80a1c0..0x80a1d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6906,13 +6906,13 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x80a010..0x80a020]
+      OutOfLinePCRanges: [0x80a1d0..0x80a1e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 144 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x80a010..0x80a020
+            - Range: 0x80a1d0..0x80a1e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6920,13 +6920,13 @@ Subprograms:
       DictRegister: null
     - ID: 43
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x80a160..0x80a170]
+      OutOfLinePCRanges: [0x80a320..0x80a330]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 146 StructureType main.deepMap1
           Locations:
-            - Range: 0x80a160..0x80a170
+            - Range: 0x80a320..0x80a330
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6934,13 +6934,13 @@ Subprograms:
       DictRegister: null
     - ID: 44
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x80a170..0x80a180]
+      OutOfLinePCRanges: [0x80a330..0x80a340]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 152 PointerType *main.deepMap7
           Locations:
-            - Range: 0x80a170..0x80a180
+            - Range: 0x80a330..0x80a340
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6948,13 +6948,13 @@ Subprograms:
       DictRegister: null
     - ID: 45
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x80a180..0x80a190]
+      OutOfLinePCRanges: [0x80a340..0x80a350]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 154 PointerType *main.stringType1
           Locations:
-            - Range: 0x80a180..0x80a190
+            - Range: 0x80a340..0x80a350
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6962,13 +6962,13 @@ Subprograms:
       DictRegister: null
     - ID: 46
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x80a190..0x80a1a0]
+      OutOfLinePCRanges: [0x80a350..0x80a360]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 156 PointerType **main.stringType2
           Locations:
-            - Range: 0x80a190..0x80a1a0
+            - Range: 0x80a350..0x80a360
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6976,15 +6976,15 @@ Subprograms:
       DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x80a1a0..0x80a380]
+      OutOfLinePCRanges: [0x80a360..0x80a540]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80a258..0x80a268
+            - Range: 0x80a418..0x80a428
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a2f8..0x80a308
+            - Range: 0x80a4b8..0x80a4c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -6992,15 +6992,15 @@ Subprograms:
         - Name: aPerArch
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80a240..0x80a244
+            - Range: 0x80a400..0x80a404
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a244..0x80a268
+            - Range: 0x80a404..0x80a428
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a268..0x80a2ec
+            - Range: 0x80a428..0x80a4ac
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x80a2ec..0x80a2f4
+            - Range: 0x80a4ac..0x80a4b4
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x80a2f4..0x80a380
+            - Range: 0x80a4b4..0x80a540
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
           DictIndex: -1
@@ -7008,21 +7008,21 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80a238..0x80a244
+            - Range: 0x80a3f8..0x80a404
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a244..0x80a244
+            - Range: 0x80a404..0x80a404
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80a244..0x80a268
+            - Range: 0x80a404..0x80a428
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a268..0x80a2ec
+            - Range: 0x80a428..0x80a4ac
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x80a2ec..0x80a2f0
+            - Range: 0x80a4ac..0x80a4b0
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x80a2f0..0x80a2f4
+            - Range: 0x80a4b0..0x80a4b4
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x80a2f4..0x80a308
+            - Range: 0x80a4b4..0x80a4c8
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x80a308..0x80a380
+            - Range: 0x80a4c8..0x80a540
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
@@ -7030,13 +7030,13 @@ Subprograms:
       DictRegister: null
     - ID: 48
       Name: main.testTakeContext
-      OutOfLinePCRanges: [0x80a6a0..0x80a6b0]
+      OutOfLinePCRanges: [0x80a970..0x80a980]
       InlinePCRanges: []
       Variables:
         - Name: ctx
           Type: 158 GoInterfaceType context.Context
           Locations:
-            - Range: 0x80a6a0..0x80a6b0
+            - Range: 0x80a970..0x80a980
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7048,13 +7048,13 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testCaptureContextImpl
-      OutOfLinePCRanges: [0x80a860..0x80a870]
+      OutOfLinePCRanges: [0x80ab30..0x80ab40]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 159 PointerType *main.contextImpl
           Locations:
-            - Range: 0x80a860..0x80a870
+            - Range: 0x80ab30..0x80ab40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7062,13 +7062,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0x80aae0..0x80aaf0]
+      OutOfLinePCRanges: [0x80adb0..0x80adc0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 161 StructureType main.manyPointers
           Locations:
-            - Range: 0x80aae0..0x80aaf0
+            - Range: 0x80adb0..0x80adc0
               Pieces: [{Size: 560, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7076,13 +7076,13 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0x80c450..0x80c460]
+      OutOfLinePCRanges: [0x80c820..0x80c830]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 164 GoSliceHeaderType []string
           Locations:
-            - Range: 0x80c450..0x80c460
+            - Range: 0x80c820..0x80c830
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7096,13 +7096,13 @@ Subprograms:
       DictRegister: null
     - ID: 52
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x80c740..0x80c800]
+      OutOfLinePCRanges: [0x80cbf0..0x80ccb0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 165 StructureType main.esotericStack
           Locations:
-            - Range: 0x80c740..0x80c778
+            - Range: 0x80cbf0..0x80cc28
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -7122,7 +7122,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x80c778..0x80c77c
+            - Range: 0x80cc28..0x80cc2c
               Pieces:
                 - Size: 4
                   Op: null
@@ -7142,7 +7142,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x80c77c..0x80c780
+            - Range: 0x80cc2c..0x80cc30
               Pieces:
                 - Size: 4
                   Op: null
@@ -7168,13 +7168,13 @@ Subprograms:
       DictRegister: null
     - ID: 53
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x80c800..0x80c870]
+      OutOfLinePCRanges: [0x80ccb0..0x80cd20]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 168 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x80c800..0x80c834
+            - Range: 0x80ccb0..0x80cce4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7182,13 +7182,13 @@ Subprograms:
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x80d8b0..0x80d940]
+      OutOfLinePCRanges: [0x80dd60..0x80ddf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d8b0..0x80d8e8
+            - Range: 0x80dd60..0x80dd98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7196,13 +7196,13 @@ Subprograms:
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x80d940..0x80da00]
+      OutOfLinePCRanges: [0x80ddf0..0x80deb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d940..0x80d95c
+            - Range: 0x80ddf0..0x80de0c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7210,7 +7210,7 @@ Subprograms:
         - Name: "y"
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d940..0x80d96c
+            - Range: 0x80ddf0..0x80de1c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7218,9 +7218,9 @@ Subprograms:
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d95c..0x80d96c
+            - Range: 0x80de0c..0x80de1c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d96c..0x80da00
+            - Range: 0x80de1c..0x80deb0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
@@ -7228,13 +7228,13 @@ Subprograms:
       DictRegister: null
     - ID: 56
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x80da00..0x80da70]
+      OutOfLinePCRanges: [0x80deb0..0x80df20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80da00..0x80da24
+            - Range: 0x80deb0..0x80ded4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7242,15 +7242,15 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x80da70..0x80db80]
+      OutOfLinePCRanges: [0x80df20..0x80e030]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80da8c..0x80daf8
+            - Range: 0x80df3c..0x80dfa8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80daf8..0x80db00
+            - Range: 0x80dfa8..0x80dfb0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7258,9 +7258,9 @@ Subprograms:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80da8c..0x80daf8
+            - Range: 0x80df3c..0x80dfa8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80daf8..0x80dafc
+            - Range: 0x80dfa8..0x80dfac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7268,13 +7268,13 @@ Subprograms:
       DictRegister: null
     - ID: 58
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x80db80..0x80db90]
+      OutOfLinePCRanges: [0x80e030..0x80e040]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80db80..0x80db88
+            - Range: 0x80e030..0x80e038
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7282,11 +7282,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80db80..0x80db88
+            - Range: 0x80e030..0x80e038
               Pieces: []
-            - Range: 0x80db88..0x80db89
+            - Range: 0x80e038..0x80e039
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80db89..0x80db90
+            - Range: 0x80e039..0x80e040
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7294,13 +7294,13 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x80db90..0x80dbe0]
+      OutOfLinePCRanges: [0x80e040..0x80e090]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 170 ArrayType [5]int
           Locations:
-            - Range: 0x80db90..0x80dbe0
+            - Range: 0x80e040..0x80e090
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7308,11 +7308,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80db90..0x80dbd0
+            - Range: 0x80e040..0x80e080
               Pieces: []
-            - Range: 0x80dbd0..0x80dbd1
+            - Range: 0x80e080..0x80e081
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80dbd1..0x80dbe0
+            - Range: 0x80e081..0x80e090
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7320,13 +7320,13 @@ Subprograms:
       DictRegister: null
     - ID: 60
       Name: main.testInterface
-      OutOfLinePCRanges: [0x80ddf0..0x80de00]
+      OutOfLinePCRanges: [0x80e3a0..0x80e3b0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 171 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80ddf0..0x80de00
+            - Range: 0x80e3a0..0x80e3b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7338,19 +7338,19 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testAny
-      OutOfLinePCRanges: [0x80de00..0x80de60]
+      OutOfLinePCRanges: [0x80e3b0..0x80e410]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80de00..0x80de2c
+            - Range: 0x80e3b0..0x80e3dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80de2c..0x80de30
+            - Range: 0x80e3dc..0x80e3e0
               Pieces:
                 - Size: 8
                   Op: null
@@ -7362,15 +7362,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80de00..0x80de40
+            - Range: 0x80e3b0..0x80e3f0
               Pieces: []
-            - Range: 0x80de40..0x80de41
+            - Range: 0x80e3f0..0x80e3f1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80de41..0x80de60
+            - Range: 0x80e3f1..0x80e410
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7378,13 +7378,13 @@ Subprograms:
       DictRegister: null
     - ID: 62
       Name: main.testError
-      OutOfLinePCRanges: [0x80de60..0x80de70]
+      OutOfLinePCRanges: [0x80e410..0x80e420]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x80de60..0x80de70
+            - Range: 0x80e410..0x80e420
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7396,13 +7396,13 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x80de70..0x80ded0]
+      OutOfLinePCRanges: [0x80e420..0x80e480]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 172 PointerType *interface {}
           Locations:
-            - Range: 0x80de70..0x80de9c
+            - Range: 0x80e420..0x80e44c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7410,15 +7410,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80de70..0x80deb0
+            - Range: 0x80e420..0x80e460
               Pieces: []
-            - Range: 0x80deb0..0x80deb1
+            - Range: 0x80e460..0x80e461
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80deb1..0x80ded0
+            - Range: 0x80e461..0x80e480
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7426,13 +7426,13 @@ Subprograms:
       DictRegister: null
     - ID: 64
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x80ded0..0x80dee0]
+      OutOfLinePCRanges: [0x80e480..0x80e490]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 173 StructureType main.structWithAny
           Locations:
-            - Range: 0x80ded0..0x80dee0
+            - Range: 0x80e480..0x80e490
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7444,13 +7444,13 @@ Subprograms:
       DictRegister: null
     - ID: 65
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x80e530..0x80e540]
+      OutOfLinePCRanges: [0x80eb90..0x80eba0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 174 StructureType main.structWithMap
           Locations:
-            - Range: 0x80e530..0x80e540
+            - Range: 0x80eb90..0x80eba0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7458,13 +7458,13 @@ Subprograms:
       DictRegister: null
     - ID: 66
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x80e540..0x80e550]
+      OutOfLinePCRanges: [0x80eba0..0x80ebb0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 180 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x80e540..0x80e550
+            - Range: 0x80eba0..0x80ebb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7472,13 +7472,13 @@ Subprograms:
       DictRegister: null
     - ID: 67
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x80e550..0x80e560]
+      OutOfLinePCRanges: [0x80ebb0..0x80ebc0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 185 GoMapType map[string]int
           Locations:
-            - Range: 0x80e550..0x80e560
+            - Range: 0x80ebb0..0x80ebc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7486,13 +7486,13 @@ Subprograms:
       DictRegister: null
     - ID: 68
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x80e560..0x80e570]
+      OutOfLinePCRanges: [0x80ebc0..0x80ebd0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 190 GoMapType map[string][]string
           Locations:
-            - Range: 0x80e560..0x80e570
+            - Range: 0x80ebc0..0x80ebd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7500,13 +7500,13 @@ Subprograms:
       DictRegister: null
     - ID: 69
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x80e570..0x80e580]
+      OutOfLinePCRanges: [0x80ebd0..0x80ebe0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 195 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x80e570..0x80e580
+            - Range: 0x80ebd0..0x80ebe0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7514,13 +7514,13 @@ Subprograms:
       DictRegister: null
     - ID: 70
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x80e580..0x80e590]
+      OutOfLinePCRanges: [0x80ebe0..0x80ebf0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 185 GoMapType map[string]int
           Locations:
-            - Range: 0x80e580..0x80e590
+            - Range: 0x80ebe0..0x80ebf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7528,13 +7528,13 @@ Subprograms:
       DictRegister: null
     - ID: 71
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x80e590..0x80e5a0]
+      OutOfLinePCRanges: [0x80ebf0..0x80ec00]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 200 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x80e590..0x80e5a0
+            - Range: 0x80ebf0..0x80ec00
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7542,13 +7542,13 @@ Subprograms:
       DictRegister: null
     - ID: 72
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x80e5a0..0x80e5b0]
+      OutOfLinePCRanges: [0x80ec00..0x80ec10]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 201 PointerType *map[string]int
           Locations:
-            - Range: 0x80e5a0..0x80e5b0
+            - Range: 0x80ec00..0x80ec10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7556,13 +7556,13 @@ Subprograms:
       DictRegister: null
     - ID: 73
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x80e5b0..0x80e5c0]
+      OutOfLinePCRanges: [0x80ec10..0x80ec20]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 175 GoMapType map[int]int
           Locations:
-            - Range: 0x80e5b0..0x80e5c0
+            - Range: 0x80ec10..0x80ec20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7570,13 +7570,13 @@ Subprograms:
       DictRegister: null
     - ID: 74
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x80e5c0..0x80e5d0]
+      OutOfLinePCRanges: [0x80ec20..0x80ec30]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 202 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x80e5c0..0x80e5d0
+            - Range: 0x80ec20..0x80ec30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7584,13 +7584,13 @@ Subprograms:
       DictRegister: null
     - ID: 75
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x80e5d0..0x80e5e0]
+      OutOfLinePCRanges: [0x80ec30..0x80ec40]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 202 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x80e5d0..0x80e5e0
+            - Range: 0x80ec30..0x80ec40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7598,13 +7598,13 @@ Subprograms:
       DictRegister: null
     - ID: 76
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x80e5e0..0x80e5f0]
+      OutOfLinePCRanges: [0x80ec40..0x80ec50]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 207 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x80e5e0..0x80e5f0
+            - Range: 0x80ec40..0x80ec50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7612,13 +7612,13 @@ Subprograms:
       DictRegister: null
     - ID: 77
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x80e5f0..0x80e600]
+      OutOfLinePCRanges: [0x80ec50..0x80ec60]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 212 GoMapType map[int]uint8
           Locations:
-            - Range: 0x80e5f0..0x80e600
+            - Range: 0x80ec50..0x80ec60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7626,13 +7626,13 @@ Subprograms:
       DictRegister: null
     - ID: 78
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x80e600..0x80e610]
+      OutOfLinePCRanges: [0x80ec60..0x80ec70]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 212 GoMapType map[int]uint8
           Locations:
-            - Range: 0x80e600..0x80e610
+            - Range: 0x80ec60..0x80ec70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7640,13 +7640,13 @@ Subprograms:
       DictRegister: null
     - ID: 79
       Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x80e610..0x80e620]
+      OutOfLinePCRanges: [0x80ec70..0x80ec80]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 217 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x80e610..0x80e620
+            - Range: 0x80ec70..0x80ec80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7654,13 +7654,13 @@ Subprograms:
       DictRegister: null
     - ID: 80
       Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x80e620..0x80e630]
+      OutOfLinePCRanges: [0x80ec80..0x80ec90]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 217 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x80e620..0x80e630
+            - Range: 0x80ec80..0x80ec90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7668,13 +7668,13 @@ Subprograms:
       DictRegister: null
     - ID: 81
       Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x80e630..0x80e640]
+      OutOfLinePCRanges: [0x80ec90..0x80eca0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 217 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x80e630..0x80e640
+            - Range: 0x80ec90..0x80eca0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7682,13 +7682,13 @@ Subprograms:
       DictRegister: null
     - ID: 82
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x80e640..0x80e650]
+      OutOfLinePCRanges: [0x80eca0..0x80ecb0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 222 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x80e640..0x80e650
+            - Range: 0x80eca0..0x80ecb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7696,13 +7696,13 @@ Subprograms:
       DictRegister: null
     - ID: 83
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x80e650..0x80e660]
+      OutOfLinePCRanges: [0x80ecb0..0x80ecc0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 227 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x80e650..0x80e660
+            - Range: 0x80ecb0..0x80ecc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7710,13 +7710,13 @@ Subprograms:
       DictRegister: null
     - ID: 84
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x80e660..0x80e670]
+      OutOfLinePCRanges: [0x80ecc0..0x80ecd0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 232 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x80e660..0x80e670
+            - Range: 0x80ecc0..0x80ecd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7724,13 +7724,13 @@ Subprograms:
       DictRegister: null
     - ID: 85
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x80e670..0x80e680]
+      OutOfLinePCRanges: [0x80ecd0..0x80ece0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 237 GoMapType map[struct {}]int
           Locations:
-            - Range: 0x80e670..0x80e680
+            - Range: 0x80ecd0..0x80ece0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7738,13 +7738,13 @@ Subprograms:
       DictRegister: null
     - ID: 86
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x80e680..0x80e690]
+      OutOfLinePCRanges: [0x80ece0..0x80ecf0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 242 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x80e680..0x80e690
+            - Range: 0x80ece0..0x80ecf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7752,13 +7752,13 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0x80e690..0x80e6a0]
+      OutOfLinePCRanges: [0x80ecf0..0x80ed00]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 247 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0x80e690..0x80e6a0
+            - Range: 0x80ecf0..0x80ed00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7766,13 +7766,13 @@ Subprograms:
       DictRegister: null
     - ID: 88
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x80fa60..0x80fa70]
+      OutOfLinePCRanges: [0x8100c0..0x8100d0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80fa60..0x80fa70
+            - Range: 0x8100c0..0x8100d0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7780,7 +7780,7 @@ Subprograms:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80fa60..0x80fa70
+            - Range: 0x8100c0..0x8100d0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7788,7 +7788,7 @@ Subprograms:
         - Name: "y"
           Type: 20 BaseType float32
           Locations:
-            - Range: 0x80fa60..0x80fa70
+            - Range: 0x8100c0..0x8100d0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7796,13 +7796,13 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x80fa80..0x80fa90]
+      OutOfLinePCRanges: [0x8100e0..0x8100f0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80fa80..0x80fa90
+            - Range: 0x8100e0..0x8100f0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7810,7 +7810,7 @@ Subprograms:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80fa80..0x80fa90
+            - Range: 0x8100e0..0x8100f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7822,7 +7822,7 @@ Subprograms:
         - Name: "y"
           Type: 20 BaseType float32
           Locations:
-            - Range: 0x80fa80..0x80fa90
+            - Range: 0x8100e0..0x8100f0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7830,13 +7830,13 @@ Subprograms:
       DictRegister: null
     - ID: 90
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x80fb40..0x80fb50]
+      OutOfLinePCRanges: [0x8101a0..0x8101b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80fb40..0x80fb50
+            - Range: 0x8101a0..0x8101b0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7844,7 +7844,7 @@ Subprograms:
         - Name: b
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80fb40..0x80fb50
+            - Range: 0x8101a0..0x8101b0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7852,7 +7852,7 @@ Subprograms:
         - Name: c
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x80fb40..0x80fb50
+            - Range: 0x8101a0..0x8101b0
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7860,7 +7860,7 @@ Subprograms:
         - Name: d
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x80fb40..0x80fb50
+            - Range: 0x8101a0..0x8101b0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7868,7 +7868,7 @@ Subprograms:
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80fb40..0x80fb50
+            - Range: 0x8101a0..0x8101b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7880,13 +7880,13 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.(*Server).handleOrder
-      OutOfLinePCRanges: [0x80fce0..0x80fe60]
+      OutOfLinePCRanges: [0x810430..0x8105b0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 252 PointerType *main.Server
           Locations:
-            - Range: 0x80fce0..0x80fd24
+            - Range: 0x810430..0x810474
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7894,9 +7894,9 @@ Subprograms:
         - Name: req
           Type: 254 PointerType *main.Request
           Locations:
-            - Range: 0x80fce0..0x80fd24
+            - Range: 0x810430..0x810474
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80fd24..0x80fe60
+            - Range: 0x810474..0x8105b0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -7904,23 +7904,23 @@ Subprograms:
         - Name: ~r0
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x80fce0..0x80fd98
+            - Range: 0x810430..0x8104e8
               Pieces: []
-            - Range: 0x80fd98..0x80fd99
+            - Range: 0x8104e8..0x8104e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80fd99..0x80fe38
+            - Range: 0x8104e9..0x810588
               Pieces: []
-            - Range: 0x80fe38..0x80fe39
+            - Range: 0x810588..0x810589
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80fe39..0x80fe60
+            - Range: 0x810589..0x8105b0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7928,13 +7928,13 @@ Subprograms:
       DictRegister: null
     - ID: 92
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x80ff10..0x80ff50]
+      OutOfLinePCRanges: [0x810750..0x810790]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x80ff10..0x80ff4c
+            - Range: 0x810750..0x81078c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7942,11 +7942,11 @@ Subprograms:
         - Name: ~r0
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x80ff10..0x80ff4c
+            - Range: 0x810750..0x81078c
               Pieces: []
-            - Range: 0x80ff4c..0x80ff4d
+            - Range: 0x81078c..0x81078d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ff4d..0x80ff50
+            - Range: 0x81078d..0x810790
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7954,13 +7954,13 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testChannel
-      OutOfLinePCRanges: [0x80ff50..0x80ff60]
+      OutOfLinePCRanges: [0x810790..0x8107a0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 256 GoChannelType chan bool
           Locations:
-            - Range: 0x80ff50..0x80ff60
+            - Range: 0x810790..0x8107a0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7968,13 +7968,13 @@ Subprograms:
       DictRegister: null
     - ID: 94
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x8100e0..0x8100f0]
+      OutOfLinePCRanges: [0x810a00..0x810a10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 257 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x8100e0..0x8100f0
+            - Range: 0x810a00..0x810a10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7982,13 +7982,13 @@ Subprograms:
       DictRegister: null
     - ID: 95
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x8100f0..0x810100]
+      OutOfLinePCRanges: [0x810a10..0x810a20]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 259 StructureType main.node
           Locations:
-            - Range: 0x8100f0..0x810100
+            - Range: 0x810a10..0x810a20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8000,13 +8000,13 @@ Subprograms:
       DictRegister: null
     - ID: 96
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x810100..0x810110]
+      OutOfLinePCRanges: [0x810a20..0x810a30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 260 PointerType *main.node
           Locations:
-            - Range: 0x810100..0x810110
+            - Range: 0x810a20..0x810a30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8014,13 +8014,13 @@ Subprograms:
       DictRegister: null
     - ID: 97
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x810110..0x810120]
+      OutOfLinePCRanges: [0x810a30..0x810a40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x810110..0x810120
+            - Range: 0x810a30..0x810a40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8028,13 +8028,13 @@ Subprograms:
       DictRegister: null
     - ID: 98
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x810130..0x810140]
+      OutOfLinePCRanges: [0x810a50..0x810a60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 PointerType *uint
           Locations:
-            - Range: 0x810130..0x810140
+            - Range: 0x810a50..0x810a60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8042,13 +8042,13 @@ Subprograms:
       DictRegister: null
     - ID: 99
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x8101a0..0x8101b0]
+      OutOfLinePCRanges: [0x810ac0..0x810ad0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 98 PointerType *string
           Locations:
-            - Range: 0x8101a0..0x8101b0
+            - Range: 0x810ac0..0x810ad0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8056,13 +8056,13 @@ Subprograms:
       DictRegister: null
     - ID: 100
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x8101c0..0x8101d0]
+      OutOfLinePCRanges: [0x810ae0..0x810af0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 13 PointerType *bool
           Locations:
-            - Range: 0x8101c0..0x8101d0
+            - Range: 0x810ae0..0x810af0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8070,7 +8070,7 @@ Subprograms:
         - Name: a
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x8101c0..0x8101d0
+            - Range: 0x810ae0..0x810af0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8078,13 +8078,13 @@ Subprograms:
       DictRegister: null
     - ID: 101
       Name: main.testCycle
-      OutOfLinePCRanges: [0x8101e0..0x8101f0]
+      OutOfLinePCRanges: [0x810b00..0x810b10]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 261 PointerType *main.t
           Locations:
-            - Range: 0x8101e0..0x8101f0
+            - Range: 0x810b00..0x810b10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8092,13 +8092,13 @@ Subprograms:
       DictRegister: null
     - ID: 102
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x8104f0..0x810570]
+      OutOfLinePCRanges: [0x810ef0..0x810f70]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8104f0..0x81050c
+            - Range: 0x810ef0..0x810f0c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8106,11 +8106,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8104f0..0x810548
+            - Range: 0x810ef0..0x810f48
               Pieces: []
-            - Range: 0x810548..0x810549
+            - Range: 0x810f48..0x810f49
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810549..0x810570
+            - Range: 0x810f49..0x810f70
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8118,9 +8118,9 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x81050c..0x810518
+            - Range: 0x810f0c..0x810f18
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810518..0x810570
+            - Range: 0x810f18..0x810f70
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
@@ -8128,15 +8128,15 @@ Subprograms:
       DictRegister: null
     - ID: 103
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x810570..0x810610]
+      OutOfLinePCRanges: [0x810f70..0x811010]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810570..0x810594
+            - Range: 0x810f70..0x810f94
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810594..0x810610
+            - Range: 0x810f94..0x811010
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8144,11 +8144,11 @@ Subprograms:
         - Name: ~r0
           Type: 103 PointerType *int
           Locations:
-            - Range: 0x810570..0x8105e4
+            - Range: 0x810f70..0x810fe4
               Pieces: []
-            - Range: 0x8105e4..0x8105e5
+            - Range: 0x810fe4..0x810fe5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8105e5..0x810610
+            - Range: 0x810fe5..0x811010
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8156,9 +8156,9 @@ Subprograms:
         - Name: '&result'
           Type: 103 PointerType *int
           Locations:
-            - Range: 0x810598..0x8105b0
+            - Range: 0x810f98..0x810fb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8105b0..0x810610
+            - Range: 0x810fb0..0x811010
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
@@ -8166,13 +8166,13 @@ Subprograms:
       DictRegister: null
     - ID: 104
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x810610..0x8106e0]
+      OutOfLinePCRanges: [0x811010..0x8110e0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810610..0x810664
+            - Range: 0x811010..0x811064
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8180,27 +8180,27 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810610..0x8106b4
+            - Range: 0x811010..0x8110b4
               Pieces: []
-            - Range: 0x8106b4..0x8106b5
+            - Range: 0x8110b4..0x8110b5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8106b5..0x8106e0
+            - Range: 0x8110b5..0x8110e0
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x810610..0x8106e0, Pieces: []}]
+          Locations: [{Range: 0x811010..0x8110e0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0x81062c..0x810668
+            - Range: 0x81102c..0x811068
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x810668..0x8106e0
+            - Range: 0x811068..0x8110e0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
@@ -8208,9 +8208,9 @@ Subprograms:
         - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x81063c..0x810668
+            - Range: 0x81103c..0x811068
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x810668..0x8106e0
+            - Range: 0x811068..0x8110e0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
@@ -8218,13 +8218,13 @@ Subprograms:
       DictRegister: null
     - ID: 105
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x8106e0..0x810760]
+      OutOfLinePCRanges: [0x8110e0..0x811160]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x8106e0..0x810704
+            - Range: 0x8110e0..0x811104
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8232,23 +8232,23 @@ Subprograms:
         - Name: ~r0
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x8106e0..0x810724
+            - Range: 0x8110e0..0x811124
               Pieces: []
-            - Range: 0x810724..0x810725
+            - Range: 0x811124..0x811125
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810725..0x810738
+            - Range: 0x811125..0x811138
               Pieces: []
-            - Range: 0x810738..0x810739
+            - Range: 0x811138..0x811139
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810739..0x810760
+            - Range: 0x811139..0x811160
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8256,31 +8256,31 @@ Subprograms:
       DictRegister: null
     - ID: 106
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x810760..0x8108d0]
+      OutOfLinePCRanges: [0x811160..0x8112d0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x810760..0x8107b0
+            - Range: 0x811160..0x8111b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8107b0..0x8107b4
+            - Range: 0x8111b0..0x8111b4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x81083c..0x810840
+            - Range: 0x81123c..0x811240
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x81087c..0x810880
+            - Range: 0x81127c..0x811280
               Pieces:
                 - Size: 8
                   Op: null
@@ -8292,7 +8292,7 @@ Subprograms:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x810760..0x8107a4
+            - Range: 0x811160..0x8111a4
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8300,39 +8300,39 @@ Subprograms:
         - Name: ~r0
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x810760..0x8107cc
+            - Range: 0x811160..0x8111cc
               Pieces: []
-            - Range: 0x8107cc..0x8107cd
+            - Range: 0x8111cc..0x8111cd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8107cd..0x810828
+            - Range: 0x8111cd..0x811228
               Pieces: []
-            - Range: 0x810828..0x810829
+            - Range: 0x811228..0x811229
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810829..0x810868
+            - Range: 0x811229..0x811268
               Pieces: []
-            - Range: 0x810868..0x810869
+            - Range: 0x811268..0x811269
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810869..0x8108a4
+            - Range: 0x811269..0x8112a4
               Pieces: []
-            - Range: 0x8108a4..0x8108a5
+            - Range: 0x8112a4..0x8112a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8108a5..0x8108d0
+            - Range: 0x8112a5..0x8112d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8340,39 +8340,39 @@ Subprograms:
         - Name: ~r1
           Type: 16 GoInterfaceType error
           Locations:
-            - Range: 0x810760..0x8107cc
+            - Range: 0x811160..0x8111cc
               Pieces: []
-            - Range: 0x8107cc..0x8107cd
+            - Range: 0x8111cc..0x8111cd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8107cd..0x810828
+            - Range: 0x8111cd..0x811228
               Pieces: []
-            - Range: 0x810828..0x810829
+            - Range: 0x811228..0x811229
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x810829..0x810868
+            - Range: 0x811229..0x811268
               Pieces: []
-            - Range: 0x810868..0x810869
+            - Range: 0x811268..0x811269
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x810869..0x8108a4
+            - Range: 0x811269..0x8112a4
               Pieces: []
-            - Range: 0x8108a4..0x8108a5
+            - Range: 0x8112a4..0x8112a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8108a5..0x8108d0
+            - Range: 0x8112a5..0x8112d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8380,7 +8380,7 @@ Subprograms:
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8107b0..0x8107b8
+            - Range: 0x8111b0..0x8111b8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8388,25 +8388,25 @@ Subprograms:
       DictRegister: null
     - ID: 107
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x8108d0..0x810ab0]
+      OutOfLinePCRanges: [0x8112d0..0x8114b0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8108d0..0x810910
+            - Range: 0x8112d0..0x811310
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810910..0x810918
+            - Range: 0x811310..0x811318
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x810918..0x810ab0
+            - Range: 0x811318..0x8114b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -8418,39 +8418,39 @@ Subprograms:
         - Name: ~r0
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8108d0..0x810970
+            - Range: 0x8112d0..0x811370
               Pieces: []
-            - Range: 0x810970..0x810971
+            - Range: 0x811370..0x811371
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810971..0x8109c4
+            - Range: 0x811371..0x8113c4
               Pieces: []
-            - Range: 0x8109c4..0x8109c5
+            - Range: 0x8113c4..0x8113c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8109c5..0x810a74
+            - Range: 0x8113c5..0x811474
               Pieces: []
-            - Range: 0x810a74..0x810a75
+            - Range: 0x811474..0x811475
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810a75..0x810a88
+            - Range: 0x811475..0x811488
               Pieces: []
-            - Range: 0x810a88..0x810a89
+            - Range: 0x811488..0x811489
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810a89..0x810ab0
+            - Range: 0x811489..0x8114b0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8458,7 +8458,7 @@ Subprograms:
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x81095c..0x810964
+            - Range: 0x81135c..0x811364
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8466,7 +8466,7 @@ Subprograms:
         - Name: '&result'
           Type: 103 PointerType *int
           Locations:
-            - Range: 0x8109a8..0x8109c4
+            - Range: 0x8113a8..0x8113c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8474,35 +8474,35 @@ Subprograms:
       DictRegister: null
     - ID: 108
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x810ab0..0x810c00]
+      OutOfLinePCRanges: [0x8114b0..0x811600]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 57 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x810ab0..0x810aec
+            - Range: 0x8114b0..0x8114ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810aec..0x810b2c
+            - Range: 0x8114ec..0x81152c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x810b2c..0x810ba0
+            - Range: 0x81152c..0x8115a0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x810ba0..0x810bc8
+            - Range: 0x8115a0..0x8115c8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x810bc8..0x810bcc
+            - Range: 0x8115c8..0x8115cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x810bcc..0x810c00
+            - Range: 0x8115cc..0x811600
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -8510,23 +8510,23 @@ Subprograms:
         - Name: ~r0
           Type: 171 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x810ab0..0x810b80
+            - Range: 0x8114b0..0x811580
               Pieces: []
-            - Range: 0x810b80..0x810b81
+            - Range: 0x811580..0x811581
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810b81..0x810b94
+            - Range: 0x811581..0x811594
               Pieces: []
-            - Range: 0x810b94..0x810b95
+            - Range: 0x811594..0x811595
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810b95..0x810c00
+            - Range: 0x811595..0x811600
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8534,39 +8534,39 @@ Subprograms:
         - Name: b
           Type: 171 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x810ab0..0x810aec
+            - Range: 0x8114b0..0x8114ec
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810aec..0x810b2c
+            - Range: 0x8114ec..0x81152c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x810b2c..0x810b34
+            - Range: 0x81152c..0x811534
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x810b34..0x810b8c
+            - Range: 0x811534..0x81158c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x810b8c..0x810b90
+            - Range: 0x81158c..0x811590
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x810b90..0x810b94
+            - Range: 0x811590..0x811594
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x810b94..0x810c00
+            - Range: 0x811594..0x811600
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
@@ -8574,13 +8574,13 @@ Subprograms:
       DictRegister: null
     - ID: 109
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x810c00..0x810c90]
+      OutOfLinePCRanges: [0x811600..0x811690]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810c00..0x810c1c
+            - Range: 0x811600..0x81161c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8588,11 +8588,11 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810c00..0x810c70
+            - Range: 0x811600..0x811670
               Pieces: []
-            - Range: 0x810c70..0x810c71
+            - Range: 0x811670..0x811671
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810c71..0x810c90
+            - Range: 0x811671..0x811690
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8600,13 +8600,13 @@ Subprograms:
       DictRegister: null
     - ID: 110
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x810c90..0x810d50]
+      OutOfLinePCRanges: [0x811690..0x811750]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810c90..0x810cdc
+            - Range: 0x811690..0x8116dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8614,11 +8614,11 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810c90..0x810d28
+            - Range: 0x811690..0x811728
               Pieces: []
-            - Range: 0x810d28..0x810d29
+            - Range: 0x811728..0x811729
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810d29..0x810d50
+            - Range: 0x811729..0x811750
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8626,11 +8626,11 @@ Subprograms:
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810c90..0x810d28
+            - Range: 0x811690..0x811728
               Pieces: []
-            - Range: 0x810d28..0x810d29
+            - Range: 0x811728..0x811729
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x810d29..0x810d50
+            - Range: 0x811729..0x811750
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8638,15 +8638,15 @@ Subprograms:
       DictRegister: null
     - ID: 111
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x810d50..0x810e10]
+      OutOfLinePCRanges: [0x811750..0x811810]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810d50..0x810d8c
+            - Range: 0x811750..0x81178c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810d8c..0x810e10
+            - Range: 0x81178c..0x811810
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8654,11 +8654,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810d50..0x810dec
+            - Range: 0x811750..0x8117ec
               Pieces: []
-            - Range: 0x810dec..0x810ded
+            - Range: 0x8117ec..0x8117ed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810ded..0x810e10
+            - Range: 0x8117ed..0x811810
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8666,11 +8666,11 @@ Subprograms:
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810d50..0x810dec
+            - Range: 0x811750..0x8117ec
               Pieces: []
-            - Range: 0x810dec..0x810ded
+            - Range: 0x8117ec..0x8117ed
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x810ded..0x810e10
+            - Range: 0x8117ed..0x811810
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8678,11 +8678,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810d50..0x810dec
+            - Range: 0x811750..0x8117ec
               Pieces: []
-            - Range: 0x810dec..0x810ded
+            - Range: 0x8117ec..0x8117ed
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x810ded..0x810e10
+            - Range: 0x8117ed..0x811810
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8690,15 +8690,15 @@ Subprograms:
       DictRegister: null
     - ID: 112
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x810e10..0x810ef0]
+      OutOfLinePCRanges: [0x811810..0x8118f0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810e10..0x810e4c
+            - Range: 0x811810..0x81184c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810e4c..0x810ef0
+            - Range: 0x81184c..0x8118f0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8706,11 +8706,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810e10..0x810ec8
+            - Range: 0x811810..0x8118c8
               Pieces: []
-            - Range: 0x810ec8..0x810ec9
+            - Range: 0x8118c8..0x8118c9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810ec9..0x810ef0
+            - Range: 0x8118c9..0x8118f0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8718,15 +8718,15 @@ Subprograms:
         - Name: r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x810e10..0x810ec8
+            - Range: 0x811810..0x8118c8
               Pieces: []
-            - Range: 0x810ec8..0x810ec9
+            - Range: 0x8118c8..0x8118c9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x810ec9..0x810ef0
+            - Range: 0x8118c9..0x8118f0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8734,15 +8734,15 @@ Subprograms:
       DictRegister: null
     - ID: 113
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x810ef0..0x8110a0]
+      OutOfLinePCRanges: [0x8118f0..0x811aa0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x810ef0..0x810f58
+            - Range: 0x8118f0..0x811958
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810f58..0x8110a0
+            - Range: 0x811958..0x811aa0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8750,7 +8750,7 @@ Subprograms:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x810f1c..0x8110a0
+            - Range: 0x81191c..0x811aa0
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
@@ -8758,7 +8758,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x810f20..0x8110a0
+            - Range: 0x811920..0x811aa0
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
@@ -8766,17 +8766,17 @@ Subprograms:
       DictRegister: null
     - ID: 114
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x811160..0x8111f0]
+      OutOfLinePCRanges: [0x811b60..0x811bf0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x811160..0x8111cc
+            - Range: 0x811b60..0x811bcc
               Pieces: []
-            - Range: 0x8111cc..0x8111cd
+            - Range: 0x811bcc..0x811bcd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8111cd..0x8111f0
+            - Range: 0x811bcd..0x811bf0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8784,11 +8784,11 @@ Subprograms:
         - Name: ~r1
           Type: 99 BaseType int16
           Locations:
-            - Range: 0x811160..0x8111cc
+            - Range: 0x811b60..0x811bcc
               Pieces: []
-            - Range: 0x8111cc..0x8111cd
+            - Range: 0x811bcc..0x811bcd
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8111cd..0x8111f0
+            - Range: 0x811bcd..0x811bf0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8796,11 +8796,11 @@ Subprograms:
         - Name: ~r2
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x811160..0x8111cc
+            - Range: 0x811b60..0x811bcc
               Pieces: []
-            - Range: 0x8111cc..0x8111cd
+            - Range: 0x811bcc..0x811bcd
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8111cd..0x8111f0
+            - Range: 0x811bcd..0x811bf0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8808,11 +8808,11 @@ Subprograms:
         - Name: ~r3
           Type: 15 BaseType int64
           Locations:
-            - Range: 0x811160..0x8111cc
+            - Range: 0x811b60..0x811bcc
               Pieces: []
-            - Range: 0x8111cc..0x8111cd
+            - Range: 0x811bcc..0x811bcd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8111cd..0x8111f0
+            - Range: 0x811bcd..0x811bf0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8820,11 +8820,11 @@ Subprograms:
         - Name: ~r4
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x811160..0x8111cc
+            - Range: 0x811b60..0x811bcc
               Pieces: []
-            - Range: 0x8111cc..0x8111cd
+            - Range: 0x811bcc..0x811bcd
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8111cd..0x8111f0
+            - Range: 0x811bcd..0x811bf0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8832,11 +8832,11 @@ Subprograms:
         - Name: ~r5
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0x811160..0x8111cc
+            - Range: 0x811b60..0x811bcc
               Pieces: []
-            - Range: 0x8111cc..0x8111cd
+            - Range: 0x811bcc..0x811bcd
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8111cd..0x8111f0
+            - Range: 0x811bcd..0x811bf0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8844,11 +8844,11 @@ Subprograms:
         - Name: ~r6
           Type: 4 BaseType uint32
           Locations:
-            - Range: 0x811160..0x8111cc
+            - Range: 0x811b60..0x811bcc
               Pieces: []
-            - Range: 0x8111cc..0x8111cd
+            - Range: 0x811bcc..0x811bcd
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8111cd..0x8111f0
+            - Range: 0x811bcd..0x811bf0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8856,11 +8856,11 @@ Subprograms:
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x811160..0x8111cc
+            - Range: 0x811b60..0x811bcc
               Pieces: []
-            - Range: 0x8111cc..0x8111cd
+            - Range: 0x811bcc..0x811bcd
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8111cd..0x8111f0
+            - Range: 0x811bcd..0x811bf0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8868,113 +8868,113 @@ Subprograms:
       DictRegister: null
     - ID: 115
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x8111f0..0x8112a0]
+      OutOfLinePCRanges: [0x811bf0..0x811ca0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r5
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r6
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r7
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r8
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r9
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r10
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r11
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r12
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r13
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r14
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8111f0..0x8112a0, Pieces: []}]
+          Locations: [{Range: 0x811bf0..0x811ca0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x8111f0..0x811288
+            - Range: 0x811bf0..0x811c88
               Pieces: []
-            - Range: 0x811288..0x811289
+            - Range: 0x811c88..0x811c89
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x811289..0x8112a0
+            - Range: 0x811c89..0x811ca0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8982,33 +8982,33 @@ Subprograms:
       DictRegister: null
     - ID: 116
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x8112a0..0x811320]
+      OutOfLinePCRanges: [0x811ca0..0x811d20]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 100 BaseType complex64
-          Locations: [{Range: 0x8112a0..0x811320, Pieces: []}]
+          Locations: [{Range: 0x811ca0..0x811d20, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 101 BaseType complex128
-          Locations: [{Range: 0x8112a0..0x811320, Pieces: []}]
+          Locations: [{Range: 0x811ca0..0x811d20, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 117
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x811320..0x8113e0]
+      OutOfLinePCRanges: [0x811d20..0x811de0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0x811320..0x8113bc
+            - Range: 0x811d20..0x811dbc
               Pieces: []
-            - Range: 0x8113bc..0x8113bd
+            - Range: 0x811dbc..0x811dbd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9030,7 +9030,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8113bd..0x8113e0
+            - Range: 0x811dbd..0x811de0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9038,17 +9038,17 @@ Subprograms:
       DictRegister: null
     - ID: 118
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x8113e0..0x811460]
+      OutOfLinePCRanges: [0x811de0..0x811e60]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 264 ArrayType [3]int
           Locations:
-            - Range: 0x8113e0..0x811448
+            - Range: 0x811de0..0x811e48
               Pieces: []
-            - Range: 0x811448..0x811449
+            - Range: 0x811e48..0x811e49
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x811449..0x811460
+            - Range: 0x811e49..0x811e60
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9056,17 +9056,17 @@ Subprograms:
       DictRegister: null
     - ID: 119
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x811460..0x8114d0]
+      OutOfLinePCRanges: [0x811e60..0x811ed0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 265 ArrayType [1]int
           Locations:
-            - Range: 0x811460..0x8114b0
+            - Range: 0x811e60..0x811eb0
               Pieces: []
-            - Range: 0x8114b0..0x8114b1
+            - Range: 0x811eb0..0x811eb1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8114b1..0x8114d0
+            - Range: 0x811eb1..0x811ed0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9074,17 +9074,17 @@ Subprograms:
       DictRegister: null
     - ID: 120
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x8114d0..0x811540]
+      OutOfLinePCRanges: [0x811ed0..0x811f40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 266 ArrayType [0]int
           Locations:
-            - Range: 0x8114d0..0x81151c
+            - Range: 0x811ed0..0x811f1c
               Pieces: []
-            - Range: 0x81151c..0x81151d
+            - Range: 0x811f1c..0x811f1d
               Pieces: []
-            - Range: 0x81151d..0x811540
+            - Range: 0x811f1d..0x811f40
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9092,29 +9092,29 @@ Subprograms:
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x811540..0x8115c0]
+      OutOfLinePCRanges: [0x811f40..0x811fc0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 267 StructureType main.mixedStruct
-          Locations: [{Range: 0x811540..0x8115c0, Pieces: []}]
+          Locations: [{Range: 0x811f40..0x811fc0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 122
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x8115c0..0x811650]
+      OutOfLinePCRanges: [0x811fc0..0x812050]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8115c0..0x811638
+            - Range: 0x811fc0..0x812038
               Pieces: []
-            - Range: 0x811638..0x811639
+            - Range: 0x812038..0x812039
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811639..0x811650
+            - Range: 0x812039..0x812050
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9122,11 +9122,11 @@ Subprograms:
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8115c0..0x811638
+            - Range: 0x811fc0..0x812038
               Pieces: []
-            - Range: 0x811638..0x811639
+            - Range: 0x812038..0x812039
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x811639..0x811650
+            - Range: 0x812039..0x812050
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9134,11 +9134,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8115c0..0x811638
+            - Range: 0x811fc0..0x812038
               Pieces: []
-            - Range: 0x811638..0x811639
+            - Range: 0x812038..0x812039
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x811639..0x811650
+            - Range: 0x812039..0x812050
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9146,11 +9146,11 @@ Subprograms:
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8115c0..0x811638
+            - Range: 0x811fc0..0x812038
               Pieces: []
-            - Range: 0x811638..0x811639
+            - Range: 0x812038..0x812039
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x811639..0x811650
+            - Range: 0x812039..0x812050
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9158,11 +9158,11 @@ Subprograms:
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8115c0..0x811638
+            - Range: 0x811fc0..0x812038
               Pieces: []
-            - Range: 0x811638..0x811639
+            - Range: 0x812038..0x812039
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x811639..0x811650
+            - Range: 0x812039..0x812050
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9170,11 +9170,11 @@ Subprograms:
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8115c0..0x811638
+            - Range: 0x811fc0..0x812038
               Pieces: []
-            - Range: 0x811638..0x811639
+            - Range: 0x812038..0x812039
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x811639..0x811650
+            - Range: 0x812039..0x812050
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9182,11 +9182,11 @@ Subprograms:
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8115c0..0x811638
+            - Range: 0x811fc0..0x812038
               Pieces: []
-            - Range: 0x811638..0x811639
+            - Range: 0x812038..0x812039
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x811639..0x811650
+            - Range: 0x812039..0x812050
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9194,11 +9194,11 @@ Subprograms:
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8115c0..0x811638
+            - Range: 0x811fc0..0x812038
               Pieces: []
-            - Range: 0x811638..0x811639
+            - Range: 0x812038..0x812039
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x811639..0x811650
+            - Range: 0x812039..0x812050
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9206,15 +9206,15 @@ Subprograms:
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8115c0..0x811638
+            - Range: 0x811fc0..0x812038
               Pieces: []
-            - Range: 0x811638..0x811639
+            - Range: 0x812038..0x812039
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x811639..0x811650
+            - Range: 0x812039..0x812050
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9222,15 +9222,15 @@ Subprograms:
       DictRegister: null
     - ID: 123
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x811650..0x811720]
+      OutOfLinePCRanges: [0x812050..0x812120]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 268 StructureType main.wideStruct
           Locations:
-            - Range: 0x811650..0x8116fc
+            - Range: 0x812050..0x8120fc
               Pieces: []
-            - Range: 0x8116fc..0x8116fd
+            - Range: 0x8120fc..0x8120fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9254,7 +9254,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x8116fd..0x811720
+            - Range: 0x8120fd..0x812120
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9262,57 +9262,57 @@ Subprograms:
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x811720..0x8117b0]
+      OutOfLinePCRanges: [0x812120..0x8121b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811720..0x81178c
+            - Range: 0x812120..0x81218c
               Pieces: []
-            - Range: 0x81178c..0x81178d
+            - Range: 0x81218c..0x81218d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x81178d..0x8117b0
+            - Range: 0x81218d..0x8121b0
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x811720..0x8117b0, Pieces: []}]
+          Locations: [{Range: 0x812120..0x8121b0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811720..0x81178c
+            - Range: 0x812120..0x81218c
               Pieces: []
-            - Range: 0x81178c..0x81178d
+            - Range: 0x81218c..0x81218d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x81178d..0x8117b0
+            - Range: 0x81218d..0x8121b0
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x811720..0x8117b0, Pieces: []}]
+          Locations: [{Range: 0x812120..0x8121b0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x811720..0x81178c
+            - Range: 0x812120..0x81218c
               Pieces: []
-            - Range: 0x81178c..0x81178d
+            - Range: 0x81218c..0x81218d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x81178d..0x8117b0
+            - Range: 0x81218d..0x8121b0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9320,17 +9320,17 @@ Subprograms:
       DictRegister: null
     - ID: 125
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x8117b0..0x811830]
+      OutOfLinePCRanges: [0x8121b0..0x812230]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 269 StructureType main.structWithArray
           Locations:
-            - Range: 0x8117b0..0x811818
+            - Range: 0x8121b0..0x812218
               Pieces: []
-            - Range: 0x811818..0x811819
+            - Range: 0x812218..0x812219
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x811819..0x811830
+            - Range: 0x812219..0x812230
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9338,47 +9338,47 @@ Subprograms:
       DictRegister: null
     - ID: 126
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x811830..0x8118a0]
+      OutOfLinePCRanges: [0x812230..0x8122a0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x811830..0x8118a0, Pieces: []}]
+          Locations: [{Range: 0x812230..0x8122a0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 127
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x8118a0..0x811910]
+      OutOfLinePCRanges: [0x8122a0..0x812310]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 20 BaseType float32
-          Locations: [{Range: 0x8118a0..0x811910, Pieces: []}]
+          Locations: [{Range: 0x8122a0..0x812310, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8118a0..0x811910, Pieces: []}]
+          Locations: [{Range: 0x8122a0..0x812310, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 128
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x811910..0x811980]
+      OutOfLinePCRanges: [0x812310..0x812380]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x811910..0x811964
+            - Range: 0x812310..0x812364
               Pieces: []
-            - Range: 0x811964..0x811965
+            - Range: 0x812364..0x812365
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811965..0x811980
+            - Range: 0x812365..0x812380
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9386,11 +9386,11 @@ Subprograms:
         - Name: ~r1
           Type: 3 BaseType uintptr
           Locations:
-            - Range: 0x811910..0x811964
+            - Range: 0x812310..0x812364
               Pieces: []
-            - Range: 0x811964..0x811965
+            - Range: 0x812364..0x812365
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x811965..0x811980
+            - Range: 0x812365..0x812380
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9398,13 +9398,13 @@ Subprograms:
       DictRegister: null
     - ID: 129
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x811980..0x811b10]
+      OutOfLinePCRanges: [0x812380..0x812510]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0x811980..0x8119d8
+            - Range: 0x812380..0x8123d8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9426,7 +9426,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8119d8..0x8119e0
+            - Range: 0x8123d8..0x8123e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9448,7 +9448,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8119e0..0x8119e8
+            - Range: 0x8123e0..0x8123e8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9470,7 +9470,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8119e8..0x8119ec
+            - Range: 0x8123e8..0x8123ec
               Pieces:
                 - Size: 8
                   Op: null
@@ -9498,9 +9498,9 @@ Subprograms:
         - Name: ~r0
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0x811980..0x811ac8
+            - Range: 0x812380..0x8124c8
               Pieces: []
-            - Range: 0x811ac8..0x811ac9
+            - Range: 0x8124c8..0x8124c9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9522,7 +9522,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x811ac9..0x811b10
+            - Range: 0x8124c9..0x812510
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9530,13 +9530,13 @@ Subprograms:
       DictRegister: null
     - ID: 130
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x811b10..0x811bd0]
+      OutOfLinePCRanges: [0x812510..0x8125d0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 264 ArrayType [3]int
           Locations:
-            - Range: 0x811b10..0x811bd0
+            - Range: 0x812510..0x8125d0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9544,11 +9544,11 @@ Subprograms:
         - Name: ~r0
           Type: 264 ArrayType [3]int
           Locations:
-            - Range: 0x811b10..0x811bb8
+            - Range: 0x812510..0x8125b8
               Pieces: []
-            - Range: 0x811bb8..0x811bb9
+            - Range: 0x8125b8..0x8125b9
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x811bb9..0x811bd0
+            - Range: 0x8125b9..0x8125d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9556,13 +9556,13 @@ Subprograms:
       DictRegister: null
     - ID: 131
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x811bd0..0x811de0]
+      OutOfLinePCRanges: [0x8125d0..0x8127e0]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0x811bd0..0x811c2c
+            - Range: 0x8125d0..0x81262c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9584,7 +9584,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x811c2c..0x811c34
+            - Range: 0x81262c..0x812634
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9606,7 +9606,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x811c34..0x811c3c
+            - Range: 0x812634..0x81263c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9628,7 +9628,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x811c3c..0x811c40
+            - Range: 0x81263c..0x812640
               Pieces:
                 - Size: 8
                   Op: null
@@ -9656,7 +9656,7 @@ Subprograms:
         - Name: s2
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0x811bd0..0x811de0
+            - Range: 0x8125d0..0x8127e0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9664,9 +9664,9 @@ Subprograms:
         - Name: ~r0
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0x811bd0..0x811d94
+            - Range: 0x8125d0..0x812794
               Pieces: []
-            - Range: 0x811d94..0x811d95
+            - Range: 0x812794..0x812795
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9688,7 +9688,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x811d95..0x811de0
+            - Range: 0x812795..0x8127e0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9696,15 +9696,15 @@ Subprograms:
       DictRegister: null
     - ID: 132
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x811de0..0x811f80]
+      OutOfLinePCRanges: [0x8127e0..0x812980]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811de0..0x811e54
+            - Range: 0x8127e0..0x812854
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811e54..0x811f80
+            - Range: 0x812854..0x812980
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -9712,9 +9712,9 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811de0..0x811e44
+            - Range: 0x8127e0..0x812844
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x811e44..0x811f80
+            - Range: 0x812844..0x812980
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
@@ -9722,9 +9722,9 @@ Subprograms:
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811de0..0x811e4c
+            - Range: 0x8127e0..0x81284c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x811e4c..0x811f80
+            - Range: 0x81284c..0x812980
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
@@ -9732,9 +9732,9 @@ Subprograms:
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811de0..0x811e54
+            - Range: 0x8127e0..0x812854
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x811e54..0x811f80
+            - Range: 0x812854..0x812980
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
@@ -9742,9 +9742,9 @@ Subprograms:
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811de0..0x811e54
+            - Range: 0x8127e0..0x812854
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x811e54..0x811f80
+            - Range: 0x812854..0x812980
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
@@ -9752,9 +9752,9 @@ Subprograms:
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811de0..0x811e54
+            - Range: 0x8127e0..0x812854
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x811e54..0x811f80
+            - Range: 0x812854..0x812980
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
@@ -9762,9 +9762,9 @@ Subprograms:
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811de0..0x811e54
+            - Range: 0x8127e0..0x812854
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x811e54..0x811f80
+            - Range: 0x812854..0x812980
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
@@ -9772,9 +9772,9 @@ Subprograms:
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811de0..0x811e54
+            - Range: 0x8127e0..0x812854
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x811e54..0x811f80
+            - Range: 0x812854..0x812980
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
@@ -9782,9 +9782,9 @@ Subprograms:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811de0..0x811e54
+            - Range: 0x8127e0..0x812854
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x811e54..0x811f80
+            - Range: 0x812854..0x812980
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
@@ -9792,11 +9792,11 @@ Subprograms:
         - Name: ~r0
           Type: 116 ArrayType [2]int
           Locations:
-            - Range: 0x811de0..0x811f3c
+            - Range: 0x8127e0..0x81293c
               Pieces: []
-            - Range: 0x811f3c..0x811f3d
+            - Range: 0x81293c..0x81293d
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x811f3d..0x811f80
+            - Range: 0x81293d..0x812980
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9804,15 +9804,15 @@ Subprograms:
       DictRegister: null
     - ID: 133
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x811f80..0x812170]
+      OutOfLinePCRanges: [0x812980..0x812b70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811f80..0x812004
+            - Range: 0x812980..0x812a04
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x812004..0x812170
+            - Range: 0x812a04..0x812b70
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9820,9 +9820,9 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811f80..0x811ff4
+            - Range: 0x812980..0x8129f4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x811ff4..0x812170
+            - Range: 0x8129f4..0x812b70
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -9830,9 +9830,9 @@ Subprograms:
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811f80..0x811ffc
+            - Range: 0x812980..0x8129fc
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x811ffc..0x812170
+            - Range: 0x8129fc..0x812b70
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -9840,9 +9840,9 @@ Subprograms:
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811f80..0x812004
+            - Range: 0x812980..0x812a04
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x812004..0x812170
+            - Range: 0x812a04..0x812b70
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
@@ -9850,9 +9850,9 @@ Subprograms:
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811f80..0x812004
+            - Range: 0x812980..0x812a04
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x812004..0x812170
+            - Range: 0x812a04..0x812b70
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
@@ -9860,9 +9860,9 @@ Subprograms:
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811f80..0x812004
+            - Range: 0x812980..0x812a04
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x812004..0x812170
+            - Range: 0x812a04..0x812b70
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
@@ -9870,9 +9870,9 @@ Subprograms:
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811f80..0x812004
+            - Range: 0x812980..0x812a04
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x812004..0x812170
+            - Range: 0x812a04..0x812b70
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
@@ -9880,9 +9880,9 @@ Subprograms:
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x811f80..0x812004
+            - Range: 0x812980..0x812a04
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x812004..0x812170
+            - Range: 0x812a04..0x812b70
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
@@ -9890,13 +9890,13 @@ Subprograms:
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x811f80..0x812004
+            - Range: 0x812980..0x812a04
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x812004..0x812170
+            - Range: 0x812a04..0x812b70
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9908,9 +9908,9 @@ Subprograms:
         - Name: ~r0
           Type: 263 StructureType main.largeStruct
           Locations:
-            - Range: 0x811f80..0x812128
+            - Range: 0x812980..0x812b28
               Pieces: []
-            - Range: 0x812128..0x812129
+            - Range: 0x812b28..0x812b29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9932,7 +9932,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x812129..0x812170
+            - Range: 0x812b29..0x812b70
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9940,13 +9940,13 @@ Subprograms:
       DictRegister: null
     - ID: 134
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x812170..0x812200]
+      OutOfLinePCRanges: [0x812b70..0x812c00]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 170 ArrayType [5]int
           Locations:
-            - Range: 0x812170..0x812200
+            - Range: 0x812b70..0x812c00
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9954,11 +9954,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x812170..0x8121e0
+            - Range: 0x812b70..0x812be0
               Pieces: []
-            - Range: 0x8121e0..0x8121e1
+            - Range: 0x812be0..0x812be1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8121e1..0x812200
+            - Range: 0x812be1..0x812c00
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9966,11 +9966,11 @@ Subprograms:
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x812170..0x8121e0
+            - Range: 0x812b70..0x812be0
               Pieces: []
-            - Range: 0x8121e0..0x8121e1
+            - Range: 0x812be0..0x812be1
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8121e1..0x812200
+            - Range: 0x812be1..0x812c00
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9978,11 +9978,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x812170..0x8121e0
+            - Range: 0x812b70..0x812be0
               Pieces: []
-            - Range: 0x8121e0..0x8121e1
+            - Range: 0x812be0..0x812be1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8121e1..0x812200
+            - Range: 0x812be1..0x812c00
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9990,13 +9990,13 @@ Subprograms:
       DictRegister: null
     - ID: 135
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x812200..0x8122d0]
+      OutOfLinePCRanges: [0x812c00..0x812cd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 116 ArrayType [2]int
           Locations:
-            - Range: 0x812200..0x8122d0
+            - Range: 0x812c00..0x812cd0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -10004,7 +10004,7 @@ Subprograms:
         - Name: b
           Type: 264 ArrayType [3]int
           Locations:
-            - Range: 0x812200..0x8122d0
+            - Range: 0x812c00..0x812cd0
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -10012,11 +10012,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x812200..0x8122b4
+            - Range: 0x812c00..0x812cb4
               Pieces: []
-            - Range: 0x8122b4..0x8122b5
+            - Range: 0x812cb4..0x812cb5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8122b5..0x8122d0
+            - Range: 0x812cb5..0x812cd0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10024,11 +10024,11 @@ Subprograms:
         - Name: ~r1
           Type: 116 ArrayType [2]int
           Locations:
-            - Range: 0x812200..0x8122b4
+            - Range: 0x812c00..0x812cb4
               Pieces: []
-            - Range: 0x8122b4..0x8122b5
+            - Range: 0x812cb4..0x812cb5
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x8122b5..0x8122d0
+            - Range: 0x812cb5..0x812cd0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10036,13 +10036,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x8122d0..0x812390]
+      OutOfLinePCRanges: [0x812cd0..0x812d90]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 269 StructureType main.structWithArray
           Locations:
-            - Range: 0x8122d0..0x812390
+            - Range: 0x812cd0..0x812d90
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -10050,11 +10050,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8122d0..0x812370
+            - Range: 0x812cd0..0x812d70
               Pieces: []
-            - Range: 0x812370..0x812371
+            - Range: 0x812d70..0x812d71
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x812371..0x812390
+            - Range: 0x812d71..0x812d90
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10062,11 +10062,11 @@ Subprograms:
         - Name: ~r1
           Type: 269 StructureType main.structWithArray
           Locations:
-            - Range: 0x8122d0..0x812370
+            - Range: 0x812cd0..0x812d70
               Pieces: []
-            - Range: 0x812370..0x812371
+            - Range: 0x812d70..0x812d71
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x812371..0x812390
+            - Range: 0x812d71..0x812d90
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10074,7 +10074,7 @@ Subprograms:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x812348..0x812390
+            - Range: 0x812d48..0x812d90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -10082,25 +10082,25 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x812390..0x812430]
+      OutOfLinePCRanges: [0x812d90..0x812e30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 266 ArrayType [0]int
-          Locations: [{Range: 0x812390..0x812430, Pieces: []}]
+          Locations: [{Range: 0x812d90..0x812e30, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x812390..0x8123cc
+            - Range: 0x812d90..0x812dcc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8123cc..0x8123e4
+            - Range: 0x812dcc..0x812de4
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x8123e4..0x8123ec
+            - Range: 0x812de4..0x812dec
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x8123ec..0x812430
+            - Range: 0x812dec..0x812e30
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
@@ -10108,11 +10108,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x812390..0x812408
+            - Range: 0x812d90..0x812e08
               Pieces: []
-            - Range: 0x812408..0x812409
+            - Range: 0x812e08..0x812e09
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x812409..0x812430
+            - Range: 0x812e09..0x812e30
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10120,11 +10120,11 @@ Subprograms:
         - Name: ~r1
           Type: 266 ArrayType [0]int
           Locations:
-            - Range: 0x812390..0x812408
+            - Range: 0x812d90..0x812e08
               Pieces: []
-            - Range: 0x812408..0x812409
+            - Range: 0x812e08..0x812e09
               Pieces: []
-            - Range: 0x812409..0x812430
+            - Range: 0x812e09..0x812e30
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10132,13 +10132,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x812870..0x812880]
+      OutOfLinePCRanges: [0x813270..0x813280]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 270 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x812870..0x812880
+            - Range: 0x813270..0x813280
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10152,13 +10152,13 @@ Subprograms:
       DictRegister: null
     - ID: 139
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x812880..0x812890]
+      OutOfLinePCRanges: [0x813280..0x813290]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 270 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x812880..0x812890
+            - Range: 0x813280..0x813290
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10172,13 +10172,13 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x812890..0x8128a0]
+      OutOfLinePCRanges: [0x813290..0x8132a0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 271 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x812890..0x8128a0
+            - Range: 0x813290..0x8132a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10192,13 +10192,13 @@ Subprograms:
       DictRegister: null
     - ID: 141
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x8128a0..0x8128b0]
+      OutOfLinePCRanges: [0x8132a0..0x8132b0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 273 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x8128a0..0x8128b0
+            - Range: 0x8132a0..0x8132b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10212,7 +10212,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8128a0..0x8128b0
+            - Range: 0x8132a0..0x8132b0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10220,13 +10220,13 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x8128b0..0x8128c0]
+      OutOfLinePCRanges: [0x8132b0..0x8132c0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 273 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x8128b0..0x8128c0
+            - Range: 0x8132b0..0x8132c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10240,7 +10240,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8128b0..0x8128c0
+            - Range: 0x8132b0..0x8132c0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10248,13 +10248,13 @@ Subprograms:
       DictRegister: null
     - ID: 143
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x8128c0..0x8128d0]
+      OutOfLinePCRanges: [0x8132c0..0x8132d0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 273 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x8128c0..0x8128d0
+            - Range: 0x8132c0..0x8132d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10268,7 +10268,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8128c0..0x8128d0
+            - Range: 0x8132c0..0x8132d0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10276,13 +10276,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x8128d0..0x8128e0]
+      OutOfLinePCRanges: [0x8132d0..0x8132e0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 164 GoSliceHeaderType []string
           Locations:
-            - Range: 0x8128d0..0x8128e0
+            - Range: 0x8132d0..0x8132e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10296,13 +10296,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x8128e0..0x8128f0]
+      OutOfLinePCRanges: [0x8132e0..0x8132f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x8128e0..0x8128f0
+            - Range: 0x8132e0..0x8132f0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10310,7 +10310,7 @@ Subprograms:
         - Name: s
           Type: 276 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x8128e0..0x8128f0
+            - Range: 0x8132e0..0x8132f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10324,7 +10324,7 @@ Subprograms:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x8128e0..0x8128f0
+            - Range: 0x8132e0..0x8132f0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10332,13 +10332,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x8128f0..0x812900]
+      OutOfLinePCRanges: [0x8132f0..0x813300]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 277 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x8128f0..0x812900
+            - Range: 0x8132f0..0x813300
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10352,13 +10352,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x812900..0x812910]
+      OutOfLinePCRanges: [0x813300..0x813310]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 270 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x812900..0x812910
+            - Range: 0x813300..0x813310
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10372,13 +10372,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x812910..0x812920]
+      OutOfLinePCRanges: [0x813310..0x813320]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 278 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0x812910..0x812920
+            - Range: 0x813310..0x813320
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10392,13 +10392,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x812920..0x812930]
+      OutOfLinePCRanges: [0x813320..0x813330]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 270 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x812920..0x812930
+            - Range: 0x813320..0x813330
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10412,7 +10412,7 @@ Subprograms:
         - Name: bs
           Type: 270 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x812920..0x812930
+            - Range: 0x813320..0x813330
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10426,7 +10426,7 @@ Subprograms:
         - Name: cs
           Type: 270 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x812920..0x812930
+            - Range: 0x813320..0x813330
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10440,13 +10440,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testByteSliceInvalidUtf8
-      OutOfLinePCRanges: [0x812960..0x812970]
+      OutOfLinePCRanges: [0x813360..0x813370]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0x812960..0x812970
+            - Range: 0x813360..0x813370
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10460,13 +10460,13 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testByteSliceMultibyteUtf8
-      OutOfLinePCRanges: [0x812970..0x812980]
+      OutOfLinePCRanges: [0x813370..0x813380]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0x812970..0x812980
+            - Range: 0x813370..0x813380
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10480,21 +10480,21 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.stackC
-      OutOfLinePCRanges: [0x812ee0..0x812f40]
+      OutOfLinePCRanges: [0x8139d0..0x813a30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x812ee0..0x812f28
+            - Range: 0x8139d0..0x813a18
               Pieces: []
-            - Range: 0x812f28..0x812f29
+            - Range: 0x813a18..0x813a19
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x812f29..0x812f40
+            - Range: 0x813a19..0x813a30
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10502,13 +10502,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x812f40..0x812f50]
+      OutOfLinePCRanges: [0x813b50..0x813b60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x812f40..0x812f50
+            - Range: 0x813b50..0x813b60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10520,13 +10520,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x812f50..0x812f60]
+      OutOfLinePCRanges: [0x813b60..0x813b70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x812f50..0x812f60
+            - Range: 0x813b60..0x813b70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10538,7 +10538,7 @@ Subprograms:
         - Name: "y"
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x812f50..0x812f60
+            - Range: 0x813b60..0x813b70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10550,7 +10550,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x812f50..0x812f60
+            - Range: 0x813b60..0x813b70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10562,13 +10562,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x812f60..0x812f70]
+      OutOfLinePCRanges: [0x813b70..0x813b80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x812f60..0x812f70
+            - Range: 0x813b70..0x813b80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10588,13 +10588,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x812f70..0x812f80]
+      OutOfLinePCRanges: [0x813b80..0x813b90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 281 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x812f70..0x812f80
+            - Range: 0x813b80..0x813b90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10602,13 +10602,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x812f80..0x812f90]
+      OutOfLinePCRanges: [0x813b90..0x813ba0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 282 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x812f80..0x812f90
+            - Range: 0x813b90..0x813ba0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10616,13 +10616,13 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x812f90..0x812fa0]
+      OutOfLinePCRanges: [0x813ba0..0x813bb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x812f90..0x812fa0
+            - Range: 0x813ba0..0x813bb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10634,13 +10634,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x812fa0..0x812fb0]
+      OutOfLinePCRanges: [0x813bb0..0x813bc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x812fa0..0x812fb0
+            - Range: 0x813bb0..0x813bc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10652,13 +10652,13 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x812fb0..0x812fc0]
+      OutOfLinePCRanges: [0x813bc0..0x813bd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x812fb0..0x812fc0
+            - Range: 0x813bc0..0x813bd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10670,13 +10670,13 @@ Subprograms:
       DictRegister: null
     - ID: 161
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x812fc0..0x812fd0]
+      OutOfLinePCRanges: [0x813bd0..0x813be0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x812fc0..0x812fd0
+            - Range: 0x813bd0..0x813be0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10688,7 +10688,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x812fc0..0x812fd0
+            - Range: 0x813bd0..0x813be0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10700,7 +10700,7 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x812fc0..0x812fd0
+            - Range: 0x813bd0..0x813be0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10712,13 +10712,13 @@ Subprograms:
       DictRegister: null
     - ID: 162
       Name: main.testInvalidUtf8Strings
-      OutOfLinePCRanges: [0x812fd0..0x812fe0]
+      OutOfLinePCRanges: [0x813be0..0x813bf0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x812fd0..0x812fe0
+            - Range: 0x813be0..0x813bf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10730,7 +10730,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x812fd0..0x812fe0
+            - Range: 0x813be0..0x813bf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10742,13 +10742,13 @@ Subprograms:
       DictRegister: null
     - ID: 163
       Name: main.testMultibyteUtf8String
-      OutOfLinePCRanges: [0x812fe0..0x812ff0]
+      OutOfLinePCRanges: [0x813bf0..0x813c00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x812fe0..0x812ff0
+            - Range: 0x813bf0..0x813c00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10760,13 +10760,13 @@ Subprograms:
       DictRegister: null
     - ID: 164
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x813170..0x813180]
+      OutOfLinePCRanges: [0x813e80..0x813e90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 284 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x813170..0x813180
+            - Range: 0x813e80..0x813e90
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -10774,13 +10774,13 @@ Subprograms:
       DictRegister: null
     - ID: 165
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x813180..0x813190]
+      OutOfLinePCRanges: [0x813e90..0x813ea0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 297 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x813180..0x813190
+            - Range: 0x813e90..0x813ea0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10800,13 +10800,13 @@ Subprograms:
       DictRegister: null
     - ID: 166
       Name: main.testStruct
-      OutOfLinePCRanges: [0x813230..0x813250]
+      OutOfLinePCRanges: [0x813f40..0x813f60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 328 StructureType main.aStruct
           Locations:
-            - Range: 0x813230..0x813250
+            - Range: 0x813f40..0x813f60
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10828,13 +10828,13 @@ Subprograms:
       DictRegister: null
     - ID: 167
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x8132c0..0x8132d0]
+      OutOfLinePCRanges: [0x813fd0..0x813fe0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x8132c0..0x8132d0
+            - Range: 0x813fd0..0x813fe0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10842,13 +10842,13 @@ Subprograms:
       DictRegister: null
     - ID: 168
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x8132d0..0x8132e0]
+      OutOfLinePCRanges: [0x813fe0..0x813ff0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 331 StructureType main.tenStrings
           Locations:
-            - Range: 0x8132d0..0x8132e0
+            - Range: 0x813fe0..0x813ff0
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -10856,25 +10856,25 @@ Subprograms:
       DictRegister: null
     - ID: 169
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x813300..0x813310]
+      OutOfLinePCRanges: [0x814010..0x814020]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 332 StructureType main.emptyStruct
-          Locations: [{Range: 0x813300..0x813310, Pieces: []}]
+          Locations: [{Range: 0x814010..0x814020, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 170
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x813310..0x813320]
+      OutOfLinePCRanges: [0x814020..0x814030]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 333 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x813310..0x813320
+            - Range: 0x814020..0x814030
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10882,13 +10882,13 @@ Subprograms:
       DictRegister: null
     - ID: 171
       Name: main.testTimeUTC
-      OutOfLinePCRanges: [0x813ca0..0x813cb0]
+      OutOfLinePCRanges: [0x814ab0..0x814ac0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 GoTimeType time.Time
           Locations:
-            - Range: 0x813ca0..0x813cb0
+            - Range: 0x814ab0..0x814ac0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10902,13 +10902,13 @@ Subprograms:
       DictRegister: null
     - ID: 172
       Name: main.testTimeFixedZone
-      OutOfLinePCRanges: [0x813cb0..0x813cc0]
+      OutOfLinePCRanges: [0x814ac0..0x814ad0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 GoTimeType time.Time
           Locations:
-            - Range: 0x813cb0..0x813cc0
+            - Range: 0x814ac0..0x814ad0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10922,13 +10922,13 @@ Subprograms:
       DictRegister: null
     - ID: 173
       Name: main.testTimeMonotonic
-      OutOfLinePCRanges: [0x813cc0..0x813cd0]
+      OutOfLinePCRanges: [0x814ad0..0x814ae0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 337 StructureType main.timeCapture
           Locations:
-            - Range: 0x813cc0..0x813cd0
+            - Range: 0x814ad0..0x814ae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10942,13 +10942,13 @@ Subprograms:
       DictRegister: null
     - ID: 174
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x814c20..0x814c30]
+      OutOfLinePCRanges: [0x815b20..0x815b30]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x814c20..0x814c30
+            - Range: 0x815b20..0x815b30
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10956,11 +10956,11 @@ Subprograms:
         - Name: ~r0
           Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x814c20..0x814c24
+            - Range: 0x815b20..0x815b24
               Pieces: []
-            - Range: 0x814c24..0x814c25
+            - Range: 0x815b24..0x815b25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x814c25..0x814c30
+            - Range: 0x815b25..0x815b30
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -10968,19 +10968,19 @@ Subprograms:
       DictRegister: 0
     - ID: 175
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x814c30..0x814c40]
+      OutOfLinePCRanges: [0x815b30..0x815b40]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x814c30..0x814c3c
+            - Range: 0x815b30..0x815b3c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x814c3c..0x814c40
+            - Range: 0x815b3c..0x815b40
               Pieces:
                 - Size: 8
                   Op: null
@@ -10992,15 +10992,15 @@ Subprograms:
         - Name: ~r0
           Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x814c30..0x814c3c
+            - Range: 0x815b30..0x815b3c
               Pieces: []
-            - Range: 0x814c3c..0x814c3d
+            - Range: 0x815b3c..0x815b3d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x814c3d..0x814c40
+            - Range: 0x815b3d..0x815b40
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11008,13 +11008,13 @@ Subprograms:
       DictRegister: 0
     - ID: 176
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x814c40..0x814c50]
+      OutOfLinePCRanges: [0x815b40..0x815b50]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x814c40..0x814c50
+            - Range: 0x815b40..0x815b50
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11022,11 +11022,11 @@ Subprograms:
         - Name: ~r0
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x814c40..0x814c44
+            - Range: 0x815b40..0x815b44
               Pieces: []
-            - Range: 0x814c44..0x814c45
+            - Range: 0x815b44..0x815b45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x814c45..0x814c50
+            - Range: 0x815b45..0x815b50
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11034,19 +11034,19 @@ Subprograms:
       DictRegister: 0
     - ID: 177
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x814c50..0x814c60]
+      OutOfLinePCRanges: [0x815b50..0x815b60]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x814c50..0x814c5c
+            - Range: 0x815b50..0x815b5c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x814c5c..0x814c60
+            - Range: 0x815b5c..0x815b60
               Pieces:
                 - Size: 8
                   Op: null
@@ -11058,15 +11058,15 @@ Subprograms:
         - Name: ~r0
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x814c50..0x814c5c
+            - Range: 0x815b50..0x815b5c
               Pieces: []
-            - Range: 0x814c5c..0x814c5d
+            - Range: 0x815b5c..0x815b5d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x814c5d..0x814c60
+            - Range: 0x815b5d..0x815b60
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11074,13 +11074,13 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x814cc0..0x814de0]
+      OutOfLinePCRanges: [0x815bc0..0x815ce0]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x814cc0..0x814cec
+            - Range: 0x815bc0..0x815bec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11088,7 +11088,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x814cec..0x814cfc
+            - Range: 0x815bec..0x815bfc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -11096,7 +11096,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x814cfc..0x814de0
+            - Range: 0x815bfc..0x815ce0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -11110,9 +11110,9 @@ Subprograms:
         - Name: pred
           Type: 344 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x814cc0..0x814cfc
+            - Range: 0x815bc0..0x815bfc
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x814cfc..0x814de0
+            - Range: 0x815bfc..0x815ce0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
@@ -11120,9 +11120,9 @@ Subprograms:
         - Name: ~r0
           Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x814cc0..0x814dac
+            - Range: 0x815bc0..0x815cac
               Pieces: []
-            - Range: 0x814dac..0x814dad
+            - Range: 0x815cac..0x815cad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11130,7 +11130,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x814dad..0x814de0
+            - Range: 0x815cad..0x815ce0
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -11138,7 +11138,7 @@ Subprograms:
         - Name: result
           Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x814cec..0x814cfc
+            - Range: 0x815bec..0x815bfc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11146,7 +11146,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x814cfc..0x814d18
+            - Range: 0x815bfc..0x815c18
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11154,7 +11154,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x814d18..0x814d1c
+            - Range: 0x815c18..0x815c1c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11162,7 +11162,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x814d1c..0x814d20
+            - Range: 0x815c1c..0x815c20
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11170,7 +11170,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x814d20..0x814d20
+            - Range: 0x815c20..0x815c20
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11178,7 +11178,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x814d20..0x814d4c
+            - Range: 0x815c20..0x815c4c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -11186,7 +11186,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x814d4c..0x814da0
+            - Range: 0x815c4c..0x815ca0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11194,7 +11194,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x814da0..0x814de0
+            - Range: 0x815ca0..0x815ce0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -11208,9 +11208,9 @@ Subprograms:
         - Name: item
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x814d3c..0x814d4c
+            - Range: 0x815c3c..0x815c4c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x814d4c..0x814da0
+            - Range: 0x815c4c..0x815ca0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
@@ -11218,13 +11218,13 @@ Subprograms:
       DictRegister: 0
     - ID: 179
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x814de0..0x814e30]
+      OutOfLinePCRanges: [0x815ce0..0x815d30]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 339 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x814de0..0x814e08
+            - Range: 0x815ce0..0x815d08
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11232,7 +11232,7 @@ Subprograms:
         - Name: f
           Type: 345 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x814de0..0x814e08
+            - Range: 0x815ce0..0x815d08
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11240,15 +11240,15 @@ Subprograms:
         - Name: ~r0
           Type: 341 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x814de0..0x814e08
+            - Range: 0x815ce0..0x815d08
               Pieces: []
-            - Range: 0x814e08..0x814e09
+            - Range: 0x815d08..0x815d09
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x814e09..0x814e30
+            - Range: 0x815d09..0x815d30
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -11256,13 +11256,13 @@ Subprograms:
       DictRegister: 0
     - ID: 180
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x8150a0..0x8150b0]
+      OutOfLinePCRanges: [0x815fa0..0x815fb0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 343 PointerType *go.shape.int
           Locations:
-            - Range: 0x8150a0..0x8150b0
+            - Range: 0x815fa0..0x815fb0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11270,11 +11270,11 @@ Subprograms:
         - Name: ~r0
           Type: 343 PointerType *go.shape.int
           Locations:
-            - Range: 0x8150a0..0x8150a4
+            - Range: 0x815fa0..0x815fa4
               Pieces: []
-            - Range: 0x8150a4..0x8150a5
+            - Range: 0x815fa4..0x815fa5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8150a5..0x8150b0
+            - Range: 0x815fa5..0x815fb0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11282,13 +11282,13 @@ Subprograms:
       DictRegister: 0
     - ID: 181
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x8150b0..0x8150c0]
+      OutOfLinePCRanges: [0x815fb0..0x815fc0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 346 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x8150b0..0x8150c0
+            - Range: 0x815fb0..0x815fc0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11296,11 +11296,11 @@ Subprograms:
         - Name: ~r0
           Type: 346 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x8150b0..0x8150b4
+            - Range: 0x815fb0..0x815fb4
               Pieces: []
-            - Range: 0x8150b4..0x8150b5
+            - Range: 0x815fb4..0x815fb5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8150b5..0x8150c0
+            - Range: 0x815fb5..0x815fc0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11308,13 +11308,13 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x8150c0..0x8150d0]
+      OutOfLinePCRanges: [0x815fc0..0x815fd0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 348 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x8150c0..0x8150d0
+            - Range: 0x815fc0..0x815fd0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11322,11 +11322,11 @@ Subprograms:
         - Name: ~r0
           Type: 348 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x8150c0..0x8150c4
+            - Range: 0x815fc0..0x815fc4
               Pieces: []
-            - Range: 0x8150c4..0x8150c5
+            - Range: 0x815fc4..0x815fc5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8150c5..0x8150d0
+            - Range: 0x815fc5..0x815fd0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11334,13 +11334,13 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x8150d0..0x8150e0]
+      OutOfLinePCRanges: [0x815fd0..0x815fe0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 350 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x8150d0..0x8150e0
+            - Range: 0x815fd0..0x815fe0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
@@ -11348,15 +11348,15 @@ Subprograms:
         - Name: ~r0
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8150d0..0x8150d4
+            - Range: 0x815fd0..0x815fd4
               Pieces: []
-            - Range: 0x8150d4..0x8150d5
+            - Range: 0x815fd4..0x815fd5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8150d5..0x8150e0
+            - Range: 0x815fd5..0x815fe0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11364,13 +11364,13 @@ Subprograms:
       DictRegister: 0
     - ID: 184
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x815160..0x815170]
+      OutOfLinePCRanges: [0x816060..0x816070]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 352 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x815160..0x815170
+            - Range: 0x816060..0x816070
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
@@ -11378,11 +11378,11 @@ Subprograms:
         - Name: ~r0
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x815160..0x815164
+            - Range: 0x816060..0x816064
               Pieces: []
-            - Range: 0x815164..0x815165
+            - Range: 0x816064..0x816065
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x815165..0x815170
+            - Range: 0x816065..0x816070
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11390,13 +11390,13 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x815200..0x815210]
+      OutOfLinePCRanges: [0x816100..0x816110]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 353 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x815200..0x815210
+            - Range: 0x816100..0x816110
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11404,7 +11404,7 @@ Subprograms:
         - Name: k
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x815200..0x815210
+            - Range: 0x816100..0x816110
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11412,7 +11412,7 @@ Subprograms:
         - Name: v
           Type: 355 BaseType go.shape.bool
           Locations:
-            - Range: 0x815200..0x815210
+            - Range: 0x816100..0x816110
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11420,13 +11420,13 @@ Subprograms:
       DictRegister: 1
     - ID: 186
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x815290..0x815300]
+      OutOfLinePCRanges: [0x816190..0x816200]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 356 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x815290..0x815300
+            - Range: 0x816190..0x816200
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11434,7 +11434,7 @@ Subprograms:
         - Name: k
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x815290..0x815300
+            - Range: 0x816190..0x816200
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -11446,7 +11446,7 @@ Subprograms:
         - Name: v
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x815290..0x815300
+            - Range: 0x816190..0x816200
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11454,13 +11454,13 @@ Subprograms:
       DictRegister: 1
     - ID: 187
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x815380..0x815390]
+      OutOfLinePCRanges: [0x816280..0x816290]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x815380..0x815390
+            - Range: 0x816280..0x816290
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11472,7 +11472,7 @@ Subprograms:
         - Name: b
           Type: 355 BaseType go.shape.bool
           Locations:
-            - Range: 0x815380..0x815390
+            - Range: 0x816280..0x816290
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11480,11 +11480,11 @@ Subprograms:
         - Name: ~r0
           Type: 355 BaseType go.shape.bool
           Locations:
-            - Range: 0x815380..0x815388
+            - Range: 0x816280..0x816288
               Pieces: []
-            - Range: 0x815388..0x815389
+            - Range: 0x816288..0x816289
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x815389..0x815390
+            - Range: 0x816289..0x816290
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11492,15 +11492,15 @@ Subprograms:
         - Name: ~r1
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x815380..0x815388
+            - Range: 0x816280..0x816288
               Pieces: []
-            - Range: 0x815388..0x815389
+            - Range: 0x816288..0x816289
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x815389..0x815390
+            - Range: 0x816289..0x816290
               Pieces: []
           Role: Return
           DictIndex: 0
@@ -11508,13 +11508,13 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x815390..0x8153b0]
+      OutOfLinePCRanges: [0x816290..0x8162b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x815390..0x8153a0
+            - Range: 0x816290..0x8162a0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11522,13 +11522,13 @@ Subprograms:
         - Name: b
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x815390..0x81539c
+            - Range: 0x816290..0x81629c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x81539c..0x8153b0
+            - Range: 0x81629c..0x8162b0
               Pieces:
                 - Size: 8
                   Op: null
@@ -11540,15 +11540,15 @@ Subprograms:
         - Name: ~r0
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x815390..0x8153a0
+            - Range: 0x816290..0x8162a0
               Pieces: []
-            - Range: 0x8153a0..0x8153a1
+            - Range: 0x8162a0..0x8162a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8153a1..0x8153b0
+            - Range: 0x8162a1..0x8162b0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11556,11 +11556,11 @@ Subprograms:
         - Name: ~r1
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x815390..0x8153a0
+            - Range: 0x816290..0x8162a0
               Pieces: []
-            - Range: 0x8153a0..0x8153a1
+            - Range: 0x8162a0..0x8162a1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8153a1..0x8153b0
+            - Range: 0x8162a1..0x8162b0
               Pieces: []
           Role: Return
           DictIndex: 0
@@ -11568,13 +11568,13 @@ Subprograms:
       DictRegister: 0
     - ID: 189
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x8153b0..0x815400]
+      OutOfLinePCRanges: [0x8162b0..0x816300]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 358 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x8153b0..0x8153d8
+            - Range: 0x8162b0..0x8162d8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11582,15 +11582,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8153b0..0x8153d8
+            - Range: 0x8162b0..0x8162d8
               Pieces: []
-            - Range: 0x8153d8..0x8153d9
+            - Range: 0x8162d8..0x8162d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8153d9..0x815400
+            - Range: 0x8162d9..0x816300
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11598,19 +11598,19 @@ Subprograms:
       DictRegister: 0
     - ID: 190
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x815400..0x815460]
+      OutOfLinePCRanges: [0x816300..0x816360]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 359 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x815400..0x81542c
+            - Range: 0x816300..0x81632c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x81542c..0x815430
+            - Range: 0x81632c..0x816330
               Pieces:
                 - Size: 8
                   Op: null
@@ -11622,15 +11622,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x815400..0x815430
+            - Range: 0x816300..0x816330
               Pieces: []
-            - Range: 0x815430..0x815431
+            - Range: 0x816330..0x816331
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x815431..0x815460
+            - Range: 0x816331..0x816360
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11638,13 +11638,13 @@ Subprograms:
       DictRegister: 0
     - ID: 191
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x815460..0x815470]
+      OutOfLinePCRanges: [0x816360..0x816370]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 360 PointerType *go.shape.string
           Locations:
-            - Range: 0x815460..0x815464
+            - Range: 0x816360..0x816364
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11652,15 +11652,15 @@ Subprograms:
         - Name: ~r0
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x815460..0x815464
+            - Range: 0x816360..0x816364
               Pieces: []
-            - Range: 0x815464..0x815465
+            - Range: 0x816364..0x816365
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x815465..0x815470
+            - Range: 0x816365..0x816370
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11668,13 +11668,13 @@ Subprograms:
       DictRegister: 0
     - ID: 192
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x815470..0x8154c0]
+      OutOfLinePCRanges: [0x816370..0x8163c0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 361 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x815470..0x8154ac
+            - Range: 0x816370..0x8163ac
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11682,9 +11682,9 @@ Subprograms:
         - Name: ~r0
           Type: 362 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x815470..0x8154b0
+            - Range: 0x816370..0x8163b0
               Pieces: []
-            - Range: 0x8154b0..0x8154b1
+            - Range: 0x8163b0..0x8163b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11698,7 +11698,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x8154b1..0x8154c0
+            - Range: 0x8163b1..0x8163c0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11706,13 +11706,13 @@ Subprograms:
       DictRegister: 0
     - ID: 193
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x8154c0..0x815500]
+      OutOfLinePCRanges: [0x8163c0..0x816400]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 342 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8154c0..0x8154cc
+            - Range: 0x8163c0..0x8163cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11720,7 +11720,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8154cc..0x815500
+            - Range: 0x8163cc..0x816400
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11734,7 +11734,7 @@ Subprograms:
         - Name: needle
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x8154c0..0x815500
+            - Range: 0x8163c0..0x816400
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11742,15 +11742,15 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x8154c0..0x8154e8
+            - Range: 0x8163c0..0x8163e8
               Pieces: []
-            - Range: 0x8154e8..0x8154e9
+            - Range: 0x8163e8..0x8163e9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8154e9..0x8154f0
+            - Range: 0x8163e9..0x8163f0
               Pieces: []
-            - Range: 0x8154f0..0x8154f1
+            - Range: 0x8163f0..0x8163f1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8154f1..0x815500
+            - Range: 0x8163f1..0x816400
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11758,7 +11758,7 @@ Subprograms:
         - Name: v
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x8154dc..0x8154ec
+            - Range: 0x8163dc..0x8163ec
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
@@ -11766,13 +11766,13 @@ Subprograms:
       DictRegister: 0
     - ID: 194
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x815500..0x8155c0]
+      OutOfLinePCRanges: [0x816400..0x8164c0]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 363 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x815500..0x815524
+            - Range: 0x816400..0x816424
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11780,7 +11780,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x815524..0x815528
+            - Range: 0x816424..0x816428
               Pieces:
                 - Size: 8
                   Op: null
@@ -11794,13 +11794,13 @@ Subprograms:
         - Name: needle
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x815500..0x815558
+            - Range: 0x816400..0x816458
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x815558..0x8155c0
+            - Range: 0x816458..0x8164c0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -11812,15 +11812,15 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x815500..0x815574
+            - Range: 0x816400..0x816474
               Pieces: []
-            - Range: 0x815574..0x815575
+            - Range: 0x816474..0x816475
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x815575..0x815584
+            - Range: 0x816475..0x816484
               Pieces: []
-            - Range: 0x815584..0x815585
+            - Range: 0x816484..0x816485
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x815585..0x8155c0
+            - Range: 0x816485..0x8164c0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11828,7 +11828,7 @@ Subprograms:
         - Name: v
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x815540..0x815558
+            - Range: 0x816440..0x816458
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11840,13 +11840,13 @@ Subprograms:
       DictRegister: 0
     - ID: 195
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x8155c0..0x8155d0]
+      OutOfLinePCRanges: [0x8164c0..0x8164d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 364 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x8155c0..0x8155c8
+            - Range: 0x8164c0..0x8164c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11854,7 +11854,7 @@ Subprograms:
         - Name: value
           Type: 338 BaseType go.shape.int
           Locations:
-            - Range: 0x8155c0..0x8155d0
+            - Range: 0x8164c0..0x8164d0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11862,11 +11862,11 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x8155c0..0x8155c8
+            - Range: 0x8164c0..0x8164c8
               Pieces: []
-            - Range: 0x8155c8..0x8155c9
+            - Range: 0x8164c8..0x8164c9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8155c9..0x8155d0
+            - Range: 0x8164c9..0x8164d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11874,25 +11874,25 @@ Subprograms:
       DictRegister: 1
     - ID: 196
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x815640..0x8156b0]
+      OutOfLinePCRanges: [0x816540..0x8165b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 365 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x815640..0x81566c
+            - Range: 0x816540..0x81656c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x81566c..0x815678
+            - Range: 0x81656c..0x816578
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x815678..0x81567c
+            - Range: 0x816578..0x81657c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11904,7 +11904,7 @@ Subprograms:
         - Name: value
           Type: 340 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x815640..0x81567c
+            - Range: 0x816540..0x81657c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11916,11 +11916,11 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x815640..0x81567c
+            - Range: 0x816540..0x81657c
               Pieces: []
-            - Range: 0x81567c..0x81567d
+            - Range: 0x81657c..0x81657d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x81567d..0x8156b0
+            - Range: 0x81657d..0x8165b0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -12158,31 +12158,31 @@ Subprograms:
       DictRegister: null
     - ID: 199
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x80d720..0x80d790]
+      OutOfLinePCRanges: [0x80dbd0..0x80dc40]
       InlinePCRanges:
-        - Ranges: [0x80d7ac..0x80d7e0]
-          RootRanges: [0x80d790..0x80d800]
-        - Ranges: [0x80d8e8..0x80d91c]
-          RootRanges: [0x80d8b0..0x80d940]
-        - Ranges: [0x80d964..0x80d998]
-          RootRanges: [0x80d940..0x80da00]
-        - Ranges: [0x80da1c..0x80da50]
-          RootRanges: [0x80da00..0x80da70]
+        - Ranges: [0x80dc5c..0x80dc90]
+          RootRanges: [0x80dc40..0x80dcb0]
+        - Ranges: [0x80dd98..0x80ddcc]
+          RootRanges: [0x80dd60..0x80ddf0]
+        - Ranges: [0x80de14..0x80de48]
+          RootRanges: [0x80ddf0..0x80deb0]
+        - Ranges: [0x80decc..0x80df00]
+          RootRanges: [0x80deb0..0x80df20]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d720..0x80d740
+            - Range: 0x80dbd0..0x80dbf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d7ac..0x80d7b4
+            - Range: 0x80dc5c..0x80dc64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d8e8..0x80d8f0
+            - Range: 0x80dd98..0x80dda0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d95c..0x80d96c
+            - Range: 0x80de0c..0x80de1c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d96c..0x80da00
+            - Range: 0x80de1c..0x80deb0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x80da00..0x80da24
+            - Range: 0x80deb0..0x80ded4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -12192,37 +12192,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80d9a4..0x80d9d8]
-          RootRanges: [0x80d940..0x80da00]
+        - Ranges: [0x80de54..0x80de88]
+          RootRanges: [0x80ddf0..0x80deb0]
       Variables: []
       DictRegister: null
     - ID: 201
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80da8c..0x80dac0, 0x80dac8..0x80dacc]
-          RootRanges: [0x80da70..0x80db80]
+        - Ranges: [0x80df3c..0x80df70, 0x80df78..0x80df7c]
+          RootRanges: [0x80df20..0x80e030]
       Variables: []
       DictRegister: null
     - ID: 202
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80db30..0x80db64]
-          RootRanges: [0x80da70..0x80db80]
+        - Ranges: [0x80dfe0..0x80e014]
+          RootRanges: [0x80df20..0x80e030]
       Variables: []
       DictRegister: null
     - ID: 203
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80db84..0x80db88]
-          RootRanges: [0x80db80..0x80db90]
+        - Ranges: [0x80e034..0x80e038]
+          RootRanges: [0x80e030..0x80e040]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80db80..0x80db88
+            - Range: 0x80e030..0x80e038
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -12232,33 +12232,33 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80dbb4..0x80dbd0]
-          RootRanges: [0x80db90..0x80dbe0]
-        - Ranges: [0x80dc3c..0x80dc5c]
-          RootRanges: [0x80dbe0..0x80dd20]
+        - Ranges: [0x80e064..0x80e080]
+          RootRanges: [0x80e040..0x80e090]
+        - Ranges: [0x80e138..0x80e158]
+          RootRanges: [0x80e090..0x80e260]
       Variables:
         - Name: a
           Type: 170 ArrayType [5]int
           Locations:
-            - Range: 0x80dba0..0x80dbe0
+            - Range: 0x80e050..0x80e090
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x80dc28..0x80dd20
-              Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
+            - Range: 0x80e124..0x80e260
+              Pieces: [{Size: 40, Op: {CfaOffset: -144}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 205
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x80dd20..0x80dd80]
+      OutOfLinePCRanges: [0x80e2d0..0x80e330]
       InlinePCRanges:
-        - Ranges: [0x815848..0x81586c]
-          RootRanges: [0x815820..0x8158b0]
+        - Ranges: [0x816748..0x81676c]
+          RootRanges: [0x816720..0x8167b0]
       Variables:
         - Name: b
           Type: 370 StructureType main.firstBehavior
           Locations:
-            - Range: 0x80dd20..0x80dd44
+            - Range: 0x80e2d0..0x80e2f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -12270,15 +12270,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80dd20..0x80dd60
+            - Range: 0x80e2d0..0x80e310
               Pieces: []
-            - Range: 0x80dd60..0x80dd61
+            - Range: 0x80e310..0x80e311
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80dd61..0x80dd80
+            - Range: 0x80e311..0x80e330
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -12288,8 +12288,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80e4c4..0x80e4d0, 0x80e4d4..0x80e4dc]
-          RootRanges: [0x80e430..0x80e530]
+        - Ranges: [0x80eb00..0x80eb0c, 0x80eb10..0x80eb18]
+          RootRanges: [0x80ea10..0x80eb90]
         - Ranges: [0x8083a8..0x8083ac, 0x8083b0..0x8083b8]
           RootRanges: [0x8083a0..0x8083c0]
       Variables: []
@@ -12970,7 +12970,7 @@ Types:
       ID: 2639
       Name: '*compress/gzip.Reader'
       ByteSize: 8
-      GoRuntimeType: 1634624
+      GoRuntimeType: 1633856
       GoKind: 22
       Pointee: 2640 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
@@ -12984,7 +12984,7 @@ Types:
       ID: 420
       Name: '*context.backgroundCtx'
       ByteSize: 8
-      GoRuntimeType: 1560832
+      GoRuntimeType: 1560352
       GoKind: 22
       Pointee: 421 GoContextImplementationType context.backgroundCtx
     - __kind: PointerType
@@ -12998,21 +12998,21 @@ Types:
       ID: 1084
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1197920
+      GoRuntimeType: 1196256
       GoKind: 22
       Pointee: 1085 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 407
       Name: '*context.emptyCtx'
       ByteSize: 8
-      GoRuntimeType: 1421888
+      GoRuntimeType: 1421728
       GoKind: 22
       Pointee: 408 GoContextImplementationType context.emptyCtx
     - __kind: PointerType
       ID: 409
       Name: '*context.stopCtx'
       ByteSize: 8
-      GoRuntimeType: 1422048
+      GoRuntimeType: 1421888
       GoKind: 22
       Pointee: 410 GoContextImplementationType context.stopCtx
     - __kind: PointerType
@@ -13026,21 +13026,21 @@ Types:
       ID: 422
       Name: '*context.todoCtx'
       ByteSize: 8
-      GoRuntimeType: 1560992
+      GoRuntimeType: 1560512
       GoKind: 22
       Pointee: 423 GoContextImplementationType context.todoCtx
     - __kind: PointerType
       ID: 416
       Name: '*context.valueCtx'
       ByteSize: 8
-      GoRuntimeType: 1560512
+      GoRuntimeType: 1560032
       GoKind: 22
       Pointee: 417 GoContextImplementationType context.valueCtx
     - __kind: PointerType
       ID: 418
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
-      GoRuntimeType: 1560672
+      GoRuntimeType: 1560192
       GoKind: 22
       Pointee: 419 GoContextImplementationType context.withoutCancelCtx
     - __kind: PointerType
@@ -13416,17 +13416,17 @@ Types:
       GoKind: 22
       Pointee: 975 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 867
+      ID: 865
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 915712
+      GoRuntimeType: 915040
       GoKind: 22
       Pointee: 762 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
       ID: 1231
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1046528
+      GoRuntimeType: 1046400
       GoKind: 22
       Pointee: 1232 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -13437,31 +13437,31 @@ Types:
       GoKind: 22
       Pointee: 763 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 1498
+      ID: 1496
       Name: '*encoding/json.Delim'
       ByteSize: 8
-      GoRuntimeType: 910624
+      GoRuntimeType: 909952
       GoKind: 22
-      Pointee: 1428 BaseType encoding/json.Delim
+      Pointee: 1426 BaseType encoding/json.Delim
     - __kind: PointerType
-      ID: 838
+      ID: 836
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 910528
+      GoRuntimeType: 909856
       GoKind: 22
-      Pointee: 839 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 837 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
       ID: 1043
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1042688
+      GoRuntimeType: 1042560
       GoKind: 22
       Pointee: 1044 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
       ID: 1668
       Name: '*encoding/json.Number'
       ByteSize: 8
-      GoRuntimeType: 1211872
+      GoRuntimeType: 1211360
       GoKind: 22
       Pointee: 1650 GoStringHeaderType encoding/json.Number
     - __kind: PointerType
@@ -13470,33 +13470,33 @@ Types:
       ByteSize: 8
       Pointee: 1651 GoStringDataType encoding/json.Number.str
     - __kind: PointerType
-      ID: 830
+      ID: 828
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 910144
+      GoRuntimeType: 909472
       GoKind: 22
-      Pointee: 831 UnresolvedPointeeType encoding/json.SyntaxError
-    - __kind: PointerType
-      ID: 836
-      Name: '*encoding/json.UnmarshalTypeError'
-      ByteSize: 8
-      GoRuntimeType: 910432
-      GoKind: 22
-      Pointee: 837 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 829 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
       ID: 834
-      Name: '*encoding/json.UnsupportedTypeError'
+      Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
-      GoRuntimeType: 910336
+      GoRuntimeType: 909760
       GoKind: 22
-      Pointee: 835 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 835 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
       ID: 832
+      Name: '*encoding/json.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 909664
+      GoKind: 22
+      Pointee: 833 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 830
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
-      GoRuntimeType: 910240
+      GoRuntimeType: 909568
       GoKind: 22
-      Pointee: 833 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 831 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
       ID: 1373
       Name: '*encoding/json.encodeState'
@@ -13505,12 +13505,12 @@ Types:
       GoKind: 22
       Pointee: 1374 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 840
+      ID: 838
       Name: '*encoding/json.jsonError'
       ByteSize: 8
-      GoRuntimeType: 910912
+      GoRuntimeType: 910240
       GoKind: 22
-      Pointee: 841 StructureType encoding/json.jsonError
+      Pointee: 839 StructureType encoding/json.jsonError
     - __kind: PointerType
       ID: 1239
       Name: '*encoding/pem.lineBreaker'
@@ -13569,14 +13569,14 @@ Types:
       ID: 806
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 901216
+      GoRuntimeType: 902080
       GoKind: 22
       Pointee: 807 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 1010
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1028480
+      GoRuntimeType: 1029504
       GoKind: 22
       Pointee: 1011 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -13611,21 +13611,21 @@ Types:
       ID: 2545
       Name: '*fmt.stringReader'
       ByteSize: 8
-      GoRuntimeType: 901312
+      GoRuntimeType: 902176
       GoKind: 22
       Pointee: 2546 UnresolvedPointeeType fmt.stringReader
     - __kind: PointerType
       ID: 1012
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1028608
+      GoRuntimeType: 1029632
       GoKind: 22
       Pointee: 1013 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 1014
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1028736
+      GoRuntimeType: 1029760
       GoKind: 22
       Pointee: 1015 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -13653,7 +13653,7 @@ Types:
       ID: 2389
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AgentPayload'
       ByteSize: 8
-      GoRuntimeType: 2209120
+      GoRuntimeType: 2208288
       GoKind: 22
       Pointee: 2390 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AgentPayload
     - __kind: PointerType
@@ -13667,7 +13667,7 @@ Types:
       ID: 2070
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType'
       ByteSize: 8
-      GoRuntimeType: 1857856
+      GoRuntimeType: 1857632
       GoKind: 22
       Pointee: 2017 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
     - __kind: PointerType
@@ -13688,7 +13688,7 @@ Types:
       ID: 2071
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType'
       ByteSize: 8
-      GoRuntimeType: 1858080
+      GoRuntimeType: 1857856
       GoKind: 22
       Pointee: 2018 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
     - __kind: PointerType
@@ -13737,7 +13737,7 @@ Types:
       ID: 2387
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.StatsPayload'
       ByteSize: 8
-      GoRuntimeType: 2208288
+      GoRuntimeType: 2207456
       GoKind: 22
       Pointee: 2388 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.StatsPayload
     - __kind: PointerType
@@ -13758,7 +13758,7 @@ Types:
       ID: 2453
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.TracerPayload'
       ByteSize: 8
-      GoRuntimeType: 2259168
+      GoRuntimeType: 2258208
       GoKind: 22
       Pointee: 2454 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.TracerPayload
     - __kind: PointerType
@@ -13776,45 +13776,45 @@ Types:
       GoKind: 22
       Pointee: 1726 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/version.Version
     - __kind: PointerType
-      ID: 849
+      ID: 847
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
-      GoRuntimeType: 913312
+      GoRuntimeType: 912640
       GoKind: 22
-      Pointee: 850 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 848 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 851
+      ID: 849
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
-      GoRuntimeType: 913408
+      GoRuntimeType: 912736
       GoKind: 22
-      Pointee: 852 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 850 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
       ID: 1177
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
-      GoRuntimeType: 913120
+      GoRuntimeType: 912448
       GoKind: 22
       Pointee: 1178 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 855
+      ID: 853
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
-      GoRuntimeType: 913696
+      GoRuntimeType: 913024
       GoKind: 22
-      Pointee: 856 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 854 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
       ID: 1179
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
-      GoRuntimeType: 913216
+      GoRuntimeType: 912544
       GoKind: 22
       Pointee: 1180 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 853
+      ID: 851
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
-      GoRuntimeType: 913504
+      GoRuntimeType: 912832
       GoKind: 22
       Pointee: 756 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
@@ -13823,10 +13823,10 @@ Types:
       ByteSize: 8
       Pointee: 757 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 848
+      ID: 846
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
-      GoRuntimeType: 913024
+      GoRuntimeType: 912352
       GoKind: 22
       Pointee: 753 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
@@ -13835,10 +13835,10 @@ Types:
       ByteSize: 8
       Pointee: 754 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 854
+      ID: 852
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
-      GoRuntimeType: 913600
+      GoRuntimeType: 912928
       GoKind: 22
       Pointee: 759 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
@@ -13850,7 +13850,7 @@ Types:
       ID: 1251
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1215200
+      GoRuntimeType: 1214688
       GoKind: 22
       Pointee: 1252 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
@@ -13871,14 +13871,14 @@ Types:
       ID: 1783
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule'
       ByteSize: 8
-      GoRuntimeType: 1561152
+      GoRuntimeType: 1560672
       GoKind: 22
       Pointee: 1784 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule
     - __kind: PointerType
       ID: 1481
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType'
       ByteSize: 8
-      GoRuntimeType: 901792
+      GoRuntimeType: 901312
       GoKind: 22
       Pointee: 1419 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType
     - __kind: PointerType
@@ -13899,14 +13899,14 @@ Types:
       ID: 394
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
-      GoRuntimeType: 1198176
+      GoRuntimeType: 1196512
       GoKind: 22
       Pointee: 395 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
       ID: 1484
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate'
       ByteSize: 8
-      GoRuntimeType: 902080
+      GoRuntimeType: 901600
       GoKind: 22
       Pointee: 1485 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate
     - __kind: PointerType
@@ -13920,7 +13920,7 @@ Types:
       ID: 1482
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule'
       ByteSize: 8
-      GoRuntimeType: 901984
+      GoRuntimeType: 901504
       GoKind: 22
       Pointee: 1483 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule
     - __kind: PointerType
@@ -13934,35 +13934,35 @@ Types:
       ID: 1667
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance'
       ByteSize: 8
-      GoRuntimeType: 1199584
+      GoRuntimeType: 1197920
       GoKind: 22
       Pointee: 1575 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance
     - __kind: PointerType
       ID: 2344
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter'
       ByteSize: 8
-      GoRuntimeType: 901888
+      GoRuntimeType: 901408
       GoKind: 22
       Pointee: 2345 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter
     - __kind: PointerType
       ID: 397
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
-      GoRuntimeType: 1198304
+      GoRuntimeType: 1196640
       GoKind: 22
       Pointee: 398 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
       ID: 2702
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
-      GoRuntimeType: 1198944
+      GoRuntimeType: 1197280
       GoKind: 22
       Pointee: 2703 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
       ID: 727
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      GoRuntimeType: 1199072
+      GoRuntimeType: 1197408
       GoKind: 22
       Pointee: 728 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
@@ -13990,7 +13990,7 @@ Types:
       ID: 1745
       Name: '*github.com/DataDog/dd-trace-go/v2/internal.TraceSource'
       ByteSize: 8
-      GoRuntimeType: 1427808
+      GoRuntimeType: 1427648
       GoKind: 22
       Pointee: 1576 BaseType github.com/DataDog/dd-trace-go/v2/internal.TraceSource
     - __kind: PointerType
@@ -14074,7 +14074,7 @@ Types:
       ID: 412
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
-      GoRuntimeType: 1428128
+      GoRuntimeType: 1427968
       GoKind: 22
       Pointee: 413 GoContextImplementationType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
@@ -14088,21 +14088,21 @@ Types:
       ID: 1607
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource'
       ByteSize: 8
-      GoRuntimeType: 1044736
+      GoRuntimeType: 1044608
       GoKind: 22
       Pointee: 1608 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource
     - __kind: PointerType
       ID: 1609
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource'
       ByteSize: 8
-      GoRuntimeType: 1044864
+      GoRuntimeType: 1044736
       GoKind: 22
       Pointee: 1610 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource
     - __kind: PointerType
       ID: 1601
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey'
       ByteSize: 8
-      GoRuntimeType: 1042304
+      GoRuntimeType: 1042176
       GoKind: 22
       Pointee: 1602 StructureType github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey
     - __kind: PointerType
@@ -14317,47 +14317,47 @@ Types:
       GoKind: 22
       Pointee: 2456 StructureType github.com/Masterminds/semver/v3.Version
     - __kind: PointerType
-      ID: 1510
+      ID: 1508
       Name: '*github.com/cihub/seelog.CfgParseParams'
       ByteSize: 8
-      GoRuntimeType: 915520
+      GoRuntimeType: 914848
       GoKind: 22
-      Pointee: 1511 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
+      Pointee: 1509 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
     - __kind: PointerType
-      ID: 1509
+      ID: 1507
       Name: '*github.com/cihub/seelog.LogLevel'
       ByteSize: 8
-      GoRuntimeType: 914656
+      GoRuntimeType: 913984
       GoKind: 22
-      Pointee: 1431 BaseType github.com/cihub/seelog.LogLevel
+      Pointee: 1429 BaseType github.com/cihub/seelog.LogLevel
     - __kind: PointerType
       ID: 2027
       Name: '*github.com/cihub/seelog.LogLevelException'
       ByteSize: 8
-      GoRuntimeType: 1814624
+      GoRuntimeType: 1814176
       GoKind: 22
       Pointee: 2028 UnresolvedPointeeType github.com/cihub/seelog.LogLevelException
     - __kind: PointerType
-      ID: 857
+      ID: 855
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
-      GoRuntimeType: 914848
+      GoRuntimeType: 914176
       GoKind: 22
-      Pointee: 858 StructureType github.com/cihub/seelog.baseError
+      Pointee: 856 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 1291
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1815072
+      GoRuntimeType: 1814624
       GoKind: 22
       Pointee: 1292 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 859
+      ID: 857
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
-      GoRuntimeType: 914944
+      GoRuntimeType: 914272
       GoKind: 22
-      Pointee: 860 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 858 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 1271
       Name: '*github.com/cihub/seelog.connWriter'
@@ -14369,42 +14369,42 @@ Types:
       ID: 1227
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1045376
+      GoRuntimeType: 1045248
       GoKind: 22
       Pointee: 1228 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1750
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1432288
+      GoRuntimeType: 1432128
       GoKind: 22
       Pointee: 1751 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
       ID: 1859
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
-      GoRuntimeType: 1646144
+      GoRuntimeType: 1645376
       GoKind: 22
       Pointee: 1860 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
       ID: 1261
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1431808
+      GoRuntimeType: 1431648
       GoKind: 22
       Pointee: 1262 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
       ID: 1863
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1646912
+      GoRuntimeType: 1646144
       GoKind: 22
       Pointee: 1864 UnresolvedPointeeType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
       ID: 1746
       Name: '*github.com/cihub/seelog.formattedWriter'
       ByteSize: 8
-      GoRuntimeType: 1431968
+      GoRuntimeType: 1431808
       GoKind: 22
       Pointee: 1747 UnresolvedPointeeType github.com/cihub/seelog.formattedWriter
     - __kind: PointerType
@@ -14418,42 +14418,42 @@ Types:
       ID: 1673
       Name: '*github.com/cihub/seelog.listConstraints'
       ByteSize: 8
-      GoRuntimeType: 1217504
+      GoRuntimeType: 1216992
       GoKind: 22
       Pointee: 1674 UnresolvedPointeeType github.com/cihub/seelog.listConstraints
     - __kind: PointerType
-      ID: 1507
+      ID: 1505
       Name: '*github.com/cihub/seelog.logFormattedMessage'
       ByteSize: 8
-      GoRuntimeType: 914560
+      GoRuntimeType: 913888
       GoKind: 22
-      Pointee: 1508 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
+      Pointee: 1506 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
     - __kind: PointerType
-      ID: 1505
+      ID: 1503
       Name: '*github.com/cihub/seelog.logMessage'
       ByteSize: 8
-      GoRuntimeType: 914464
+      GoRuntimeType: 913792
       GoKind: 22
-      Pointee: 1506 UnresolvedPointeeType github.com/cihub/seelog.logMessage
+      Pointee: 1504 UnresolvedPointeeType github.com/cihub/seelog.logMessage
     - __kind: PointerType
       ID: 1613
       Name: '*github.com/cihub/seelog.minMaxConstraints'
       ByteSize: 8
-      GoRuntimeType: 1045888
+      GoRuntimeType: 1045760
       GoKind: 22
       Pointee: 1614 UnresolvedPointeeType github.com/cihub/seelog.minMaxConstraints
     - __kind: PointerType
-      ID: 863
+      ID: 861
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
-      GoRuntimeType: 915136
+      GoRuntimeType: 914464
       GoKind: 22
-      Pointee: 864 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 862 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 1611
       Name: '*github.com/cihub/seelog.offConstraints'
       ByteSize: 8
-      GoRuntimeType: 1045760
+      GoRuntimeType: 1045632
       GoKind: 22
       Pointee: 1612 UnresolvedPointeeType github.com/cihub/seelog.offConstraints
     - __kind: PointerType
@@ -14481,35 +14481,35 @@ Types:
       ID: 1229
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1045504
+      GoRuntimeType: 1045376
       GoKind: 22
       Pointee: 1230 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
       ID: 1861
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1646336
+      GoRuntimeType: 1645568
       GoKind: 22
       Pointee: 1862 UnresolvedPointeeType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 861
+      ID: 859
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
-      GoRuntimeType: 915040
+      GoRuntimeType: 914368
       GoKind: 22
-      Pointee: 862 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 860 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 865
+      ID: 863
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
-      GoRuntimeType: 915232
+      GoRuntimeType: 914560
       GoKind: 22
-      Pointee: 866 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 864 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 1748
       Name: '*github.com/cihub/seelog.xmlNode'
       ByteSize: 8
-      GoRuntimeType: 1432128
+      GoRuntimeType: 1431968
       GoKind: 22
       Pointee: 1749 UnresolvedPointeeType github.com/cihub/seelog.xmlNode
     - __kind: PointerType
@@ -15361,42 +15361,42 @@ Types:
       ID: 1096
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1206368
+      GoRuntimeType: 1205856
       GoKind: 22
       Pointee: 1097 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 1090
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1205984
+      GoRuntimeType: 1205472
       GoKind: 22
       Pointee: 1091 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 1029
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1036928
+      GoRuntimeType: 1036800
       GoKind: 22
       Pointee: 1030 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 1102
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1206752
+      GoRuntimeType: 1206240
       GoKind: 22
       Pointee: 1103 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 1028
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1036800
+      GoRuntimeType: 1036672
       GoKind: 22
       Pointee: 1007 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 1094
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1206240
+      GoRuntimeType: 1205728
       GoKind: 22
       Pointee: 1095 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
@@ -15407,31 +15407,31 @@ Types:
       GoKind: 22
       Pointee: 2678 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Reader
     - __kind: PointerType
-      ID: 1491
+      ID: 1489
       Name: '*github.com/tinylib/msgp/msgp.Type'
       ByteSize: 8
-      GoRuntimeType: 906592
+      GoRuntimeType: 905920
       GoKind: 22
       Pointee: 1185 BaseType github.com/tinylib/msgp/msgp.Type
     - __kind: PointerType
       ID: 1092
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1206112
+      GoRuntimeType: 1205600
       GoKind: 22
       Pointee: 1093 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 1100
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1206624
+      GoRuntimeType: 1206112
       GoKind: 22
       Pointee: 1101 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 1098
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1206496
+      GoRuntimeType: 1205984
       GoKind: 22
       Pointee: 1099 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
@@ -15445,28 +15445,28 @@ Types:
       ID: 1106
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1207136
+      GoRuntimeType: 1206624
       GoKind: 22
       Pointee: 1107 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 1033
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1037184
+      GoRuntimeType: 1037056
       GoKind: 22
       Pointee: 1034 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 1031
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1037056
+      GoRuntimeType: 1036928
       GoKind: 22
       Pointee: 1032 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 1104
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1207008
+      GoRuntimeType: 1206496
       GoKind: 22
       Pointee: 1105 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -17522,77 +17522,77 @@ Types:
       ID: 2549
       Name: '*io.LimitedReader'
       ByteSize: 8
-      GoRuntimeType: 901504
+      GoRuntimeType: 902368
       GoKind: 22
       Pointee: 2550 UnresolvedPointeeType io.LimitedReader
     - __kind: PointerType
       ID: 2654
       Name: '*io.PipeReader'
       ByteSize: 8
-      GoRuntimeType: 1849120
+      GoRuntimeType: 1851360
       GoKind: 22
       Pointee: 2655 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
       ID: 1249
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1197664
+      GoRuntimeType: 1200864
       GoKind: 22
       Pointee: 1250 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 2633
       Name: '*io.SectionReader'
       ByteSize: 8
-      GoRuntimeType: 1560192
+      GoRuntimeType: 1561792
       GoKind: 22
       Pointee: 2634 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
       ID: 1247
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1197280
+      GoRuntimeType: 1200480
       GoKind: 22
       Pointee: 1248 StructureType io.discard
     - __kind: PointerType
       ID: 2551
       Name: '*io.eofReader'
       ByteSize: 8
-      GoRuntimeType: 901600
+      GoRuntimeType: 902464
       GoKind: 22
       Pointee: 2552 StructureType io.eofReader
     - __kind: PointerType
       ID: 2607
       Name: '*io.multiReader'
       ByteSize: 8
-      GoRuntimeType: 1197024
+      GoRuntimeType: 1200224
       GoKind: 22
       Pointee: 2608 UnresolvedPointeeType io.multiReader
     - __kind: PointerType
       ID: 1221
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1029504
+      GoRuntimeType: 1030528
       GoKind: 22
       Pointee: 1222 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 2575
       Name: '*io.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1029760
+      GoRuntimeType: 1030784
       GoKind: 22
       Pointee: 2576 StructureType io.nopCloser
     - __kind: PointerType
       ID: 2609
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
-      GoRuntimeType: 1197152
+      GoRuntimeType: 1200352
       GoKind: 22
       Pointee: 2610 StructureType io.nopCloserWriterTo
     - __kind: PointerType
       ID: 2547
       Name: '*io.teeReader'
       ByteSize: 8
-      GoRuntimeType: 901408
+      GoRuntimeType: 902272
       GoKind: 22
       Pointee: 2548 UnresolvedPointeeType io.teeReader
     - __kind: PointerType
@@ -17620,28 +17620,28 @@ Types:
       ID: 1675
       Name: '*log/slog.Attr'
       ByteSize: 8
-      GoRuntimeType: 1218144
+      GoRuntimeType: 1217632
       GoKind: 22
       Pointee: 1676 StructureType log/slog.Attr
     - __kind: PointerType
-      ID: 1512
+      ID: 1510
       Name: '*log/slog.Kind'
       ByteSize: 8
-      GoRuntimeType: 915616
+      GoRuntimeType: 914944
       GoKind: 22
-      Pointee: 1432 BaseType log/slog.Kind
+      Pointee: 1430 BaseType log/slog.Kind
     - __kind: PointerType
       ID: 2029
       Name: '*log/slog.Level'
       ByteSize: 8
-      GoRuntimeType: 1815520
+      GoRuntimeType: 1815072
       GoKind: 22
       Pointee: 1779 BaseType log/slog.Level
     - __kind: PointerType
       ID: 2391
       Name: '*log/slog.Value'
       ByteSize: 8
-      GoRuntimeType: 2209536
+      GoRuntimeType: 2208704
       GoKind: 22
       Pointee: 2019 StructureType log/slog.Value
     - __kind: PointerType
@@ -18165,7 +18165,7 @@ Types:
       ID: 2641
       Name: '*math/rand/v2.ChaCha8'
       ByteSize: 8
-      GoRuntimeType: 1643264
+      GoRuntimeType: 1642496
       GoKind: 22
       Pointee: 2642 UnresolvedPointeeType math/rand/v2.ChaCha8
     - __kind: PointerType
@@ -18214,21 +18214,21 @@ Types:
       ID: 1113
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1213024
+      GoRuntimeType: 1212512
       GoKind: 22
       Pointee: 1114 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 1144
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1430048
+      GoRuntimeType: 1429888
       GoKind: 22
       Pointee: 1145 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1503
+      ID: 1501
       Name: '*net.HardwareAddr.array'
       ByteSize: 8
-      Pointee: 1502 GoSliceDataType net.HardwareAddr.array
+      Pointee: 1500 GoSliceDataType net.HardwareAddr.array
     - __kind: PointerType
       ID: 2354
       Name: '*net.IP'
@@ -18259,7 +18259,7 @@ Types:
       ID: 1603
       Name: '*net.IPMask'
       ByteSize: 8
-      GoRuntimeType: 1043328
+      GoRuntimeType: 1043200
       GoKind: 22
       Pointee: 1604 GoSliceHeaderType net.IPMask
     - __kind: PointerType
@@ -18271,28 +18271,28 @@ Types:
       ID: 1669
       Name: '*net.IPNet'
       ByteSize: 8
-      GoRuntimeType: 1212768
+      GoRuntimeType: 1212256
       GoKind: 22
       Pointee: 1670 UnresolvedPointeeType net.IPNet
     - __kind: PointerType
       ID: 1142
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1429728
+      GoRuntimeType: 1429568
       GoKind: 22
       Pointee: 1143 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 1115
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1213152
+      GoRuntimeType: 1212640
       GoKind: 22
       Pointee: 1116 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 2025
       Name: '*net.TCPAddr'
       ByteSize: 8
-      GoRuntimeType: 1813728
+      GoRuntimeType: 1813280
       GoKind: 22
       Pointee: 2026 UnresolvedPointeeType net.TCPAddr
     - __kind: PointerType
@@ -18306,7 +18306,7 @@ Types:
       ID: 2023
       Name: '*net.UDPAddr'
       ByteSize: 8
-      GoRuntimeType: 1813504
+      GoRuntimeType: 1813056
       GoKind: 22
       Pointee: 2024 UnresolvedPointeeType net.UDPAddr
     - __kind: PointerType
@@ -18334,7 +18334,7 @@ Types:
       ID: 1112
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1212256
+      GoRuntimeType: 1211744
       GoKind: 22
       Pointee: 1081 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -18346,37 +18346,37 @@ Types:
       ID: 2168
       Name: '*net.addrPortUDPAddr'
       ByteSize: 8
-      GoRuntimeType: 2022368
+      GoRuntimeType: 2022080
       GoKind: 22
       Pointee: 2169 StructureType net.addrPortUDPAddr
     - __kind: PointerType
       ID: 1045
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1043584
+      GoRuntimeType: 1043456
       GoKind: 22
       Pointee: 1046 StructureType net.canceledError
     - __kind: PointerType
       ID: 1331
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2022080
+      GoRuntimeType: 2021792
       GoKind: 22
       Pointee: 1332 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1186
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1859648
+      GoRuntimeType: 1859424
       GoKind: 22
       Pointee: 1187 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1504
+      ID: 1502
       Name: '*net.hostLookupOrder'
       ByteSize: 8
-      GoRuntimeType: 912256
+      GoRuntimeType: 911584
       GoKind: 22
-      Pointee: 1430 BaseType net.hostLookupOrder
+      Pointee: 1428 BaseType net.hostLookupOrder
     - __kind: PointerType
       ID: 1377
       Name: '*net.netFD'
@@ -18385,157 +18385,157 @@ Types:
       GoKind: 22
       Pointee: 1378 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 842
+      ID: 840
       Name: '*net.notFoundError'
       ByteSize: 8
-      GoRuntimeType: 911872
+      GoRuntimeType: 911200
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType net.notFoundError
+      Pointee: 841 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 414
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
-      GoRuntimeType: 1429888
+      GoRuntimeType: 1429728
       GoKind: 22
       Pointee: 415 GoContextImplementationType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 844
+      ID: 842
       Name: '*net.result·2'
       ByteSize: 8
-      GoRuntimeType: 912544
+      GoRuntimeType: 911872
       GoKind: 22
-      Pointee: 845 StructureType net.result·2
+      Pointee: 843 StructureType net.result·2
     - __kind: PointerType
       ID: 1359
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
-      GoRuntimeType: 2260128
+      GoRuntimeType: 2259168
       GoKind: 22
       Pointee: 1360 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
       ID: 1357
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
-      GoRuntimeType: 2259648
+      GoRuntimeType: 2258688
       GoKind: 22
       Pointee: 1358 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
       ID: 1117
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1213792
+      GoRuntimeType: 1213280
       GoKind: 22
       Pointee: 1118 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 1146
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1430208
+      GoRuntimeType: 1430048
       GoKind: 22
       Pointee: 1147 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 1597
       Name: '*net/http.Cookie'
       ByteSize: 8
-      GoRuntimeType: 1037952
+      GoRuntimeType: 1037824
       GoKind: 22
       Pointee: 1598 UnresolvedPointeeType net/http.Cookie
     - __kind: PointerType
       ID: 1035
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1039616
+      GoRuntimeType: 1039488
       GoKind: 22
       Pointee: 1036 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 2022
       Name: '*net/http.Protocols'
       ByteSize: 8
-      GoRuntimeType: 1812832
+      GoRuntimeType: 1812384
       GoKind: 22
       Pointee: 1937 StructureType net/http.Protocols
     - __kind: PointerType
       ID: 2621
       Name: '*net/http.body'
       ByteSize: 8
-      GoRuntimeType: 1813280
+      GoRuntimeType: 1812832
       GoKind: 22
       Pointee: 2622 UnresolvedPointeeType net/http.body
     - __kind: PointerType
       ID: 2611
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
-      GoRuntimeType: 1208160
+      GoRuntimeType: 1207648
       GoKind: 22
       Pointee: 2612 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
       ID: 2553
       Name: '*net/http.bodyLocked'
       ByteSize: 8
-      GoRuntimeType: 907456
+      GoRuntimeType: 906784
       GoKind: 22
       Pointee: 2554 StructureType net/http.bodyLocked
     - __kind: PointerType
       ID: 1203
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
-      GoRuntimeType: 907648
+      GoRuntimeType: 906976
       GoKind: 22
       Pointee: 1204 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
       ID: 2555
       Name: '*net/http.byteReader'
       ByteSize: 8
-      GoRuntimeType: 907744
+      GoRuntimeType: 907072
       GoKind: 22
       Pointee: 2556 UnresolvedPointeeType net/http.byteReader
     - __kind: PointerType
       ID: 2587
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
-      GoRuntimeType: 1039488
+      GoRuntimeType: 1039360
       GoKind: 22
       Pointee: 2588 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 1494
+      ID: 1492
       Name: '*net/http.connectMethodKey'
       ByteSize: 8
-      GoRuntimeType: 908224
+      GoRuntimeType: 907552
       GoKind: 22
-      Pointee: 1495 StructureType net/http.connectMethodKey
+      Pointee: 1493 StructureType net/http.connectMethodKey
     - __kind: PointerType
-      ID: 1496
+      ID: 1494
       Name: '*net/http.contextKey'
       ByteSize: 8
-      GoRuntimeType: 909568
+      GoRuntimeType: 908896
       GoKind: 22
-      Pointee: 1497 UnresolvedPointeeType net/http.contextKey
+      Pointee: 1495 UnresolvedPointeeType net/http.contextKey
     - __kind: PointerType
       ID: 2557
       Name: '*net/http.errorReader'
       ByteSize: 8
-      GoRuntimeType: 907840
+      GoRuntimeType: 907168
       GoKind: 22
       Pointee: 2558 StructureType net/http.errorReader
     - __kind: PointerType
       ID: 2559
       Name: '*net/http.finishAsyncByteRead'
       ByteSize: 8
-      GoRuntimeType: 907936
+      GoRuntimeType: 907264
       GoKind: 22
       Pointee: 2560 StructureType net/http.finishAsyncByteRead
     - __kind: PointerType
       ID: 2589
       Name: '*net/http.gzipReader'
       ByteSize: 8
-      GoRuntimeType: 1040128
+      GoRuntimeType: 1040000
       GoKind: 22
       Pointee: 2590 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 819
+      ID: 817
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 908320
+      GoRuntimeType: 907648
       GoKind: 22
       Pointee: 734 BaseType net/http.http2ConnectionError
     - __kind: PointerType
@@ -18556,7 +18556,7 @@ Types:
       ID: 1594
       Name: '*net/http.http2ErrCode'
       ByteSize: 8
-      GoRuntimeType: 1037696
+      GoRuntimeType: 1037568
       GoKind: 22
       Pointee: 1159 BaseType net/http.http2ErrCode
     - __kind: PointerType
@@ -18567,52 +18567,52 @@ Types:
       GoKind: 22
       Pointee: 1788 StructureType net/http.http2FrameHeader
     - __kind: PointerType
-      ID: 1492
+      ID: 1490
       Name: '*net/http.http2FrameType'
       ByteSize: 8
-      GoRuntimeType: 906784
+      GoRuntimeType: 906112
       GoKind: 22
-      Pointee: 1425 BaseType net/http.http2FrameType
+      Pointee: 1423 BaseType net/http.http2FrameType
     - __kind: PointerType
-      ID: 820
+      ID: 818
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
-      GoRuntimeType: 908416
+      GoRuntimeType: 907744
       GoKind: 22
-      Pointee: 821 StructureType net/http.http2GoAwayError
+      Pointee: 819 StructureType net/http.http2GoAwayError
     - __kind: PointerType
       ID: 1851
       Name: '*net/http.http2GoAwayFrame'
       ByteSize: 8
-      GoRuntimeType: 1635392
+      GoRuntimeType: 1634624
       GoKind: 22
       Pointee: 1852 StructureType net/http.http2GoAwayFrame
     - __kind: PointerType
       ID: 2069
       Name: '*net/http.http2HeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 1856064
+      GoRuntimeType: 1855840
       GoKind: 22
       Pointee: 2068 StructureType net/http.http2HeadersFrame
     - __kind: PointerType
       ID: 2166
       Name: '*net/http.http2MetaHeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 2021216
+      GoRuntimeType: 2020928
       GoKind: 22
       Pointee: 2167 StructureType net/http.http2MetaHeadersFrame
     - __kind: PointerType
       ID: 1853
       Name: '*net/http.http2PingFrame'
       ByteSize: 8
-      GoRuntimeType: 1635584
+      GoRuntimeType: 1634816
       GoKind: 22
       Pointee: 1854 StructureType net/http.http2PingFrame
     - __kind: PointerType
       ID: 1855
       Name: '*net/http.http2PriorityFrame'
       ByteSize: 8
-      GoRuntimeType: 1635776
+      GoRuntimeType: 1635008
       GoKind: 22
       Pointee: 1856 StructureType net/http.http2PriorityFrame
     - __kind: PointerType
@@ -18633,16 +18633,16 @@ Types:
       ID: 1595
       Name: '*net/http.http2Setting'
       ByteSize: 8
-      GoRuntimeType: 1037824
+      GoRuntimeType: 1037696
       GoKind: 22
       Pointee: 1596 StructureType net/http.http2Setting
     - __kind: PointerType
-      ID: 1493
+      ID: 1491
       Name: '*net/http.http2SettingID'
       ByteSize: 8
-      GoRuntimeType: 907072
+      GoRuntimeType: 906400
       GoKind: 22
-      Pointee: 1426 BaseType net/http.http2SettingID
+      Pointee: 1424 BaseType net/http.http2SettingID
     - __kind: PointerType
       ID: 2126
       Name: '*net/http.http2SettingsFrame'
@@ -18654,14 +18654,14 @@ Types:
       ID: 1138
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1426048
+      GoRuntimeType: 1425888
       GoKind: 22
       Pointee: 1139 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 1857
       Name: '*net/http.http2UnknownFrame'
       ByteSize: 8
-      GoRuntimeType: 1637120
+      GoRuntimeType: 1636352
       GoKind: 22
       Pointee: 1858 StructureType net/http.http2UnknownFrame
     - __kind: PointerType
@@ -18675,16 +18675,16 @@ Types:
       ID: 2635
       Name: '*net/http.http2clientStream'
       ByteSize: 8
-      GoRuntimeType: 2021504
+      GoRuntimeType: 2021216
       GoKind: 22
       Pointee: 2636 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 824
+      ID: 822
       Name: '*net/http.http2connError'
       ByteSize: 8
-      GoRuntimeType: 908992
+      GoRuntimeType: 908320
       GoKind: 22
-      Pointee: 825 StructureType net/http.http2connError
+      Pointee: 823 StructureType net/http.http2connError
     - __kind: PointerType
       ID: 1267
       Name: '*net/http.http2dataBuffer'
@@ -18693,10 +18693,10 @@ Types:
       GoKind: 22
       Pointee: 1268 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 823
+      ID: 821
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 908896
+      GoRuntimeType: 908224
       GoKind: 22
       Pointee: 738 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
@@ -18708,14 +18708,14 @@ Types:
       ID: 2585
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
-      GoRuntimeType: 1039232
+      GoRuntimeType: 1039104
       GoKind: 22
       Pointee: 2586 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 827
+      ID: 825
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 909184
+      GoRuntimeType: 908512
       GoKind: 22
       Pointee: 744 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
@@ -18724,10 +18724,10 @@ Types:
       ByteSize: 8
       Pointee: 745 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 826
+      ID: 824
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 909088
+      GoRuntimeType: 908416
       GoKind: 22
       Pointee: 741 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
@@ -18739,28 +18739,28 @@ Types:
       ID: 1110
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1209056
+      GoRuntimeType: 1208544
       GoKind: 22
       Pointee: 1111 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 2581
       Name: '*net/http.http2missingBody'
       ByteSize: 8
-      GoRuntimeType: 1038976
+      GoRuntimeType: 1038848
       GoKind: 22
       Pointee: 2582 StructureType net/http.http2missingBody
     - __kind: PointerType
       ID: 2591
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
-      GoRuntimeType: 1040384
+      GoRuntimeType: 1040256
       GoKind: 22
       Pointee: 2592 StructureType net/http.http2noBodyReader
     - __kind: PointerType
       ID: 1041
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1040256
+      GoRuntimeType: 1040128
       GoKind: 22
       Pointee: 1042 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
@@ -18771,10 +18771,10 @@ Types:
       GoKind: 22
       Pointee: 1322 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 822
+      ID: 820
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 908800
+      GoRuntimeType: 908128
       GoKind: 22
       Pointee: 735 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
@@ -18786,98 +18786,98 @@ Types:
       ID: 1205
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
-      GoRuntimeType: 909280
+      GoRuntimeType: 908608
       GoKind: 22
       Pointee: 1206 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
       ID: 2583
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
-      GoRuntimeType: 1039104
+      GoRuntimeType: 1038976
       GoKind: 22
       Pointee: 2584 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
       ID: 2579
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
-      GoRuntimeType: 1038592
+      GoRuntimeType: 1038464
       GoKind: 22
       Pointee: 2580 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
       ID: 2613
       Name: '*net/http.noBody'
       ByteSize: 8
-      GoRuntimeType: 1208288
+      GoRuntimeType: 1207776
       GoKind: 22
       Pointee: 2614 StructureType net/http.noBody
     - __kind: PointerType
       ID: 1037
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1039872
+      GoRuntimeType: 1039744
       GoKind: 22
       Pointee: 1038 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1849
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1635008
+      GoRuntimeType: 1634240
       GoKind: 22
       Pointee: 1850 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
       ID: 1269
       Name: '*net/http.persistConn'
       ByteSize: 8
-      GoRuntimeType: 2189600
+      GoRuntimeType: 2189184
       GoKind: 22
       Pointee: 1270 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
       ID: 1225
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1039744
+      GoRuntimeType: 1039616
       GoKind: 22
       Pointee: 1226 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 2577
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
-      GoRuntimeType: 1038208
+      GoRuntimeType: 1038080
       GoKind: 22
       Pointee: 2578 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
       ID: 1259
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1426208
+      GoRuntimeType: 1426048
       GoKind: 22
       Pointee: 1260 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 828
+      ID: 826
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
-      GoRuntimeType: 909376
+      GoRuntimeType: 908704
       GoKind: 22
-      Pointee: 829 StructureType net/http.requestBodyReadError
+      Pointee: 827 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 1599
       Name: '*net/http.socksAddr'
       ByteSize: 8
-      GoRuntimeType: 1038336
+      GoRuntimeType: 1038208
       GoKind: 22
       Pointee: 1600 UnresolvedPointeeType net/http.socksAddr
     - __kind: PointerType
       ID: 1140
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1427328
+      GoRuntimeType: 1427168
       GoKind: 22
       Pointee: 1141 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 1108
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1208928
+      GoRuntimeType: 1208416
       GoKind: 22
       Pointee: 1109 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
@@ -18891,23 +18891,23 @@ Types:
       ID: 1039
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1040000
+      GoRuntimeType: 1039872
       GoKind: 22
       Pointee: 1040 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1301
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1856512
+      GoRuntimeType: 1856288
       GoKind: 22
       Pointee: 1302 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 817
+      ID: 815
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
-      GoRuntimeType: 907552
+      GoRuntimeType: 906880
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 816 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 2601
       Name: '*net/http/httputil.failureToReadBody'
@@ -19029,14 +19029,14 @@ Types:
       ID: 1148
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1430528
+      GoRuntimeType: 1430368
       GoKind: 22
       Pointee: 1149 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 846
+      ID: 844
       Name: '*net/url.EscapeError'
       ByteSize: 8
-      GoRuntimeType: 912640
+      GoRuntimeType: 911968
       GoKind: 22
       Pointee: 747 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
@@ -19045,10 +19045,10 @@ Types:
       ByteSize: 8
       Pointee: 748 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 847
+      ID: 845
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
-      GoRuntimeType: 912736
+      GoRuntimeType: 912064
       GoKind: 22
       Pointee: 750 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
@@ -19067,7 +19067,7 @@ Types:
       ID: 1671
       Name: '*net/url.Userinfo'
       ByteSize: 8
-      GoRuntimeType: 1214560
+      GoRuntimeType: 1214048
       GoKind: 22
       Pointee: 1672 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
@@ -19339,19 +19339,19 @@ Types:
       GoKind: 22
       Pointee: 785 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 1489
+      ID: 1511
       Name: '*reflect.ChanDir'
       ByteSize: 8
-      GoRuntimeType: 905728
+      GoRuntimeType: 915136
       GoKind: 22
-      Pointee: 1422 BaseType reflect.ChanDir
+      Pointee: 1431 BaseType reflect.ChanDir
     - __kind: PointerType
-      ID: 1490
+      ID: 1512
       Name: '*reflect.Kind'
       ByteSize: 8
-      GoRuntimeType: 905920
+      GoRuntimeType: 915328
       GoKind: 22
-      Pointee: 1423 BaseType reflect.Kind
+      Pointee: 1432 BaseType reflect.Kind
     - __kind: PointerType
       ID: 2518
       Name: '*reflect.Value'
@@ -19360,12 +19360,12 @@ Types:
       GoKind: 22
       Pointee: 2519 StructureType reflect.Value
     - __kind: PointerType
-      ID: 815
+      ID: 866
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 906304
+      GoRuntimeType: 915712
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType reflect.ValueError
+      Pointee: 867 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 2502
       Name: '*reflect.rtype'
@@ -19585,12 +19585,12 @@ Types:
       GoKind: 22
       Pointee: 36 BaseType runtime.waitReason
     - __kind: PointerType
-      ID: 1499
+      ID: 1497
       Name: '*runtime/debug.BuildInfo'
       ByteSize: 8
-      GoRuntimeType: 911584
+      GoRuntimeType: 910912
       GoKind: 22
-      Pointee: 1500 UnresolvedPointeeType runtime/debug.BuildInfo
+      Pointee: 1498 UnresolvedPointeeType runtime/debug.BuildInfo
     - __kind: PointerType
       ID: 1513
       Name: '*runtime/pprof.labelMap'
@@ -31689,7 +31689,7 @@ Types:
     - __kind: ArrayType
       ID: 1934
       Name: '[0]func()'
-      GoRuntimeType: 736352
+      GoRuntimeType: 734336
       GoKind: 17
       HasCount: true
       Element: 62 GoSubroutineType func()
@@ -32011,7 +32011,7 @@ Types:
       ID: 2015
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 698656
+      GoRuntimeType: 697792
       GoKind: 17
       Count: 8
       HasCount: true
@@ -32020,7 +32020,7 @@ Types:
       ID: 1414
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
-      GoRuntimeType: 484480
+      GoRuntimeType: 484288
       GoKind: 23
       RawFields:
         - Name: array
@@ -32580,7 +32580,7 @@ Types:
       ID: 393
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
-      GoRuntimeType: 484032
+      GoRuntimeType: 483840
       GoKind: 23
       RawFields:
         - Name: array
@@ -32603,7 +32603,7 @@ Types:
       ID: 396
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
-      GoRuntimeType: 484224
+      GoRuntimeType: 484032
       GoKind: 23
       RawFields:
         - Name: array
@@ -32649,7 +32649,7 @@ Types:
       ID: 366
       Name: '[]go.shape.float64'
       ByteSize: 24
-      GoRuntimeType: 486592
+      GoRuntimeType: 486464
       GoKind: 23
       RawFields:
         - Name: array
@@ -33236,7 +33236,7 @@ Types:
       ID: 2199
       Name: '[]vendor/golang.org/x/net/http2/hpack.HeaderField'
       ByteSize: 24
-      GoRuntimeType: 496096
+      GoRuntimeType: 495264
       GoKind: 23
       RawFields:
         - Name: array
@@ -33479,7 +33479,7 @@ Types:
       ID: 158
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1290144
+      GoRuntimeType: 1290016
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33531,7 +33531,7 @@ Types:
       ID: 712
       Name: context.canceler
       ByteSize: 16
-      GoRuntimeType: 1117504
+      GoRuntimeType: 1116608
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33543,7 +33543,7 @@ Types:
     - __kind: StructureType
       ID: 1085
       Name: context.deadlineExceededError
-      GoRuntimeType: 1473472
+      GoRuntimeType: 1472352
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
@@ -33574,7 +33574,7 @@ Types:
       ID: 433
       Name: context.timerCtx
       ByteSize: 112
-      GoRuntimeType: 1624256
+      GoRuntimeType: 1623872
       GoKind: 25
       RawFields:
         - Name: cancelCtx
@@ -33604,7 +33604,7 @@ Types:
       ID: 417
       Name: context.valueCtx
       ByteSize: 48
-      GoRuntimeType: 1849344
+      GoRuntimeType: 1848224
       GoKind: 25
       RawFields:
         - Name: Context
@@ -34049,7 +34049,7 @@ Types:
       ID: 762
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 838464
+      GoRuntimeType: 838272
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1232
@@ -34062,13 +34062,13 @@ Types:
       GoRuntimeType: 838656
       GoKind: 8
     - __kind: BaseType
-      ID: 1428
+      ID: 1426
       Name: encoding/json.Delim
       ByteSize: 4
-      GoRuntimeType: 837120
+      GoRuntimeType: 836928
       GoKind: 5
     - __kind: UnresolvedPointeeType
-      ID: 839
+      ID: 837
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34095,19 +34095,19 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 831
+      ID: 829
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 835
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 835
+      ID: 833
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 833
+      ID: 831
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34115,10 +34115,10 @@ Types:
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 841
+      ID: 839
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1428768
+      GoRuntimeType: 1428608
       GoKind: 25
       RawFields:
         - Name: error
@@ -34200,7 +34200,7 @@ Types:
       ID: 2668
       Name: fmt.ScanState
       ByteSize: 16
-      GoRuntimeType: 1472672
+      GoRuntimeType: 1474752
       GoKind: 20
       RawFields:
         - Name: tab
@@ -34213,7 +34213,7 @@ Types:
       ID: 405
       Name: fmt.Stringer
       ByteSize: 16
-      GoRuntimeType: 1029248
+      GoRuntimeType: 1030272
       GoKind: 20
       RawFields:
         - Name: tab
@@ -34321,7 +34321,7 @@ Types:
       ID: 2017
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
       ByteSize: 4
-      GoRuntimeType: 1770080
+      GoRuntimeType: 1769504
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 2182
@@ -34335,7 +34335,7 @@ Types:
       ID: 2018
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
       ByteSize: 4
-      GoRuntimeType: 1770272
+      GoRuntimeType: 1769696
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 2484
@@ -34396,7 +34396,7 @@ Types:
       Name: github.com/DataDog/datadog-agent/pkg/version.Version
       ByteSize: 8
     - __kind: StructureType
-      ID: 850
+      ID: 848
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1741312
@@ -34412,7 +34412,7 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 852
+      ID: 850
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34420,7 +34420,7 @@ Types:
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 856
+      ID: 854
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1120192
       GoKind: 25
@@ -34433,7 +34433,7 @@ Types:
       ID: 756
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
-      GoRuntimeType: 837888
+      GoRuntimeType: 837696
       GoKind: 24
       RawFields:
         - Name: str
@@ -34501,13 +34501,13 @@ Types:
       ID: 1175
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
-      GoRuntimeType: 590048
+      GoRuntimeType: 589984
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 753
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
-      GoRuntimeType: 837792
+      GoRuntimeType: 837600
       GoKind: 24
       RawFields:
         - Name: str
@@ -34526,7 +34526,7 @@ Types:
       ID: 759
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
-      GoRuntimeType: 837984
+      GoRuntimeType: 837792
       GoKind: 24
       RawFields:
         - Name: str
@@ -34737,7 +34737,7 @@ Types:
       ID: 395
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
-      GoRuntimeType: 1924704
+      GoRuntimeType: 1924448
       GoKind: 25
       RawFields:
         - Name: TraceID
@@ -34810,7 +34810,7 @@ Types:
       ID: 383
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 1290272
+      GoRuntimeType: 1290144
       GoKind: 21
       HeaderType: 385 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
@@ -34831,7 +34831,7 @@ Types:
       ID: 1416
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
-      GoRuntimeType: 587232
+      GoRuntimeType: 587168
       GoKind: 10
     - __kind: StructureType
       ID: 398
@@ -34860,7 +34860,7 @@ Types:
       ID: 728
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
-      GoRuntimeType: 1924960
+      GoRuntimeType: 1924704
       GoKind: 25
       RawFields:
         - Name: Type
@@ -34891,7 +34891,7 @@ Types:
       ID: 403
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
-      GoRuntimeType: 2118048
+      GoRuntimeType: 2117696
       GoKind: 25
       RawFields:
         - Name: mu
@@ -34928,7 +34928,7 @@ Types:
       ID: 404
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
-      GoRuntimeType: 902176
+      GoRuntimeType: 901696
       GoKind: 17
       Count: 16
       HasCount: true
@@ -34947,7 +34947,7 @@ Types:
       ID: 1576
       Name: github.com/DataDog/dd-trace-go/v2/internal.TraceSource
       ByteSize: 1
-      GoRuntimeType: 996416
+      GoRuntimeType: 996320
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1370
@@ -34994,16 +34994,16 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/waf.Feature
       ByteSize: 8
     - __kind: BaseType
-      ID: 1424
+      ID: 1422
       Name: github.com/DataDog/dd-trace-go/v2/internal/log.Level
       ByteSize: 8
-      GoRuntimeType: 836064
+      GoRuntimeType: 835872
       GoKind: 2
     - __kind: GoContextImplementationType
       ID: 413
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
-      GoRuntimeType: 1638272
+      GoRuntimeType: 1637504
       GoKind: 25
       RawFields:
         - Name: Context
@@ -35395,24 +35395,24 @@ Types:
           Offset: 56
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1511
+      ID: 1509
       Name: github.com/cihub/seelog.CfgParseParams
       ByteSize: 8
     - __kind: BaseType
-      ID: 1431
+      ID: 1429
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
-      GoRuntimeType: 838272
+      GoRuntimeType: 838080
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 2028
       Name: github.com/cihub/seelog.LogLevelException
       ByteSize: 8
     - __kind: StructureType
-      ID: 858
+      ID: 856
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1431008
+      GoRuntimeType: 1430848
       GoKind: 25
       RawFields:
         - Name: message
@@ -35423,15 +35423,15 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 860
+      ID: 858
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1431168
+      GoRuntimeType: 1431008
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 858 StructureType github.com/cihub/seelog.baseError
+          Type: 856 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1272
       Name: github.com/cihub/seelog.connWriter
@@ -35469,11 +35469,11 @@ Types:
       Name: github.com/cihub/seelog.listConstraints
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1508
+      ID: 1506
       Name: github.com/cihub/seelog.logFormattedMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1506
+      ID: 1504
       Name: github.com/cihub/seelog.logMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -35481,15 +35481,15 @@ Types:
       Name: github.com/cihub/seelog.minMaxConstraints
       ByteSize: 8
     - __kind: StructureType
-      ID: 864
+      ID: 862
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1431488
+      GoRuntimeType: 1431328
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 858 StructureType github.com/cihub/seelog.baseError
+          Type: 856 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1612
       Name: github.com/cihub/seelog.offConstraints
@@ -35536,25 +35536,25 @@ Types:
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 862
+      ID: 860
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1431328
+      GoRuntimeType: 1431168
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 858 StructureType github.com/cihub/seelog.baseError
+          Type: 856 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 866
+      ID: 864
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1431648
+      GoRuntimeType: 1431488
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 858 StructureType github.com/cihub/seelog.baseError
+          Type: 856 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1749
       Name: github.com/cihub/seelog.xmlNode
@@ -36179,7 +36179,7 @@ Types:
       ID: 1097
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1854720
+      GoRuntimeType: 1854496
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -36212,7 +36212,7 @@ Types:
       ID: 1103
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1855168
+      GoRuntimeType: 1854944
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36228,13 +36228,13 @@ Types:
       ID: 1007
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 995840
+      GoRuntimeType: 995744
       GoKind: 8
     - __kind: StructureType
       ID: 1095
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1854496
+      GoRuntimeType: 1854272
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -36254,13 +36254,13 @@ Types:
       ID: 1185
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
-      GoRuntimeType: 836160
+      GoRuntimeType: 835968
       GoKind: 8
     - __kind: StructureType
       ID: 1093
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1854272
+      GoRuntimeType: 1854048
       GoKind: 25
       RawFields:
         - Name: Method
@@ -36276,7 +36276,7 @@ Types:
       ID: 1101
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1767392
+      GoRuntimeType: 1766816
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36289,7 +36289,7 @@ Types:
       ID: 1099
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1854944
+      GoRuntimeType: 1854720
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36309,7 +36309,7 @@ Types:
       ID: 1107
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1634048
+      GoRuntimeType: 1633280
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -36331,7 +36331,7 @@ Types:
       ID: 1105
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1767584
+      GoRuntimeType: 1767008
       GoKind: 25
       RawFields:
         - Name: cause
@@ -38997,7 +38997,7 @@ Types:
       ID: 2647
       Name: io.Closer
       ByteSize: 16
-      GoRuntimeType: 1030272
+      GoRuntimeType: 1031296
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39022,7 +39022,7 @@ Types:
       ID: 1290
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1197408
+      GoRuntimeType: 1200608
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39035,7 +39035,7 @@ Types:
       ID: 406
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1029632
+      GoRuntimeType: 1030656
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39052,7 +39052,7 @@ Types:
       ID: 1277
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1116992
+      GoRuntimeType: 1117248
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39065,7 +39065,7 @@ Types:
       ID: 134
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1029376
+      GoRuntimeType: 1030400
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39078,7 +39078,7 @@ Types:
       ID: 2646
       Name: io.WriterTo
       ByteSize: 16
-      GoRuntimeType: 1030144
+      GoRuntimeType: 1031168
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39090,13 +39090,13 @@ Types:
     - __kind: StructureType
       ID: 1248
       Name: io.discard
-      GoRuntimeType: 1473152
+      GoRuntimeType: 1475232
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 2552
       Name: io.eofReader
-      GoRuntimeType: 1116736
+      GoRuntimeType: 1116992
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -39111,7 +39111,7 @@ Types:
       ID: 2576
       Name: io.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1560032
+      GoRuntimeType: 1561632
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -39121,7 +39121,7 @@ Types:
       ID: 2610
       Name: io.nopCloserWriterTo
       ByteSize: 16
-      GoRuntimeType: 1623872
+      GoRuntimeType: 1625024
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -39168,7 +39168,7 @@ Types:
       ID: 1676
       Name: log/slog.Attr
       ByteSize: 40
-      GoRuntimeType: 1775456
+      GoRuntimeType: 1774880
       GoKind: 25
       RawFields:
         - Name: Key
@@ -39178,16 +39178,16 @@ Types:
           Offset: 16
           Type: 2019 StructureType log/slog.Value
     - __kind: BaseType
-      ID: 1432
+      ID: 1430
       Name: log/slog.Kind
       ByteSize: 8
-      GoRuntimeType: 838368
+      GoRuntimeType: 838176
       GoKind: 2
     - __kind: BaseType
       ID: 1779
       Name: log/slog.Level
       ByteSize: 8
-      GoRuntimeType: 1494592
+      GoRuntimeType: 1493472
       GoKind: 2
     - __kind: StructureType
       ID: 2019
@@ -41774,16 +41774,16 @@ Types:
       Name: net.DNSError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1429
+      ID: 1427
       Name: net.Flags
       ByteSize: 8
-      GoRuntimeType: 837312
+      GoRuntimeType: 837120
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 1501
+      ID: 1499
       Name: net.HardwareAddr
       ByteSize: 24
-      GoRuntimeType: 912064
+      GoRuntimeType: 911392
       GoKind: 23
       RawFields:
         - Name: array
@@ -41795,9 +41795,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1502 GoSliceDataType net.HardwareAddr.array
+      Data: 1500 GoSliceDataType net.HardwareAddr.array
     - __kind: GoSliceDataType
-      ID: 1502
+      ID: 1500
       Name: net.HardwareAddr.array
       DynamicSizeClass: slice
       ByteSize: 1
@@ -41837,7 +41837,7 @@ Types:
       ID: 1604
       Name: net.IPMask
       ByteSize: 24
-      GoRuntimeType: 1043456
+      GoRuntimeType: 1043328
       GoKind: 23
       RawFields:
         - Name: array
@@ -41951,10 +41951,10 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: BaseType
-      ID: 1430
+      ID: 1428
       Name: net.hostLookupOrder
       ByteSize: 8
-      GoRuntimeType: 837408
+      GoRuntimeType: 837216
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1378
@@ -41973,14 +41973,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 841
       Name: net.notFoundError
       ByteSize: 8
     - __kind: GoContextImplementationType
       ID: 415
       Name: net.onlyValuesCtx
       ByteSize: 32
-      GoRuntimeType: 1772384
+      GoRuntimeType: 1771808
       GoKind: 25
       RawFields:
         - Name: Context
@@ -41992,7 +41992,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: StructureType
-      ID: 845
+      ID: 843
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1741120
@@ -42042,10 +42042,10 @@ Types:
       Name: net.timeoutError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1427
+      ID: 1425
       Name: net/http.ConnState
       ByteSize: 8
-      GoRuntimeType: 836544
+      GoRuntimeType: 836352
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1598
@@ -42074,7 +42074,7 @@ Types:
       ID: 2554
       Name: net/http.bodyLocked
       ByteSize: 8
-      GoRuntimeType: 1426368
+      GoRuntimeType: 1426208
       GoKind: 25
       RawFields:
         - Name: b
@@ -42084,7 +42084,7 @@ Types:
       ID: 1204
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1426528
+      GoRuntimeType: 1426368
       GoKind: 25
       RawFields:
         - Name: w
@@ -42099,7 +42099,7 @@ Types:
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 1495
+      ID: 1493
       Name: net/http.connectMethodKey
       ByteSize: 56
       GoRuntimeType: 1837632
@@ -42118,14 +42118,14 @@ Types:
           Offset: 48
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1497
+      ID: 1495
       Name: net/http.contextKey
       ByteSize: 8
     - __kind: StructureType
       ID: 2558
       Name: net/http.errorReader
       ByteSize: 16
-      GoRuntimeType: 1426688
+      GoRuntimeType: 1426528
       GoKind: 25
       RawFields:
         - Name: err
@@ -42135,7 +42135,7 @@ Types:
       ID: 2560
       Name: net/http.finishAsyncByteRead
       ByteSize: 8
-      GoRuntimeType: 1426848
+      GoRuntimeType: 1426688
       GoKind: 25
       RawFields:
         - Name: tw
@@ -42149,13 +42149,13 @@ Types:
       ID: 734
       Name: net/http.http2ConnectionError
       ByteSize: 4
-      GoRuntimeType: 836640
+      GoRuntimeType: 836448
       GoKind: 10
     - __kind: StructureType
       ID: 1941
       Name: net/http.http2ContinuationFrame
       ByteSize: 40
-      GoRuntimeType: 1769504
+      GoRuntimeType: 1768928
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42168,7 +42168,7 @@ Types:
       ID: 1936
       Name: net/http.http2DataFrame
       ByteSize: 40
-      GoRuntimeType: 1767776
+      GoRuntimeType: 1767200
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42181,13 +42181,13 @@ Types:
       ID: 1159
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 995936
+      GoRuntimeType: 995840
       GoKind: 10
     - __kind: BaseType
       ID: 2014
       Name: net/http.http2Flags
       ByteSize: 1
-      GoRuntimeType: 836352
+      GoRuntimeType: 836160
       GoKind: 8
     - __kind: StructureType
       ID: 1788
@@ -42201,7 +42201,7 @@ Types:
           Type: 6 BaseType bool
         - Name: Type
           Offset: 1
-          Type: 1425 BaseType net/http.http2FrameType
+          Type: 1423 BaseType net/http.http2FrameType
         - Name: Flags
           Offset: 2
           Type: 2014 BaseType net/http.http2Flags
@@ -42212,13 +42212,13 @@ Types:
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1425
+      ID: 1423
       Name: net/http.http2FrameType
       ByteSize: 1
-      GoRuntimeType: 836256
+      GoRuntimeType: 836064
       GoKind: 8
     - __kind: StructureType
-      ID: 821
+      ID: 819
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1739776
@@ -42237,7 +42237,7 @@ Types:
       ID: 1852
       Name: net/http.http2GoAwayFrame
       ByteSize: 48
-      GoRuntimeType: 1928800
+      GoRuntimeType: 1928544
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42256,7 +42256,7 @@ Types:
       ID: 2068
       Name: net/http.http2HeadersFrame
       ByteSize: 48
-      GoRuntimeType: 1855840
+      GoRuntimeType: 1855616
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42288,7 +42288,7 @@ Types:
       ID: 1854
       Name: net/http.http2PingFrame
       ByteSize: 20
-      GoRuntimeType: 1767968
+      GoRuntimeType: 1767392
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42330,7 +42330,7 @@ Types:
       ID: 1939
       Name: net/http.http2PushPromiseFrame
       ByteSize: 40
-      GoRuntimeType: 1857632
+      GoRuntimeType: 1857408
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42346,7 +42346,7 @@ Types:
       ID: 1790
       Name: net/http.http2RSTStreamFrame
       ByteSize: 16
-      GoRuntimeType: 1768160
+      GoRuntimeType: 1767584
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42364,21 +42364,21 @@ Types:
       RawFields:
         - Name: ID
           Offset: 0
-          Type: 1426 BaseType net/http.http2SettingID
+          Type: 1424 BaseType net/http.http2SettingID
         - Name: Val
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1426
+      ID: 1424
       Name: net/http.http2SettingID
       ByteSize: 2
-      GoRuntimeType: 836448
+      GoRuntimeType: 836256
       GoKind: 9
     - __kind: StructureType
       ID: 2016
       Name: net/http.http2SettingsFrame
       ByteSize: 40
-      GoRuntimeType: 1768352
+      GoRuntimeType: 1767776
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42391,7 +42391,7 @@ Types:
       ID: 1139
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1912224
+      GoRuntimeType: 1911968
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -42407,7 +42407,7 @@ Types:
       ID: 1858
       Name: net/http.http2UnknownFrame
       ByteSize: 40
-      GoRuntimeType: 1769312
+      GoRuntimeType: 1768736
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42420,7 +42420,7 @@ Types:
       ID: 1792
       Name: net/http.http2WindowUpdateFrame
       ByteSize: 16
-      GoRuntimeType: 1768544
+      GoRuntimeType: 1767968
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42434,7 +42434,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 823
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1605984
@@ -42454,7 +42454,7 @@ Types:
       ID: 738
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 836832
+      GoRuntimeType: 836640
       GoKind: 24
       RawFields:
         - Name: str
@@ -42477,7 +42477,7 @@ Types:
       ID: 744
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 837024
+      GoRuntimeType: 836832
       GoKind: 24
       RawFields:
         - Name: str
@@ -42496,7 +42496,7 @@ Types:
       ID: 741
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 836928
+      GoRuntimeType: 836736
       GoKind: 24
       RawFields:
         - Name: str
@@ -42541,7 +42541,7 @@ Types:
       ID: 735
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 836736
+      GoRuntimeType: 836544
       GoKind: 24
       RawFields:
         - Name: str
@@ -42579,7 +42579,7 @@ Types:
       ID: 1299
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
-      GoRuntimeType: 1425728
+      GoRuntimeType: 1425568
       GoKind: 20
       RawFields:
         - Name: tab
@@ -42601,7 +42601,7 @@ Types:
     - __kind: ArrayType
       ID: 1287
       Name: net/http.incomparable
-      GoRuntimeType: 907360
+      GoRuntimeType: 906688
       GoKind: 17
       HasCount: true
       Element: 62 GoSubroutineType func()
@@ -42612,7 +42612,7 @@ Types:
     - __kind: StructureType
       ID: 2614
       Name: net/http.noBody
-      GoRuntimeType: 1484992
+      GoRuntimeType: 1483872
       GoKind: 25
       RawFields: []
     - __kind: StructureType
@@ -42651,7 +42651,7 @@ Types:
       ID: 1260
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1813056
+      GoRuntimeType: 1812608
       GoKind: 25
       RawFields:
         - Name: _
@@ -42664,10 +42664,10 @@ Types:
           Offset: 8
           Type: 1290 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 829
+      ID: 827
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1427488
+      GoRuntimeType: 1427328
       GoKind: 25
       RawFields:
         - Name: error
@@ -42684,7 +42684,7 @@ Types:
     - __kind: StructureType
       ID: 1109
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1486272
+      GoRuntimeType: 1485152
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -42705,7 +42705,7 @@ Types:
       ID: 1302
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2038752
+      GoRuntimeType: 2038464
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -42715,7 +42715,7 @@ Types:
           Offset: 16
           Type: 1182 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 816
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -42883,7 +42883,7 @@ Types:
       ID: 747
       Name: net/url.EscapeError
       ByteSize: 16
-      GoRuntimeType: 837504
+      GoRuntimeType: 837312
       GoKind: 24
       RawFields:
         - Name: str
@@ -42902,7 +42902,7 @@ Types:
       ID: 750
       Name: net/url.InvalidHostError
       ByteSize: 16
-      GoRuntimeType: 837600
+      GoRuntimeType: 837408
       GoKind: 24
       RawFields:
         - Name: str
@@ -43001,7 +43001,7 @@ Types:
       ID: 710
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
-      GoRuntimeType: 693408
+      GoRuntimeType: 691968
       GoKind: 17
       Count: 8
       HasCount: true
@@ -43082,7 +43082,7 @@ Types:
       ID: 725
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
-      GoRuntimeType: 694048
+      GoRuntimeType: 692608
       GoKind: 17
       Count: 8
       HasCount: true
@@ -43091,7 +43091,7 @@ Types:
       ID: 2539
       Name: noalg.[8]struct { key string; elem *regexp.Regexp }
       ByteSize: 192
-      GoRuntimeType: 695200
+      GoRuntimeType: 694048
       GoKind: 17
       Count: 8
       HasCount: true
@@ -43118,7 +43118,7 @@ Types:
       ID: 692
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
-      GoRuntimeType: 693952
+      GoRuntimeType: 692512
       GoKind: 17
       Count: 8
       HasCount: true
@@ -43307,7 +43307,7 @@ Types:
       ID: 709
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
-      GoRuntimeType: 1308192
+      GoRuntimeType: 1308064
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43424,7 +43424,7 @@ Types:
       ID: 724
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
-      GoRuntimeType: 1309088
+      GoRuntimeType: 1308960
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43437,7 +43437,7 @@ Types:
       ID: 2538
       Name: noalg.map.group[string]*regexp.Regexp
       ByteSize: 200
-      GoRuntimeType: 1309856
+      GoRuntimeType: 1309728
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43476,7 +43476,7 @@ Types:
       ID: 691
       Name: noalg.map.group[string]float64
       ByteSize: 200
-      GoRuntimeType: 1308832
+      GoRuntimeType: 1308704
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43730,7 +43730,7 @@ Types:
       ID: 711
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
-      GoRuntimeType: 1308064
+      GoRuntimeType: 1307936
       GoKind: 25
       RawFields:
         - Name: key
@@ -43847,7 +43847,7 @@ Types:
       ID: 726
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
-      GoRuntimeType: 1308960
+      GoRuntimeType: 1308832
       GoKind: 25
       RawFields:
         - Name: key
@@ -43860,7 +43860,7 @@ Types:
       ID: 2540
       Name: noalg.struct { key string; elem *regexp.Regexp }
       ByteSize: 24
-      GoRuntimeType: 1309728
+      GoRuntimeType: 1309600
       GoKind: 25
       RawFields:
         - Name: key
@@ -43899,7 +43899,7 @@ Types:
       ID: 693
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
-      GoRuntimeType: 1308704
+      GoRuntimeType: 1308576
       GoKind: 25
       RawFields:
         - Name: key
@@ -44218,16 +44218,16 @@ Types:
       GoRuntimeType: 842784
       GoKind: 2
     - __kind: BaseType
-      ID: 1422
+      ID: 1431
       Name: reflect.ChanDir
       ByteSize: 8
-      GoRuntimeType: 835872
+      GoRuntimeType: 838368
       GoKind: 2
     - __kind: BaseType
-      ID: 1423
+      ID: 1432
       Name: reflect.Kind
       ByteSize: 8
-      GoRuntimeType: 835968
+      GoRuntimeType: 838464
       GoKind: 7
     - __kind: StructureType
       ID: 2519
@@ -44246,14 +44246,14 @@ Types:
           Offset: 16
           Type: 2520 BaseType reflect.flag
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 867
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: BaseType
       ID: 2520
       Name: reflect.flag
       ByteSize: 8
-      GoRuntimeType: 1766432
+      GoRuntimeType: 1775072
       GoKind: 12
     - __kind: UnresolvedPointeeType
       ID: 2503
@@ -45221,7 +45221,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1500
+      ID: 1498
       Name: runtime/debug.BuildInfo
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -45277,7 +45277,7 @@ Types:
       ID: 2606
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
-      GoRuntimeType: 1720736
+      GoRuntimeType: 1720160
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -45290,7 +45290,7 @@ Types:
       ID: 2604
       Name: struct { io.Reader; io.WriterTo }
       ByteSize: 32
-      GoRuntimeType: 1720544
+      GoRuntimeType: 1719968
       GoKind: 25
       RawFields:
         - Name: Reader

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -20,11 +20,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3023 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x80f888", Frameless: false}]
+              InjectionPoints: [{PC: "0x8101b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3024 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x80f8b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8101e8", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -40,11 +40,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2858 EventRootType Probe[main.testAny]
-              InjectionPoints: [{PC: "0x80a778", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ac48", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2859 EventRootType Probe[main.testAny]Return
-              InjectionPoints: [{PC: "0x80a7a0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ac70", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -66,11 +66,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2861 EventRootType Probe[main.testAnyPtr]
-              InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80acb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2862 EventRootType Probe[main.testAnyPtr]Return
-              InjectionPoints: [{PC: "0x80a810", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ace0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -91,11 +91,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2992 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x80e4bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ed2c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2993 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80e550", Frameless: false}]
+              InjectionPoints: [{PC: "0x80edc0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -183,7 +183,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2870 EventRootType Probe[main.testArrayOfMaps]
-              InjectionPoints: [{PC: "0x80af40", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b4b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -248,11 +248,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2894 EventRootType Probe[main.testAtomicAdd]
-              InjectionPoints: [{PC: "0x80c8a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cf90", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2895 EventRootType Probe[main.testAtomicAdd]Return
-              InjectionPoints: [{PC: "0x80c8dc", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cfcc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -274,7 +274,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2823 EventRootType Probe[main.testBigStruct]
-              InjectionPoints: [{PC: "0x806450", Frameless: true}]
+              InjectionPoints: [{PC: "0x8065d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -340,7 +340,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3021 EventRootType Probe[main.testByteSliceInvalidUtf8]
-              InjectionPoints: [{PC: "0x80f320", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fb90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -362,7 +362,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3022 EventRootType Probe[main.testByteSliceMultibyteUtf8]
-              InjectionPoints: [{PC: "0x80f330", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fba0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -383,7 +383,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2837 EventRootType Probe[main.testCaptureContextImpl]
-              InjectionPoints: [{PC: "0x806f80", Frameless: true}]
+              InjectionPoints: [{PC: "0x8071c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -410,7 +410,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3042 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80fba0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8106a0", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -418,7 +418,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: ""
       segments: []
@@ -430,15 +430,15 @@ Probes:
             - Kind: Line
               Type: 3104 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x80a098"
+                - PC: "0x80a4a8"
                   Frameless: false
-                - PC: "0x80a10c"
+                - PC: "0x80a51c"
                   Frameless: false
-                - PC: "0x80a240"
+                - PC: "0x80a650"
                   Frameless: false
-                - PC: "0x80a2c4"
+                - PC: "0x80a6d4"
                   Frameless: false
-                - PC: "0x80a37c"
+                - PC: "0x80a78c"
                   Frameless: false
               Condition: null
     - id: testCaptureExprLineCond
@@ -447,7 +447,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       when: {dsl: x == 3, json: {eq: [{ref: x}, 3]}}
       sampling: {snapshotsPerSecond: 100}
       template: ""
@@ -460,15 +460,15 @@ Probes:
             - Kind: Line
               Type: 3105 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x80a098"
+                - PC: "0x80a4a8"
                   Frameless: false
-                - PC: "0x80a10c"
+                - PC: "0x80a51c"
                   Frameless: false
-                - PC: "0x80a240"
+                - PC: "0x80a650"
                   Frameless: false
-                - PC: "0x80a2c4"
+                - PC: "0x80a6d4"
                   Frameless: false
-                - PC: "0x80a37c"
+                - PC: "0x80a78c"
                   Frameless: false
               Condition:
                 Type: 6 BaseType bool
@@ -494,7 +494,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: x={x}
       segments: [x=, {json: {ref: x}, dsl: x}]
@@ -506,15 +506,15 @@ Probes:
             - Kind: Line
               Type: 3106 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x80a098"
+                - PC: "0x80a4a8"
                   Frameless: false
-                - PC: "0x80a10c"
+                - PC: "0x80a51c"
                   Frameless: false
-                - PC: "0x80a240"
+                - PC: "0x80a650"
                   Frameless: false
-                - PC: "0x80a2c4"
+                - PC: "0x80a6d4"
                   Frameless: false
-                - PC: "0x80a37c"
+                - PC: "0x80a78c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -542,7 +542,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2889 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80c3d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c940", Frameless: true}]
               Condition: null
     - id: testCaptureExprWithTemplate
       version: 0
@@ -561,7 +561,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2890 EventRootType Probe[main.testCombinedString]
-              InjectionPoints: [{PC: "0x80c3d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -587,7 +587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3048 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x80fc10", Frameless: true}]
+              InjectionPoints: [{PC: "0x810710", Frameless: true}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -625,7 +625,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2896 EventRootType Probe[main.testChannel]
-              InjectionPoints: [{PC: "0x80c8e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80cfd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -655,7 +655,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2888 EventRootType Probe[main.testCombinedByte]
-              InjectionPoints: [{PC: "0x80c3b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80c920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{w}, {x}, {y}'
@@ -684,11 +684,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2957 EventRootType Probe[main.testConflictingReturn]
-              InjectionPoints: [{PC: "0x80d7b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e028", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2958 EventRootType Probe[main.testConflictingReturn]Return
-              InjectionPoints: [{PC: "0x80d85c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e0cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -710,7 +710,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2904 EventRootType Probe[main.testCycle]
-              InjectionPoints: [{PC: "0x80cb60", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d310", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{t}'
@@ -732,7 +732,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2829 EventRootType Probe[main.testDeepMap1]
-              InjectionPoints: [{PC: "0x8068b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806a30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -754,7 +754,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2830 EventRootType Probe[main.testDeepMap7]
-              InjectionPoints: [{PC: "0x8068c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806a40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -776,7 +776,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2825 EventRootType Probe[main.testDeepPtr1]
-              InjectionPoints: [{PC: "0x806620", Frameless: true}]
+              InjectionPoints: [{PC: "0x8067a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -798,7 +798,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2826 EventRootType Probe[main.testDeepPtr7]
-              InjectionPoints: [{PC: "0x806630", Frameless: true}]
+              InjectionPoints: [{PC: "0x8067b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -820,7 +820,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2827 EventRootType Probe[main.testDeepSlice1]
-              InjectionPoints: [{PC: "0x806750", Frameless: true}]
+              InjectionPoints: [{PC: "0x8068d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -842,7 +842,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2828 EventRootType Probe[main.testDeepSlice7]
-              InjectionPoints: [{PC: "0x806760", Frameless: true}]
+              InjectionPoints: [{PC: "0x8068e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -864,7 +864,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3009 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x80f240", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fab0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -891,7 +891,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3012 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x80f270", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -919,7 +919,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3035 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x80f940", Frameless: true}]
+              InjectionPoints: [{PC: "0x810370", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -941,7 +941,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3049 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x80fc40", Frameless: true}]
+              InjectionPoints: [{PC: "0x810740", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -962,7 +962,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3050 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x80fc50", Frameless: true}]
+              InjectionPoints: [{PC: "0x810750", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -984,7 +984,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2860 EventRootType Probe[main.testError]
-              InjectionPoints: [{PC: "0x80a7c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ac90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -999,7 +999,7 @@ Probes:
       where:
         methodName: main.testErrorAtLine
         sourceFile: complex.go
-        lines: ["108"]
+        lines: ["111"]
       tags:
         - config_diff:arch=amd64,toolchain=go1.26rc1
         - skip_integration:arch=arm64,toolchain=go1.25.0
@@ -1018,7 +1018,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2824 EventRootType Probe[main.testErrorAtLine]Line
-              InjectionPoints: [{PC: "0x8064e0", Frameless: false}]
+              InjectionPoints: [{PC: "0x806660", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}, err={err}
@@ -1046,11 +1046,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2842 EventRootType Probe[main.testEsotericHeap]
-              InjectionPoints: [{PC: "0x809178", Frameless: false}]
+              InjectionPoints: [{PC: "0x809588", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2843 EventRootType Probe[main.testEsotericHeap]Return
-              InjectionPoints: [{PC: "0x8091b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x8095c0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1072,11 +1072,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2840 EventRootType Probe[main.testEsotericStack]
-              InjectionPoints: [{PC: "0x8090bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8094cc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2841 EventRootType Probe[main.testEsotericStack]Return
-              InjectionPoints: [{PC: "0x809118", Frameless: false}]
+              InjectionPoints: [{PC: "0x809528", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1098,11 +1098,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2852 EventRootType Probe[main.testFrameless]
-              InjectionPoints: [{PC: "0x80a4e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a8f0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 2853 EventRootType Probe[main.testFrameless]Return
-              InjectionPoints: [{PC: "0x80a4e8", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a8f8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1124,11 +1124,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2854 EventRootType Probe[main.testFramelessArray]
-              InjectionPoints: [{PC: "0x80a4fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a90c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2855 EventRootType Probe[main.testFramelessArray]Return
-              InjectionPoints: [{PC: "0x80a530", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a940", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1143,7 +1143,7 @@ Probes:
       where:
         methodName: main.testFramelessArray
         sourceFile: inlined.go
-        lines: ["93"]
+        lines: ["96"]
       sampling: {snapshotsPerSecond: 100}
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
@@ -1153,7 +1153,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2856 EventRootType Probe[main.testFramelessArray]Line
-              InjectionPoints: [{PC: "0x80a4fc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a90c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -1175,11 +1175,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3090 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x811b60", Frameless: true}]
+              InjectionPoints: [{PC: "0x8127e0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3091 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x811b64", Frameless: true}]
+              InjectionPoints: [{PC: "0x8127e4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1193,11 +1193,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3092 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x811b80", Frameless: false}]
+              InjectionPoints: [{PC: "0x812800", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3093 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x811bb4", Frameless: false}]
+              InjectionPoints: [{PC: "0x812834", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1220,11 +1220,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3086 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x811ac8", Frameless: false}]
+              InjectionPoints: [{PC: "0x812748", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3087 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x811ad8", Frameless: false}]
+              InjectionPoints: [{PC: "0x812758", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1238,11 +1238,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3088 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x811b18", Frameless: false}]
+              InjectionPoints: [{PC: "0x812798", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3089 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x811b30", Frameless: false}]
+              InjectionPoints: [{PC: "0x8127b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1265,14 +1265,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 3094 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x811bc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x812840", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3095 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x811be8"
+                - PC: "0x812868"
                   Frameless: true
-                - PC: "0x811bf0"
+                - PC: "0x812870"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1287,14 +1287,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 3096 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x811c18", Frameless: false}]
+              InjectionPoints: [{PC: "0x812898", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3097 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x811c78"
+                - PC: "0x8128f8"
                   Frameless: false
-                - PC: "0x811c88"
+                - PC: "0x812908"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1321,7 +1321,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3098 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x811bc4", Frameless: true}]
+              InjectionPoints: [{PC: "0x812844", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1333,7 +1333,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3099 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x811c28", Frameless: false}]
+              InjectionPoints: [{PC: "0x8128a8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1354,11 +1354,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3074 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x811840", Frameless: true}]
+              InjectionPoints: [{PC: "0x8124c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3075 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x811844", Frameless: true}]
+              InjectionPoints: [{PC: "0x8124c4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1372,11 +1372,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3076 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x8118c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x812540", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3077 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x8118c4", Frameless: true}]
+              InjectionPoints: [{PC: "0x812544", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1400,11 +1400,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3062 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x81144c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8120cc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3063 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x811598", Frameless: false}]
+              InjectionPoints: [{PC: "0x812218", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1446,11 +1446,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3066 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x8115e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x812268", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3067 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8115f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x812278", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1473,11 +1473,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3100 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x811cc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x812940", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3101 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x811cc8", Frameless: true}]
+              InjectionPoints: [{PC: "0x812948", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1491,11 +1491,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3102 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x811d38", Frameless: false}]
+              InjectionPoints: [{PC: "0x8129b8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3103 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x811d5c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8129dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1518,11 +1518,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3058 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x8113b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x812030", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3059 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8113b4", Frameless: true}]
+              InjectionPoints: [{PC: "0x812034", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1536,11 +1536,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3060 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x8113c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x812040", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3061 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8113cc", Frameless: true}]
+              InjectionPoints: [{PC: "0x81204c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1563,11 +1563,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3078 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x811940", Frameless: true}]
+              InjectionPoints: [{PC: "0x8125c0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3079 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x811948", Frameless: true}]
+              InjectionPoints: [{PC: "0x8125c8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1581,11 +1581,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3080 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x8119c8", Frameless: false}]
+              InjectionPoints: [{PC: "0x812648", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3081 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x8119f0", Frameless: false}]
+              InjectionPoints: [{PC: "0x812670", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1608,11 +1608,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3068 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x811810", Frameless: true}]
+              InjectionPoints: [{PC: "0x812490", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3069 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x811814", Frameless: true}]
+              InjectionPoints: [{PC: "0x812494", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1626,11 +1626,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3070 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x811820", Frameless: true}]
+              InjectionPoints: [{PC: "0x8124a0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3071 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x811824", Frameless: true}]
+              InjectionPoints: [{PC: "0x8124a4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1644,11 +1644,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3072 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x811830", Frameless: true}]
+              InjectionPoints: [{PC: "0x8124b0", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3073 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x811834", Frameless: true}]
+              InjectionPoints: [{PC: "0x8124b4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1671,11 +1671,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3082 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x811a80", Frameless: true}]
+              InjectionPoints: [{PC: "0x812700", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3083 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x811a88", Frameless: true}]
+              InjectionPoints: [{PC: "0x812708", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1689,11 +1689,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3084 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x811a90", Frameless: true}]
+              InjectionPoints: [{PC: "0x812710", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3085 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x811aa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x812720", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1716,11 +1716,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3054 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x811390", Frameless: true}]
+              InjectionPoints: [{PC: "0x812010", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3055 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x811394", Frameless: true}]
+              InjectionPoints: [{PC: "0x812014", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1734,11 +1734,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3056 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x8113a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x812020", Frameless: true}]
               Condition: null
             - Kind: Return
               Type: 3057 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8113ac", Frameless: true}]
+              InjectionPoints: [{PC: "0x81202c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1761,14 +1761,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2892 EventRootType Probe[main.(*Server).handleOrder]
-              InjectionPoints: [{PC: "0x80c64c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80cc7c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2893 EventRootType Probe[main.(*Server).handleOrder]Return
               InjectionPoints:
-                - PC: "0x80c724"
+                - PC: "0x80cd54"
                   Frameless: false
-                - PC: "0x80c7c8"
+                - PC: "0x80cdf8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1791,11 +1791,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2844 EventRootType Probe[main.testInlinedBA]
-              InjectionPoints: [{PC: "0x80a228", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a638", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2845 EventRootType Probe[main.testInlinedBA]Return
-              InjectionPoints: [{PC: "0x80a274", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a684", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1822,11 +1822,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2846 EventRootType Probe[main.testInlinedBB]
-              InjectionPoints: [{PC: "0x80a2b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a6c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2847 EventRootType Probe[main.testInlinedBB]Return
-              InjectionPoints: [{PC: "0x80a338", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a748", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}'
@@ -1853,11 +1853,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2848 EventRootType Probe[main.testInlinedBBA]
-              InjectionPoints: [{PC: "0x80a378", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a788", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2849 EventRootType Probe[main.testInlinedBBA]Return
-              InjectionPoints: [{PC: "0x80a3b0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a7c0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -1879,7 +1879,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3110 EventRootType Probe[main.testInlinedBBB]
-              InjectionPoints: [{PC: "0x80a304", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a714", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBBB
@@ -1897,11 +1897,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2850 EventRootType Probe[main.testInlinedBC]
-              InjectionPoints: [{PC: "0x80a3e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a7f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2851 EventRootType Probe[main.testInlinedBC]Return
-              InjectionPoints: [{PC: "0x80a4c4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a8d4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBC
@@ -1919,7 +1919,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3111 EventRootType Probe[main.testInlinedBCA]
-              InjectionPoints: [{PC: "0x80a3ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a7fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1930,7 +1930,7 @@ Probes:
       where:
         methodName: main.testInlinedBCA
         sourceFile: inlined.go
-        lines: ["63"]
+        lines: ["66"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCA
       segments: [testInlinedBCA]
@@ -1940,7 +1940,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3112 EventRootType Probe[main.testInlinedBCA]Line
-              InjectionPoints: [{PC: "0x80a3ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a7fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCA
@@ -1958,7 +1958,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3113 EventRootType Probe[main.testInlinedBCB]
-              InjectionPoints: [{PC: "0x80a490", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a8a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -1969,7 +1969,7 @@ Probes:
       where:
         methodName: main.testInlinedBCB
         sourceFile: inlined.go
-        lines: ["67"]
+        lines: ["70"]
       sampling: {snapshotsPerSecond: 100}
       template: testInlinedBCB
       segments: [testInlinedBCB]
@@ -1979,7 +1979,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3114 EventRootType Probe[main.testInlinedBCB]Line
-              InjectionPoints: [{PC: "0x80a490", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a8a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testInlinedBCB
@@ -2000,7 +2000,7 @@ Probes:
               InjectionPoints:
                 - PC: "0x804bd8"
                   Frameless: true
-                - PC: "0x80ae74"
+                - PC: "0x80b3c0"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2021,20 +2021,20 @@ Probes:
             - Kind: Entry
               Type: 3107 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
-                - PC: "0x80a098"
+                - PC: "0x80a4a8"
                   Frameless: false
-                - PC: "0x80a10c"
+                - PC: "0x80a51c"
                   Frameless: false
-                - PC: "0x80a240"
+                - PC: "0x80a650"
                   Frameless: false
-                - PC: "0x80a2c4"
+                - PC: "0x80a6d4"
                   Frameless: false
-                - PC: "0x80a37c"
+                - PC: "0x80a78c"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 3108 EventRootType Probe[main.testInlinedPrint]Return
-              InjectionPoints: [{PC: "0x80a0cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80a4dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2049,7 +2049,7 @@ Probes:
       where:
         methodName: main.testInlinedPrint
         sourceFile: inlined.go
-        lines: ["14"]
+        lines: ["17"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2060,15 +2060,15 @@ Probes:
             - Kind: Line
               Type: 3109 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
-                - PC: "0x80a098"
+                - PC: "0x80a4a8"
                   Frameless: false
-                - PC: "0x80a10c"
+                - PC: "0x80a51c"
                   Frameless: false
-                - PC: "0x80a240"
+                - PC: "0x80a650"
                   Frameless: false
-                - PC: "0x80a2c4"
+                - PC: "0x80a6d4"
                   Frameless: false
-                - PC: "0x80a37c"
+                - PC: "0x80a78c"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2091,7 +2091,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3115 EventRootType Probe[main.testInlinedSq]
-              InjectionPoints: [{PC: "0x80a4e4", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a8f4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2106,7 +2106,7 @@ Probes:
       where:
         methodName: main.testInlinedSq
         sourceFile: inlined.go
-        lines: ["75"]
+        lines: ["78"]
       sampling: {snapshotsPerSecond: 100}
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
@@ -2116,7 +2116,7 @@ Probes:
           events:
             - Kind: Line
               Type: 3116 EventRootType Probe[main.testInlinedSq]Line
-              InjectionPoints: [{PC: "0x80a4e4", Frameless: true}]
+              InjectionPoints: [{PC: "0x80a8f4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2140,9 +2140,9 @@ Probes:
             - Kind: Entry
               Type: 3117 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
-                - PC: "0x80a514"
+                - PC: "0x80a924"
                   Frameless: false
-                - PC: "0x80a59c"
+                - PC: "0x80a9f4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -2275,7 +2275,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2857 EventRootType Probe[main.testInterface]
-              InjectionPoints: [{PC: "0x80a750", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ac20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{b}'
@@ -2302,7 +2302,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3037 EventRootType Probe[main.testInvalidUtf8Strings]
-              InjectionPoints: [{PC: "0x80f960", Frameless: true}]
+              InjectionPoints: [{PC: "0x810390", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -2328,11 +2328,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2990 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x80e330", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eba0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2991 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80e460", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ecd0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2354,7 +2354,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2898 EventRootType Probe[main.testLinkedList]
-              InjectionPoints: [{PC: "0x80ca70", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d220", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -2369,7 +2369,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["230"]
+        lines: ["233"]
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
       segments: [testLongFunctionWithChangingState]
@@ -2379,7 +2379,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2833 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x80690c", Frameless: false}]
+              InjectionPoints: [{PC: "0x806a8c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2390,7 +2390,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["237"]
+        lines: ["240"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2401,7 +2401,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2834 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x8069ac", Frameless: false}]
+              InjectionPoints: [{PC: "0x806b2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2412,7 +2412,7 @@ Probes:
       where:
         methodName: main.testLongFunctionWithChangingState
         sourceFile: complex.go
-        lines: ["242"]
+        lines: ["245"]
       tags: ['version_diff:go1.26rc1']
       sampling: {snapshotsPerSecond: 100}
       template: testLongFunctionWithChangingState
@@ -2423,7 +2423,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2835 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-              InjectionPoints: [{PC: "0x806a50", Frameless: false}]
+              InjectionPoints: [{PC: "0x806bd0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testLongFunctionWithChangingState
@@ -2466,11 +2466,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2996 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x80e79c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f00c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2997 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x80e8f0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f160", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2533,7 +2533,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2838 EventRootType Probe[main.testManyPointers]
-              InjectionPoints: [{PC: "0x807220", Frameless: true}]
+              InjectionPoints: [{PC: "0x807460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2557,7 +2557,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2839 EventRootType Probe[main.testManyStrings]
-              InjectionPoints: [{PC: "0x808dd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x809100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{ss}'
@@ -2579,7 +2579,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2868 EventRootType Probe[main.testMapArrayToArray]
-              InjectionPoints: [{PC: "0x80af20", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b490", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2601,7 +2601,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2875 EventRootType Probe[main.testMapEmbeddedMaps]
-              InjectionPoints: [{PC: "0x80af80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b4f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2623,7 +2623,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2885 EventRootType Probe[main.testMapEmptyKey]
-              InjectionPoints: [{PC: "0x80b020", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b590", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2645,7 +2645,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2887 EventRootType Probe[main.testMapEmptyKeyAndValue]
-              InjectionPoints: [{PC: "0x80b040", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b5b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2667,7 +2667,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2886 EventRootType Probe[main.testMapEmptyValue]
-              InjectionPoints: [{PC: "0x80b030", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2689,7 +2689,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2872 EventRootType Probe[main.testMapIntToInt]
-              InjectionPoints: [{PC: "0x80af60", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b4d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2711,7 +2711,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2884 EventRootType Probe[main.testMapLargeKeyLargeValue]
-              InjectionPoints: [{PC: "0x80b010", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2733,7 +2733,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2883 EventRootType Probe[main.testMapLargeKeySmallValue]
-              InjectionPoints: [{PC: "0x80b000", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b570", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2757,7 +2757,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2873 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x80af70", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2781,7 +2781,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2874 EventRootType Probe[main.testMapMassive]
-              InjectionPoints: [{PC: "0x80af70", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -2803,7 +2803,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2882 EventRootType Probe[main.testMapSmallKeyLargeValue]
-              InjectionPoints: [{PC: "0x80aff0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2825,7 +2825,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2881 EventRootType Probe[main.testMapSmallKeySmallValue]
-              InjectionPoints: [{PC: "0x80afe0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b550", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2847,7 +2847,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2866 EventRootType Probe[main.testMapStringToInt]
-              InjectionPoints: [{PC: "0x80af00", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b470", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2869,7 +2869,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2867 EventRootType Probe[main.testMapStringToSlice]
-              InjectionPoints: [{PC: "0x80af10", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2891,7 +2891,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2865 EventRootType Probe[main.testMapStringToStruct]
-              InjectionPoints: [{PC: "0x80aef0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2913,7 +2913,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2876 EventRootType Probe[main.testMapWithLinkedList]
-              InjectionPoints: [{PC: "0x80af90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2935,7 +2935,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2879 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-              InjectionPoints: [{PC: "0x80afc0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b530", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2957,7 +2957,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2880 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-              InjectionPoints: [{PC: "0x80afd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -2979,7 +2979,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2877 EventRootType Probe[main.testMapWithSmallValue]
-              InjectionPoints: [{PC: "0x80afa0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b510", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3003,7 +3003,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2878 EventRootType Probe[main.testMapWithSmallValueMassive]
-              InjectionPoints: [{PC: "0x80afb0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{redactMyEntries}'
@@ -3025,7 +3025,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3032 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80f920", Frameless: true}]
+              InjectionPoints: [{PC: "0x810350", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3048,7 +3048,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3033 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80f920", Frameless: true}]
+              InjectionPoints: [{PC: "0x810350", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3095,11 +3095,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2998 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x80e950", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f1c0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2999 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x80eadc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f34c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -3161,7 +3161,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3038 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0x80f970", Frameless: true}]
+              InjectionPoints: [{PC: "0x8103a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3184,7 +3184,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3039 EventRootType Probe[main.testMultibyteUtf8String]
-              InjectionPoints: [{PC: "0x80f970", Frameless: true}]
+              InjectionPoints: [{PC: "0x8103a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3210,11 +3210,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3002 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x80ebcc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f43c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3003 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x80ec68", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f4d8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3245,11 +3245,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2994 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x80e590", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ee00", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2995 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x80e738", Frameless: false}]
+              InjectionPoints: [{PC: "0x80efa8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3275,11 +3275,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2935 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80d638", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dea8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2936 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80d6bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80df2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3315,7 +3315,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2891 EventRootType Probe[main.testMultipleSimpleParams]
-              InjectionPoints: [{PC: "0x80c490", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ca00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -3356,11 +3356,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2929 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80d598", Frameless: false}]
+              InjectionPoints: [{PC: "0x80de08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2930 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80d5f4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80de64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -3384,11 +3384,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2931 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80d598", Frameless: false}]
+              InjectionPoints: [{PC: "0x80de08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2932 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80d5f4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80de64", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameMultiCaptureExpr
       version: 0
@@ -3407,11 +3407,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2937 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80d638", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dea8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2938 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80d6bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80df2c", Frameless: false}]
               Condition: null
     - id: testNamedReturnByNameTemplate
       version: 0
@@ -3431,11 +3431,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2939 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80d638", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dea8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2940 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80d6bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80df2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r1={result} r2={result2}
@@ -3468,11 +3468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2933 EventRootType Probe[main.testNamedReturn]
-              InjectionPoints: [{PC: "0x80d598", Frameless: false}]
+              InjectionPoints: [{PC: "0x80de08", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2934 EventRootType Probe[main.testNamedReturn]Return
-              InjectionPoints: [{PC: "0x80d5f4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80de64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Parameter {i} * 2 = result {result}
@@ -3500,7 +3500,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3044 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80fc00", Frameless: true}]
+              InjectionPoints: [{PC: "0x810700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3525,7 +3525,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3045 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80fc00", Frameless: true}]
+              InjectionPoints: [{PC: "0x810700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3556,7 +3556,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3046 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80fc00", Frameless: true}]
+              InjectionPoints: [{PC: "0x810700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3581,7 +3581,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3047 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80fc00", Frameless: true}]
+              InjectionPoints: [{PC: "0x810700", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3608,7 +3608,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2903 EventRootType Probe[main.testNilPointer]
-              InjectionPoints: [{PC: "0x80cb40", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d2f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}, {a}'
@@ -3635,7 +3635,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3016 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x80f2b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fb20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3662,7 +3662,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3013 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x80f280", Frameless: true}]
+              InjectionPoints: [{PC: "0x80faf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3697,7 +3697,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3015 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x80f2a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fb10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3729,7 +3729,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3031 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x80f910", Frameless: true}]
+              InjectionPoints: [{PC: "0x810340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3751,7 +3751,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2899 EventRootType Probe[main.testPointerLoop]
-              InjectionPoints: [{PC: "0x80ca80", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d230", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3773,7 +3773,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2871 EventRootType Probe[main.testPointerToMap]
-              InjectionPoints: [{PC: "0x80af50", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b4c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -3795,7 +3795,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2897 EventRootType Probe[main.testPointerToSimpleStruct]
-              InjectionPoints: [{PC: "0x80ca60", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d210", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3819,11 +3819,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2905 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80ce78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d6e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2906 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80ceb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d728", Frameless: false}]
               Condition: null
     - id: testReturnCondMulti
       version: 0
@@ -3843,11 +3843,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2949 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80d6f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80df68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2950 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80d780", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dff0", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3892,11 +3892,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2915 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80cf98", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d808", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2916 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80d028", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d898", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3938,11 +3938,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2907 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80ce78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d6e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2908 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80ceb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d728", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -3987,11 +3987,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2917 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80cf98", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d808", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2918 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80d028", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d898", Frameless: false}]
               Condition:
                 Type: 6 BaseType bool
                 Operations:
@@ -4035,11 +4035,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2951 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80d6f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80df68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2952 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80d780", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dff0", Frameless: false}]
               Condition: null
     - id: testReturnMultiTemplate
       version: 0
@@ -4056,11 +4056,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2953 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80d6f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80df68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2954 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80d780", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dff0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: r0={@return.r0}
@@ -4082,11 +4082,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2909 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80ce78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d6e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2910 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80ceb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d728", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: result={@return}
@@ -4109,18 +4109,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2925 EventRootType Probe[main.testReturnsAny]
-              InjectionPoints: [{PC: "0x80d268", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dad8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2926 EventRootType Probe[main.testReturnsAny]Return
               InjectionPoints:
-                - PC: "0x80d2f0"
+                - PC: "0x80db60"
                   Frameless: false
-                - PC: "0x80d344"
+                - PC: "0x80dbb4"
                   Frameless: false
-                - PC: "0x80d3fc"
+                - PC: "0x80dc6c"
                   Frameless: false
-                - PC: "0x80d410"
+                - PC: "0x80dc80"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4148,18 +4148,18 @@ Probes:
           events:
             - Kind: Entry
               Type: 2923 EventRootType Probe[main.testReturnsAnyAndError]
-              InjectionPoints: [{PC: "0x80d0e8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d958", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2924 EventRootType Probe[main.testReturnsAnyAndError]Return
               InjectionPoints:
-                - PC: "0x80d13c"
+                - PC: "0x80d9ac"
                   Frameless: false
-                - PC: "0x80d198"
+                - PC: "0x80da08"
                   Frameless: false
-                - PC: "0x80d1e0"
+                - PC: "0x80da50"
                   Frameless: false
-                - PC: "0x80d224"
+                - PC: "0x80da94"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4186,11 +4186,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2968 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x80dd6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e5dc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2969 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x80ddbc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e62c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -4207,11 +4207,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2970 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x80ddf8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e668", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2971 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x80de30", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e6a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -4228,11 +4228,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2972 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x80de68", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e6d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2973 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x80de9c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e70c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4249,11 +4249,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2976 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x80df58", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e7c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2977 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x80dfb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e828", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4270,11 +4270,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2988 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x80e2b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eb28", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2989 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x80e2f4", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eb64", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4291,11 +4291,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2964 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x80dc28", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e498", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2965 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x80dc70", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e4e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4313,14 +4313,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2921 EventRootType Probe[main.testReturnsError]
-              InjectionPoints: [{PC: "0x80d068", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d8d8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2922 EventRootType Probe[main.testReturnsError]Return
               InjectionPoints:
-                - PC: "0x80d09c"
+                - PC: "0x80d90c"
                   Frameless: false
-                - PC: "0x80d0b0"
+                - PC: "0x80d920"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4342,11 +4342,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2911 EventRootType Probe[main.testReturnsInt]
-              InjectionPoints: [{PC: "0x80ce78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d6e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2912 EventRootType Probe[main.testReturnsInt]Return
-              InjectionPoints: [{PC: "0x80ceb8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d728", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4367,11 +4367,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2919 EventRootType Probe[main.testReturnsIntAndFloat]
-              InjectionPoints: [{PC: "0x80cf98", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d808", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2920 EventRootType Probe[main.testReturnsIntAndFloat]Return
-              InjectionPoints: [{PC: "0x80d028", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d898", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4392,11 +4392,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2913 EventRootType Probe[main.testReturnsIntPointer]
-              InjectionPoints: [{PC: "0x80cef8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d768", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2914 EventRootType Probe[main.testReturnsIntPointer]Return
-              InjectionPoints: [{PC: "0x80cf54", Frameless: false}]
+              InjectionPoints: [{PC: "0x80d7c4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4418,14 +4418,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 2927 EventRootType Probe[main.testReturnsInterface]
-              InjectionPoints: [{PC: "0x80d448", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dcb8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2928 EventRootType Probe[main.testReturnsInterface]Return
               InjectionPoints:
-                - PC: "0x80d500"
+                - PC: "0x80dd70"
                   Frameless: false
-                - PC: "0x80d514"
+                - PC: "0x80dd84"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -4447,11 +4447,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2966 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x80dcb0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e520", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2967 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x80dd30", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e5a0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4468,11 +4468,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2962 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x80db78", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e3e8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2963 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x80dbf8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e468", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4489,11 +4489,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2980 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x80e0b8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e928", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2981 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x80e10c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e97c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4510,11 +4510,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2974 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x80ded8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e748", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2975 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x80df1c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e78c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4531,11 +4531,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2986 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x80e248", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eab8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2987 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x80e288", Frameless: false}]
+              InjectionPoints: [{PC: "0x80eaf8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
@@ -4555,7 +4555,7 @@ Probes:
           events:
             - Kind: Line
               Type: 2959 EventRootType Probe[main.testReturnsNamedDeferLine]Line
-              InjectionPoints: [{PC: "0x80d944", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e1b4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -4576,11 +4576,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2984 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x80e1d8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ea48", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2985 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x80e214", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ea84", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4597,11 +4597,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2960 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x80dae8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e358", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2961 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x80db3c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e3ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4618,11 +4618,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2982 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x80e14c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e9bc", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2983 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x80e19c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ea0c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4639,11 +4639,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2978 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x80dff0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e860", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2979 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x80e080", Frameless: false}]
+              InjectionPoints: [{PC: "0x80e8f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4696,11 +4696,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2941 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80d638", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dea8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2942 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80d6bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80df2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -4746,7 +4746,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2809 EventRootType Probe[main.testSingleBool]
-              InjectionPoints: [{PC: "0x806280", Frameless: true}]
+              InjectionPoints: [{PC: "0x806340", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4768,7 +4768,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2807 EventRootType Probe[main.testSingleByte]
-              InjectionPoints: [{PC: "0x806260", Frameless: true}]
+              InjectionPoints: [{PC: "0x806320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4790,7 +4790,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2820 EventRootType Probe[main.testSingleFloat32]
-              InjectionPoints: [{PC: "0x806330", Frameless: true}]
+              InjectionPoints: [{PC: "0x8063f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4808,7 +4808,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2821 EventRootType Probe[main.testSingleFloat64]
-              InjectionPoints: [{PC: "0x806340", Frameless: true}]
+              InjectionPoints: [{PC: "0x806400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4826,7 +4826,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2810 EventRootType Probe[main.testSingleInt]
-              InjectionPoints: [{PC: "0x806290", Frameless: true}]
+              InjectionPoints: [{PC: "0x806350", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4848,7 +4848,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2812 EventRootType Probe[main.testSingleInt16]
-              InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806370", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}
@@ -4871,7 +4871,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2813 EventRootType Probe[main.testSingleInt32]
-              InjectionPoints: [{PC: "0x8062c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4893,7 +4893,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2814 EventRootType Probe[main.testSingleInt64]
-              InjectionPoints: [{PC: "0x8062d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806390", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4922,7 +4922,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2811 EventRootType Probe[main.testSingleInt8]
-              InjectionPoints: [{PC: "0x8062a0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: parameter = {x}{x}{x}
@@ -4953,7 +4953,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2808 EventRootType Probe[main.testSingleRune]
-              InjectionPoints: [{PC: "0x806270", Frameless: true}]
+              InjectionPoints: [{PC: "0x806330", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4975,7 +4975,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3025 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x80f8d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810300", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4997,7 +4997,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2815 EventRootType Probe[main.testSingleUint]
-              InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8063a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5019,7 +5019,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2817 EventRootType Probe[main.testSingleUint16]
-              InjectionPoints: [{PC: "0x806300", Frameless: true}]
+              InjectionPoints: [{PC: "0x8063c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5041,7 +5041,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2818 EventRootType Probe[main.testSingleUint32]
-              InjectionPoints: [{PC: "0x806310", Frameless: true}]
+              InjectionPoints: [{PC: "0x8063d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5063,7 +5063,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2819 EventRootType Probe[main.testSingleUint64]
-              InjectionPoints: [{PC: "0x806320", Frameless: true}]
+              InjectionPoints: [{PC: "0x8063e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5085,7 +5085,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2816 EventRootType Probe[main.testSingleUint8]
-              InjectionPoints: [{PC: "0x8062f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5107,7 +5107,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3019 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x80f2d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fb40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5129,7 +5129,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3010 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x80f250", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5151,7 +5151,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2869 EventRootType Probe[main.testSmallMap]
-              InjectionPoints: [{PC: "0x80af30", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b4a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{m}'
@@ -5172,11 +5172,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2955 EventRootType Probe[main.testSomeNamedReturn]
-              InjectionPoints: [{PC: "0x80d6f8", Frameless: false}]
+              InjectionPoints: [{PC: "0x80df68", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2956 EventRootType Probe[main.testSomeNamedReturn]Return
-              InjectionPoints: [{PC: "0x80d780", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dff0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{i}'
@@ -5197,11 +5197,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3000 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x80eb38", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f3a8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3001 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x80eb94", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f404", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5245,7 +5245,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2902 EventRootType Probe[main.testStringPointer]
-              InjectionPoints: [{PC: "0x80cb20", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d2d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{z}'
@@ -5267,7 +5267,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3014 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x80f290", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fb00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5289,7 +5289,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2831 EventRootType Probe[main.testStringType1]
-              InjectionPoints: [{PC: "0x8068d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806a50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5311,7 +5311,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2832 EventRootType Probe[main.testStringType2]
-              InjectionPoints: [{PC: "0x8068e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x806a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5333,7 +5333,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3043 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80fba0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8106a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5360,7 +5360,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3011 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x80f260", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fad0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5387,7 +5387,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2863 EventRootType Probe[main.testStructWithAny]
-              InjectionPoints: [{PC: "0x80a830", Frameless: true}]
+              InjectionPoints: [{PC: "0x80ad00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5408,11 +5408,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3004 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x80ec9c", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f50c", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3005 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x80ed24", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f594", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5434,7 +5434,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3041 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x80fb00", Frameless: true}]
+              InjectionPoints: [{PC: "0x810600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5455,7 +5455,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3040 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x80faf0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8105f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5482,7 +5482,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2864 EventRootType Probe[main.testStructWithMap]
-              InjectionPoints: [{PC: "0x80aee0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80b450", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s} {@duration}'
@@ -5515,7 +5515,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3020 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x80f2e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fb50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5555,7 +5555,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3036 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x80f950", Frameless: true}]
+              InjectionPoints: [{PC: "0x810380", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5587,7 +5587,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2836 EventRootType Probe[main.testTakeContext]
-              InjectionPoints: [{PC: "0x806dd0", Frameless: true}]
+              InjectionPoints: [{PC: "0x807010", Frameless: true}]
               Condition: null
     - id: testTemplateWithNonexistantVariableName
       version: 0
@@ -5603,11 +5603,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2943 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80d638", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dea8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2944 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80d6bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80df2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{nonexistentVariable}'
@@ -5628,11 +5628,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2945 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80d638", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dea8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2946 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80d6bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80df2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{unsupportedExpression}'
@@ -5655,11 +5655,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 2947 EventRootType Probe[main.testMultipleNamedReturn]
-              InjectionPoints: [{PC: "0x80d638", Frameless: false}]
+              InjectionPoints: [{PC: "0x80dea8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 2948 EventRootType Probe[main.testMultipleNamedReturn]Return
-              InjectionPoints: [{PC: "0x80d6bc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80df2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -5691,7 +5691,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3026 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x80f8e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810310", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5723,7 +5723,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3027 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80f8f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5753,7 +5753,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3028 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80f8f0", Frameless: true}]
+              InjectionPoints: [{PC: "0x810320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5785,7 +5785,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3029 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80f900", Frameless: true}]
+              InjectionPoints: [{PC: "0x810330", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5815,7 +5815,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3030 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80f900", Frameless: true}]
+              InjectionPoints: [{PC: "0x810330", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5847,7 +5847,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3052 EventRootType Probe[main.testTimeFixedZone]
-              InjectionPoints: [{PC: "0x8105d0", Frameless: true}]
+              InjectionPoints: [{PC: "0x811190", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5869,7 +5869,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3053 EventRootType Probe[main.testTimeMonotonic]
-              InjectionPoints: [{PC: "0x8105e0", Frameless: true}]
+              InjectionPoints: [{PC: "0x8111a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{c}'
@@ -5891,7 +5891,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3051 EventRootType Probe[main.testTimeUTC]
-              InjectionPoints: [{PC: "0x8105c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x811180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5913,7 +5913,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2822 EventRootType Probe[main.testTypeAlias]
-              InjectionPoints: [{PC: "0x806350", Frameless: true}]
+              InjectionPoints: [{PC: "0x806410", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6045,7 +6045,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2901 EventRootType Probe[main.testUintPointer]
-              InjectionPoints: [{PC: "0x80cab0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d260", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6067,7 +6067,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3008 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x80f230", Frameless: true}]
+              InjectionPoints: [{PC: "0x80faa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -6089,7 +6089,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3034 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x80f930", Frameless: true}]
+              InjectionPoints: [{PC: "0x810360", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6111,7 +6111,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 2900 EventRootType Probe[main.testUnsafePointer]
-              InjectionPoints: [{PC: "0x80ca90", Frameless: true}]
+              InjectionPoints: [{PC: "0x80d240", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -6155,7 +6155,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3017 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80f2c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fb30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6177,7 +6177,7 @@ Probes:
           events:
             - Kind: Entry
               Type: 3018 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80f2c0", Frameless: true}]
+              InjectionPoints: [{PC: "0x80fb30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -6200,14 +6200,14 @@ Probes:
             - Kind: Entry
               Type: 3118 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
-                - PC: "0x80a698"
+                - PC: "0x80ab68"
                   Frameless: false
-                - PC: "0x811f00"
+                - PC: "0x812b80"
                   Frameless: false
               Condition: null
             - Kind: Return
               Type: 3119 EventRootType Probe[main.firstBehavior.DoSomething]Return
-              InjectionPoints: [{PC: "0x80a6c0", Frameless: false}]
+              InjectionPoints: [{PC: "0x80ab90", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testWhollyInlinedSubroutine
@@ -6229,11 +6229,11 @@ Probes:
           events:
             - Kind: Entry
               Type: 3006 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x80ed58", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f5c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 3007 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80edbc", Frameless: false}]
+              InjectionPoints: [{PC: "0x80f62c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -6530,13 +6530,13 @@ Subprograms:
       DictRegister: null
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x806260..0x806270]
+      OutOfLinePCRanges: [0x806320..0x806330]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x806260..0x806270
+            - Range: 0x806320..0x806330
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6544,13 +6544,13 @@ Subprograms:
       DictRegister: null
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x806270..0x806280]
+      OutOfLinePCRanges: [0x806330..0x806340]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x806270..0x806280
+            - Range: 0x806330..0x806340
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6558,13 +6558,13 @@ Subprograms:
       DictRegister: null
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x806280..0x806290]
+      OutOfLinePCRanges: [0x806340..0x806350]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x806280..0x806290
+            - Range: 0x806340..0x806350
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6572,13 +6572,13 @@ Subprograms:
       DictRegister: null
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x806290..0x8062a0]
+      OutOfLinePCRanges: [0x806350..0x806360]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x806290..0x8062a0
+            - Range: 0x806350..0x806360
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6586,13 +6586,13 @@ Subprograms:
       DictRegister: null
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x8062a0..0x8062b0]
+      OutOfLinePCRanges: [0x806360..0x806370]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 21 BaseType int8
           Locations:
-            - Range: 0x8062a0..0x8062b0
+            - Range: 0x806360..0x806370
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6600,13 +6600,13 @@ Subprograms:
       DictRegister: null
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x8062b0..0x8062c0]
+      OutOfLinePCRanges: [0x806370..0x806380]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 BaseType int16
           Locations:
-            - Range: 0x8062b0..0x8062c0
+            - Range: 0x806370..0x806380
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6614,13 +6614,13 @@ Subprograms:
       DictRegister: null
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x8062c0..0x8062d0]
+      OutOfLinePCRanges: [0x806380..0x806390]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x8062c0..0x8062d0
+            - Range: 0x806380..0x806390
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6628,13 +6628,13 @@ Subprograms:
       DictRegister: null
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x8062d0..0x8062e0]
+      OutOfLinePCRanges: [0x806390..0x8063a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int64
           Locations:
-            - Range: 0x8062d0..0x8062e0
+            - Range: 0x806390..0x8063a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6642,13 +6642,13 @@ Subprograms:
       DictRegister: null
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x8062e0..0x8062f0]
+      OutOfLinePCRanges: [0x8063a0..0x8063b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType uint
           Locations:
-            - Range: 0x8062e0..0x8062f0
+            - Range: 0x8063a0..0x8063b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6656,13 +6656,13 @@ Subprograms:
       DictRegister: null
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x8062f0..0x806300]
+      OutOfLinePCRanges: [0x8063b0..0x8063c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x8062f0..0x806300
+            - Range: 0x8063b0..0x8063c0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6670,13 +6670,13 @@ Subprograms:
       DictRegister: null
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x806300..0x806310]
+      OutOfLinePCRanges: [0x8063c0..0x8063d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0x806300..0x806310
+            - Range: 0x8063c0..0x8063d0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6684,13 +6684,13 @@ Subprograms:
       DictRegister: null
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x806310..0x806320]
+      OutOfLinePCRanges: [0x8063d0..0x8063e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint32
           Locations:
-            - Range: 0x806310..0x806320
+            - Range: 0x8063d0..0x8063e0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6698,13 +6698,13 @@ Subprograms:
       DictRegister: null
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x806320..0x806330]
+      OutOfLinePCRanges: [0x8063e0..0x8063f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x806320..0x806330
+            - Range: 0x8063e0..0x8063f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6712,13 +6712,13 @@ Subprograms:
       DictRegister: null
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x806330..0x806340]
+      OutOfLinePCRanges: [0x8063f0..0x806400]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 BaseType float32
           Locations:
-            - Range: 0x806330..0x806340
+            - Range: 0x8063f0..0x806400
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6726,13 +6726,13 @@ Subprograms:
       DictRegister: null
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x806340..0x806350]
+      OutOfLinePCRanges: [0x806400..0x806410]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x806340..0x806350
+            - Range: 0x806400..0x806410
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6740,13 +6740,13 @@ Subprograms:
       DictRegister: null
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x806350..0x806360]
+      OutOfLinePCRanges: [0x806410..0x806420]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 136 BaseType main.typeAlias
           Locations:
-            - Range: 0x806350..0x806360
+            - Range: 0x806410..0x806420
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6754,13 +6754,13 @@ Subprograms:
       DictRegister: null
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x806450..0x806460]
+      OutOfLinePCRanges: [0x8065d0..0x8065e0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 137 StructureType main.bigStruct
           Locations:
-            - Range: 0x806450..0x806460
+            - Range: 0x8065d0..0x8065e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6780,45 +6780,45 @@ Subprograms:
       DictRegister: null
     - ID: 38
       Name: main.testErrorAtLine
-      OutOfLinePCRanges: [0x806480..0x806590]
+      OutOfLinePCRanges: [0x806600..0x806710]
       InlinePCRanges: []
       Variables:
         - Name: shouldErr
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x806480..0x8064a0
+            - Range: 0x806600..0x806620
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x806480..0x806590, Pieces: []}]
+          Locations: [{Range: 0x806600..0x806710, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: x
           Type: 9 BaseType int
-          Locations: [{Range: 0x806480..0x806590, Pieces: []}]
+          Locations: [{Range: 0x806600..0x806710, Pieces: []}]
           Role: Local
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: err
           Type: 17 GoInterfaceType error
           Locations:
-            - Range: 0x806498..0x8064dc
+            - Range: 0x806618..0x80665c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x8064dc..0x80653c
+            - Range: 0x80665c..0x8066bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
-            - Range: 0x80653c..0x806590
+            - Range: 0x8066bc..0x806710
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
@@ -6830,13 +6830,13 @@ Subprograms:
       DictRegister: null
     - ID: 39
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x806620..0x806630]
+      OutOfLinePCRanges: [0x8067a0..0x8067b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 141 StructureType main.deepPtr1
           Locations:
-            - Range: 0x806620..0x806630
+            - Range: 0x8067a0..0x8067b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6844,13 +6844,13 @@ Subprograms:
       DictRegister: null
     - ID: 40
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x806630..0x806640]
+      OutOfLinePCRanges: [0x8067b0..0x8067c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 144 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x806630..0x806640
+            - Range: 0x8067b0..0x8067c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -6858,13 +6858,13 @@ Subprograms:
       DictRegister: null
     - ID: 41
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x806750..0x806760]
+      OutOfLinePCRanges: [0x8068d0..0x8068e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 146 StructureType main.deepSlice1
           Locations:
-            - Range: 0x806750..0x806760
+            - Range: 0x8068d0..0x8068e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6878,67 +6878,11 @@ Subprograms:
       DictRegister: null
     - ID: 42
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x806760..0x806770]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 150 PointerType *main.deepSlice7
-          Locations:
-            - Range: 0x806760..0x806770
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 43
-      Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x8068b0..0x8068c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 152 StructureType main.deepMap1
-          Locations:
-            - Range: 0x8068b0..0x8068c0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 44
-      Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x8068c0..0x8068d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 158 PointerType *main.deepMap7
-          Locations:
-            - Range: 0x8068c0..0x8068d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 45
-      Name: main.testStringType1
-      OutOfLinePCRanges: [0x8068d0..0x8068e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 160 PointerType *main.stringType1
-          Locations:
-            - Range: 0x8068d0..0x8068e0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-          LoopBaseOffset: 0
-      DictRegister: null
-    - ID: 46
-      Name: main.testStringType2
       OutOfLinePCRanges: [0x8068e0..0x8068f0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 162 PointerType **main.stringType2
+          Type: 150 PointerType *main.deepSlice7
           Locations:
             - Range: 0x8068e0..0x8068f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -6946,17 +6890,73 @@ Subprograms:
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
+    - ID: 43
+      Name: main.testDeepMap1
+      OutOfLinePCRanges: [0x806a30..0x806a40]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 152 StructureType main.deepMap1
+          Locations:
+            - Range: 0x806a30..0x806a40
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 44
+      Name: main.testDeepMap7
+      OutOfLinePCRanges: [0x806a40..0x806a50]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 158 PointerType *main.deepMap7
+          Locations:
+            - Range: 0x806a40..0x806a50
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 45
+      Name: main.testStringType1
+      OutOfLinePCRanges: [0x806a50..0x806a60]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 160 PointerType *main.stringType1
+          Locations:
+            - Range: 0x806a50..0x806a60
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
+    - ID: 46
+      Name: main.testStringType2
+      OutOfLinePCRanges: [0x806a60..0x806a70]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 162 PointerType **main.stringType2
+          Locations:
+            - Range: 0x806a60..0x806a70
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+          LoopBaseOffset: 0
+      DictRegister: null
     - ID: 47
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x8068f0..0x806ad0]
+      OutOfLinePCRanges: [0x806a70..0x806c50]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8069ac..0x8069c0
+            - Range: 0x806b2c..0x806b40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806a50..0x806a64
+            - Range: 0x806bd0..0x806be4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -6964,7 +6964,7 @@ Subprograms:
         - Name: aPerArch
           Type: 9 BaseType int
           Locations:
-            - Range: 0x806910..0x806ad0
+            - Range: 0x806a90..0x806c50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -6972,21 +6972,21 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80698c..0x806998
+            - Range: 0x806b0c..0x806b18
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806998..0x806998
+            - Range: 0x806b18..0x806b18
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x806998..0x8069ac
+            - Range: 0x806b18..0x806b2c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8069ac..0x806a44
+            - Range: 0x806b2c..0x806bc4
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x806a44..0x806a48
+            - Range: 0x806bc4..0x806bc8
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x806a48..0x806a4c
+            - Range: 0x806bc8..0x806bcc
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x806a4c..0x806a64
+            - Range: 0x806bcc..0x806be4
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x806a64..0x806ad0
+            - Range: 0x806be4..0x806c50
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
           DictIndex: -1
@@ -6994,13 +6994,13 @@ Subprograms:
       DictRegister: null
     - ID: 48
       Name: main.testTakeContext
-      OutOfLinePCRanges: [0x806dd0..0x806de0]
+      OutOfLinePCRanges: [0x807010..0x807020]
       InlinePCRanges: []
       Variables:
         - Name: ctx
           Type: 164 GoInterfaceType context.Context
           Locations:
-            - Range: 0x806dd0..0x806de0
+            - Range: 0x807010..0x807020
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7012,13 +7012,13 @@ Subprograms:
       DictRegister: null
     - ID: 49
       Name: main.testCaptureContextImpl
-      OutOfLinePCRanges: [0x806f80..0x806f90]
+      OutOfLinePCRanges: [0x8071c0..0x8071d0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 165 PointerType *main.contextImpl
           Locations:
-            - Range: 0x806f80..0x806f90
+            - Range: 0x8071c0..0x8071d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7026,13 +7026,13 @@ Subprograms:
       DictRegister: null
     - ID: 50
       Name: main.testManyPointers
-      OutOfLinePCRanges: [0x807220..0x807230]
+      OutOfLinePCRanges: [0x807460..0x807470]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 167 StructureType main.manyPointers
           Locations:
-            - Range: 0x807220..0x807230
+            - Range: 0x807460..0x807470
               Pieces: [{Size: 560, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7040,13 +7040,13 @@ Subprograms:
       DictRegister: null
     - ID: 51
       Name: main.testManyStrings
-      OutOfLinePCRanges: [0x808dd0..0x808de0]
+      OutOfLinePCRanges: [0x809100..0x809110]
       InlinePCRanges: []
       Variables:
         - Name: ss
           Type: 170 GoSliceHeaderType []string
           Locations:
-            - Range: 0x808dd0..0x808de0
+            - Range: 0x809100..0x809110
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7060,13 +7060,13 @@ Subprograms:
       DictRegister: null
     - ID: 52
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x8090a0..0x809160]
+      OutOfLinePCRanges: [0x8094b0..0x809570]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 171 StructureType main.esotericStack
           Locations:
-            - Range: 0x8090a0..0x8090d8
+            - Range: 0x8094b0..0x8094e8
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -7086,7 +7086,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x8090d8..0x8090dc
+            - Range: 0x8094e8..0x8094ec
               Pieces:
                 - Size: 4
                   Op: null
@@ -7106,7 +7106,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x8090dc..0x8090e0
+            - Range: 0x8094ec..0x8094f0
               Pieces:
                 - Size: 4
                   Op: null
@@ -7132,13 +7132,13 @@ Subprograms:
       DictRegister: null
     - ID: 53
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x809160..0x8091d0]
+      OutOfLinePCRanges: [0x809570..0x8095e0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 174 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x809160..0x809194
+            - Range: 0x809570..0x8095a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7146,13 +7146,13 @@ Subprograms:
       DictRegister: null
     - ID: 54
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x80a210..0x80a2a0]
+      OutOfLinePCRanges: [0x80a620..0x80a6b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80a210..0x80a240
+            - Range: 0x80a620..0x80a650
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7160,13 +7160,13 @@ Subprograms:
       DictRegister: null
     - ID: 55
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x80a2a0..0x80a360]
+      OutOfLinePCRanges: [0x80a6b0..0x80a770]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80a2a0..0x80a2bc
+            - Range: 0x80a6b0..0x80a6cc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7174,7 +7174,7 @@ Subprograms:
         - Name: "y"
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80a2a0..0x80a2cc
+            - Range: 0x80a6b0..0x80a6dc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7182,9 +7182,9 @@ Subprograms:
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80a2bc..0x80a2cc
+            - Range: 0x80a6cc..0x80a6dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a2cc..0x80a360
+            - Range: 0x80a6dc..0x80a770
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
           DictIndex: -1
@@ -7192,13 +7192,13 @@ Subprograms:
       DictRegister: null
     - ID: 56
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x80a360..0x80a3d0]
+      OutOfLinePCRanges: [0x80a770..0x80a7e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80a360..0x80a384
+            - Range: 0x80a770..0x80a794
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7206,15 +7206,15 @@ Subprograms:
       DictRegister: null
     - ID: 57
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x80a3d0..0x80a4e0]
+      OutOfLinePCRanges: [0x80a7e0..0x80a8f0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80a3ec..0x80a458
+            - Range: 0x80a7fc..0x80a868
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a458..0x80a460
+            - Range: 0x80a868..0x80a870
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7222,9 +7222,9 @@ Subprograms:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80a3ec..0x80a458
+            - Range: 0x80a7fc..0x80a868
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a458..0x80a45c
+            - Range: 0x80a868..0x80a86c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -7232,13 +7232,13 @@ Subprograms:
       DictRegister: null
     - ID: 58
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x80a4e0..0x80a4f0]
+      OutOfLinePCRanges: [0x80a8f0..0x80a900]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80a4e0..0x80a4e8
+            - Range: 0x80a8f0..0x80a8f8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7246,11 +7246,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80a4e0..0x80a4e8
+            - Range: 0x80a8f0..0x80a8f8
               Pieces: []
-            - Range: 0x80a4e8..0x80a4e9
+            - Range: 0x80a8f8..0x80a8f9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a4e9..0x80a4f0
+            - Range: 0x80a8f9..0x80a900
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7258,13 +7258,13 @@ Subprograms:
       DictRegister: null
     - ID: 59
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x80a4f0..0x80a540]
+      OutOfLinePCRanges: [0x80a900..0x80a950]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 176 ArrayType [5]int
           Locations:
-            - Range: 0x80a4f0..0x80a540
+            - Range: 0x80a900..0x80a950
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7272,11 +7272,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80a4f0..0x80a530
+            - Range: 0x80a900..0x80a940
               Pieces: []
-            - Range: 0x80a530..0x80a531
+            - Range: 0x80a940..0x80a941
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a531..0x80a540
+            - Range: 0x80a941..0x80a950
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7284,13 +7284,13 @@ Subprograms:
       DictRegister: null
     - ID: 60
       Name: main.testInterface
-      OutOfLinePCRanges: [0x80a750..0x80a760]
+      OutOfLinePCRanges: [0x80ac20..0x80ac30]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 177 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80a750..0x80a760
+            - Range: 0x80ac20..0x80ac30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7302,19 +7302,19 @@ Subprograms:
       DictRegister: null
     - ID: 61
       Name: main.testAny
-      OutOfLinePCRanges: [0x80a760..0x80a7c0]
+      OutOfLinePCRanges: [0x80ac30..0x80ac90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 61 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a760..0x80a78c
+            - Range: 0x80ac30..0x80ac5c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a78c..0x80a790
+            - Range: 0x80ac5c..0x80ac60
               Pieces:
                 - Size: 8
                   Op: null
@@ -7326,15 +7326,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80a760..0x80a7a0
+            - Range: 0x80ac30..0x80ac70
               Pieces: []
-            - Range: 0x80a7a0..0x80a7a1
+            - Range: 0x80ac70..0x80ac71
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a7a1..0x80a7c0
+            - Range: 0x80ac71..0x80ac90
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7342,13 +7342,13 @@ Subprograms:
       DictRegister: null
     - ID: 62
       Name: main.testError
-      OutOfLinePCRanges: [0x80a7c0..0x80a7d0]
+      OutOfLinePCRanges: [0x80ac90..0x80aca0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 17 GoInterfaceType error
           Locations:
-            - Range: 0x80a7c0..0x80a7d0
+            - Range: 0x80ac90..0x80aca0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7360,13 +7360,13 @@ Subprograms:
       DictRegister: null
     - ID: 63
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x80a7d0..0x80a830]
+      OutOfLinePCRanges: [0x80aca0..0x80ad00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 178 PointerType *interface {}
           Locations:
-            - Range: 0x80a7d0..0x80a7fc
+            - Range: 0x80aca0..0x80accc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7374,15 +7374,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80a7d0..0x80a810
+            - Range: 0x80aca0..0x80ace0
               Pieces: []
-            - Range: 0x80a810..0x80a811
+            - Range: 0x80ace0..0x80ace1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a811..0x80a830
+            - Range: 0x80ace1..0x80ad00
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7390,13 +7390,13 @@ Subprograms:
       DictRegister: null
     - ID: 64
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x80a830..0x80a840]
+      OutOfLinePCRanges: [0x80ad00..0x80ad10]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 179 StructureType main.structWithAny
           Locations:
-            - Range: 0x80a830..0x80a840
+            - Range: 0x80ad00..0x80ad10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7408,13 +7408,13 @@ Subprograms:
       DictRegister: null
     - ID: 65
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x80aee0..0x80aef0]
+      OutOfLinePCRanges: [0x80b450..0x80b460]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 180 StructureType main.structWithMap
           Locations:
-            - Range: 0x80aee0..0x80aef0
+            - Range: 0x80b450..0x80b460
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7422,13 +7422,13 @@ Subprograms:
       DictRegister: null
     - ID: 66
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x80aef0..0x80af00]
+      OutOfLinePCRanges: [0x80b460..0x80b470]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 186 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x80aef0..0x80af00
+            - Range: 0x80b460..0x80b470
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7436,13 +7436,13 @@ Subprograms:
       DictRegister: null
     - ID: 67
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x80af00..0x80af10]
+      OutOfLinePCRanges: [0x80b470..0x80b480]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 191 GoMapType map[string]int
           Locations:
-            - Range: 0x80af00..0x80af10
+            - Range: 0x80b470..0x80b480
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7450,13 +7450,13 @@ Subprograms:
       DictRegister: null
     - ID: 68
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x80af10..0x80af20]
+      OutOfLinePCRanges: [0x80b480..0x80b490]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 196 GoMapType map[string][]string
           Locations:
-            - Range: 0x80af10..0x80af20
+            - Range: 0x80b480..0x80b490
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7464,13 +7464,13 @@ Subprograms:
       DictRegister: null
     - ID: 69
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x80af20..0x80af30]
+      OutOfLinePCRanges: [0x80b490..0x80b4a0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 201 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x80af20..0x80af30
+            - Range: 0x80b490..0x80b4a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7478,13 +7478,13 @@ Subprograms:
       DictRegister: null
     - ID: 70
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x80af30..0x80af40]
+      OutOfLinePCRanges: [0x80b4a0..0x80b4b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 191 GoMapType map[string]int
           Locations:
-            - Range: 0x80af30..0x80af40
+            - Range: 0x80b4a0..0x80b4b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7492,13 +7492,13 @@ Subprograms:
       DictRegister: null
     - ID: 71
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x80af40..0x80af50]
+      OutOfLinePCRanges: [0x80b4b0..0x80b4c0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 206 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x80af40..0x80af50
+            - Range: 0x80b4b0..0x80b4c0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -7506,13 +7506,13 @@ Subprograms:
       DictRegister: null
     - ID: 72
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x80af50..0x80af60]
+      OutOfLinePCRanges: [0x80b4c0..0x80b4d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 207 PointerType *map[string]int
           Locations:
-            - Range: 0x80af50..0x80af60
+            - Range: 0x80b4c0..0x80b4d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7520,13 +7520,13 @@ Subprograms:
       DictRegister: null
     - ID: 73
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x80af60..0x80af70]
+      OutOfLinePCRanges: [0x80b4d0..0x80b4e0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 181 GoMapType map[int]int
           Locations:
-            - Range: 0x80af60..0x80af70
+            - Range: 0x80b4d0..0x80b4e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7534,13 +7534,13 @@ Subprograms:
       DictRegister: null
     - ID: 74
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x80af70..0x80af80]
+      OutOfLinePCRanges: [0x80b4e0..0x80b4f0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 208 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x80af70..0x80af80
+            - Range: 0x80b4e0..0x80b4f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7548,13 +7548,13 @@ Subprograms:
       DictRegister: null
     - ID: 75
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x80af80..0x80af90]
+      OutOfLinePCRanges: [0x80b4f0..0x80b500]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 208 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x80af80..0x80af90
+            - Range: 0x80b4f0..0x80b500
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7562,13 +7562,13 @@ Subprograms:
       DictRegister: null
     - ID: 76
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x80af90..0x80afa0]
+      OutOfLinePCRanges: [0x80b500..0x80b510]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 213 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x80af90..0x80afa0
+            - Range: 0x80b500..0x80b510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7576,13 +7576,13 @@ Subprograms:
       DictRegister: null
     - ID: 77
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x80afa0..0x80afb0]
+      OutOfLinePCRanges: [0x80b510..0x80b520]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 218 GoMapType map[int]uint8
           Locations:
-            - Range: 0x80afa0..0x80afb0
+            - Range: 0x80b510..0x80b520
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7590,13 +7590,13 @@ Subprograms:
       DictRegister: null
     - ID: 78
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x80afb0..0x80afc0]
+      OutOfLinePCRanges: [0x80b520..0x80b530]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 218 GoMapType map[int]uint8
           Locations:
-            - Range: 0x80afb0..0x80afc0
+            - Range: 0x80b520..0x80b530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7604,13 +7604,13 @@ Subprograms:
       DictRegister: null
     - ID: 79
       Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x80afc0..0x80afd0]
+      OutOfLinePCRanges: [0x80b530..0x80b540]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 223 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x80afc0..0x80afd0
+            - Range: 0x80b530..0x80b540
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7618,13 +7618,13 @@ Subprograms:
       DictRegister: null
     - ID: 80
       Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x80afd0..0x80afe0]
+      OutOfLinePCRanges: [0x80b540..0x80b550]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 223 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x80afd0..0x80afe0
+            - Range: 0x80b540..0x80b550
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7632,13 +7632,13 @@ Subprograms:
       DictRegister: null
     - ID: 81
       Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x80afe0..0x80aff0]
+      OutOfLinePCRanges: [0x80b550..0x80b560]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 223 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x80afe0..0x80aff0
+            - Range: 0x80b550..0x80b560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7646,13 +7646,13 @@ Subprograms:
       DictRegister: null
     - ID: 82
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x80aff0..0x80b000]
+      OutOfLinePCRanges: [0x80b560..0x80b570]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 228 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x80aff0..0x80b000
+            - Range: 0x80b560..0x80b570
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7660,13 +7660,13 @@ Subprograms:
       DictRegister: null
     - ID: 83
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x80b000..0x80b010]
+      OutOfLinePCRanges: [0x80b570..0x80b580]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 233 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x80b000..0x80b010
+            - Range: 0x80b570..0x80b580
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7674,13 +7674,13 @@ Subprograms:
       DictRegister: null
     - ID: 84
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x80b010..0x80b020]
+      OutOfLinePCRanges: [0x80b580..0x80b590]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 238 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x80b010..0x80b020
+            - Range: 0x80b580..0x80b590
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7688,13 +7688,13 @@ Subprograms:
       DictRegister: null
     - ID: 85
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x80b020..0x80b030]
+      OutOfLinePCRanges: [0x80b590..0x80b5a0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 243 GoMapType map[struct {}]int
           Locations:
-            - Range: 0x80b020..0x80b030
+            - Range: 0x80b590..0x80b5a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7702,13 +7702,13 @@ Subprograms:
       DictRegister: null
     - ID: 86
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x80b030..0x80b040]
+      OutOfLinePCRanges: [0x80b5a0..0x80b5b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 248 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x80b030..0x80b040
+            - Range: 0x80b5a0..0x80b5b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7716,13 +7716,13 @@ Subprograms:
       DictRegister: null
     - ID: 87
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0x80b040..0x80b050]
+      OutOfLinePCRanges: [0x80b5b0..0x80b5c0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 253 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0x80b040..0x80b050
+            - Range: 0x80b5b0..0x80b5c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7730,13 +7730,13 @@ Subprograms:
       DictRegister: null
     - ID: 88
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x80c3b0..0x80c3c0]
+      OutOfLinePCRanges: [0x80c920..0x80c930]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80c3b0..0x80c3c0
+            - Range: 0x80c920..0x80c930
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7744,7 +7744,7 @@ Subprograms:
         - Name: x
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80c3b0..0x80c3c0
+            - Range: 0x80c920..0x80c930
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7752,7 +7752,7 @@ Subprograms:
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0x80c3b0..0x80c3c0
+            - Range: 0x80c920..0x80c930
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7760,13 +7760,13 @@ Subprograms:
       DictRegister: null
     - ID: 89
       Name: main.testCombinedString
-      OutOfLinePCRanges: [0x80c3d0..0x80c3e0]
+      OutOfLinePCRanges: [0x80c940..0x80c950]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80c3d0..0x80c3e0
+            - Range: 0x80c940..0x80c950
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7774,7 +7774,7 @@ Subprograms:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80c3d0..0x80c3e0
+            - Range: 0x80c940..0x80c950
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7786,7 +7786,7 @@ Subprograms:
         - Name: "y"
           Type: 19 BaseType float32
           Locations:
-            - Range: 0x80c3d0..0x80c3e0
+            - Range: 0x80c940..0x80c950
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7794,13 +7794,13 @@ Subprograms:
       DictRegister: null
     - ID: 90
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x80c490..0x80c4a0]
+      OutOfLinePCRanges: [0x80ca00..0x80ca10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80c490..0x80c4a0
+            - Range: 0x80ca00..0x80ca10
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7808,7 +7808,7 @@ Subprograms:
         - Name: b
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80c490..0x80c4a0
+            - Range: 0x80ca00..0x80ca10
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7816,7 +7816,7 @@ Subprograms:
         - Name: c
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x80c490..0x80c4a0
+            - Range: 0x80ca00..0x80ca10
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7824,7 +7824,7 @@ Subprograms:
         - Name: d
           Type: 13 BaseType uint
           Locations:
-            - Range: 0x80c490..0x80c4a0
+            - Range: 0x80ca00..0x80ca10
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7832,7 +7832,7 @@ Subprograms:
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80c490..0x80c4a0
+            - Range: 0x80ca00..0x80ca10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7844,13 +7844,13 @@ Subprograms:
       DictRegister: null
     - ID: 91
       Name: main.(*Server).handleOrder
-      OutOfLinePCRanges: [0x80c630..0x80c7f0]
+      OutOfLinePCRanges: [0x80cc60..0x80ce20]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 258 PointerType *main.Server
           Locations:
-            - Range: 0x80c630..0x80c678
+            - Range: 0x80cc60..0x80cca8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7858,9 +7858,9 @@ Subprograms:
         - Name: req
           Type: 260 PointerType *main.Request
           Locations:
-            - Range: 0x80c630..0x80c678
+            - Range: 0x80cc60..0x80cca8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80c678..0x80c7f0
+            - Range: 0x80cca8..0x80ce20
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -7868,23 +7868,23 @@ Subprograms:
         - Name: ~r0
           Type: 17 GoInterfaceType error
           Locations:
-            - Range: 0x80c630..0x80c724
+            - Range: 0x80cc60..0x80cd54
               Pieces: []
-            - Range: 0x80c724..0x80c725
+            - Range: 0x80cd54..0x80cd55
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c725..0x80c7c8
+            - Range: 0x80cd55..0x80cdf8
               Pieces: []
-            - Range: 0x80c7c8..0x80c7c9
+            - Range: 0x80cdf8..0x80cdf9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c7c9..0x80c7f0
+            - Range: 0x80cdf9..0x80ce20
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7892,13 +7892,13 @@ Subprograms:
       DictRegister: null
     - ID: 92
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x80c8a0..0x80c8e0]
+      OutOfLinePCRanges: [0x80cf90..0x80cfd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x80c8a0..0x80c8dc
+            - Range: 0x80cf90..0x80cfcc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7906,11 +7906,11 @@ Subprograms:
         - Name: ~r0
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x80c8a0..0x80c8dc
+            - Range: 0x80cf90..0x80cfcc
               Pieces: []
-            - Range: 0x80c8dc..0x80c8dd
+            - Range: 0x80cfcc..0x80cfcd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c8dd..0x80c8e0
+            - Range: 0x80cfcd..0x80cfd0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -7918,13 +7918,13 @@ Subprograms:
       DictRegister: null
     - ID: 93
       Name: main.testChannel
-      OutOfLinePCRanges: [0x80c8e0..0x80c8f0]
+      OutOfLinePCRanges: [0x80cfd0..0x80cfe0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 262 GoChannelType chan bool
           Locations:
-            - Range: 0x80c8e0..0x80c8f0
+            - Range: 0x80cfd0..0x80cfe0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7932,13 +7932,13 @@ Subprograms:
       DictRegister: null
     - ID: 94
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x80ca60..0x80ca70]
+      OutOfLinePCRanges: [0x80d210..0x80d220]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 263 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x80ca60..0x80ca70
+            - Range: 0x80d210..0x80d220
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7946,13 +7946,13 @@ Subprograms:
       DictRegister: null
     - ID: 95
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x80ca70..0x80ca80]
+      OutOfLinePCRanges: [0x80d220..0x80d230]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 265 StructureType main.node
           Locations:
-            - Range: 0x80ca70..0x80ca80
+            - Range: 0x80d220..0x80d230
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7964,13 +7964,13 @@ Subprograms:
       DictRegister: null
     - ID: 96
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x80ca80..0x80ca90]
+      OutOfLinePCRanges: [0x80d230..0x80d240]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 266 PointerType *main.node
           Locations:
-            - Range: 0x80ca80..0x80ca90
+            - Range: 0x80d230..0x80d240
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7978,13 +7978,13 @@ Subprograms:
       DictRegister: null
     - ID: 97
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x80ca90..0x80caa0]
+      OutOfLinePCRanges: [0x80d240..0x80d250]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x80ca90..0x80caa0
+            - Range: 0x80d240..0x80d250
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -7992,13 +7992,13 @@ Subprograms:
       DictRegister: null
     - ID: 98
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x80cab0..0x80cac0]
+      OutOfLinePCRanges: [0x80d260..0x80d270]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 115 PointerType *uint
           Locations:
-            - Range: 0x80cab0..0x80cac0
+            - Range: 0x80d260..0x80d270
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8006,13 +8006,13 @@ Subprograms:
       DictRegister: null
     - ID: 99
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x80cb20..0x80cb30]
+      OutOfLinePCRanges: [0x80d2d0..0x80d2e0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 104 PointerType *string
           Locations:
-            - Range: 0x80cb20..0x80cb30
+            - Range: 0x80d2d0..0x80d2e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8020,13 +8020,13 @@ Subprograms:
       DictRegister: null
     - ID: 100
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x80cb40..0x80cb50]
+      OutOfLinePCRanges: [0x80d2f0..0x80d300]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 12 PointerType *bool
           Locations:
-            - Range: 0x80cb40..0x80cb50
+            - Range: 0x80d2f0..0x80d300
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8034,7 +8034,7 @@ Subprograms:
         - Name: a
           Type: 13 BaseType uint
           Locations:
-            - Range: 0x80cb40..0x80cb50
+            - Range: 0x80d2f0..0x80d300
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8042,13 +8042,13 @@ Subprograms:
       DictRegister: null
     - ID: 101
       Name: main.testCycle
-      OutOfLinePCRanges: [0x80cb60..0x80cb70]
+      OutOfLinePCRanges: [0x80d310..0x80d320]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 267 PointerType *main.t
           Locations:
-            - Range: 0x80cb60..0x80cb70
+            - Range: 0x80d310..0x80d320
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8056,13 +8056,13 @@ Subprograms:
       DictRegister: null
     - ID: 102
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x80ce60..0x80cee0]
+      OutOfLinePCRanges: [0x80d6d0..0x80d750]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ce60..0x80ce7c
+            - Range: 0x80d6d0..0x80d6ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8070,11 +8070,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ce60..0x80ceb8
+            - Range: 0x80d6d0..0x80d728
               Pieces: []
-            - Range: 0x80ceb8..0x80ceb9
+            - Range: 0x80d728..0x80d729
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ceb9..0x80cee0
+            - Range: 0x80d729..0x80d750
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8082,9 +8082,9 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ce7c..0x80ce88
+            - Range: 0x80d6ec..0x80d6f8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ce88..0x80cee0
+            - Range: 0x80d6f8..0x80d750
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: -1
@@ -8092,15 +8092,15 @@ Subprograms:
       DictRegister: null
     - ID: 103
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x80cee0..0x80cf80]
+      OutOfLinePCRanges: [0x80d750..0x80d7f0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80cee0..0x80cf04
+            - Range: 0x80d750..0x80d774
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80cf04..0x80cf80
+            - Range: 0x80d774..0x80d7f0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8108,11 +8108,11 @@ Subprograms:
         - Name: ~r0
           Type: 108 PointerType *int
           Locations:
-            - Range: 0x80cee0..0x80cf54
+            - Range: 0x80d750..0x80d7c4
               Pieces: []
-            - Range: 0x80cf54..0x80cf55
+            - Range: 0x80d7c4..0x80d7c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80cf55..0x80cf80
+            - Range: 0x80d7c5..0x80d7f0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8120,9 +8120,9 @@ Subprograms:
         - Name: '&result'
           Type: 108 PointerType *int
           Locations:
-            - Range: 0x80cf08..0x80cf20
+            - Range: 0x80d778..0x80d790
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80cf20..0x80cf80
+            - Range: 0x80d790..0x80d7f0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
           DictIndex: -1
@@ -8130,13 +8130,13 @@ Subprograms:
       DictRegister: null
     - ID: 104
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x80cf80..0x80d050]
+      OutOfLinePCRanges: [0x80d7f0..0x80d8c0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80cf80..0x80cfd8
+            - Range: 0x80d7f0..0x80d848
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8144,27 +8144,27 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80cf80..0x80d028
+            - Range: 0x80d7f0..0x80d898
               Pieces: []
-            - Range: 0x80d028..0x80d029
+            - Range: 0x80d898..0x80d899
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d029..0x80d050
+            - Range: 0x80d899..0x80d8c0
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80cf80..0x80d050, Pieces: []}]
+          Locations: [{Range: 0x80d7f0..0x80d8c0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80cf9c..0x80cfdc
+            - Range: 0x80d80c..0x80d84c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80cfdc..0x80d050
+            - Range: 0x80d84c..0x80d8c0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: -1
@@ -8172,9 +8172,9 @@ Subprograms:
         - Name: resultFloat
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x80cfac..0x80cfdc
+            - Range: 0x80d81c..0x80d84c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x80cfdc..0x80d050
+            - Range: 0x80d84c..0x80d8c0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: -1
@@ -8182,13 +8182,13 @@ Subprograms:
       DictRegister: null
     - ID: 105
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x80d050..0x80d0d0]
+      OutOfLinePCRanges: [0x80d8c0..0x80d940]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80d050..0x80d070
+            - Range: 0x80d8c0..0x80d8e0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8196,23 +8196,23 @@ Subprograms:
         - Name: ~r0
           Type: 17 GoInterfaceType error
           Locations:
-            - Range: 0x80d050..0x80d09c
+            - Range: 0x80d8c0..0x80d90c
               Pieces: []
-            - Range: 0x80d09c..0x80d09d
+            - Range: 0x80d90c..0x80d90d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d09d..0x80d0b0
+            - Range: 0x80d90d..0x80d920
               Pieces: []
-            - Range: 0x80d0b0..0x80d0b1
+            - Range: 0x80d920..0x80d921
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d0b1..0x80d0d0
+            - Range: 0x80d921..0x80d940
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8220,31 +8220,31 @@ Subprograms:
       DictRegister: null
     - ID: 106
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x80d0d0..0x80d250]
+      OutOfLinePCRanges: [0x80d940..0x80dac0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 61 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80d0d0..0x80d120
+            - Range: 0x80d940..0x80d990
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d120..0x80d124
+            - Range: 0x80d990..0x80d994
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x80d1a8..0x80d1b0
+            - Range: 0x80da18..0x80da20
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d1f0..0x80d1f8
+            - Range: 0x80da60..0x80da68
               Pieces:
                 - Size: 8
                   Op: null
@@ -8256,7 +8256,7 @@ Subprograms:
         - Name: failed
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80d0d0..0x80d128
+            - Range: 0x80d940..0x80d998
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8264,39 +8264,39 @@ Subprograms:
         - Name: ~r0
           Type: 61 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80d0d0..0x80d13c
+            - Range: 0x80d940..0x80d9ac
               Pieces: []
-            - Range: 0x80d13c..0x80d13d
+            - Range: 0x80d9ac..0x80d9ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d13d..0x80d198
+            - Range: 0x80d9ad..0x80da08
               Pieces: []
-            - Range: 0x80d198..0x80d199
+            - Range: 0x80da08..0x80da09
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d199..0x80d1e0
+            - Range: 0x80da09..0x80da50
               Pieces: []
-            - Range: 0x80d1e0..0x80d1e1
+            - Range: 0x80da50..0x80da51
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d1e1..0x80d224
+            - Range: 0x80da51..0x80da94
               Pieces: []
-            - Range: 0x80d224..0x80d225
+            - Range: 0x80da94..0x80da95
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d225..0x80d250
+            - Range: 0x80da95..0x80dac0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8304,39 +8304,39 @@ Subprograms:
         - Name: ~r1
           Type: 17 GoInterfaceType error
           Locations:
-            - Range: 0x80d0d0..0x80d13c
+            - Range: 0x80d940..0x80d9ac
               Pieces: []
-            - Range: 0x80d13c..0x80d13d
+            - Range: 0x80d9ac..0x80d9ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80d13d..0x80d198
+            - Range: 0x80d9ad..0x80da08
               Pieces: []
-            - Range: 0x80d198..0x80d199
+            - Range: 0x80da08..0x80da09
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80d199..0x80d1e0
+            - Range: 0x80da09..0x80da50
               Pieces: []
-            - Range: 0x80d1e0..0x80d1e1
+            - Range: 0x80da50..0x80da51
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80d1e1..0x80d224
+            - Range: 0x80da51..0x80da94
               Pieces: []
-            - Range: 0x80d224..0x80d225
+            - Range: 0x80da94..0x80da95
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80d225..0x80d250
+            - Range: 0x80da95..0x80dac0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8344,7 +8344,7 @@ Subprograms:
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d120..0x80d128
+            - Range: 0x80d990..0x80d998
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8352,25 +8352,25 @@ Subprograms:
       DictRegister: null
     - ID: 107
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x80d250..0x80d430]
+      OutOfLinePCRanges: [0x80dac0..0x80dca0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 61 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80d250..0x80d290
+            - Range: 0x80dac0..0x80db00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d290..0x80d298
+            - Range: 0x80db00..0x80db08
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80d298..0x80d430
+            - Range: 0x80db08..0x80dca0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -8382,39 +8382,39 @@ Subprograms:
         - Name: ~r0
           Type: 61 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80d250..0x80d2f0
+            - Range: 0x80dac0..0x80db60
               Pieces: []
-            - Range: 0x80d2f0..0x80d2f1
+            - Range: 0x80db60..0x80db61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d2f1..0x80d344
+            - Range: 0x80db61..0x80dbb4
               Pieces: []
-            - Range: 0x80d344..0x80d345
+            - Range: 0x80dbb4..0x80dbb5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d345..0x80d3fc
+            - Range: 0x80dbb5..0x80dc6c
               Pieces: []
-            - Range: 0x80d3fc..0x80d3fd
+            - Range: 0x80dc6c..0x80dc6d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d3fd..0x80d410
+            - Range: 0x80dc6d..0x80dc80
               Pieces: []
-            - Range: 0x80d410..0x80d411
+            - Range: 0x80dc80..0x80dc81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d411..0x80d430
+            - Range: 0x80dc81..0x80dca0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8422,7 +8422,7 @@ Subprograms:
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d2dc..0x80d2e4
+            - Range: 0x80db4c..0x80db54
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8430,7 +8430,7 @@ Subprograms:
         - Name: '&result'
           Type: 108 PointerType *int
           Locations:
-            - Range: 0x80d328..0x80d344
+            - Range: 0x80db98..0x80dbb4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -8438,35 +8438,35 @@ Subprograms:
       DictRegister: null
     - ID: 108
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x80d430..0x80d580]
+      OutOfLinePCRanges: [0x80dca0..0x80ddf0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 61 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80d430..0x80d46c
+            - Range: 0x80dca0..0x80dcdc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d46c..0x80d4b0
+            - Range: 0x80dcdc..0x80dd20
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80d4b0..0x80d520
+            - Range: 0x80dd20..0x80dd90
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80d520..0x80d548
+            - Range: 0x80dd90..0x80ddb8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80d548..0x80d54c
+            - Range: 0x80ddb8..0x80ddbc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80d54c..0x80d580
+            - Range: 0x80ddbc..0x80ddf0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -8474,23 +8474,23 @@ Subprograms:
         - Name: ~r0
           Type: 177 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80d430..0x80d500
+            - Range: 0x80dca0..0x80dd70
               Pieces: []
-            - Range: 0x80d500..0x80d501
+            - Range: 0x80dd70..0x80dd71
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d501..0x80d514
+            - Range: 0x80dd71..0x80dd84
               Pieces: []
-            - Range: 0x80d514..0x80d515
+            - Range: 0x80dd84..0x80dd85
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d515..0x80d580
+            - Range: 0x80dd85..0x80ddf0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8498,39 +8498,39 @@ Subprograms:
         - Name: b
           Type: 177 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80d430..0x80d46c
+            - Range: 0x80dca0..0x80dcdc
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80d46c..0x80d4b0
+            - Range: 0x80dcdc..0x80dd20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80d4b0..0x80d4b8
+            - Range: 0x80dd20..0x80dd28
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80d4b8..0x80d50c
+            - Range: 0x80dd28..0x80dd7c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80d50c..0x80d510
+            - Range: 0x80dd7c..0x80dd80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80d510..0x80d514
+            - Range: 0x80dd80..0x80dd84
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80d514..0x80d580
+            - Range: 0x80dd84..0x80ddf0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
           DictIndex: -1
@@ -8538,13 +8538,13 @@ Subprograms:
       DictRegister: null
     - ID: 109
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x80d580..0x80d620]
+      OutOfLinePCRanges: [0x80ddf0..0x80de90]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d580..0x80d59c
+            - Range: 0x80ddf0..0x80de0c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8552,11 +8552,11 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d580..0x80d5f4
+            - Range: 0x80ddf0..0x80de64
               Pieces: []
-            - Range: 0x80d5f4..0x80d5f5
+            - Range: 0x80de64..0x80de65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d5f5..0x80d620
+            - Range: 0x80de65..0x80de90
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8564,13 +8564,13 @@ Subprograms:
       DictRegister: null
     - ID: 110
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x80d620..0x80d6e0]
+      OutOfLinePCRanges: [0x80de90..0x80df50]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d620..0x80d670
+            - Range: 0x80de90..0x80dee0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -8578,11 +8578,11 @@ Subprograms:
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d620..0x80d6bc
+            - Range: 0x80de90..0x80df2c
               Pieces: []
-            - Range: 0x80d6bc..0x80d6bd
+            - Range: 0x80df2c..0x80df2d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d6bd..0x80d6e0
+            - Range: 0x80df2d..0x80df50
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8590,11 +8590,11 @@ Subprograms:
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d620..0x80d6bc
+            - Range: 0x80de90..0x80df2c
               Pieces: []
-            - Range: 0x80d6bc..0x80d6bd
+            - Range: 0x80df2c..0x80df2d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80d6bd..0x80d6e0
+            - Range: 0x80df2d..0x80df50
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8602,15 +8602,15 @@ Subprograms:
       DictRegister: null
     - ID: 111
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x80d6e0..0x80d7a0]
+      OutOfLinePCRanges: [0x80df50..0x80e010]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d6e0..0x80d720
+            - Range: 0x80df50..0x80df90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d720..0x80d7a0
+            - Range: 0x80df90..0x80e010
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8618,11 +8618,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d6e0..0x80d780
+            - Range: 0x80df50..0x80dff0
               Pieces: []
-            - Range: 0x80d780..0x80d781
+            - Range: 0x80dff0..0x80dff1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d781..0x80d7a0
+            - Range: 0x80dff1..0x80e010
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8630,11 +8630,11 @@ Subprograms:
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d6e0..0x80d780
+            - Range: 0x80df50..0x80dff0
               Pieces: []
-            - Range: 0x80d780..0x80d781
+            - Range: 0x80dff0..0x80dff1
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80d781..0x80d7a0
+            - Range: 0x80dff1..0x80e010
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8642,11 +8642,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d6e0..0x80d780
+            - Range: 0x80df50..0x80dff0
               Pieces: []
-            - Range: 0x80d780..0x80d781
+            - Range: 0x80dff0..0x80dff1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80d781..0x80d7a0
+            - Range: 0x80dff1..0x80e010
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8654,15 +8654,15 @@ Subprograms:
       DictRegister: null
     - ID: 112
       Name: main.testConflictingReturn
-      OutOfLinePCRanges: [0x80d7a0..0x80d880]
+      OutOfLinePCRanges: [0x80e010..0x80e0f0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d7a0..0x80d7e0
+            - Range: 0x80e010..0x80e050
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d7e0..0x80d880
+            - Range: 0x80e050..0x80e0f0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8670,11 +8670,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d7a0..0x80d85c
+            - Range: 0x80e010..0x80e0cc
               Pieces: []
-            - Range: 0x80d85c..0x80d85d
+            - Range: 0x80e0cc..0x80e0cd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d85d..0x80d880
+            - Range: 0x80e0cd..0x80e0f0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8682,15 +8682,15 @@ Subprograms:
         - Name: r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80d7a0..0x80d85c
+            - Range: 0x80e010..0x80e0cc
               Pieces: []
-            - Range: 0x80d85c..0x80d85d
+            - Range: 0x80e0cc..0x80e0cd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80d85d..0x80d880
+            - Range: 0x80e0cd..0x80e0f0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8698,15 +8698,15 @@ Subprograms:
       DictRegister: null
     - ID: 113
       Name: main.testReturnsNamedDeferLine
-      OutOfLinePCRanges: [0x80d880..0x80da10]
+      OutOfLinePCRanges: [0x80e0f0..0x80e280]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80d880..0x80d8e0
+            - Range: 0x80e0f0..0x80e150
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d8e0..0x80da10
+            - Range: 0x80e150..0x80e280
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -8714,7 +8714,7 @@ Subprograms:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80d8ac..0x80da10
+            - Range: 0x80e11c..0x80e280
               Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
           Role: Return
           DictIndex: -1
@@ -8722,7 +8722,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80d8b0..0x80da10
+            - Range: 0x80e120..0x80e280
               Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
           Role: Return
           DictIndex: -1
@@ -8730,17 +8730,17 @@ Subprograms:
       DictRegister: null
     - ID: 114
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x80dad0..0x80db60]
+      OutOfLinePCRanges: [0x80e340..0x80e3d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 21 BaseType int8
           Locations:
-            - Range: 0x80dad0..0x80db3c
+            - Range: 0x80e340..0x80e3ac
               Pieces: []
-            - Range: 0x80db3c..0x80db3d
+            - Range: 0x80e3ac..0x80e3ad
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80db3d..0x80db60
+            - Range: 0x80e3ad..0x80e3d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8748,11 +8748,11 @@ Subprograms:
         - Name: ~r1
           Type: 105 BaseType int16
           Locations:
-            - Range: 0x80dad0..0x80db3c
+            - Range: 0x80e340..0x80e3ac
               Pieces: []
-            - Range: 0x80db3c..0x80db3d
+            - Range: 0x80e3ac..0x80e3ad
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80db3d..0x80db60
+            - Range: 0x80e3ad..0x80e3d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8760,11 +8760,11 @@ Subprograms:
         - Name: ~r2
           Type: 14 BaseType int32
           Locations:
-            - Range: 0x80dad0..0x80db3c
+            - Range: 0x80e340..0x80e3ac
               Pieces: []
-            - Range: 0x80db3c..0x80db3d
+            - Range: 0x80e3ac..0x80e3ad
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80db3d..0x80db60
+            - Range: 0x80e3ad..0x80e3d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8772,11 +8772,11 @@ Subprograms:
         - Name: ~r3
           Type: 15 BaseType int64
           Locations:
-            - Range: 0x80dad0..0x80db3c
+            - Range: 0x80e340..0x80e3ac
               Pieces: []
-            - Range: 0x80db3c..0x80db3d
+            - Range: 0x80e3ac..0x80e3ad
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80db3d..0x80db60
+            - Range: 0x80e3ad..0x80e3d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8784,11 +8784,11 @@ Subprograms:
         - Name: ~r4
           Type: 5 BaseType uint8
           Locations:
-            - Range: 0x80dad0..0x80db3c
+            - Range: 0x80e340..0x80e3ac
               Pieces: []
-            - Range: 0x80db3c..0x80db3d
+            - Range: 0x80e3ac..0x80e3ad
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80db3d..0x80db60
+            - Range: 0x80e3ad..0x80e3d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8796,11 +8796,11 @@ Subprograms:
         - Name: ~r5
           Type: 8 BaseType uint16
           Locations:
-            - Range: 0x80dad0..0x80db3c
+            - Range: 0x80e340..0x80e3ac
               Pieces: []
-            - Range: 0x80db3c..0x80db3d
+            - Range: 0x80e3ac..0x80e3ad
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80db3d..0x80db60
+            - Range: 0x80e3ad..0x80e3d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8808,11 +8808,11 @@ Subprograms:
         - Name: ~r6
           Type: 4 BaseType uint32
           Locations:
-            - Range: 0x80dad0..0x80db3c
+            - Range: 0x80e340..0x80e3ac
               Pieces: []
-            - Range: 0x80db3c..0x80db3d
+            - Range: 0x80e3ac..0x80e3ad
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80db3d..0x80db60
+            - Range: 0x80e3ad..0x80e3d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8820,11 +8820,11 @@ Subprograms:
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x80dad0..0x80db3c
+            - Range: 0x80e340..0x80e3ac
               Pieces: []
-            - Range: 0x80db3c..0x80db3d
+            - Range: 0x80e3ac..0x80e3ad
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80db3d..0x80db60
+            - Range: 0x80e3ad..0x80e3d0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8832,113 +8832,113 @@ Subprograms:
       DictRegister: null
     - ID: 115
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x80db60..0x80dc10]
+      OutOfLinePCRanges: [0x80e3d0..0x80e480]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r5
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r6
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r7
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r8
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r9
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r10
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r11
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r12
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r13
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r14
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: onlyOnAmd64_16
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80db60..0x80dc10, Pieces: []}]
+          Locations: [{Range: 0x80e3d0..0x80e480, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: bothArmAndAmd64
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x80db60..0x80dbf8
+            - Range: 0x80e3d0..0x80e468
               Pieces: []
-            - Range: 0x80dbf8..0x80dbf9
+            - Range: 0x80e468..0x80e469
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80dbf9..0x80dc10
+            - Range: 0x80e469..0x80e480
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -8946,33 +8946,33 @@ Subprograms:
       DictRegister: null
     - ID: 116
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x80dc10..0x80dc90]
+      OutOfLinePCRanges: [0x80e480..0x80e500]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 106 BaseType complex64
-          Locations: [{Range: 0x80dc10..0x80dc90, Pieces: []}]
+          Locations: [{Range: 0x80e480..0x80e500, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 20 BaseType complex128
-          Locations: [{Range: 0x80dc10..0x80dc90, Pieces: []}]
+          Locations: [{Range: 0x80e480..0x80e500, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 117
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x80dc90..0x80dd50]
+      OutOfLinePCRanges: [0x80e500..0x80e5c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 269 StructureType main.largeStruct
           Locations:
-            - Range: 0x80dc90..0x80dd30
+            - Range: 0x80e500..0x80e5a0
               Pieces: []
-            - Range: 0x80dd30..0x80dd31
+            - Range: 0x80e5a0..0x80e5a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8994,7 +8994,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80dd31..0x80dd50
+            - Range: 0x80e5a1..0x80e5c0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9002,17 +9002,17 @@ Subprograms:
       DictRegister: null
     - ID: 118
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x80dd50..0x80dde0]
+      OutOfLinePCRanges: [0x80e5c0..0x80e650]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 270 ArrayType [3]int
           Locations:
-            - Range: 0x80dd50..0x80ddbc
+            - Range: 0x80e5c0..0x80e62c
               Pieces: []
-            - Range: 0x80ddbc..0x80ddbd
+            - Range: 0x80e62c..0x80e62d
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80ddbd..0x80dde0
+            - Range: 0x80e62d..0x80e650
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9020,17 +9020,17 @@ Subprograms:
       DictRegister: null
     - ID: 119
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x80dde0..0x80de50]
+      OutOfLinePCRanges: [0x80e650..0x80e6c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 271 ArrayType [1]int
           Locations:
-            - Range: 0x80dde0..0x80de30
+            - Range: 0x80e650..0x80e6a0
               Pieces: []
-            - Range: 0x80de30..0x80de31
+            - Range: 0x80e6a0..0x80e6a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80de31..0x80de50
+            - Range: 0x80e6a1..0x80e6c0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9038,17 +9038,17 @@ Subprograms:
       DictRegister: null
     - ID: 120
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x80de50..0x80dec0]
+      OutOfLinePCRanges: [0x80e6c0..0x80e730]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 272 ArrayType [0]int
           Locations:
-            - Range: 0x80de50..0x80de9c
+            - Range: 0x80e6c0..0x80e70c
               Pieces: []
-            - Range: 0x80de9c..0x80de9d
+            - Range: 0x80e70c..0x80e70d
               Pieces: []
-            - Range: 0x80de9d..0x80dec0
+            - Range: 0x80e70d..0x80e730
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9056,29 +9056,29 @@ Subprograms:
       DictRegister: null
     - ID: 121
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x80dec0..0x80df40]
+      OutOfLinePCRanges: [0x80e730..0x80e7b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 273 StructureType main.mixedStruct
-          Locations: [{Range: 0x80dec0..0x80df40, Pieces: []}]
+          Locations: [{Range: 0x80e730..0x80e7b0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 122
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x80df40..0x80dfd0]
+      OutOfLinePCRanges: [0x80e7b0..0x80e840]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80df40..0x80dfb8
+            - Range: 0x80e7b0..0x80e828
               Pieces: []
-            - Range: 0x80dfb8..0x80dfb9
+            - Range: 0x80e828..0x80e829
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80dfb9..0x80dfd0
+            - Range: 0x80e829..0x80e840
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9086,11 +9086,11 @@ Subprograms:
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80df40..0x80dfb8
+            - Range: 0x80e7b0..0x80e828
               Pieces: []
-            - Range: 0x80dfb8..0x80dfb9
+            - Range: 0x80e828..0x80e829
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80dfb9..0x80dfd0
+            - Range: 0x80e829..0x80e840
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9098,11 +9098,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80df40..0x80dfb8
+            - Range: 0x80e7b0..0x80e828
               Pieces: []
-            - Range: 0x80dfb8..0x80dfb9
+            - Range: 0x80e828..0x80e829
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80dfb9..0x80dfd0
+            - Range: 0x80e829..0x80e840
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9110,11 +9110,11 @@ Subprograms:
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80df40..0x80dfb8
+            - Range: 0x80e7b0..0x80e828
               Pieces: []
-            - Range: 0x80dfb8..0x80dfb9
+            - Range: 0x80e828..0x80e829
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80dfb9..0x80dfd0
+            - Range: 0x80e829..0x80e840
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9122,11 +9122,11 @@ Subprograms:
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80df40..0x80dfb8
+            - Range: 0x80e7b0..0x80e828
               Pieces: []
-            - Range: 0x80dfb8..0x80dfb9
+            - Range: 0x80e828..0x80e829
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80dfb9..0x80dfd0
+            - Range: 0x80e829..0x80e840
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9134,11 +9134,11 @@ Subprograms:
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80df40..0x80dfb8
+            - Range: 0x80e7b0..0x80e828
               Pieces: []
-            - Range: 0x80dfb8..0x80dfb9
+            - Range: 0x80e828..0x80e829
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80dfb9..0x80dfd0
+            - Range: 0x80e829..0x80e840
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9146,11 +9146,11 @@ Subprograms:
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80df40..0x80dfb8
+            - Range: 0x80e7b0..0x80e828
               Pieces: []
-            - Range: 0x80dfb8..0x80dfb9
+            - Range: 0x80e828..0x80e829
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80dfb9..0x80dfd0
+            - Range: 0x80e829..0x80e840
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9158,11 +9158,11 @@ Subprograms:
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80df40..0x80dfb8
+            - Range: 0x80e7b0..0x80e828
               Pieces: []
-            - Range: 0x80dfb8..0x80dfb9
+            - Range: 0x80e828..0x80e829
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80dfb9..0x80dfd0
+            - Range: 0x80e829..0x80e840
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9170,15 +9170,15 @@ Subprograms:
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80df40..0x80dfb8
+            - Range: 0x80e7b0..0x80e828
               Pieces: []
-            - Range: 0x80dfb8..0x80dfb9
+            - Range: 0x80e828..0x80e829
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80dfb9..0x80dfd0
+            - Range: 0x80e829..0x80e840
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9186,15 +9186,15 @@ Subprograms:
       DictRegister: null
     - ID: 123
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x80dfd0..0x80e0a0]
+      OutOfLinePCRanges: [0x80e840..0x80e910]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 274 StructureType main.wideStruct
           Locations:
-            - Range: 0x80dfd0..0x80e080
+            - Range: 0x80e840..0x80e8f0
               Pieces: []
-            - Range: 0x80e080..0x80e081
+            - Range: 0x80e8f0..0x80e8f1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9218,7 +9218,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x80e081..0x80e0a0
+            - Range: 0x80e8f1..0x80e910
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9226,57 +9226,57 @@ Subprograms:
       DictRegister: null
     - ID: 124
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x80e0a0..0x80e130]
+      OutOfLinePCRanges: [0x80e910..0x80e9a0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e0a0..0x80e10c
+            - Range: 0x80e910..0x80e97c
               Pieces: []
-            - Range: 0x80e10c..0x80e10d
+            - Range: 0x80e97c..0x80e97d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e10d..0x80e130
+            - Range: 0x80e97d..0x80e9a0
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80e0a0..0x80e130, Pieces: []}]
+          Locations: [{Range: 0x80e910..0x80e9a0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e0a0..0x80e10c
+            - Range: 0x80e910..0x80e97c
               Pieces: []
-            - Range: 0x80e10c..0x80e10d
+            - Range: 0x80e97c..0x80e97d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80e10d..0x80e130
+            - Range: 0x80e97d..0x80e9a0
               Pieces: []
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80e0a0..0x80e130, Pieces: []}]
+          Locations: [{Range: 0x80e910..0x80e9a0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80e0a0..0x80e10c
+            - Range: 0x80e910..0x80e97c
               Pieces: []
-            - Range: 0x80e10c..0x80e10d
+            - Range: 0x80e97c..0x80e97d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80e10d..0x80e130
+            - Range: 0x80e97d..0x80e9a0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9284,17 +9284,17 @@ Subprograms:
       DictRegister: null
     - ID: 125
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x80e130..0x80e1c0]
+      OutOfLinePCRanges: [0x80e9a0..0x80ea30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 275 StructureType main.structWithArray
           Locations:
-            - Range: 0x80e130..0x80e19c
+            - Range: 0x80e9a0..0x80ea0c
               Pieces: []
-            - Range: 0x80e19c..0x80e19d
+            - Range: 0x80ea0c..0x80ea0d
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80e19d..0x80e1c0
+            - Range: 0x80ea0d..0x80ea30
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9302,47 +9302,47 @@ Subprograms:
       DictRegister: null
     - ID: 126
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x80e1c0..0x80e230]
+      OutOfLinePCRanges: [0x80ea30..0x80eaa0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80e1c0..0x80e230, Pieces: []}]
+          Locations: [{Range: 0x80ea30..0x80eaa0, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 127
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x80e230..0x80e2a0]
+      OutOfLinePCRanges: [0x80eaa0..0x80eb10]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType float32
-          Locations: [{Range: 0x80e230..0x80e2a0, Pieces: []}]
+          Locations: [{Range: 0x80eaa0..0x80eb10, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80e230..0x80e2a0, Pieces: []}]
+          Locations: [{Range: 0x80eaa0..0x80eb10, Pieces: []}]
           Role: Return
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 128
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x80e2a0..0x80e310]
+      OutOfLinePCRanges: [0x80eb10..0x80eb80]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x80e2a0..0x80e2f4
+            - Range: 0x80eb10..0x80eb64
               Pieces: []
-            - Range: 0x80e2f4..0x80e2f5
+            - Range: 0x80eb64..0x80eb65
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e2f5..0x80e310
+            - Range: 0x80eb65..0x80eb80
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9350,11 +9350,11 @@ Subprograms:
         - Name: ~r1
           Type: 3 BaseType uintptr
           Locations:
-            - Range: 0x80e2a0..0x80e2f4
+            - Range: 0x80eb10..0x80eb64
               Pieces: []
-            - Range: 0x80e2f4..0x80e2f5
+            - Range: 0x80eb64..0x80eb65
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80e2f5..0x80e310
+            - Range: 0x80eb65..0x80eb80
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9362,13 +9362,13 @@ Subprograms:
       DictRegister: null
     - ID: 129
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x80e310..0x80e4a0]
+      OutOfLinePCRanges: [0x80eb80..0x80ed10]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 269 StructureType main.largeStruct
           Locations:
-            - Range: 0x80e310..0x80e344
+            - Range: 0x80eb80..0x80ebb4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9390,7 +9390,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80e344..0x80e374
+            - Range: 0x80ebb4..0x80ebe4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9412,7 +9412,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80e374..0x80e37c
+            - Range: 0x80ebe4..0x80ebec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9434,7 +9434,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80e37c..0x80e380
+            - Range: 0x80ebec..0x80ebf0
               Pieces:
                 - Size: 8
                   Op: null
@@ -9462,9 +9462,9 @@ Subprograms:
         - Name: ~r0
           Type: 269 StructureType main.largeStruct
           Locations:
-            - Range: 0x80e310..0x80e460
+            - Range: 0x80eb80..0x80ecd0
               Pieces: []
-            - Range: 0x80e460..0x80e461
+            - Range: 0x80ecd0..0x80ecd1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9486,7 +9486,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80e461..0x80e4a0
+            - Range: 0x80ecd1..0x80ed10
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9494,13 +9494,13 @@ Subprograms:
       DictRegister: null
     - ID: 130
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x80e4a0..0x80e570]
+      OutOfLinePCRanges: [0x80ed10..0x80ede0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 270 ArrayType [3]int
           Locations:
-            - Range: 0x80e4a0..0x80e570
+            - Range: 0x80ed10..0x80ede0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9508,11 +9508,11 @@ Subprograms:
         - Name: ~r0
           Type: 270 ArrayType [3]int
           Locations:
-            - Range: 0x80e4a0..0x80e550
+            - Range: 0x80ed10..0x80edc0
               Pieces: []
-            - Range: 0x80e550..0x80e551
+            - Range: 0x80edc0..0x80edc1
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80e551..0x80e570
+            - Range: 0x80edc1..0x80ede0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9520,13 +9520,13 @@ Subprograms:
       DictRegister: null
     - ID: 131
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x80e570..0x80e780]
+      OutOfLinePCRanges: [0x80ede0..0x80eff0]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 269 StructureType main.largeStruct
           Locations:
-            - Range: 0x80e570..0x80e5a4
+            - Range: 0x80ede0..0x80ee14
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9548,7 +9548,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80e5a4..0x80e5d8
+            - Range: 0x80ee14..0x80ee48
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9570,7 +9570,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80e5d8..0x80e5e0
+            - Range: 0x80ee48..0x80ee50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9592,7 +9592,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80e5e0..0x80e5e4
+            - Range: 0x80ee50..0x80ee54
               Pieces:
                 - Size: 8
                   Op: null
@@ -9620,7 +9620,7 @@ Subprograms:
         - Name: s2
           Type: 269 StructureType main.largeStruct
           Locations:
-            - Range: 0x80e570..0x80e780
+            - Range: 0x80ede0..0x80eff0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9628,9 +9628,9 @@ Subprograms:
         - Name: ~r0
           Type: 269 StructureType main.largeStruct
           Locations:
-            - Range: 0x80e570..0x80e738
+            - Range: 0x80ede0..0x80efa8
               Pieces: []
-            - Range: 0x80e738..0x80e739
+            - Range: 0x80efa8..0x80efa9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9652,7 +9652,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80e739..0x80e780
+            - Range: 0x80efa9..0x80eff0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9660,15 +9660,15 @@ Subprograms:
       DictRegister: null
     - ID: 132
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x80e780..0x80e930]
+      OutOfLinePCRanges: [0x80eff0..0x80f1a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e780..0x80e808
+            - Range: 0x80eff0..0x80f078
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e808..0x80e930
+            - Range: 0x80f078..0x80f1a0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -9676,9 +9676,9 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e780..0x80e7c8
+            - Range: 0x80eff0..0x80f038
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80e7c8..0x80e930
+            - Range: 0x80f038..0x80f1a0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
@@ -9686,9 +9686,9 @@ Subprograms:
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e780..0x80e800
+            - Range: 0x80eff0..0x80f070
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80e800..0x80e930
+            - Range: 0x80f070..0x80f1a0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
@@ -9696,9 +9696,9 @@ Subprograms:
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e780..0x80e808
+            - Range: 0x80eff0..0x80f078
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80e808..0x80e930
+            - Range: 0x80f078..0x80f1a0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
@@ -9706,9 +9706,9 @@ Subprograms:
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e780..0x80e808
+            - Range: 0x80eff0..0x80f078
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80e808..0x80e930
+            - Range: 0x80f078..0x80f1a0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
@@ -9716,9 +9716,9 @@ Subprograms:
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e780..0x80e808
+            - Range: 0x80eff0..0x80f078
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80e808..0x80e930
+            - Range: 0x80f078..0x80f1a0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
@@ -9726,9 +9726,9 @@ Subprograms:
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e780..0x80e808
+            - Range: 0x80eff0..0x80f078
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80e808..0x80e930
+            - Range: 0x80f078..0x80f1a0
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
@@ -9736,9 +9736,9 @@ Subprograms:
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e780..0x80e808
+            - Range: 0x80eff0..0x80f078
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80e808..0x80e930
+            - Range: 0x80f078..0x80f1a0
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
@@ -9746,9 +9746,9 @@ Subprograms:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e780..0x80e808
+            - Range: 0x80eff0..0x80f078
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x80e808..0x80e930
+            - Range: 0x80f078..0x80f1a0
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
@@ -9756,11 +9756,11 @@ Subprograms:
         - Name: ~r0
           Type: 122 ArrayType [2]int
           Locations:
-            - Range: 0x80e780..0x80e8f0
+            - Range: 0x80eff0..0x80f160
               Pieces: []
-            - Range: 0x80e8f0..0x80e8f1
+            - Range: 0x80f160..0x80f161
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x80e8f1..0x80e930
+            - Range: 0x80f161..0x80f1a0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9768,15 +9768,15 @@ Subprograms:
       DictRegister: null
     - ID: 133
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x80e930..0x80eb20]
+      OutOfLinePCRanges: [0x80f1a0..0x80f390]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e930..0x80e9b8
+            - Range: 0x80f1a0..0x80f228
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80e9b8..0x80eb20
+            - Range: 0x80f228..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9784,9 +9784,9 @@ Subprograms:
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e930..0x80e97c
+            - Range: 0x80f1a0..0x80f1ec
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80e97c..0x80eb20
+            - Range: 0x80f1ec..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -9794,9 +9794,9 @@ Subprograms:
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e930..0x80e9b0
+            - Range: 0x80f1a0..0x80f220
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80e9b0..0x80eb20
+            - Range: 0x80f220..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -9804,9 +9804,9 @@ Subprograms:
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e930..0x80e9b8
+            - Range: 0x80f1a0..0x80f228
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80e9b8..0x80eb20
+            - Range: 0x80f228..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
@@ -9814,9 +9814,9 @@ Subprograms:
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e930..0x80e9b8
+            - Range: 0x80f1a0..0x80f228
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80e9b8..0x80eb20
+            - Range: 0x80f228..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
@@ -9824,9 +9824,9 @@ Subprograms:
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e930..0x80e9b8
+            - Range: 0x80f1a0..0x80f228
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80e9b8..0x80eb20
+            - Range: 0x80f228..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
@@ -9834,9 +9834,9 @@ Subprograms:
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e930..0x80e9b8
+            - Range: 0x80f1a0..0x80f228
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80e9b8..0x80eb20
+            - Range: 0x80f228..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
@@ -9844,9 +9844,9 @@ Subprograms:
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80e930..0x80e9b8
+            - Range: 0x80f1a0..0x80f228
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80e9b8..0x80eb20
+            - Range: 0x80f228..0x80f390
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
@@ -9854,13 +9854,13 @@ Subprograms:
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80e930..0x80e9b8
+            - Range: 0x80f1a0..0x80f228
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80e9b8..0x80eb20
+            - Range: 0x80f228..0x80f390
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9872,9 +9872,9 @@ Subprograms:
         - Name: ~r0
           Type: 269 StructureType main.largeStruct
           Locations:
-            - Range: 0x80e930..0x80eadc
+            - Range: 0x80f1a0..0x80f34c
               Pieces: []
-            - Range: 0x80eadc..0x80eadd
+            - Range: 0x80f34c..0x80f34d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9896,7 +9896,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80eadd..0x80eb20
+            - Range: 0x80f34d..0x80f390
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9904,13 +9904,13 @@ Subprograms:
       DictRegister: null
     - ID: 134
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x80eb20..0x80ebb0]
+      OutOfLinePCRanges: [0x80f390..0x80f420]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 176 ArrayType [5]int
           Locations:
-            - Range: 0x80eb20..0x80ebb0
+            - Range: 0x80f390..0x80f420
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9918,11 +9918,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80eb20..0x80eb94
+            - Range: 0x80f390..0x80f404
               Pieces: []
-            - Range: 0x80eb94..0x80eb95
+            - Range: 0x80f404..0x80f405
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80eb95..0x80ebb0
+            - Range: 0x80f405..0x80f420
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9930,11 +9930,11 @@ Subprograms:
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80eb20..0x80eb94
+            - Range: 0x80f390..0x80f404
               Pieces: []
-            - Range: 0x80eb94..0x80eb95
+            - Range: 0x80f404..0x80f405
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80eb95..0x80ebb0
+            - Range: 0x80f405..0x80f420
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9942,11 +9942,11 @@ Subprograms:
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80eb20..0x80eb94
+            - Range: 0x80f390..0x80f404
               Pieces: []
-            - Range: 0x80eb94..0x80eb95
+            - Range: 0x80f404..0x80f405
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80eb95..0x80ebb0
+            - Range: 0x80f405..0x80f420
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9954,13 +9954,13 @@ Subprograms:
       DictRegister: null
     - ID: 135
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x80ebb0..0x80ec80]
+      OutOfLinePCRanges: [0x80f420..0x80f4f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 122 ArrayType [2]int
           Locations:
-            - Range: 0x80ebb0..0x80ec80
+            - Range: 0x80f420..0x80f4f0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -9968,7 +9968,7 @@ Subprograms:
         - Name: b
           Type: 270 ArrayType [3]int
           Locations:
-            - Range: 0x80ebb0..0x80ec80
+            - Range: 0x80f420..0x80f4f0
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -9976,11 +9976,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ebb0..0x80ec68
+            - Range: 0x80f420..0x80f4d8
               Pieces: []
-            - Range: 0x80ec68..0x80ec69
+            - Range: 0x80f4d8..0x80f4d9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ec69..0x80ec80
+            - Range: 0x80f4d9..0x80f4f0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -9988,11 +9988,11 @@ Subprograms:
         - Name: ~r1
           Type: 122 ArrayType [2]int
           Locations:
-            - Range: 0x80ebb0..0x80ec68
+            - Range: 0x80f420..0x80f4d8
               Pieces: []
-            - Range: 0x80ec68..0x80ec69
+            - Range: 0x80f4d8..0x80f4d9
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x80ec69..0x80ec80
+            - Range: 0x80f4d9..0x80f4f0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10000,13 +10000,13 @@ Subprograms:
       DictRegister: null
     - ID: 136
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x80ec80..0x80ed40]
+      OutOfLinePCRanges: [0x80f4f0..0x80f5b0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 275 StructureType main.structWithArray
           Locations:
-            - Range: 0x80ec80..0x80ed40
+            - Range: 0x80f4f0..0x80f5b0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -10014,11 +10014,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ec80..0x80ed24
+            - Range: 0x80f4f0..0x80f594
               Pieces: []
-            - Range: 0x80ed24..0x80ed25
+            - Range: 0x80f594..0x80f595
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ed25..0x80ed40
+            - Range: 0x80f595..0x80f5b0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10026,11 +10026,11 @@ Subprograms:
         - Name: ~r1
           Type: 275 StructureType main.structWithArray
           Locations:
-            - Range: 0x80ec80..0x80ed24
+            - Range: 0x80f4f0..0x80f594
               Pieces: []
-            - Range: 0x80ed24..0x80ed25
+            - Range: 0x80f594..0x80f595
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80ed25..0x80ed40
+            - Range: 0x80f595..0x80f5b0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10038,7 +10038,7 @@ Subprograms:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ed00..0x80ed40
+            - Range: 0x80f570..0x80f5b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -10046,25 +10046,25 @@ Subprograms:
       DictRegister: null
     - ID: 137
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x80ed40..0x80ede0]
+      OutOfLinePCRanges: [0x80f5b0..0x80f650]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 ArrayType [0]int
-          Locations: [{Range: 0x80ed40..0x80ede0, Pieces: []}]
+          Locations: [{Range: 0x80f5b0..0x80f650, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ed40..0x80ed80
+            - Range: 0x80f5b0..0x80f5f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ed80..0x80ed98
+            - Range: 0x80f5f0..0x80f608
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80ed98..0x80eda0
+            - Range: 0x80f608..0x80f610
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x80eda0..0x80ede0
+            - Range: 0x80f610..0x80f650
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
@@ -10072,11 +10072,11 @@ Subprograms:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80ed40..0x80edbc
+            - Range: 0x80f5b0..0x80f62c
               Pieces: []
-            - Range: 0x80edbc..0x80edbd
+            - Range: 0x80f62c..0x80f62d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80edbd..0x80ede0
+            - Range: 0x80f62d..0x80f650
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10084,11 +10084,11 @@ Subprograms:
         - Name: ~r1
           Type: 272 ArrayType [0]int
           Locations:
-            - Range: 0x80ed40..0x80edbc
+            - Range: 0x80f5b0..0x80f62c
               Pieces: []
-            - Range: 0x80edbc..0x80edbd
+            - Range: 0x80f62c..0x80f62d
               Pieces: []
-            - Range: 0x80edbd..0x80ede0
+            - Range: 0x80f62d..0x80f650
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10096,13 +10096,13 @@ Subprograms:
       DictRegister: null
     - ID: 138
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80f230..0x80f240]
+      OutOfLinePCRanges: [0x80faa0..0x80fab0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 276 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80f230..0x80f240
+            - Range: 0x80faa0..0x80fab0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10116,13 +10116,13 @@ Subprograms:
       DictRegister: null
     - ID: 139
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x80f240..0x80f250]
+      OutOfLinePCRanges: [0x80fab0..0x80fac0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 276 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80f240..0x80f250
+            - Range: 0x80fab0..0x80fac0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10136,13 +10136,13 @@ Subprograms:
       DictRegister: null
     - ID: 140
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x80f250..0x80f260]
+      OutOfLinePCRanges: [0x80fac0..0x80fad0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 277 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x80f250..0x80f260
+            - Range: 0x80fac0..0x80fad0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10156,13 +10156,13 @@ Subprograms:
       DictRegister: null
     - ID: 141
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x80f260..0x80f270]
+      OutOfLinePCRanges: [0x80fad0..0x80fae0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 279 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80f260..0x80f270
+            - Range: 0x80fad0..0x80fae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10176,7 +10176,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80f260..0x80f270
+            - Range: 0x80fad0..0x80fae0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10184,13 +10184,13 @@ Subprograms:
       DictRegister: null
     - ID: 142
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x80f270..0x80f280]
+      OutOfLinePCRanges: [0x80fae0..0x80faf0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 279 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80f270..0x80f280
+            - Range: 0x80fae0..0x80faf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10204,7 +10204,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80f270..0x80f280
+            - Range: 0x80fae0..0x80faf0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10212,13 +10212,13 @@ Subprograms:
       DictRegister: null
     - ID: 143
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x80f280..0x80f290]
+      OutOfLinePCRanges: [0x80faf0..0x80fb00]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 279 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80f280..0x80f290
+            - Range: 0x80faf0..0x80fb00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10232,7 +10232,7 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80f280..0x80f290
+            - Range: 0x80faf0..0x80fb00
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10240,13 +10240,13 @@ Subprograms:
       DictRegister: null
     - ID: 144
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x80f290..0x80f2a0]
+      OutOfLinePCRanges: [0x80fb00..0x80fb10]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 170 GoSliceHeaderType []string
           Locations:
-            - Range: 0x80f290..0x80f2a0
+            - Range: 0x80fb00..0x80fb10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10260,13 +10260,13 @@ Subprograms:
       DictRegister: null
     - ID: 145
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x80f2a0..0x80f2b0]
+      OutOfLinePCRanges: [0x80fb10..0x80fb20]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 21 BaseType int8
           Locations:
-            - Range: 0x80f2a0..0x80f2b0
+            - Range: 0x80fb10..0x80fb20
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10274,7 +10274,7 @@ Subprograms:
         - Name: s
           Type: 282 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x80f2a0..0x80f2b0
+            - Range: 0x80fb10..0x80fb20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10288,7 +10288,7 @@ Subprograms:
         - Name: x
           Type: 13 BaseType uint
           Locations:
-            - Range: 0x80f2a0..0x80f2b0
+            - Range: 0x80fb10..0x80fb20
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10296,13 +10296,13 @@ Subprograms:
       DictRegister: null
     - ID: 146
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x80f2b0..0x80f2c0]
+      OutOfLinePCRanges: [0x80fb20..0x80fb30]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 283 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x80f2b0..0x80f2c0
+            - Range: 0x80fb20..0x80fb30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10316,13 +10316,13 @@ Subprograms:
       DictRegister: null
     - ID: 147
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x80f2c0..0x80f2d0]
+      OutOfLinePCRanges: [0x80fb30..0x80fb40]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 276 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80f2c0..0x80f2d0
+            - Range: 0x80fb30..0x80fb40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10336,13 +10336,13 @@ Subprograms:
       DictRegister: null
     - ID: 148
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x80f2d0..0x80f2e0]
+      OutOfLinePCRanges: [0x80fb40..0x80fb50]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 284 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0x80f2d0..0x80f2e0
+            - Range: 0x80fb40..0x80fb50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10356,13 +10356,13 @@ Subprograms:
       DictRegister: null
     - ID: 149
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x80f2e0..0x80f2f0]
+      OutOfLinePCRanges: [0x80fb50..0x80fb60]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 276 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80f2e0..0x80f2f0
+            - Range: 0x80fb50..0x80fb60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10376,7 +10376,7 @@ Subprograms:
         - Name: bs
           Type: 276 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80f2e0..0x80f2f0
+            - Range: 0x80fb50..0x80fb60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10390,7 +10390,7 @@ Subprograms:
         - Name: cs
           Type: 276 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80f2e0..0x80f2f0
+            - Range: 0x80fb50..0x80fb60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10404,13 +10404,13 @@ Subprograms:
       DictRegister: null
     - ID: 150
       Name: main.testByteSliceInvalidUtf8
-      OutOfLinePCRanges: [0x80f320..0x80f330]
+      OutOfLinePCRanges: [0x80fb90..0x80fba0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 41 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0x80f320..0x80f330
+            - Range: 0x80fb90..0x80fba0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10424,13 +10424,13 @@ Subprograms:
       DictRegister: null
     - ID: 151
       Name: main.testByteSliceMultibyteUtf8
-      OutOfLinePCRanges: [0x80f330..0x80f340]
+      OutOfLinePCRanges: [0x80fba0..0x80fbb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 41 GoSliceHeaderType []uint8
           Locations:
-            - Range: 0x80f330..0x80f340
+            - Range: 0x80fba0..0x80fbb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10444,21 +10444,21 @@ Subprograms:
       DictRegister: null
     - ID: 152
       Name: main.stackC
-      OutOfLinePCRanges: [0x80f870..0x80f8d0]
+      OutOfLinePCRanges: [0x8101a0..0x810200]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f870..0x80f8b8
+            - Range: 0x8101a0..0x8101e8
               Pieces: []
-            - Range: 0x80f8b8..0x80f8b9
+            - Range: 0x8101e8..0x8101e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80f8b9..0x80f8d0
+            - Range: 0x8101e9..0x810200
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -10466,13 +10466,13 @@ Subprograms:
       DictRegister: null
     - ID: 153
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x80f8d0..0x80f8e0]
+      OutOfLinePCRanges: [0x810300..0x810310]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f8d0..0x80f8e0
+            - Range: 0x810300..0x810310
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10484,13 +10484,13 @@ Subprograms:
       DictRegister: null
     - ID: 154
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x80f8e0..0x80f8f0]
+      OutOfLinePCRanges: [0x810310..0x810320]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f8e0..0x80f8f0
+            - Range: 0x810310..0x810320
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10502,7 +10502,7 @@ Subprograms:
         - Name: "y"
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f8e0..0x80f8f0
+            - Range: 0x810310..0x810320
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10514,7 +10514,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f8e0..0x80f8f0
+            - Range: 0x810310..0x810320
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10526,13 +10526,13 @@ Subprograms:
       DictRegister: null
     - ID: 155
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80f8f0..0x80f900]
+      OutOfLinePCRanges: [0x810320..0x810330]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 286 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x80f8f0..0x80f900
+            - Range: 0x810320..0x810330
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10552,13 +10552,13 @@ Subprograms:
       DictRegister: null
     - ID: 156
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80f900..0x80f910]
+      OutOfLinePCRanges: [0x810330..0x810340]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 287 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x80f900..0x80f910
+            - Range: 0x810330..0x810340
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10566,13 +10566,13 @@ Subprograms:
       DictRegister: null
     - ID: 157
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x80f910..0x80f920]
+      OutOfLinePCRanges: [0x810340..0x810350]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 288 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x80f910..0x80f920
+            - Range: 0x810340..0x810350
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10580,13 +10580,13 @@ Subprograms:
       DictRegister: null
     - ID: 158
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x80f920..0x80f930]
+      OutOfLinePCRanges: [0x810350..0x810360]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f920..0x80f930
+            - Range: 0x810350..0x810360
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10598,13 +10598,13 @@ Subprograms:
       DictRegister: null
     - ID: 159
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x80f930..0x80f940]
+      OutOfLinePCRanges: [0x810360..0x810370]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f930..0x80f940
+            - Range: 0x810360..0x810370
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10616,13 +10616,13 @@ Subprograms:
       DictRegister: null
     - ID: 160
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x80f940..0x80f950]
+      OutOfLinePCRanges: [0x810370..0x810380]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f940..0x80f950
+            - Range: 0x810370..0x810380
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10634,13 +10634,13 @@ Subprograms:
       DictRegister: null
     - ID: 161
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x80f950..0x80f960]
+      OutOfLinePCRanges: [0x810380..0x810390]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f950..0x80f960
+            - Range: 0x810380..0x810390
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10652,7 +10652,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f950..0x80f960
+            - Range: 0x810380..0x810390
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10664,7 +10664,7 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f950..0x80f960
+            - Range: 0x810380..0x810390
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -10676,13 +10676,13 @@ Subprograms:
       DictRegister: null
     - ID: 162
       Name: main.testInvalidUtf8Strings
-      OutOfLinePCRanges: [0x80f960..0x80f970]
+      OutOfLinePCRanges: [0x810390..0x8103a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f960..0x80f970
+            - Range: 0x810390..0x8103a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10694,7 +10694,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f960..0x80f970
+            - Range: 0x810390..0x8103a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10706,13 +10706,13 @@ Subprograms:
       DictRegister: null
     - ID: 163
       Name: main.testMultibyteUtf8String
-      OutOfLinePCRanges: [0x80f970..0x80f980]
+      OutOfLinePCRanges: [0x8103a0..0x8103b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80f970..0x80f980
+            - Range: 0x8103a0..0x8103b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10724,13 +10724,13 @@ Subprograms:
       DictRegister: null
     - ID: 164
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x80faf0..0x80fb00]
+      OutOfLinePCRanges: [0x8105f0..0x810600]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 290 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x80faf0..0x80fb00
+            - Range: 0x8105f0..0x810600
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -10738,13 +10738,13 @@ Subprograms:
       DictRegister: null
     - ID: 165
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x80fb00..0x80fb10]
+      OutOfLinePCRanges: [0x810600..0x810610]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 303 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x80fb00..0x80fb10
+            - Range: 0x810600..0x810610
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10764,13 +10764,13 @@ Subprograms:
       DictRegister: null
     - ID: 166
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80fba0..0x80fbb0]
+      OutOfLinePCRanges: [0x8106a0..0x8106b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 StructureType main.aStruct
           Locations:
-            - Range: 0x80fba0..0x80fbb0
+            - Range: 0x8106a0..0x8106b0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -10792,13 +10792,13 @@ Subprograms:
       DictRegister: null
     - ID: 167
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x80fc00..0x80fc10]
+      OutOfLinePCRanges: [0x810700..0x810710]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x80fc00..0x80fc10
+            - Range: 0x810700..0x810710
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10806,13 +10806,13 @@ Subprograms:
       DictRegister: null
     - ID: 168
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x80fc10..0x80fc20]
+      OutOfLinePCRanges: [0x810710..0x810720]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 337 StructureType main.tenStrings
           Locations:
-            - Range: 0x80fc10..0x80fc20
+            - Range: 0x810710..0x810720
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
@@ -10820,25 +10820,25 @@ Subprograms:
       DictRegister: null
     - ID: 169
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80fc40..0x80fc50]
+      OutOfLinePCRanges: [0x810740..0x810750]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 338 StructureType main.emptyStruct
-          Locations: [{Range: 0x80fc40..0x80fc50, Pieces: []}]
+          Locations: [{Range: 0x810740..0x810750, Pieces: []}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 170
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80fc50..0x80fc60]
+      OutOfLinePCRanges: [0x810750..0x810760]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 339 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80fc50..0x80fc60
+            - Range: 0x810750..0x810760
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -10846,13 +10846,13 @@ Subprograms:
       DictRegister: null
     - ID: 171
       Name: main.testTimeUTC
-      OutOfLinePCRanges: [0x8105c0..0x8105d0]
+      OutOfLinePCRanges: [0x811180..0x811190]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 GoTimeType time.Time
           Locations:
-            - Range: 0x8105c0..0x8105d0
+            - Range: 0x811180..0x811190
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10866,13 +10866,13 @@ Subprograms:
       DictRegister: null
     - ID: 172
       Name: main.testTimeFixedZone
-      OutOfLinePCRanges: [0x8105d0..0x8105e0]
+      OutOfLinePCRanges: [0x811190..0x8111a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 GoTimeType time.Time
           Locations:
-            - Range: 0x8105d0..0x8105e0
+            - Range: 0x811190..0x8111a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10886,13 +10886,13 @@ Subprograms:
       DictRegister: null
     - ID: 173
       Name: main.testTimeMonotonic
-      OutOfLinePCRanges: [0x8105e0..0x8105f0]
+      OutOfLinePCRanges: [0x8111a0..0x8111b0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 343 StructureType main.timeCapture
           Locations:
-            - Range: 0x8105e0..0x8105f0
+            - Range: 0x8111a0..0x8111b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10906,13 +10906,13 @@ Subprograms:
       DictRegister: null
     - ID: 174
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x811390..0x8113a0]
+      OutOfLinePCRanges: [0x812010..0x812020]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0x811390..0x8113a0
+            - Range: 0x812010..0x812020
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10920,11 +10920,11 @@ Subprograms:
         - Name: ~r0
           Type: 345 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x811390..0x811394
+            - Range: 0x812010..0x812014
               Pieces: []
-            - Range: 0x811394..0x811395
+            - Range: 0x812014..0x812015
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811395..0x8113a0
+            - Range: 0x812015..0x812020
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -10932,19 +10932,19 @@ Subprograms:
       DictRegister: 0
     - ID: 175
       Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x8113a0..0x8113b0]
+      OutOfLinePCRanges: [0x812020..0x812030]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8113a0..0x8113ac
+            - Range: 0x812020..0x81202c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8113ac..0x8113b0
+            - Range: 0x81202c..0x812030
               Pieces:
                 - Size: 8
                   Op: null
@@ -10956,15 +10956,15 @@ Subprograms:
         - Name: ~r0
           Type: 347 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x8113a0..0x8113ac
+            - Range: 0x812020..0x81202c
               Pieces: []
-            - Range: 0x8113ac..0x8113ad
+            - Range: 0x81202c..0x81202d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8113ad..0x8113b0
+            - Range: 0x81202d..0x812030
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -10972,13 +10972,13 @@ Subprograms:
       DictRegister: 0
     - ID: 176
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x8113b0..0x8113c0]
+      OutOfLinePCRanges: [0x812030..0x812040]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 345 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x8113b0..0x8113c0
+            - Range: 0x812030..0x812040
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -10986,11 +10986,11 @@ Subprograms:
         - Name: ~r0
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0x8113b0..0x8113b4
+            - Range: 0x812030..0x812034
               Pieces: []
-            - Range: 0x8113b4..0x8113b5
+            - Range: 0x812034..0x812035
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8113b5..0x8113c0
+            - Range: 0x812035..0x812040
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -10998,19 +10998,19 @@ Subprograms:
       DictRegister: 0
     - ID: 177
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x8113c0..0x8113d0]
+      OutOfLinePCRanges: [0x812040..0x812050]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 347 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x8113c0..0x8113cc
+            - Range: 0x812040..0x81204c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8113cc..0x8113d0
+            - Range: 0x81204c..0x812050
               Pieces:
                 - Size: 8
                   Op: null
@@ -11022,15 +11022,15 @@ Subprograms:
         - Name: ~r0
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8113c0..0x8113cc
+            - Range: 0x812040..0x81204c
               Pieces: []
-            - Range: 0x8113cc..0x8113cd
+            - Range: 0x81204c..0x81204d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8113cd..0x8113d0
+            - Range: 0x81204d..0x812050
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11038,13 +11038,13 @@ Subprograms:
       DictRegister: 0
     - ID: 178
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x811430..0x8115d0]
+      OutOfLinePCRanges: [0x8120b0..0x812250]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 348 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x811430..0x811460
+            - Range: 0x8120b0..0x8120e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11052,7 +11052,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x811460..0x811474
+            - Range: 0x8120e0..0x8120f4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -11060,7 +11060,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x811474..0x8115d0
+            - Range: 0x8120f4..0x812250
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -11074,9 +11074,9 @@ Subprograms:
         - Name: pred
           Type: 350 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x811430..0x811474
+            - Range: 0x8120b0..0x8120f4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x811474..0x8115d0
+            - Range: 0x8120f4..0x812250
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
@@ -11084,9 +11084,9 @@ Subprograms:
         - Name: ~r0
           Type: 348 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x811430..0x811598
+            - Range: 0x8120b0..0x812218
               Pieces: []
-            - Range: 0x811598..0x811599
+            - Range: 0x812218..0x812219
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11094,7 +11094,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x811599..0x8115d0
+            - Range: 0x812219..0x812250
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -11102,7 +11102,7 @@ Subprograms:
         - Name: result
           Type: 348 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x811460..0x811474
+            - Range: 0x8120e0..0x8120f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11110,7 +11110,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x811474..0x811494
+            - Range: 0x8120f4..0x812114
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11118,7 +11118,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x811494..0x811498
+            - Range: 0x812114..0x812118
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11126,7 +11126,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x811498..0x811498
+            - Range: 0x812118..0x812118
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11134,7 +11134,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x811498..0x8114c8
+            - Range: 0x812118..0x812148
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -11142,7 +11142,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x8114c8..0x811558
+            - Range: 0x812148..0x8121d8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -11150,7 +11150,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x811558..0x81156c
+            - Range: 0x8121d8..0x8121ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -11158,7 +11158,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x81156c..0x811580
+            - Range: 0x8121ec..0x812200
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11166,7 +11166,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x811580..0x81158c
+            - Range: 0x812200..0x81220c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11174,7 +11174,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x81158c..0x8115d0
+            - Range: 0x81220c..0x812250
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11188,9 +11188,9 @@ Subprograms:
         - Name: item
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0x8114b8..0x8114c8
+            - Range: 0x812138..0x812148
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8114c8..0x811558
+            - Range: 0x812148..0x8121d8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: 4
@@ -11198,13 +11198,13 @@ Subprograms:
       DictRegister: 0
     - ID: 179
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x8115d0..0x811620]
+      OutOfLinePCRanges: [0x812250..0x8122a0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 345 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x8115d0..0x8115f8
+            - Range: 0x812250..0x812278
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11212,7 +11212,7 @@ Subprograms:
         - Name: f
           Type: 351 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x8115d0..0x8115f8
+            - Range: 0x812250..0x812278
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11220,15 +11220,15 @@ Subprograms:
         - Name: ~r0
           Type: 347 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x8115d0..0x8115f8
+            - Range: 0x812250..0x812278
               Pieces: []
-            - Range: 0x8115f8..0x8115f9
+            - Range: 0x812278..0x812279
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8115f9..0x811620
+            - Range: 0x812279..0x8122a0
               Pieces: []
           Role: Return
           DictIndex: 2
@@ -11236,13 +11236,13 @@ Subprograms:
       DictRegister: 0
     - ID: 180
       Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x811810..0x811820]
+      OutOfLinePCRanges: [0x812490..0x8124a0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 349 PointerType *go.shape.int
           Locations:
-            - Range: 0x811810..0x811820
+            - Range: 0x812490..0x8124a0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11250,11 +11250,11 @@ Subprograms:
         - Name: ~r0
           Type: 349 PointerType *go.shape.int
           Locations:
-            - Range: 0x811810..0x811814
+            - Range: 0x812490..0x812494
               Pieces: []
-            - Range: 0x811814..0x811815
+            - Range: 0x812494..0x812495
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811815..0x811820
+            - Range: 0x812495..0x8124a0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11262,13 +11262,13 @@ Subprograms:
       DictRegister: 0
     - ID: 181
       Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x811820..0x811830]
+      OutOfLinePCRanges: [0x8124a0..0x8124b0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 352 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x811820..0x811830
+            - Range: 0x8124a0..0x8124b0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11276,11 +11276,11 @@ Subprograms:
         - Name: ~r0
           Type: 352 PointerType *go.shape.struct { Name string }
           Locations:
-            - Range: 0x811820..0x811824
+            - Range: 0x8124a0..0x8124a4
               Pieces: []
-            - Range: 0x811824..0x811825
+            - Range: 0x8124a4..0x8124a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811825..0x811830
+            - Range: 0x8124a5..0x8124b0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11288,13 +11288,13 @@ Subprograms:
       DictRegister: 0
     - ID: 182
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x811830..0x811840]
+      OutOfLinePCRanges: [0x8124b0..0x8124c0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 354 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x811830..0x811840
+            - Range: 0x8124b0..0x8124c0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11302,11 +11302,11 @@ Subprograms:
         - Name: ~r0
           Type: 354 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x811830..0x811834
+            - Range: 0x8124b0..0x8124b4
               Pieces: []
-            - Range: 0x811834..0x811835
+            - Range: 0x8124b4..0x8124b5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811835..0x811840
+            - Range: 0x8124b5..0x8124c0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11314,13 +11314,13 @@ Subprograms:
       DictRegister: 0
     - ID: 183
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x811840..0x811850]
+      OutOfLinePCRanges: [0x8124c0..0x8124d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 356 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x811840..0x811850
+            - Range: 0x8124c0..0x8124d0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
@@ -11328,15 +11328,15 @@ Subprograms:
         - Name: ~r0
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x811840..0x811844
+            - Range: 0x8124c0..0x8124c4
               Pieces: []
-            - Range: 0x811844..0x811845
+            - Range: 0x8124c4..0x8124c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x811845..0x811850
+            - Range: 0x8124c5..0x8124d0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11344,13 +11344,13 @@ Subprograms:
       DictRegister: 0
     - ID: 184
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x8118c0..0x8118d0]
+      OutOfLinePCRanges: [0x812540..0x812550]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 358 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x8118c0..0x8118d0
+            - Range: 0x812540..0x812550
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
@@ -11358,11 +11358,11 @@ Subprograms:
         - Name: ~r0
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0x8118c0..0x8118c4
+            - Range: 0x812540..0x812544
               Pieces: []
-            - Range: 0x8118c4..0x8118c5
+            - Range: 0x812544..0x812545
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8118c5..0x8118d0
+            - Range: 0x812545..0x812550
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11370,13 +11370,13 @@ Subprograms:
       DictRegister: 0
     - ID: 185
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x811940..0x811950]
+      OutOfLinePCRanges: [0x8125c0..0x8125d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 359 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x811940..0x811950
+            - Range: 0x8125c0..0x8125d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11384,7 +11384,7 @@ Subprograms:
         - Name: k
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0x811940..0x811950
+            - Range: 0x8125c0..0x8125d0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11392,7 +11392,7 @@ Subprograms:
         - Name: v
           Type: 361 BaseType go.shape.bool
           Locations:
-            - Range: 0x811940..0x811950
+            - Range: 0x8125c0..0x8125d0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11400,13 +11400,13 @@ Subprograms:
       DictRegister: 1
     - ID: 186
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x8119b0..0x811a20]
+      OutOfLinePCRanges: [0x812630..0x8126a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 362 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x8119b0..0x811a20
+            - Range: 0x812630..0x8126a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11414,7 +11414,7 @@ Subprograms:
         - Name: k
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8119b0..0x811a20
+            - Range: 0x812630..0x8126a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -11426,7 +11426,7 @@ Subprograms:
         - Name: v
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0x8119b0..0x811a20
+            - Range: 0x812630..0x8126a0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
@@ -11434,13 +11434,13 @@ Subprograms:
       DictRegister: 1
     - ID: 187
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x811a80..0x811a90]
+      OutOfLinePCRanges: [0x812700..0x812710]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x811a80..0x811a90
+            - Range: 0x812700..0x812710
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11452,7 +11452,7 @@ Subprograms:
         - Name: b
           Type: 361 BaseType go.shape.bool
           Locations:
-            - Range: 0x811a80..0x811a90
+            - Range: 0x812700..0x812710
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11460,11 +11460,11 @@ Subprograms:
         - Name: ~r0
           Type: 361 BaseType go.shape.bool
           Locations:
-            - Range: 0x811a80..0x811a88
+            - Range: 0x812700..0x812708
               Pieces: []
-            - Range: 0x811a88..0x811a89
+            - Range: 0x812708..0x812709
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811a89..0x811a90
+            - Range: 0x812709..0x812710
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11472,15 +11472,15 @@ Subprograms:
         - Name: ~r1
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x811a80..0x811a88
+            - Range: 0x812700..0x812708
               Pieces: []
-            - Range: 0x811a88..0x811a89
+            - Range: 0x812708..0x812709
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x811a89..0x811a90
+            - Range: 0x812709..0x812710
               Pieces: []
           Role: Return
           DictIndex: 0
@@ -11488,13 +11488,13 @@ Subprograms:
       DictRegister: 0
     - ID: 188
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x811a90..0x811ab0]
+      OutOfLinePCRanges: [0x812710..0x812730]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0x811a90..0x811aa0
+            - Range: 0x812710..0x812720
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11502,13 +11502,13 @@ Subprograms:
         - Name: b
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x811a90..0x811a9c
+            - Range: 0x812710..0x81271c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x811a9c..0x811ab0
+            - Range: 0x81271c..0x812730
               Pieces:
                 - Size: 8
                   Op: null
@@ -11520,15 +11520,15 @@ Subprograms:
         - Name: ~r0
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x811a90..0x811aa0
+            - Range: 0x812710..0x812720
               Pieces: []
-            - Range: 0x811aa0..0x811aa1
+            - Range: 0x812720..0x812721
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x811aa1..0x811ab0
+            - Range: 0x812721..0x812730
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11536,11 +11536,11 @@ Subprograms:
         - Name: ~r1
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0x811a90..0x811aa0
+            - Range: 0x812710..0x812720
               Pieces: []
-            - Range: 0x811aa0..0x811aa1
+            - Range: 0x812720..0x812721
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x811aa1..0x811ab0
+            - Range: 0x812721..0x812730
               Pieces: []
           Role: Return
           DictIndex: 0
@@ -11548,13 +11548,13 @@ Subprograms:
       DictRegister: 0
     - ID: 189
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x811ab0..0x811b00]
+      OutOfLinePCRanges: [0x812730..0x812780]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 364 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x811ab0..0x811ad8
+            - Range: 0x812730..0x812758
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11562,15 +11562,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x811ab0..0x811ad8
+            - Range: 0x812730..0x812758
               Pieces: []
-            - Range: 0x811ad8..0x811ad9
+            - Range: 0x812758..0x812759
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x811ad9..0x811b00
+            - Range: 0x812759..0x812780
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11578,19 +11578,19 @@ Subprograms:
       DictRegister: 0
     - ID: 190
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x811b00..0x811b60]
+      OutOfLinePCRanges: [0x812780..0x8127e0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 365 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x811b00..0x811b2c
+            - Range: 0x812780..0x8127ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x811b2c..0x811b30
+            - Range: 0x8127ac..0x8127b0
               Pieces:
                 - Size: 8
                   Op: null
@@ -11602,15 +11602,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x811b00..0x811b30
+            - Range: 0x812780..0x8127b0
               Pieces: []
-            - Range: 0x811b30..0x811b31
+            - Range: 0x8127b0..0x8127b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x811b31..0x811b60
+            - Range: 0x8127b1..0x8127e0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11618,13 +11618,13 @@ Subprograms:
       DictRegister: 0
     - ID: 191
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x811b60..0x811b70]
+      OutOfLinePCRanges: [0x8127e0..0x8127f0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 366 PointerType *go.shape.string
           Locations:
-            - Range: 0x811b60..0x811b64
+            - Range: 0x8127e0..0x8127e4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11632,15 +11632,15 @@ Subprograms:
         - Name: ~r0
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x811b60..0x811b64
+            - Range: 0x8127e0..0x8127e4
               Pieces: []
-            - Range: 0x811b64..0x811b65
+            - Range: 0x8127e4..0x8127e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x811b65..0x811b70
+            - Range: 0x8127e5..0x8127f0
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11648,13 +11648,13 @@ Subprograms:
       DictRegister: 0
     - ID: 192
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x811b70..0x811bc0]
+      OutOfLinePCRanges: [0x8127f0..0x812840]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 367 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x811b70..0x811bb0
+            - Range: 0x8127f0..0x812830
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11662,9 +11662,9 @@ Subprograms:
         - Name: ~r0
           Type: 368 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x811b70..0x811bb4
+            - Range: 0x8127f0..0x812834
               Pieces: []
-            - Range: 0x811bb4..0x811bb5
+            - Range: 0x812834..0x812835
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11678,7 +11678,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x811bb5..0x811bc0
+            - Range: 0x812835..0x812840
               Pieces: []
           Role: Return
           DictIndex: 1
@@ -11686,13 +11686,13 @@ Subprograms:
       DictRegister: 0
     - ID: 193
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x811bc0..0x811c00]
+      OutOfLinePCRanges: [0x812840..0x812880]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 348 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x811bc0..0x811bcc
+            - Range: 0x812840..0x81284c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11700,7 +11700,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x811bcc..0x811c00
+            - Range: 0x81284c..0x812880
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11714,7 +11714,7 @@ Subprograms:
         - Name: needle
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0x811bc0..0x811c00
+            - Range: 0x812840..0x812880
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11722,15 +11722,15 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x811bc0..0x811be8
+            - Range: 0x812840..0x812868
               Pieces: []
-            - Range: 0x811be8..0x811be9
+            - Range: 0x812868..0x812869
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811be9..0x811bf0
+            - Range: 0x812869..0x812870
               Pieces: []
-            - Range: 0x811bf0..0x811bf1
+            - Range: 0x812870..0x812871
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811bf1..0x811c00
+            - Range: 0x812871..0x812880
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11738,7 +11738,7 @@ Subprograms:
         - Name: v
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0x811bdc..0x811bec
+            - Range: 0x81285c..0x81286c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
@@ -11746,13 +11746,13 @@ Subprograms:
       DictRegister: 0
     - ID: 194
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x811c00..0x811cc0]
+      OutOfLinePCRanges: [0x812880..0x812940]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 369 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x811c00..0x811c24
+            - Range: 0x812880..0x8128a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -11760,7 +11760,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x811c24..0x811c28
+            - Range: 0x8128a4..0x8128a8
               Pieces:
                 - Size: 8
                   Op: null
@@ -11774,13 +11774,13 @@ Subprograms:
         - Name: needle
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x811c00..0x811c5c
+            - Range: 0x812880..0x8128dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x811c5c..0x811cc0
+            - Range: 0x8128dc..0x812940
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -11792,15 +11792,15 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x811c00..0x811c78
+            - Range: 0x812880..0x8128f8
               Pieces: []
-            - Range: 0x811c78..0x811c79
+            - Range: 0x8128f8..0x8128f9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811c79..0x811c88
+            - Range: 0x8128f9..0x812908
               Pieces: []
-            - Range: 0x811c88..0x811c89
+            - Range: 0x812908..0x812909
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811c89..0x811cc0
+            - Range: 0x812909..0x812940
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11808,7 +11808,7 @@ Subprograms:
         - Name: v
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x811c44..0x811c5c
+            - Range: 0x8128c4..0x8128dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11820,13 +11820,13 @@ Subprograms:
       DictRegister: 0
     - ID: 195
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x811cc0..0x811cd0]
+      OutOfLinePCRanges: [0x812940..0x812950]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 370 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x811cc0..0x811cc8
+            - Range: 0x812940..0x812948
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
@@ -11834,7 +11834,7 @@ Subprograms:
         - Name: value
           Type: 344 BaseType go.shape.int
           Locations:
-            - Range: 0x811cc0..0x811cd0
+            - Range: 0x812940..0x812950
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
@@ -11842,11 +11842,11 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x811cc0..0x811cc8
+            - Range: 0x812940..0x812948
               Pieces: []
-            - Range: 0x811cc8..0x811cc9
+            - Range: 0x812948..0x812949
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811cc9..0x811cd0
+            - Range: 0x812949..0x812950
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -11854,25 +11854,25 @@ Subprograms:
       DictRegister: 1
     - ID: 196
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x811d20..0x811d90]
+      OutOfLinePCRanges: [0x8129a0..0x812a10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 371 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x811d20..0x811d4c
+            - Range: 0x8129a0..0x8129cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x811d4c..0x811d58
+            - Range: 0x8129cc..0x8129d8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x811d58..0x811d5c
+            - Range: 0x8129d8..0x8129dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -11884,7 +11884,7 @@ Subprograms:
         - Name: value
           Type: 346 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x811d20..0x811d5c
+            - Range: 0x8129a0..0x8129dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -11896,11 +11896,11 @@ Subprograms:
         - Name: ~r0
           Type: 6 BaseType bool
           Locations:
-            - Range: 0x811d20..0x811d5c
+            - Range: 0x8129a0..0x8129dc
               Pieces: []
-            - Range: 0x811d5c..0x811d5d
+            - Range: 0x8129dc..0x8129dd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x811d5d..0x811d90
+            - Range: 0x8129dd..0x812a10
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -12154,31 +12154,31 @@ Subprograms:
       DictRegister: null
     - ID: 199
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x80a080..0x80a0f0]
+      OutOfLinePCRanges: [0x80a490..0x80a500]
       InlinePCRanges:
-        - Ranges: [0x80a10c..0x80a140]
-          RootRanges: [0x80a0f0..0x80a160]
-        - Ranges: [0x80a240..0x80a274]
-          RootRanges: [0x80a210..0x80a2a0]
-        - Ranges: [0x80a2c4..0x80a2f8]
-          RootRanges: [0x80a2a0..0x80a360]
-        - Ranges: [0x80a37c..0x80a3b0]
-          RootRanges: [0x80a360..0x80a3d0]
+        - Ranges: [0x80a51c..0x80a550]
+          RootRanges: [0x80a500..0x80a570]
+        - Ranges: [0x80a650..0x80a684]
+          RootRanges: [0x80a620..0x80a6b0]
+        - Ranges: [0x80a6d4..0x80a708]
+          RootRanges: [0x80a6b0..0x80a770]
+        - Ranges: [0x80a78c..0x80a7c0]
+          RootRanges: [0x80a770..0x80a7e0]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80a080..0x80a0a0
+            - Range: 0x80a490..0x80a4b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a10c..0x80a114
+            - Range: 0x80a51c..0x80a524
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a240..0x80a248
+            - Range: 0x80a650..0x80a658
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a2bc..0x80a2cc
+            - Range: 0x80a6cc..0x80a6dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a2cc..0x80a360
+            - Range: 0x80a6dc..0x80a770
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x80a360..0x80a384
+            - Range: 0x80a770..0x80a794
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -12188,37 +12188,37 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80a304..0x80a338]
-          RootRanges: [0x80a2a0..0x80a360]
+        - Ranges: [0x80a714..0x80a748]
+          RootRanges: [0x80a6b0..0x80a770]
       Variables: []
       DictRegister: null
     - ID: 201
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80a3ec..0x80a420, 0x80a428..0x80a42c]
-          RootRanges: [0x80a3d0..0x80a4e0]
+        - Ranges: [0x80a7fc..0x80a830, 0x80a838..0x80a83c]
+          RootRanges: [0x80a7e0..0x80a8f0]
       Variables: []
       DictRegister: null
     - ID: 202
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80a490..0x80a4c4]
-          RootRanges: [0x80a3d0..0x80a4e0]
+        - Ranges: [0x80a8a0..0x80a8d4]
+          RootRanges: [0x80a7e0..0x80a8f0]
       Variables: []
       DictRegister: null
     - ID: 203
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80a4e4..0x80a4e8]
-          RootRanges: [0x80a4e0..0x80a4f0]
+        - Ranges: [0x80a8f4..0x80a8f8]
+          RootRanges: [0x80a8f0..0x80a900]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x80a4e0..0x80a4e8
+            - Range: 0x80a8f0..0x80a8f8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
@@ -12228,33 +12228,33 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80a514..0x80a530]
-          RootRanges: [0x80a4f0..0x80a540]
-        - Ranges: [0x80a59c..0x80a5bc]
-          RootRanges: [0x80a540..0x80a680]
+        - Ranges: [0x80a924..0x80a940]
+          RootRanges: [0x80a900..0x80a950]
+        - Ranges: [0x80a9f4..0x80aa14]
+          RootRanges: [0x80a950..0x80ab00]
       Variables:
         - Name: a
           Type: 176 ArrayType [5]int
           Locations:
-            - Range: 0x80a500..0x80a540
+            - Range: 0x80a910..0x80a950
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x80a588..0x80a680
-              Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
+            - Range: 0x80a9e0..0x80ab00
+              Pieces: [{Size: 40, Op: {CfaOffset: -144}}]
           Role: Parameter
           DictIndex: -1
           LoopBaseOffset: 0
       DictRegister: null
     - ID: 205
       Name: main.firstBehavior.DoSomething
-      OutOfLinePCRanges: [0x80a680..0x80a6e0]
+      OutOfLinePCRanges: [0x80ab50..0x80abb0]
       InlinePCRanges:
-        - Ranges: [0x811f00..0x811f24]
-          RootRanges: [0x811ee0..0x811f50]
+        - Ranges: [0x812b80..0x812ba4]
+          RootRanges: [0x812b60..0x812bd0]
       Variables:
         - Name: b
           Type: 376 StructureType main.firstBehavior
           Locations:
-            - Range: 0x80a680..0x80a6a4
+            - Range: 0x80ab50..0x80ab74
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -12266,15 +12266,15 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x80a680..0x80a6c0
+            - Range: 0x80ab50..0x80ab90
               Pieces: []
-            - Range: 0x80a6c0..0x80a6c1
+            - Range: 0x80ab90..0x80ab91
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a6c1..0x80a6e0
+            - Range: 0x80ab91..0x80abb0
               Pieces: []
           Role: Return
           DictIndex: -1
@@ -12284,8 +12284,8 @@ Subprograms:
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x80ae74..0x80ae80, 0x80ae84..0x80ae8c]
-          RootRanges: [0x80ade0..0x80aee0]
+        - Ranges: [0x80b3c0..0x80b3cc, 0x80b3d0..0x80b3d8]
+          RootRanges: [0x80b2d0..0x80b450]
         - Ranges: [0x804bd8..0x804bdc, 0x804be0..0x804be8]
           RootRanges: [0x804bd0..0x804bf0]
       Variables: []
@@ -12973,7 +12973,7 @@ Types:
       ID: 2657
       Name: '*compress/gzip.Reader'
       ByteSize: 8
-      GoRuntimeType: 1650528
+      GoRuntimeType: 1649760
       GoKind: 22
       Pointee: 2658 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
@@ -12994,7 +12994,7 @@ Types:
       ID: 426
       Name: '*context.backgroundCtx'
       ByteSize: 8
-      GoRuntimeType: 1573952
+      GoRuntimeType: 1573472
       GoKind: 22
       Pointee: 427 GoContextImplementationType context.backgroundCtx
     - __kind: PointerType
@@ -13008,21 +13008,21 @@ Types:
       ID: 1090
       Name: '*context.deadlineExceededError'
       ByteSize: 8
-      GoRuntimeType: 1205696
+      GoRuntimeType: 1204032
       GoKind: 22
       Pointee: 1091 StructureType context.deadlineExceededError
     - __kind: PointerType
       ID: 413
       Name: '*context.emptyCtx'
       ByteSize: 8
-      GoRuntimeType: 1432480
+      GoRuntimeType: 1432320
       GoKind: 22
       Pointee: 414 GoContextImplementationType context.emptyCtx
     - __kind: PointerType
       ID: 415
       Name: '*context.stopCtx'
       ByteSize: 8
-      GoRuntimeType: 1432640
+      GoRuntimeType: 1432480
       GoKind: 22
       Pointee: 416 GoContextImplementationType context.stopCtx
     - __kind: PointerType
@@ -13036,21 +13036,21 @@ Types:
       ID: 428
       Name: '*context.todoCtx'
       ByteSize: 8
-      GoRuntimeType: 1574112
+      GoRuntimeType: 1573632
       GoKind: 22
       Pointee: 429 GoContextImplementationType context.todoCtx
     - __kind: PointerType
       ID: 422
       Name: '*context.valueCtx'
       ByteSize: 8
-      GoRuntimeType: 1573632
+      GoRuntimeType: 1573152
       GoKind: 22
       Pointee: 423 GoContextImplementationType context.valueCtx
     - __kind: PointerType
       ID: 424
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
-      GoRuntimeType: 1573792
+      GoRuntimeType: 1573312
       GoKind: 22
       Pointee: 425 GoContextImplementationType context.withoutCancelCtx
     - __kind: PointerType
@@ -13468,17 +13468,17 @@ Types:
       GoKind: 22
       Pointee: 981 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 877
+      ID: 875
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
-      GoRuntimeType: 924224
+      GoRuntimeType: 923552
       GoKind: 22
       Pointee: 772 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
       ID: 1237
       Name: '*encoding/base64.encoder'
       ByteSize: 8
-      GoRuntimeType: 1055584
+      GoRuntimeType: 1055456
       GoKind: 22
       Pointee: 1238 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
@@ -13489,31 +13489,31 @@ Types:
       GoKind: 22
       Pointee: 773 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 1502
+      ID: 1500
       Name: '*encoding/json.Delim'
       ByteSize: 8
-      GoRuntimeType: 919136
+      GoRuntimeType: 918464
       GoKind: 22
-      Pointee: 1431 BaseType encoding/json.Delim
+      Pointee: 1429 BaseType encoding/json.Delim
     - __kind: PointerType
-      ID: 848
+      ID: 846
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
-      GoRuntimeType: 919040
+      GoRuntimeType: 918368
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 847 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
       ID: 1049
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
-      GoRuntimeType: 1051744
+      GoRuntimeType: 1051616
       GoKind: 22
       Pointee: 1050 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
       ID: 1679
       Name: '*encoding/json.Number'
       ByteSize: 8
-      GoRuntimeType: 1220032
+      GoRuntimeType: 1219520
       GoKind: 22
       Pointee: 1661 GoStringHeaderType encoding/json.Number
     - __kind: PointerType
@@ -13522,33 +13522,33 @@ Types:
       ByteSize: 8
       Pointee: 1662 GoStringDataType encoding/json.Number.str
     - __kind: PointerType
-      ID: 840
+      ID: 838
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
-      GoRuntimeType: 918656
+      GoRuntimeType: 917984
       GoKind: 22
-      Pointee: 841 UnresolvedPointeeType encoding/json.SyntaxError
-    - __kind: PointerType
-      ID: 846
-      Name: '*encoding/json.UnmarshalTypeError'
-      ByteSize: 8
-      GoRuntimeType: 918944
-      GoKind: 22
-      Pointee: 847 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 839 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
       ID: 844
-      Name: '*encoding/json.UnsupportedTypeError'
+      Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
-      GoRuntimeType: 918848
+      GoRuntimeType: 918272
       GoKind: 22
-      Pointee: 845 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 845 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
       ID: 842
+      Name: '*encoding/json.UnsupportedTypeError'
+      ByteSize: 8
+      GoRuntimeType: 918176
+      GoKind: 22
+      Pointee: 843 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+    - __kind: PointerType
+      ID: 840
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
-      GoRuntimeType: 918752
+      GoRuntimeType: 918080
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 841 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
       ID: 1378
       Name: '*encoding/json.encodeState'
@@ -13557,12 +13557,12 @@ Types:
       GoKind: 22
       Pointee: 1379 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 850
+      ID: 848
       Name: '*encoding/json.jsonError'
       ByteSize: 8
-      GoRuntimeType: 919424
+      GoRuntimeType: 918752
       GoKind: 22
-      Pointee: 851 StructureType encoding/json.jsonError
+      Pointee: 849 StructureType encoding/json.jsonError
     - __kind: PointerType
       ID: 1245
       Name: '*encoding/pem.lineBreaker'
@@ -13588,14 +13588,14 @@ Types:
       ID: 814
       Name: '*errors.errorString'
       ByteSize: 8
-      GoRuntimeType: 909440
+      GoRuntimeType: 910304
       GoKind: 22
       Pointee: 815 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
       ID: 1016
       Name: '*errors.joinError'
       ByteSize: 8
-      GoRuntimeType: 1037280
+      GoRuntimeType: 1038304
       GoKind: 22
       Pointee: 1017 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
@@ -13630,21 +13630,21 @@ Types:
       ID: 2558
       Name: '*fmt.stringReader'
       ByteSize: 8
-      GoRuntimeType: 909536
+      GoRuntimeType: 910400
       GoKind: 22
       Pointee: 2559 UnresolvedPointeeType fmt.stringReader
     - __kind: PointerType
       ID: 1018
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1037408
+      GoRuntimeType: 1038432
       GoKind: 22
       Pointee: 1019 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 1020
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1037536
+      GoRuntimeType: 1038560
       GoKind: 22
       Pointee: 1021 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -13686,7 +13686,7 @@ Types:
       ID: 2084
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType'
       ByteSize: 8
-      GoRuntimeType: 1876288
+      GoRuntimeType: 1876064
       GoKind: 22
       Pointee: 2031 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
     - __kind: PointerType
@@ -13707,7 +13707,7 @@ Types:
       ID: 2085
       Name: '*github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType'
       ByteSize: 8
-      GoRuntimeType: 1876512
+      GoRuntimeType: 1876288
       GoKind: 22
       Pointee: 2032 BaseType github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
     - __kind: PointerType
@@ -13795,45 +13795,45 @@ Types:
       GoKind: 22
       Pointee: 1737 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/version.Version
     - __kind: PointerType
-      ID: 859
+      ID: 857
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
-      GoRuntimeType: 921824
+      GoRuntimeType: 921152
       GoKind: 22
-      Pointee: 860 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 858 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 861
+      ID: 859
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
-      GoRuntimeType: 921920
+      GoRuntimeType: 921248
       GoKind: 22
-      Pointee: 862 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 860 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
       ID: 1183
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
-      GoRuntimeType: 921632
+      GoRuntimeType: 920960
       GoKind: 22
       Pointee: 1184 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 865
+      ID: 863
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
-      GoRuntimeType: 922208
+      GoRuntimeType: 921536
       GoKind: 22
-      Pointee: 866 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 864 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
       ID: 1185
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
-      GoRuntimeType: 921728
+      GoRuntimeType: 921056
       GoKind: 22
       Pointee: 1186 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 863
+      ID: 861
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
-      GoRuntimeType: 922016
+      GoRuntimeType: 921344
       GoKind: 22
       Pointee: 766 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
@@ -13842,10 +13842,10 @@ Types:
       ByteSize: 8
       Pointee: 767 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 858
+      ID: 856
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
-      GoRuntimeType: 921536
+      GoRuntimeType: 920864
       GoKind: 22
       Pointee: 763 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
@@ -13854,10 +13854,10 @@ Types:
       ByteSize: 8
       Pointee: 764 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 864
+      ID: 862
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
-      GoRuntimeType: 922112
+      GoRuntimeType: 921440
       GoKind: 22
       Pointee: 769 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
@@ -13869,7 +13869,7 @@ Types:
       ID: 1257
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
-      GoRuntimeType: 1223360
+      GoRuntimeType: 1222848
       GoKind: 22
       Pointee: 1258 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
@@ -13890,14 +13890,14 @@ Types:
       ID: 1793
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule'
       ByteSize: 8
-      GoRuntimeType: 1574272
+      GoRuntimeType: 1573792
       GoKind: 22
       Pointee: 1794 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRule
     - __kind: PointerType
       ID: 1485
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType'
       ByteSize: 8
-      GoRuntimeType: 910016
+      GoRuntimeType: 909536
       GoKind: 22
       Pointee: 1422 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SamplingRuleType
     - __kind: PointerType
@@ -13918,14 +13918,14 @@ Types:
       ID: 400
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
-      GoRuntimeType: 1205952
+      GoRuntimeType: 1204288
       GoKind: 22
       Pointee: 401 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
       ID: 1488
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate'
       ByteSize: 8
-      GoRuntimeType: 910304
+      GoRuntimeType: 909824
       GoKind: 22
       Pointee: 1489 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.abandonedSpanCandidate
     - __kind: PointerType
@@ -13939,7 +13939,7 @@ Types:
       ID: 1486
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule'
       ByteSize: 8
-      GoRuntimeType: 910208
+      GoRuntimeType: 909728
       GoKind: 22
       Pointee: 1487 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.jsonRule
     - __kind: PointerType
@@ -13953,35 +13953,35 @@ Types:
       ID: 1678
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance'
       ByteSize: 8
-      GoRuntimeType: 1207360
+      GoRuntimeType: 1205696
       GoKind: 22
       Pointee: 1584 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.provenance
     - __kind: PointerType
       ID: 2357
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter'
       ByteSize: 8
-      GoRuntimeType: 910112
+      GoRuntimeType: 909632
       GoKind: 22
       Pointee: 2358 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.rateLimiter
     - __kind: PointerType
       ID: 403
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
-      GoRuntimeType: 1206080
+      GoRuntimeType: 1204416
       GoKind: 22
       Pointee: 404 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
       ID: 2720
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
-      GoRuntimeType: 1206720
+      GoRuntimeType: 1205056
       GoKind: 22
       Pointee: 2721 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
       ID: 737
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      GoRuntimeType: 1206848
+      GoRuntimeType: 1205184
       GoKind: 22
       Pointee: 738 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
@@ -14009,7 +14009,7 @@ Types:
       ID: 1755
       Name: '*github.com/DataDog/dd-trace-go/v2/internal.TraceSource'
       ByteSize: 8
-      GoRuntimeType: 1438080
+      GoRuntimeType: 1437920
       GoKind: 22
       Pointee: 1585 BaseType github.com/DataDog/dd-trace-go/v2/internal.TraceSource
     - __kind: PointerType
@@ -14093,7 +14093,7 @@ Types:
       ID: 418
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
-      GoRuntimeType: 1438400
+      GoRuntimeType: 1438240
       GoKind: 22
       Pointee: 419 GoContextImplementationType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
@@ -14107,21 +14107,21 @@ Types:
       ID: 1617
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource'
       ByteSize: 8
-      GoRuntimeType: 1053792
+      GoRuntimeType: 1053664
       GoKind: 22
       Pointee: 1618 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.DatadogSource
     - __kind: PointerType
       ID: 1619
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource'
       ByteSize: 8
-      GoRuntimeType: 1053920
+      GoRuntimeType: 1053792
       GoKind: 22
       Pointee: 1620 StructureType github.com/DataDog/dd-trace-go/v2/internal/remoteconfig.EmployeeSource
     - __kind: PointerType
       ID: 1611
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey'
       ByteSize: 8
-      GoRuntimeType: 1051360
+      GoRuntimeType: 1051232
       GoKind: 22
       Pointee: 1612 StructureType github.com/DataDog/dd-trace-go/v2/internal/telemetry.metricKey
     - __kind: PointerType
@@ -14336,47 +14336,47 @@ Types:
       GoKind: 22
       Pointee: 2469 StructureType github.com/Masterminds/semver/v3.Version
     - __kind: PointerType
-      ID: 1514
+      ID: 1512
       Name: '*github.com/cihub/seelog.CfgParseParams'
       ByteSize: 8
-      GoRuntimeType: 924032
+      GoRuntimeType: 923360
       GoKind: 22
-      Pointee: 1515 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
+      Pointee: 1513 UnresolvedPointeeType github.com/cihub/seelog.CfgParseParams
     - __kind: PointerType
-      ID: 1513
+      ID: 1511
       Name: '*github.com/cihub/seelog.LogLevel'
       ByteSize: 8
-      GoRuntimeType: 923168
+      GoRuntimeType: 922496
       GoKind: 22
-      Pointee: 1434 BaseType github.com/cihub/seelog.LogLevel
+      Pointee: 1432 BaseType github.com/cihub/seelog.LogLevel
     - __kind: PointerType
       ID: 2041
       Name: '*github.com/cihub/seelog.LogLevelException'
       ByteSize: 8
-      GoRuntimeType: 1832608
+      GoRuntimeType: 1832160
       GoKind: 22
       Pointee: 2042 UnresolvedPointeeType github.com/cihub/seelog.LogLevelException
     - __kind: PointerType
-      ID: 867
+      ID: 865
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
-      GoRuntimeType: 923360
+      GoRuntimeType: 922688
       GoKind: 22
-      Pointee: 868 StructureType github.com/cihub/seelog.baseError
+      Pointee: 866 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
       ID: 1298
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
-      GoRuntimeType: 1833056
+      GoRuntimeType: 1832608
       GoKind: 22
       Pointee: 1299 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 869
+      ID: 867
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
-      GoRuntimeType: 923456
+      GoRuntimeType: 922784
       GoKind: 22
-      Pointee: 870 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 868 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
       ID: 1277
       Name: '*github.com/cihub/seelog.connWriter'
@@ -14388,42 +14388,42 @@ Types:
       ID: 1233
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
-      GoRuntimeType: 1054432
+      GoRuntimeType: 1054304
       GoKind: 22
       Pointee: 1234 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
       ID: 1760
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1442560
+      GoRuntimeType: 1442400
       GoKind: 22
       Pointee: 1761 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
       ID: 1873
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
-      GoRuntimeType: 1661856
+      GoRuntimeType: 1661088
       GoKind: 22
       Pointee: 1874 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
       ID: 1267
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
-      GoRuntimeType: 1442080
+      GoRuntimeType: 1441920
       GoKind: 22
       Pointee: 1268 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
       ID: 1877
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1662624
+      GoRuntimeType: 1661856
       GoKind: 22
       Pointee: 1878 UnresolvedPointeeType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
       ID: 1756
       Name: '*github.com/cihub/seelog.formattedWriter'
       ByteSize: 8
-      GoRuntimeType: 1442240
+      GoRuntimeType: 1442080
       GoKind: 22
       Pointee: 1757 UnresolvedPointeeType github.com/cihub/seelog.formattedWriter
     - __kind: PointerType
@@ -14437,42 +14437,42 @@ Types:
       ID: 1684
       Name: '*github.com/cihub/seelog.listConstraints'
       ByteSize: 8
-      GoRuntimeType: 1225664
+      GoRuntimeType: 1225152
       GoKind: 22
       Pointee: 1685 UnresolvedPointeeType github.com/cihub/seelog.listConstraints
     - __kind: PointerType
-      ID: 1511
+      ID: 1509
       Name: '*github.com/cihub/seelog.logFormattedMessage'
       ByteSize: 8
-      GoRuntimeType: 923072
+      GoRuntimeType: 922400
       GoKind: 22
-      Pointee: 1512 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
+      Pointee: 1510 UnresolvedPointeeType github.com/cihub/seelog.logFormattedMessage
     - __kind: PointerType
-      ID: 1509
+      ID: 1507
       Name: '*github.com/cihub/seelog.logMessage'
       ByteSize: 8
-      GoRuntimeType: 922976
+      GoRuntimeType: 922304
       GoKind: 22
-      Pointee: 1510 UnresolvedPointeeType github.com/cihub/seelog.logMessage
+      Pointee: 1508 UnresolvedPointeeType github.com/cihub/seelog.logMessage
     - __kind: PointerType
       ID: 1623
       Name: '*github.com/cihub/seelog.minMaxConstraints'
       ByteSize: 8
-      GoRuntimeType: 1054944
+      GoRuntimeType: 1054816
       GoKind: 22
       Pointee: 1624 UnresolvedPointeeType github.com/cihub/seelog.minMaxConstraints
     - __kind: PointerType
-      ID: 873
+      ID: 871
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
-      GoRuntimeType: 923648
+      GoRuntimeType: 922976
       GoKind: 22
-      Pointee: 874 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 872 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
       ID: 1621
       Name: '*github.com/cihub/seelog.offConstraints'
       ByteSize: 8
-      GoRuntimeType: 1054816
+      GoRuntimeType: 1054688
       GoKind: 22
       Pointee: 1622 UnresolvedPointeeType github.com/cihub/seelog.offConstraints
     - __kind: PointerType
@@ -14500,35 +14500,35 @@ Types:
       ID: 1235
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
-      GoRuntimeType: 1054560
+      GoRuntimeType: 1054432
       GoKind: 22
       Pointee: 1236 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
       ID: 1875
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
-      GoRuntimeType: 1662048
+      GoRuntimeType: 1661280
       GoKind: 22
       Pointee: 1876 UnresolvedPointeeType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 871
+      ID: 869
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
-      GoRuntimeType: 923552
+      GoRuntimeType: 922880
       GoKind: 22
-      Pointee: 872 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 870 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 875
+      ID: 873
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
-      GoRuntimeType: 923744
+      GoRuntimeType: 923072
       GoKind: 22
-      Pointee: 876 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 874 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
       ID: 1758
       Name: '*github.com/cihub/seelog.xmlNode'
       ByteSize: 8
-      GoRuntimeType: 1442400
+      GoRuntimeType: 1442240
       GoKind: 22
       Pointee: 1759 UnresolvedPointeeType github.com/cihub/seelog.xmlNode
     - __kind: PointerType
@@ -15380,42 +15380,42 @@ Types:
       ID: 1102
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
-      GoRuntimeType: 1214528
+      GoRuntimeType: 1214016
       GoKind: 22
       Pointee: 1103 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
       ID: 1096
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
-      GoRuntimeType: 1214144
+      GoRuntimeType: 1213632
       GoKind: 22
       Pointee: 1097 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
       ID: 1035
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
-      GoRuntimeType: 1045856
+      GoRuntimeType: 1045728
       GoKind: 22
       Pointee: 1036 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
       ID: 1108
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
-      GoRuntimeType: 1214912
+      GoRuntimeType: 1214400
       GoKind: 22
       Pointee: 1109 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
       ID: 1034
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
-      GoRuntimeType: 1045728
+      GoRuntimeType: 1045600
       GoKind: 22
       Pointee: 1013 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
       ID: 1100
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
-      GoRuntimeType: 1214400
+      GoRuntimeType: 1213888
       GoKind: 22
       Pointee: 1101 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
@@ -15426,31 +15426,31 @@ Types:
       GoKind: 22
       Pointee: 2696 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Reader
     - __kind: PointerType
-      ID: 1495
+      ID: 1493
       Name: '*github.com/tinylib/msgp/msgp.Type'
       ByteSize: 8
-      GoRuntimeType: 915104
+      GoRuntimeType: 914432
       GoKind: 22
       Pointee: 1191 BaseType github.com/tinylib/msgp/msgp.Type
     - __kind: PointerType
       ID: 1098
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
-      GoRuntimeType: 1214272
+      GoRuntimeType: 1213760
       GoKind: 22
       Pointee: 1099 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
       ID: 1106
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
-      GoRuntimeType: 1214784
+      GoRuntimeType: 1214272
       GoKind: 22
       Pointee: 1107 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
       ID: 1104
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
-      GoRuntimeType: 1214656
+      GoRuntimeType: 1214144
       GoKind: 22
       Pointee: 1105 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
@@ -15464,28 +15464,28 @@ Types:
       ID: 1112
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
-      GoRuntimeType: 1215296
+      GoRuntimeType: 1214784
       GoKind: 22
       Pointee: 1113 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
       ID: 1039
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
-      GoRuntimeType: 1046112
+      GoRuntimeType: 1045984
       GoKind: 22
       Pointee: 1040 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
       ID: 1037
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
-      GoRuntimeType: 1045984
+      GoRuntimeType: 1045856
       GoKind: 22
       Pointee: 1038 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
       ID: 1110
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
-      GoRuntimeType: 1215168
+      GoRuntimeType: 1214656
       GoKind: 22
       Pointee: 1111 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
@@ -17555,77 +17555,77 @@ Types:
       ID: 2562
       Name: '*io.LimitedReader'
       ByteSize: 8
-      GoRuntimeType: 909728
+      GoRuntimeType: 910592
       GoKind: 22
       Pointee: 2563 UnresolvedPointeeType io.LimitedReader
     - __kind: PointerType
       ID: 2672
       Name: '*io.PipeReader'
       ByteSize: 8
-      GoRuntimeType: 1867104
+      GoRuntimeType: 1869344
       GoKind: 22
       Pointee: 2673 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
       ID: 1255
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1205440
+      GoRuntimeType: 1208640
       GoKind: 22
       Pointee: 1256 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 2646
       Name: '*io.SectionReader'
       ByteSize: 8
-      GoRuntimeType: 1573312
+      GoRuntimeType: 1574912
       GoKind: 22
       Pointee: 2647 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
       ID: 1253
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1205056
+      GoRuntimeType: 1208256
       GoKind: 22
       Pointee: 1254 StructureType io.discard
     - __kind: PointerType
       ID: 2564
       Name: '*io.eofReader'
       ByteSize: 8
-      GoRuntimeType: 909824
+      GoRuntimeType: 910688
       GoKind: 22
       Pointee: 2565 StructureType io.eofReader
     - __kind: PointerType
       ID: 2620
       Name: '*io.multiReader'
       ByteSize: 8
-      GoRuntimeType: 1204800
+      GoRuntimeType: 1208000
       GoKind: 22
       Pointee: 2621 UnresolvedPointeeType io.multiReader
     - __kind: PointerType
       ID: 1227
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1038304
+      GoRuntimeType: 1039328
       GoKind: 22
       Pointee: 1228 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
       ID: 2588
       Name: '*io.nopCloser'
       ByteSize: 8
-      GoRuntimeType: 1038560
+      GoRuntimeType: 1039584
       GoKind: 22
       Pointee: 2589 StructureType io.nopCloser
     - __kind: PointerType
       ID: 2622
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
-      GoRuntimeType: 1204928
+      GoRuntimeType: 1208128
       GoKind: 22
       Pointee: 2623 StructureType io.nopCloserWriterTo
     - __kind: PointerType
       ID: 2560
       Name: '*io.teeReader'
       ByteSize: 8
-      GoRuntimeType: 909632
+      GoRuntimeType: 910496
       GoKind: 22
       Pointee: 2561 UnresolvedPointeeType io.teeReader
     - __kind: PointerType
@@ -17653,21 +17653,21 @@ Types:
       ID: 1686
       Name: '*log/slog.Attr'
       ByteSize: 8
-      GoRuntimeType: 1226304
+      GoRuntimeType: 1225792
       GoKind: 22
       Pointee: 1687 StructureType log/slog.Attr
     - __kind: PointerType
-      ID: 1516
+      ID: 1514
       Name: '*log/slog.Kind'
       ByteSize: 8
-      GoRuntimeType: 924128
+      GoRuntimeType: 923456
       GoKind: 22
-      Pointee: 1435 BaseType log/slog.Kind
+      Pointee: 1433 BaseType log/slog.Kind
     - __kind: PointerType
       ID: 2043
       Name: '*log/slog.Level'
       ByteSize: 8
-      GoRuntimeType: 1833504
+      GoRuntimeType: 1833056
       GoKind: 22
       Pointee: 1789 BaseType log/slog.Level
     - __kind: PointerType
@@ -18198,7 +18198,7 @@ Types:
       ID: 2659
       Name: '*math/rand/v2.ChaCha8'
       ByteSize: 8
-      GoRuntimeType: 1658976
+      GoRuntimeType: 1658208
       GoKind: 22
       Pointee: 2660 UnresolvedPointeeType math/rand/v2.ChaCha8
     - __kind: PointerType
@@ -18247,21 +18247,21 @@ Types:
       ID: 1119
       Name: '*net.AddrError'
       ByteSize: 8
-      GoRuntimeType: 1221184
+      GoRuntimeType: 1220672
       GoKind: 22
       Pointee: 1120 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
       ID: 1150
       Name: '*net.DNSError'
       ByteSize: 8
-      GoRuntimeType: 1440320
+      GoRuntimeType: 1440160
       GoKind: 22
       Pointee: 1151 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1507
+      ID: 1505
       Name: '*net.HardwareAddr.array'
       ByteSize: 8
-      Pointee: 1506 GoSliceDataType net.HardwareAddr.array
+      Pointee: 1504 GoSliceDataType net.HardwareAddr.array
     - __kind: PointerType
       ID: 2367
       Name: '*net.IP'
@@ -18285,14 +18285,14 @@ Types:
       ID: 1360
       Name: '*net.IPConn'
       ByteSize: 8
-      GoRuntimeType: 2268768
+      GoRuntimeType: 2267808
       GoKind: 22
       Pointee: 1361 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
       ID: 1613
       Name: '*net.IPMask'
       ByteSize: 8
-      GoRuntimeType: 1052384
+      GoRuntimeType: 1052256
       GoKind: 22
       Pointee: 1614 GoSliceHeaderType net.IPMask
     - __kind: PointerType
@@ -18304,28 +18304,28 @@ Types:
       ID: 1680
       Name: '*net.IPNet'
       ByteSize: 8
-      GoRuntimeType: 1220928
+      GoRuntimeType: 1220416
       GoKind: 22
       Pointee: 1681 UnresolvedPointeeType net.IPNet
     - __kind: PointerType
       ID: 1148
       Name: '*net.OpError'
       ByteSize: 8
-      GoRuntimeType: 1440000
+      GoRuntimeType: 1439840
       GoKind: 22
       Pointee: 1149 UnresolvedPointeeType net.OpError
     - __kind: PointerType
       ID: 1121
       Name: '*net.ParseError'
       ByteSize: 8
-      GoRuntimeType: 1221312
+      GoRuntimeType: 1220800
       GoKind: 22
       Pointee: 1122 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
       ID: 2039
       Name: '*net.TCPAddr'
       ByteSize: 8
-      GoRuntimeType: 1831936
+      GoRuntimeType: 1831488
       GoKind: 22
       Pointee: 2040 UnresolvedPointeeType net.TCPAddr
     - __kind: PointerType
@@ -18339,7 +18339,7 @@ Types:
       ID: 2037
       Name: '*net.UDPAddr'
       ByteSize: 8
-      GoRuntimeType: 1831712
+      GoRuntimeType: 1831264
       GoKind: 22
       Pointee: 2038 UnresolvedPointeeType net.UDPAddr
     - __kind: PointerType
@@ -18367,7 +18367,7 @@ Types:
       ID: 1118
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
-      GoRuntimeType: 1220416
+      GoRuntimeType: 1219904
       GoKind: 22
       Pointee: 1087 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
@@ -18379,37 +18379,37 @@ Types:
       ID: 2182
       Name: '*net.addrPortUDPAddr'
       ByteSize: 8
-      GoRuntimeType: 2043584
+      GoRuntimeType: 2043296
       GoKind: 22
       Pointee: 2183 StructureType net.addrPortUDPAddr
     - __kind: PointerType
       ID: 1051
       Name: '*net.canceledError'
       ByteSize: 8
-      GoRuntimeType: 1052640
+      GoRuntimeType: 1052512
       GoKind: 22
       Pointee: 1052 StructureType net.canceledError
     - __kind: PointerType
       ID: 1338
       Name: '*net.conn'
       ByteSize: 8
-      GoRuntimeType: 2043296
+      GoRuntimeType: 2043008
       GoKind: 22
       Pointee: 1339 UnresolvedPointeeType net.conn
     - __kind: PointerType
       ID: 1192
       Name: '*net.dialResult·1'
       ByteSize: 8
-      GoRuntimeType: 1878080
+      GoRuntimeType: 1877856
       GoKind: 22
       Pointee: 1193 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1508
+      ID: 1506
       Name: '*net.hostLookupOrder'
       ByteSize: 8
-      GoRuntimeType: 920768
+      GoRuntimeType: 920096
       GoKind: 22
-      Pointee: 1433 BaseType net.hostLookupOrder
+      Pointee: 1431 BaseType net.hostLookupOrder
     - __kind: PointerType
       ID: 1382
       Name: '*net.netFD'
@@ -18418,26 +18418,26 @@ Types:
       GoKind: 22
       Pointee: 1383 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 852
+      ID: 850
       Name: '*net.notFoundError'
       ByteSize: 8
-      GoRuntimeType: 920384
+      GoRuntimeType: 919712
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType net.notFoundError
+      Pointee: 851 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
       ID: 420
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
-      GoRuntimeType: 1440160
+      GoRuntimeType: 1440000
       GoKind: 22
       Pointee: 421 GoContextImplementationType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 854
+      ID: 852
       Name: '*net.result·2'
       ByteSize: 8
-      GoRuntimeType: 921056
+      GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 855 StructureType net.result·2
+      Pointee: 853 StructureType net.result·2
     - __kind: PointerType
       ID: 1364
       Name: '*net.tcpConnWithoutReadFrom'
@@ -18456,112 +18456,112 @@ Types:
       ID: 1123
       Name: '*net.temporaryError'
       ByteSize: 8
-      GoRuntimeType: 1221952
+      GoRuntimeType: 1221440
       GoKind: 22
       Pointee: 1124 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
       ID: 1152
       Name: '*net.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1440480
+      GoRuntimeType: 1440320
       GoKind: 22
       Pointee: 1153 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
       ID: 1607
       Name: '*net/http.Cookie'
       ByteSize: 8
-      GoRuntimeType: 1046880
+      GoRuntimeType: 1046752
       GoKind: 22
       Pointee: 1608 UnresolvedPointeeType net/http.Cookie
     - __kind: PointerType
       ID: 1041
       Name: '*net/http.ProtocolError'
       ByteSize: 8
-      GoRuntimeType: 1048672
+      GoRuntimeType: 1048544
       GoKind: 22
       Pointee: 1042 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 2036
       Name: '*net/http.Protocols'
       ByteSize: 8
-      GoRuntimeType: 1831040
+      GoRuntimeType: 1830592
       GoKind: 22
       Pointee: 1951 StructureType net/http.Protocols
     - __kind: PointerType
       ID: 2634
       Name: '*net/http.body'
       ByteSize: 8
-      GoRuntimeType: 1831488
+      GoRuntimeType: 1831040
       GoKind: 22
       Pointee: 2635 UnresolvedPointeeType net/http.body
     - __kind: PointerType
       ID: 2624
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
-      GoRuntimeType: 1216320
+      GoRuntimeType: 1215808
       GoKind: 22
       Pointee: 2625 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
       ID: 2566
       Name: '*net/http.bodyLocked'
       ByteSize: 8
-      GoRuntimeType: 915968
+      GoRuntimeType: 915296
       GoKind: 22
       Pointee: 2567 StructureType net/http.bodyLocked
     - __kind: PointerType
       ID: 1209
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
-      GoRuntimeType: 916160
+      GoRuntimeType: 915488
       GoKind: 22
       Pointee: 1210 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
       ID: 2568
       Name: '*net/http.byteReader'
       ByteSize: 8
-      GoRuntimeType: 916256
+      GoRuntimeType: 915584
       GoKind: 22
       Pointee: 2569 UnresolvedPointeeType net/http.byteReader
     - __kind: PointerType
       ID: 2602
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
-      GoRuntimeType: 1048544
+      GoRuntimeType: 1048416
       GoKind: 22
       Pointee: 2603 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 1498
+      ID: 1496
       Name: '*net/http.connectMethodKey'
       ByteSize: 8
-      GoRuntimeType: 916736
+      GoRuntimeType: 916064
       GoKind: 22
-      Pointee: 1499 StructureType net/http.connectMethodKey
+      Pointee: 1497 StructureType net/http.connectMethodKey
     - __kind: PointerType
-      ID: 1500
+      ID: 1498
       Name: '*net/http.contextKey'
       ByteSize: 8
-      GoRuntimeType: 918080
+      GoRuntimeType: 917408
       GoKind: 22
-      Pointee: 1501 UnresolvedPointeeType net/http.contextKey
+      Pointee: 1499 UnresolvedPointeeType net/http.contextKey
     - __kind: PointerType
       ID: 2590
       Name: '*net/http.eofReader'
       ByteSize: 8
-      GoRuntimeType: 1047136
+      GoRuntimeType: 1047008
       GoKind: 22
       Pointee: 2591 StructureType net/http.eofReader
     - __kind: PointerType
       ID: 2570
       Name: '*net/http.errorReader'
       ByteSize: 8
-      GoRuntimeType: 916352
+      GoRuntimeType: 915680
       GoKind: 22
       Pointee: 2571 StructureType net/http.errorReader
     - __kind: PointerType
       ID: 2572
       Name: '*net/http.finishAsyncByteRead'
       ByteSize: 8
-      GoRuntimeType: 916448
+      GoRuntimeType: 915776
       GoKind: 22
       Pointee: 2573 StructureType net/http.finishAsyncByteRead
     - __kind: PointerType
@@ -18572,10 +18572,10 @@ Types:
       GoKind: 22
       Pointee: 2653 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 829
+      ID: 827
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
-      GoRuntimeType: 916832
+      GoRuntimeType: 916160
       GoKind: 22
       Pointee: 744 BaseType net/http.http2ConnectionError
     - __kind: PointerType
@@ -18596,7 +18596,7 @@ Types:
       ID: 1604
       Name: '*net/http.http2ErrCode'
       ByteSize: 8
-      GoRuntimeType: 1046624
+      GoRuntimeType: 1046496
       GoKind: 22
       Pointee: 1165 BaseType net/http.http2ErrCode
     - __kind: PointerType
@@ -18607,52 +18607,52 @@ Types:
       GoKind: 22
       Pointee: 1798 StructureType net/http.http2FrameHeader
     - __kind: PointerType
-      ID: 1496
+      ID: 1494
       Name: '*net/http.http2FrameType'
       ByteSize: 8
-      GoRuntimeType: 915296
+      GoRuntimeType: 914624
       GoKind: 22
-      Pointee: 1428 BaseType net/http.http2FrameType
+      Pointee: 1426 BaseType net/http.http2FrameType
     - __kind: PointerType
-      ID: 830
+      ID: 828
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
-      GoRuntimeType: 916928
+      GoRuntimeType: 916256
       GoKind: 22
-      Pointee: 831 StructureType net/http.http2GoAwayError
+      Pointee: 829 StructureType net/http.http2GoAwayError
     - __kind: PointerType
       ID: 1865
       Name: '*net/http.http2GoAwayFrame'
       ByteSize: 8
-      GoRuntimeType: 1651296
+      GoRuntimeType: 1650528
       GoKind: 22
       Pointee: 1866 StructureType net/http.http2GoAwayFrame
     - __kind: PointerType
       ID: 2083
       Name: '*net/http.http2HeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 1874048
+      GoRuntimeType: 1873824
       GoKind: 22
       Pointee: 2082 StructureType net/http.http2HeadersFrame
     - __kind: PointerType
       ID: 2180
       Name: '*net/http.http2MetaHeadersFrame'
       ByteSize: 8
-      GoRuntimeType: 2042432
+      GoRuntimeType: 2042144
       GoKind: 22
       Pointee: 2181 StructureType net/http.http2MetaHeadersFrame
     - __kind: PointerType
       ID: 1867
       Name: '*net/http.http2PingFrame'
       ByteSize: 8
-      GoRuntimeType: 1651488
+      GoRuntimeType: 1650720
       GoKind: 22
       Pointee: 1868 StructureType net/http.http2PingFrame
     - __kind: PointerType
       ID: 1869
       Name: '*net/http.http2PriorityFrame'
       ByteSize: 8
-      GoRuntimeType: 1651680
+      GoRuntimeType: 1650912
       GoKind: 22
       Pointee: 1870 StructureType net/http.http2PriorityFrame
     - __kind: PointerType
@@ -18673,16 +18673,16 @@ Types:
       ID: 1605
       Name: '*net/http.http2Setting'
       ByteSize: 8
-      GoRuntimeType: 1046752
+      GoRuntimeType: 1046624
       GoKind: 22
       Pointee: 1606 StructureType net/http.http2Setting
     - __kind: PointerType
-      ID: 1497
+      ID: 1495
       Name: '*net/http.http2SettingID'
       ByteSize: 8
-      GoRuntimeType: 915584
+      GoRuntimeType: 914912
       GoKind: 22
-      Pointee: 1429 BaseType net/http.http2SettingID
+      Pointee: 1427 BaseType net/http.http2SettingID
     - __kind: PointerType
       ID: 2140
       Name: '*net/http.http2SettingsFrame'
@@ -18694,14 +18694,14 @@ Types:
       ID: 1144
       Name: '*net/http.http2StreamError'
       ByteSize: 8
-      GoRuntimeType: 1436320
+      GoRuntimeType: 1436160
       GoKind: 22
       Pointee: 1145 StructureType net/http.http2StreamError
     - __kind: PointerType
       ID: 1871
       Name: '*net/http.http2UnknownFrame'
       ByteSize: 8
-      GoRuntimeType: 1653024
+      GoRuntimeType: 1652256
       GoKind: 22
       Pointee: 1872 StructureType net/http.http2UnknownFrame
     - __kind: PointerType
@@ -18715,16 +18715,16 @@ Types:
       ID: 2648
       Name: '*net/http.http2clientStream'
       ByteSize: 8
-      GoRuntimeType: 2042720
+      GoRuntimeType: 2042432
       GoKind: 22
       Pointee: 2649 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 834
+      ID: 832
       Name: '*net/http.http2connError'
       ByteSize: 8
-      GoRuntimeType: 917504
+      GoRuntimeType: 916832
       GoKind: 22
-      Pointee: 835 StructureType net/http.http2connError
+      Pointee: 833 StructureType net/http.http2connError
     - __kind: PointerType
       ID: 1273
       Name: '*net/http.http2dataBuffer'
@@ -18733,10 +18733,10 @@ Types:
       GoKind: 22
       Pointee: 1274 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 833
+      ID: 831
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 917408
+      GoRuntimeType: 916736
       GoKind: 22
       Pointee: 748 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
@@ -18748,7 +18748,7 @@ Types:
       ID: 2596
       Name: '*net/http.http2eofReader'
       ByteSize: 8
-      GoRuntimeType: 1048032
+      GoRuntimeType: 1047904
       GoKind: 22
       Pointee: 2597 StructureType net/http.http2eofReader
     - __kind: PointerType
@@ -18759,10 +18759,10 @@ Types:
       GoKind: 22
       Pointee: 2651 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 837
+      ID: 835
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
-      GoRuntimeType: 917696
+      GoRuntimeType: 917024
       GoKind: 22
       Pointee: 754 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
@@ -18771,10 +18771,10 @@ Types:
       ByteSize: 8
       Pointee: 755 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 836
+      ID: 834
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
-      GoRuntimeType: 917600
+      GoRuntimeType: 916928
       GoKind: 22
       Pointee: 751 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
@@ -18786,28 +18786,28 @@ Types:
       ID: 1116
       Name: '*net/http.http2httpError'
       ByteSize: 8
-      GoRuntimeType: 1217216
+      GoRuntimeType: 1216704
       GoKind: 22
       Pointee: 1117 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
       ID: 2598
       Name: '*net/http.http2missingBody'
       ByteSize: 8
-      GoRuntimeType: 1048160
+      GoRuntimeType: 1048032
       GoKind: 22
       Pointee: 2599 StructureType net/http.http2missingBody
     - __kind: PointerType
       ID: 2604
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
-      GoRuntimeType: 1049312
+      GoRuntimeType: 1049184
       GoKind: 22
       Pointee: 2605 StructureType net/http.http2noBodyReader
     - __kind: PointerType
       ID: 1047
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
-      GoRuntimeType: 1049184
+      GoRuntimeType: 1049056
       GoKind: 22
       Pointee: 1048 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
@@ -18818,10 +18818,10 @@ Types:
       GoKind: 22
       Pointee: 1329 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 832
+      ID: 830
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
-      GoRuntimeType: 917312
+      GoRuntimeType: 916640
       GoKind: 22
       Pointee: 745 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
@@ -18833,42 +18833,42 @@ Types:
       ID: 1211
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
-      GoRuntimeType: 917792
+      GoRuntimeType: 917120
       GoKind: 22
       Pointee: 1212 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
       ID: 2600
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
-      GoRuntimeType: 1048288
+      GoRuntimeType: 1048160
       GoKind: 22
       Pointee: 2601 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
       ID: 2594
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
-      GoRuntimeType: 1047648
+      GoRuntimeType: 1047520
       GoKind: 22
       Pointee: 2595 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
       ID: 2626
       Name: '*net/http.noBody'
       ByteSize: 8
-      GoRuntimeType: 1216448
+      GoRuntimeType: 1215936
       GoKind: 22
       Pointee: 2627 StructureType net/http.noBody
     - __kind: PointerType
       ID: 1043
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
-      GoRuntimeType: 1048928
+      GoRuntimeType: 1048800
       GoKind: 22
       Pointee: 1044 StructureType net/http.nothingWrittenError
     - __kind: PointerType
       ID: 1863
       Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 1650912
+      GoRuntimeType: 1650144
       GoKind: 22
       Pointee: 1864 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
@@ -18882,49 +18882,49 @@ Types:
       ID: 1231
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
-      GoRuntimeType: 1048800
+      GoRuntimeType: 1048672
       GoKind: 22
       Pointee: 1232 StructureType net/http.persistConnWriter
     - __kind: PointerType
       ID: 2592
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
-      GoRuntimeType: 1047264
+      GoRuntimeType: 1047136
       GoKind: 22
       Pointee: 2593 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
       ID: 1265
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
-      GoRuntimeType: 1436480
+      GoRuntimeType: 1436320
       GoKind: 22
       Pointee: 1266 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 838
+      ID: 836
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
-      GoRuntimeType: 917888
+      GoRuntimeType: 917216
       GoKind: 22
-      Pointee: 839 StructureType net/http.requestBodyReadError
+      Pointee: 837 StructureType net/http.requestBodyReadError
     - __kind: PointerType
       ID: 1609
       Name: '*net/http.socksAddr'
       ByteSize: 8
-      GoRuntimeType: 1047392
+      GoRuntimeType: 1047264
       GoKind: 22
       Pointee: 1610 UnresolvedPointeeType net/http.socksAddr
     - __kind: PointerType
       ID: 1146
       Name: '*net/http.timeoutError'
       ByteSize: 8
-      GoRuntimeType: 1437600
+      GoRuntimeType: 1437440
       GoKind: 22
       Pointee: 1147 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
       ID: 1114
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
-      GoRuntimeType: 1217088
+      GoRuntimeType: 1216576
       GoKind: 22
       Pointee: 1115 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
@@ -18938,23 +18938,23 @@ Types:
       ID: 1045
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
-      GoRuntimeType: 1049056
+      GoRuntimeType: 1048928
       GoKind: 22
       Pointee: 1046 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
       ID: 1308
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
-      GoRuntimeType: 1874496
+      GoRuntimeType: 1874272
       GoKind: 22
       Pointee: 1309 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 827
+      ID: 825
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
-      GoRuntimeType: 916064
+      GoRuntimeType: 915392
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 826 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
       ID: 2614
       Name: '*net/http/httputil.failureToReadBody'
@@ -19076,14 +19076,14 @@ Types:
       ID: 1154
       Name: '*net/url.Error'
       ByteSize: 8
-      GoRuntimeType: 1440800
+      GoRuntimeType: 1440640
       GoKind: 22
       Pointee: 1155 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 856
+      ID: 854
       Name: '*net/url.EscapeError'
       ByteSize: 8
-      GoRuntimeType: 921152
+      GoRuntimeType: 920480
       GoKind: 22
       Pointee: 757 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
@@ -19092,10 +19092,10 @@ Types:
       ByteSize: 8
       Pointee: 758 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 857
+      ID: 855
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
-      GoRuntimeType: 921248
+      GoRuntimeType: 920576
       GoKind: 22
       Pointee: 760 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
@@ -19114,7 +19114,7 @@ Types:
       ID: 1682
       Name: '*net/url.Userinfo'
       ByteSize: 8
-      GoRuntimeType: 1222720
+      GoRuntimeType: 1222208
       GoKind: 22
       Pointee: 1683 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
@@ -19386,19 +19386,19 @@ Types:
       GoKind: 22
       Pointee: 793 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 1493
+      ID: 1515
       Name: '*reflect.ChanDir'
       ByteSize: 8
-      GoRuntimeType: 914240
+      GoRuntimeType: 923648
       GoKind: 22
-      Pointee: 1425 BaseType reflect.ChanDir
+      Pointee: 1434 BaseType reflect.ChanDir
     - __kind: PointerType
-      ID: 1494
+      ID: 1516
       Name: '*reflect.Kind'
       ByteSize: 8
-      GoRuntimeType: 914432
+      GoRuntimeType: 923840
       GoKind: 22
-      Pointee: 1426 BaseType reflect.Kind
+      Pointee: 1435 BaseType reflect.Kind
     - __kind: PointerType
       ID: 2531
       Name: '*reflect.Value'
@@ -19407,12 +19407,12 @@ Types:
       GoKind: 22
       Pointee: 2532 StructureType reflect.Value
     - __kind: PointerType
-      ID: 825
+      ID: 876
       Name: '*reflect.ValueError'
       ByteSize: 8
-      GoRuntimeType: 914816
+      GoRuntimeType: 924224
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType reflect.ValueError
+      Pointee: 877 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
       ID: 2515
       Name: '*reflect.rtype'
@@ -19639,12 +19639,12 @@ Types:
       GoKind: 22
       Pointee: 56 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 1503
+      ID: 1501
       Name: '*runtime/debug.BuildInfo'
       ByteSize: 8
-      GoRuntimeType: 920096
+      GoRuntimeType: 919424
       GoKind: 22
-      Pointee: 1504 UnresolvedPointeeType runtime/debug.BuildInfo
+      Pointee: 1502 UnresolvedPointeeType runtime/debug.BuildInfo
     - __kind: PointerType
       ID: 1517
       Name: '*runtime/pprof.labelMap'
@@ -31746,7 +31746,7 @@ Types:
     - __kind: ArrayType
       ID: 1948
       Name: '[0]func()'
-      GoRuntimeType: 743040
+      GoRuntimeType: 741696
       GoKind: 17
       HasCount: true
       Element: 66 GoSubroutineType func()
@@ -32068,7 +32068,7 @@ Types:
       ID: 2029
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 705760
+      GoRuntimeType: 704896
       GoKind: 17
       Count: 8
       HasCount: true
@@ -32077,7 +32077,7 @@ Types:
       ID: 1417
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
-      GoRuntimeType: 490144
+      GoRuntimeType: 489952
       GoKind: 23
       RawFields:
         - Name: array
@@ -32637,7 +32637,7 @@ Types:
       ID: 399
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
-      GoRuntimeType: 489696
+      GoRuntimeType: 489504
       GoKind: 23
       RawFields:
         - Name: array
@@ -32660,7 +32660,7 @@ Types:
       ID: 402
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
-      GoRuntimeType: 489888
+      GoRuntimeType: 489696
       GoKind: 23
       RawFields:
         - Name: array
@@ -32706,7 +32706,7 @@ Types:
       ID: 372
       Name: '[]go.shape.float64'
       ByteSize: 24
-      GoRuntimeType: 492256
+      GoRuntimeType: 492128
       GoKind: 23
       RawFields:
         - Name: array
@@ -33293,7 +33293,7 @@ Types:
       ID: 2213
       Name: '[]vendor/golang.org/x/net/http2/hpack.HeaderField'
       ByteSize: 24
-      GoRuntimeType: 501952
+      GoRuntimeType: 500992
       GoKind: 23
       RawFields:
         - Name: array
@@ -33536,7 +33536,7 @@ Types:
       ID: 164
       Name: context.Context
       ByteSize: 16
-      GoRuntimeType: 1300224
+      GoRuntimeType: 1300096
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33606,7 +33606,7 @@ Types:
       ID: 722
       Name: context.canceler
       ByteSize: 16
-      GoRuntimeType: 1125728
+      GoRuntimeType: 1124832
       GoKind: 20
       RawFields:
         - Name: tab
@@ -33618,7 +33618,7 @@ Types:
     - __kind: StructureType
       ID: 1091
       Name: context.deadlineExceededError
-      GoRuntimeType: 1484672
+      GoRuntimeType: 1483552
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
@@ -33649,7 +33649,7 @@ Types:
       ID: 439
       Name: context.timerCtx
       ByteSize: 112
-      GoRuntimeType: 1639776
+      GoRuntimeType: 1639392
       GoKind: 25
       RawFields:
         - Name: cancelCtx
@@ -33679,7 +33679,7 @@ Types:
       ID: 423
       Name: context.valueCtx
       ByteSize: 48
-      GoRuntimeType: 1867328
+      GoRuntimeType: 1866208
       GoKind: 25
       RawFields:
         - Name: Context
@@ -34189,7 +34189,7 @@ Types:
       ID: 772
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
-      GoRuntimeType: 845248
+      GoRuntimeType: 845056
       GoKind: 6
     - __kind: UnresolvedPointeeType
       ID: 1238
@@ -34202,13 +34202,13 @@ Types:
       GoRuntimeType: 845440
       GoKind: 8
     - __kind: BaseType
-      ID: 1431
+      ID: 1429
       Name: encoding/json.Delim
       ByteSize: 4
-      GoRuntimeType: 843904
+      GoRuntimeType: 843712
       GoKind: 5
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 847
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34235,19 +34235,19 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 841
+      ID: 839
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 845
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 845
+      ID: 843
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 841
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34255,10 +34255,10 @@ Types:
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 851
+      ID: 849
       Name: encoding/json.jsonError
       ByteSize: 16
-      GoRuntimeType: 1439040
+      GoRuntimeType: 1438880
       GoKind: 25
       RawFields:
         - Name: error
@@ -34309,7 +34309,7 @@ Types:
       ID: 2686
       Name: fmt.ScanState
       ByteSize: 16
-      GoRuntimeType: 1483872
+      GoRuntimeType: 1485952
       GoKind: 20
       RawFields:
         - Name: tab
@@ -34322,7 +34322,7 @@ Types:
       ID: 411
       Name: fmt.Stringer
       ByteSize: 16
-      GoRuntimeType: 1038048
+      GoRuntimeType: 1039072
       GoKind: 20
       RawFields:
         - Name: tab
@@ -34430,7 +34430,7 @@ Types:
       ID: 2031
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeAnyValue_AttributeAnyValueType
       ByteSize: 4
-      GoRuntimeType: 1787872
+      GoRuntimeType: 1787296
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 2196
@@ -34444,7 +34444,7 @@ Types:
       ID: 2032
       Name: github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.AttributeArrayValue_AttributeArrayValueType
       ByteSize: 4
-      GoRuntimeType: 1788064
+      GoRuntimeType: 1787488
       GoKind: 5
     - __kind: UnresolvedPointeeType
       ID: 2497
@@ -34505,7 +34505,7 @@ Types:
       Name: github.com/DataDog/datadog-agent/pkg/version.Version
       ByteSize: 8
     - __kind: StructureType
-      ID: 860
+      ID: 858
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1758752
@@ -34521,7 +34521,7 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 862
+      ID: 860
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34529,7 +34529,7 @@ Types:
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 866
+      ID: 864
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1128416
       GoKind: 25
@@ -34542,7 +34542,7 @@ Types:
       ID: 766
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
-      GoRuntimeType: 844672
+      GoRuntimeType: 844480
       GoKind: 24
       RawFields:
         - Name: str
@@ -34610,13 +34610,13 @@ Types:
       ID: 1181
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
-      GoRuntimeType: 595648
+      GoRuntimeType: 595584
       GoKind: 2
     - __kind: GoStringHeaderType
       ID: 763
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
-      GoRuntimeType: 844576
+      GoRuntimeType: 844384
       GoKind: 24
       RawFields:
         - Name: str
@@ -34635,7 +34635,7 @@ Types:
       ID: 769
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
-      GoRuntimeType: 844768
+      GoRuntimeType: 844576
       GoKind: 24
       RawFields:
         - Name: str
@@ -34846,7 +34846,7 @@ Types:
       ID: 401
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
-      GoRuntimeType: 1943520
+      GoRuntimeType: 1943264
       GoKind: 25
       RawFields:
         - Name: TraceID
@@ -34919,7 +34919,7 @@ Types:
       ID: 389
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 1300352
+      GoRuntimeType: 1300224
       GoKind: 21
       HeaderType: 391 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
@@ -34940,7 +34940,7 @@ Types:
       ID: 1419
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
-      GoRuntimeType: 592896
+      GoRuntimeType: 592832
       GoKind: 10
     - __kind: StructureType
       ID: 404
@@ -34969,7 +34969,7 @@ Types:
       ID: 738
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
-      GoRuntimeType: 1943776
+      GoRuntimeType: 1943520
       GoKind: 25
       RawFields:
         - Name: Type
@@ -35000,7 +35000,7 @@ Types:
       ID: 409
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
-      GoRuntimeType: 2139456
+      GoRuntimeType: 2139104
       GoKind: 25
       RawFields:
         - Name: mu
@@ -35037,7 +35037,7 @@ Types:
       ID: 410
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
-      GoRuntimeType: 910400
+      GoRuntimeType: 909920
       GoKind: 17
       Count: 16
       HasCount: true
@@ -35056,7 +35056,7 @@ Types:
       ID: 1585
       Name: github.com/DataDog/dd-trace-go/v2/internal.TraceSource
       ByteSize: 1
-      GoRuntimeType: 1005408
+      GoRuntimeType: 1005312
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 1375
@@ -35103,16 +35103,16 @@ Types:
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec/listener/waf.Feature
       ByteSize: 8
     - __kind: BaseType
-      ID: 1427
+      ID: 1425
       Name: github.com/DataDog/dd-trace-go/v2/internal/log.Level
       ByteSize: 8
-      GoRuntimeType: 842848
+      GoRuntimeType: 842656
       GoKind: 2
     - __kind: GoContextImplementationType
       ID: 419
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
-      GoRuntimeType: 1653984
+      GoRuntimeType: 1653216
       GoKind: 25
       RawFields:
         - Name: Context
@@ -35504,24 +35504,24 @@ Types:
           Offset: 56
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1515
+      ID: 1513
       Name: github.com/cihub/seelog.CfgParseParams
       ByteSize: 8
     - __kind: BaseType
-      ID: 1434
+      ID: 1432
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
-      GoRuntimeType: 845056
+      GoRuntimeType: 844864
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 2042
       Name: github.com/cihub/seelog.LogLevelException
       ByteSize: 8
     - __kind: StructureType
-      ID: 868
+      ID: 866
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
-      GoRuntimeType: 1441280
+      GoRuntimeType: 1441120
       GoKind: 25
       RawFields:
         - Name: message
@@ -35532,15 +35532,15 @@ Types:
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 870
+      ID: 868
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
-      GoRuntimeType: 1441440
+      GoRuntimeType: 1441280
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 868 StructureType github.com/cihub/seelog.baseError
+          Type: 866 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1278
       Name: github.com/cihub/seelog.connWriter
@@ -35578,11 +35578,11 @@ Types:
       Name: github.com/cihub/seelog.listConstraints
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1512
+      ID: 1510
       Name: github.com/cihub/seelog.logFormattedMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1510
+      ID: 1508
       Name: github.com/cihub/seelog.logMessage
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -35590,15 +35590,15 @@ Types:
       Name: github.com/cihub/seelog.minMaxConstraints
       ByteSize: 8
     - __kind: StructureType
-      ID: 874
+      ID: 872
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
-      GoRuntimeType: 1441760
+      GoRuntimeType: 1441600
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 868 StructureType github.com/cihub/seelog.baseError
+          Type: 866 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1622
       Name: github.com/cihub/seelog.offConstraints
@@ -35645,25 +35645,25 @@ Types:
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 872
+      ID: 870
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
-      GoRuntimeType: 1441600
+      GoRuntimeType: 1441440
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 868 StructureType github.com/cihub/seelog.baseError
+          Type: 866 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 876
+      ID: 874
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
-      GoRuntimeType: 1441920
+      GoRuntimeType: 1441760
       GoKind: 25
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 868 StructureType github.com/cihub/seelog.baseError
+          Type: 866 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
       ID: 1759
       Name: github.com/cihub/seelog.xmlNode
@@ -36288,7 +36288,7 @@ Types:
       ID: 1103
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
-      GoRuntimeType: 1872704
+      GoRuntimeType: 1872480
       GoKind: 25
       RawFields:
         - Name: Wanted
@@ -36321,7 +36321,7 @@ Types:
       ID: 1109
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
-      GoRuntimeType: 1873152
+      GoRuntimeType: 1872928
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36337,13 +36337,13 @@ Types:
       ID: 1013
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
-      GoRuntimeType: 1004832
+      GoRuntimeType: 1004736
       GoKind: 8
     - __kind: StructureType
       ID: 1101
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
-      GoRuntimeType: 1872480
+      GoRuntimeType: 1872256
       GoKind: 25
       RawFields:
         - Name: Nanos
@@ -36363,13 +36363,13 @@ Types:
       ID: 1191
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
-      GoRuntimeType: 842944
+      GoRuntimeType: 842752
       GoKind: 8
     - __kind: StructureType
       ID: 1099
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
-      GoRuntimeType: 1872256
+      GoRuntimeType: 1872032
       GoKind: 25
       RawFields:
         - Name: Method
@@ -36385,7 +36385,7 @@ Types:
       ID: 1107
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
-      GoRuntimeType: 1785568
+      GoRuntimeType: 1784992
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36398,7 +36398,7 @@ Types:
       ID: 1105
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
-      GoRuntimeType: 1872928
+      GoRuntimeType: 1872704
       GoKind: 25
       RawFields:
         - Name: Value
@@ -36418,7 +36418,7 @@ Types:
       ID: 1113
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
-      GoRuntimeType: 1649952
+      GoRuntimeType: 1649184
       GoKind: 25
       RawFields:
         - Name: ctx
@@ -36440,7 +36440,7 @@ Types:
       ID: 1111
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
-      GoRuntimeType: 1785760
+      GoRuntimeType: 1785184
       GoKind: 25
       RawFields:
         - Name: cause
@@ -39109,7 +39109,7 @@ Types:
       ID: 2665
       Name: io.Closer
       ByteSize: 16
-      GoRuntimeType: 1039072
+      GoRuntimeType: 1040096
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39134,7 +39134,7 @@ Types:
       ID: 1297
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1205184
+      GoRuntimeType: 1208384
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39147,7 +39147,7 @@ Types:
       ID: 412
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1038432
+      GoRuntimeType: 1039456
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39164,7 +39164,7 @@ Types:
       ID: 1283
       Name: io.WriteCloser
       ByteSize: 16
-      GoRuntimeType: 1125216
+      GoRuntimeType: 1125472
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39177,7 +39177,7 @@ Types:
       ID: 140
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1038176
+      GoRuntimeType: 1039200
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39190,7 +39190,7 @@ Types:
       ID: 2664
       Name: io.WriterTo
       ByteSize: 16
-      GoRuntimeType: 1038944
+      GoRuntimeType: 1039968
       GoKind: 20
       RawFields:
         - Name: tab
@@ -39202,13 +39202,13 @@ Types:
     - __kind: StructureType
       ID: 1254
       Name: io.discard
-      GoRuntimeType: 1484352
+      GoRuntimeType: 1486432
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 2565
       Name: io.eofReader
-      GoRuntimeType: 1124960
+      GoRuntimeType: 1125216
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -39223,7 +39223,7 @@ Types:
       ID: 2589
       Name: io.nopCloser
       ByteSize: 16
-      GoRuntimeType: 1573152
+      GoRuntimeType: 1574752
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -39233,7 +39233,7 @@ Types:
       ID: 2623
       Name: io.nopCloserWriterTo
       ByteSize: 16
-      GoRuntimeType: 1639392
+      GoRuntimeType: 1640544
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -39280,7 +39280,7 @@ Types:
       ID: 1687
       Name: log/slog.Attr
       ByteSize: 40
-      GoRuntimeType: 1793248
+      GoRuntimeType: 1792672
       GoKind: 25
       RawFields:
         - Name: Key
@@ -39290,16 +39290,16 @@ Types:
           Offset: 16
           Type: 2033 StructureType log/slog.Value
     - __kind: BaseType
-      ID: 1435
+      ID: 1433
       Name: log/slog.Kind
       ByteSize: 8
-      GoRuntimeType: 845152
+      GoRuntimeType: 844960
       GoKind: 2
     - __kind: BaseType
       ID: 1789
       Name: log/slog.Level
       ByteSize: 8
-      GoRuntimeType: 1506592
+      GoRuntimeType: 1505472
       GoKind: 2
     - __kind: StructureType
       ID: 2033
@@ -41886,16 +41886,16 @@ Types:
       Name: net.DNSError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1432
+      ID: 1430
       Name: net.Flags
       ByteSize: 8
-      GoRuntimeType: 844096
+      GoRuntimeType: 843904
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 1505
+      ID: 1503
       Name: net.HardwareAddr
       ByteSize: 24
-      GoRuntimeType: 920576
+      GoRuntimeType: 919904
       GoKind: 23
       RawFields:
         - Name: array
@@ -41907,9 +41907,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1506 GoSliceDataType net.HardwareAddr.array
+      Data: 1504 GoSliceDataType net.HardwareAddr.array
     - __kind: GoSliceDataType
-      ID: 1506
+      ID: 1504
       Name: net.HardwareAddr.array
       DynamicSizeClass: slice
       ByteSize: 1
@@ -41949,7 +41949,7 @@ Types:
       ID: 1614
       Name: net.IPMask
       ByteSize: 24
-      GoRuntimeType: 1052512
+      GoRuntimeType: 1052384
       GoKind: 23
       RawFields:
         - Name: array
@@ -42063,10 +42063,10 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: BaseType
-      ID: 1433
+      ID: 1431
       Name: net.hostLookupOrder
       ByteSize: 8
-      GoRuntimeType: 844192
+      GoRuntimeType: 844000
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1383
@@ -42085,14 +42085,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 851
       Name: net.notFoundError
       ByteSize: 8
     - __kind: GoContextImplementationType
       ID: 421
       Name: net.onlyValuesCtx
       ByteSize: 32
-      GoRuntimeType: 1790176
+      GoRuntimeType: 1789600
       GoKind: 25
       RawFields:
         - Name: Context
@@ -42104,7 +42104,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: StructureType
-      ID: 855
+      ID: 853
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1758560
@@ -42154,10 +42154,10 @@ Types:
       Name: net.timeoutError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1430
+      ID: 1428
       Name: net/http.ConnState
       ByteSize: 8
-      GoRuntimeType: 843328
+      GoRuntimeType: 843136
       GoKind: 2
     - __kind: UnresolvedPointeeType
       ID: 1608
@@ -42186,7 +42186,7 @@ Types:
       ID: 2567
       Name: net/http.bodyLocked
       ByteSize: 8
-      GoRuntimeType: 1436640
+      GoRuntimeType: 1436480
       GoKind: 25
       RawFields:
         - Name: b
@@ -42196,7 +42196,7 @@ Types:
       ID: 1210
       Name: net/http.bufioFlushWriter
       ByteSize: 16
-      GoRuntimeType: 1436800
+      GoRuntimeType: 1436640
       GoKind: 25
       RawFields:
         - Name: w
@@ -42211,7 +42211,7 @@ Types:
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 1499
+      ID: 1497
       Name: net/http.connectMethodKey
       ByteSize: 56
       GoRuntimeType: 1855840
@@ -42230,7 +42230,7 @@ Types:
           Offset: 48
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1501
+      ID: 1499
       Name: net/http.contextKey
       ByteSize: 8
     - __kind: StructureType
@@ -42243,7 +42243,7 @@ Types:
       ID: 2571
       Name: net/http.errorReader
       ByteSize: 16
-      GoRuntimeType: 1436960
+      GoRuntimeType: 1436800
       GoKind: 25
       RawFields:
         - Name: err
@@ -42253,7 +42253,7 @@ Types:
       ID: 2573
       Name: net/http.finishAsyncByteRead
       ByteSize: 8
-      GoRuntimeType: 1437120
+      GoRuntimeType: 1436960
       GoKind: 25
       RawFields:
         - Name: tw
@@ -42267,13 +42267,13 @@ Types:
       ID: 744
       Name: net/http.http2ConnectionError
       ByteSize: 4
-      GoRuntimeType: 843424
+      GoRuntimeType: 843232
       GoKind: 10
     - __kind: StructureType
       ID: 1955
       Name: net/http.http2ContinuationFrame
       ByteSize: 40
-      GoRuntimeType: 1787488
+      GoRuntimeType: 1786912
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42286,7 +42286,7 @@ Types:
       ID: 1950
       Name: net/http.http2DataFrame
       ByteSize: 40
-      GoRuntimeType: 1785952
+      GoRuntimeType: 1785376
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42299,13 +42299,13 @@ Types:
       ID: 1165
       Name: net/http.http2ErrCode
       ByteSize: 4
-      GoRuntimeType: 1004928
+      GoRuntimeType: 1004832
       GoKind: 10
     - __kind: BaseType
       ID: 2028
       Name: net/http.http2Flags
       ByteSize: 1
-      GoRuntimeType: 843136
+      GoRuntimeType: 842944
       GoKind: 8
     - __kind: StructureType
       ID: 1798
@@ -42319,7 +42319,7 @@ Types:
           Type: 6 BaseType bool
         - Name: Type
           Offset: 1
-          Type: 1428 BaseType net/http.http2FrameType
+          Type: 1426 BaseType net/http.http2FrameType
         - Name: Flags
           Offset: 2
           Type: 2028 BaseType net/http.http2Flags
@@ -42330,13 +42330,13 @@ Types:
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1428
+      ID: 1426
       Name: net/http.http2FrameType
       ByteSize: 1
-      GoRuntimeType: 843040
+      GoRuntimeType: 842848
       GoKind: 8
     - __kind: StructureType
-      ID: 831
+      ID: 829
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1756832
@@ -42355,7 +42355,7 @@ Types:
       ID: 1866
       Name: net/http.http2GoAwayFrame
       ByteSize: 48
-      GoRuntimeType: 1947616
+      GoRuntimeType: 1947360
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42374,7 +42374,7 @@ Types:
       ID: 2082
       Name: net/http.http2HeadersFrame
       ByteSize: 48
-      GoRuntimeType: 1873824
+      GoRuntimeType: 1873600
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42406,7 +42406,7 @@ Types:
       ID: 1868
       Name: net/http.http2PingFrame
       ByteSize: 20
-      GoRuntimeType: 1786144
+      GoRuntimeType: 1785568
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42432,7 +42432,7 @@ Types:
       ID: 2076
       Name: net/http.http2PriorityParam
       ByteSize: 8
-      GoRuntimeType: 1929760
+      GoRuntimeType: 1929504
       GoKind: 25
       RawFields:
         - Name: StreamDep
@@ -42454,7 +42454,7 @@ Types:
       ID: 1953
       Name: net/http.http2PushPromiseFrame
       ByteSize: 40
-      GoRuntimeType: 1875840
+      GoRuntimeType: 1875616
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42470,7 +42470,7 @@ Types:
       ID: 1800
       Name: net/http.http2RSTStreamFrame
       ByteSize: 16
-      GoRuntimeType: 1786336
+      GoRuntimeType: 1785760
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42488,21 +42488,21 @@ Types:
       RawFields:
         - Name: ID
           Offset: 0
-          Type: 1429 BaseType net/http.http2SettingID
+          Type: 1427 BaseType net/http.http2SettingID
         - Name: Val
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: BaseType
-      ID: 1429
+      ID: 1427
       Name: net/http.http2SettingID
       ByteSize: 2
-      GoRuntimeType: 843232
+      GoRuntimeType: 843040
       GoKind: 9
     - __kind: StructureType
       ID: 2030
       Name: net/http.http2SettingsFrame
       ByteSize: 40
-      GoRuntimeType: 1786528
+      GoRuntimeType: 1785952
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42515,7 +42515,7 @@ Types:
       ID: 1145
       Name: net/http.http2StreamError
       ByteSize: 24
-      GoRuntimeType: 1930016
+      GoRuntimeType: 1929760
       GoKind: 25
       RawFields:
         - Name: StreamID
@@ -42531,7 +42531,7 @@ Types:
       ID: 1872
       Name: net/http.http2UnknownFrame
       ByteSize: 40
-      GoRuntimeType: 1787296
+      GoRuntimeType: 1786720
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42544,7 +42544,7 @@ Types:
       ID: 1802
       Name: net/http.http2WindowUpdateFrame
       ByteSize: 16
-      GoRuntimeType: 1786720
+      GoRuntimeType: 1786144
       GoKind: 25
       RawFields:
         - Name: http2FrameHeader
@@ -42558,7 +42558,7 @@ Types:
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 835
+      ID: 833
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1621024
@@ -42578,7 +42578,7 @@ Types:
       ID: 748
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 843616
+      GoRuntimeType: 843424
       GoKind: 24
       RawFields:
         - Name: str
@@ -42607,7 +42607,7 @@ Types:
       ID: 754
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
-      GoRuntimeType: 843808
+      GoRuntimeType: 843616
       GoKind: 24
       RawFields:
         - Name: str
@@ -42626,7 +42626,7 @@ Types:
       ID: 751
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
-      GoRuntimeType: 843712
+      GoRuntimeType: 843520
       GoKind: 24
       RawFields:
         - Name: str
@@ -42671,7 +42671,7 @@ Types:
       ID: 745
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
-      GoRuntimeType: 843520
+      GoRuntimeType: 843328
       GoKind: 24
       RawFields:
         - Name: str
@@ -42715,7 +42715,7 @@ Types:
     - __kind: ArrayType
       ID: 1294
       Name: net/http.incomparable
-      GoRuntimeType: 915872
+      GoRuntimeType: 915200
       GoKind: 17
       HasCount: true
       Element: 66 GoSubroutineType func()
@@ -42726,7 +42726,7 @@ Types:
     - __kind: StructureType
       ID: 2627
       Name: net/http.noBody
-      GoRuntimeType: 1497152
+      GoRuntimeType: 1496032
       GoKind: 25
       RawFields: []
     - __kind: StructureType
@@ -42765,7 +42765,7 @@ Types:
       ID: 1266
       Name: net/http.readWriteCloserBody
       ByteSize: 24
-      GoRuntimeType: 1831264
+      GoRuntimeType: 1830816
       GoKind: 25
       RawFields:
         - Name: _
@@ -42778,10 +42778,10 @@ Types:
           Offset: 8
           Type: 1297 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 839
+      ID: 837
       Name: net/http.requestBodyReadError
       ByteSize: 16
-      GoRuntimeType: 1437760
+      GoRuntimeType: 1437600
       GoKind: 25
       RawFields:
         - Name: error
@@ -42798,7 +42798,7 @@ Types:
     - __kind: StructureType
       ID: 1115
       Name: net/http.tlsHandshakeTimeoutError
-      GoRuntimeType: 1498272
+      GoRuntimeType: 1497152
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -42819,7 +42819,7 @@ Types:
       ID: 1309
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
-      GoRuntimeType: 2060832
+      GoRuntimeType: 2060544
       GoKind: 25
       RawFields:
         - Name: Conn
@@ -42829,7 +42829,7 @@ Types:
           Offset: 16
           Type: 1188 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 826
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
@@ -42997,7 +42997,7 @@ Types:
       ID: 757
       Name: net/url.EscapeError
       ByteSize: 16
-      GoRuntimeType: 844288
+      GoRuntimeType: 844096
       GoKind: 24
       RawFields:
         - Name: str
@@ -43016,7 +43016,7 @@ Types:
       ID: 760
       Name: net/url.InvalidHostError
       ByteSize: 16
-      GoRuntimeType: 844384
+      GoRuntimeType: 844192
       GoKind: 24
       RawFields:
         - Name: str
@@ -43115,7 +43115,7 @@ Types:
       ID: 720
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
-      GoRuntimeType: 700512
+      GoRuntimeType: 699072
       GoKind: 17
       Count: 8
       HasCount: true
@@ -43196,7 +43196,7 @@ Types:
       ID: 735
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
-      GoRuntimeType: 701152
+      GoRuntimeType: 699712
       GoKind: 17
       Count: 8
       HasCount: true
@@ -43205,7 +43205,7 @@ Types:
       ID: 2552
       Name: noalg.[8]struct { key string; elem *regexp.Regexp }
       ByteSize: 192
-      GoRuntimeType: 702304
+      GoRuntimeType: 701152
       GoKind: 17
       Count: 8
       HasCount: true
@@ -43232,7 +43232,7 @@ Types:
       ID: 702
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
-      GoRuntimeType: 701056
+      GoRuntimeType: 699616
       GoKind: 17
       Count: 8
       HasCount: true
@@ -43421,7 +43421,7 @@ Types:
       ID: 719
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
-      GoRuntimeType: 1318656
+      GoRuntimeType: 1318528
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43538,7 +43538,7 @@ Types:
       ID: 734
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
-      GoRuntimeType: 1319680
+      GoRuntimeType: 1319552
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43551,7 +43551,7 @@ Types:
       ID: 2551
       Name: noalg.map.group[string]*regexp.Regexp
       ByteSize: 200
-      GoRuntimeType: 1320448
+      GoRuntimeType: 1320320
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43590,7 +43590,7 @@ Types:
       ID: 701
       Name: noalg.map.group[string]float64
       ByteSize: 200
-      GoRuntimeType: 1319424
+      GoRuntimeType: 1319296
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -43844,7 +43844,7 @@ Types:
       ID: 721
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
-      GoRuntimeType: 1318528
+      GoRuntimeType: 1318400
       GoKind: 25
       RawFields:
         - Name: key
@@ -43961,7 +43961,7 @@ Types:
       ID: 736
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
-      GoRuntimeType: 1319552
+      GoRuntimeType: 1319424
       GoKind: 25
       RawFields:
         - Name: key
@@ -43974,7 +43974,7 @@ Types:
       ID: 2553
       Name: noalg.struct { key string; elem *regexp.Regexp }
       ByteSize: 24
-      GoRuntimeType: 1320320
+      GoRuntimeType: 1320192
       GoKind: 25
       RawFields:
         - Name: key
@@ -44013,7 +44013,7 @@ Types:
       ID: 703
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
-      GoRuntimeType: 1319296
+      GoRuntimeType: 1319168
       GoKind: 25
       RawFields:
         - Name: key
@@ -44332,16 +44332,16 @@ Types:
       GoRuntimeType: 849664
       GoKind: 2
     - __kind: BaseType
-      ID: 1425
+      ID: 1434
       Name: reflect.ChanDir
       ByteSize: 8
-      GoRuntimeType: 842656
+      GoRuntimeType: 845152
       GoKind: 2
     - __kind: BaseType
-      ID: 1426
+      ID: 1435
       Name: reflect.Kind
       ByteSize: 8
-      GoRuntimeType: 842752
+      GoRuntimeType: 845248
       GoKind: 7
     - __kind: StructureType
       ID: 2532
@@ -44360,14 +44360,14 @@ Types:
           Offset: 16
           Type: 2533 BaseType reflect.flag
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 877
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: BaseType
       ID: 2533
       Name: reflect.flag
       ByteSize: 8
-      GoRuntimeType: 1784608
+      GoRuntimeType: 1792864
       GoKind: 12
     - __kind: UnresolvedPointeeType
       ID: 2516
@@ -45365,7 +45365,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1504
+      ID: 1502
       Name: runtime/debug.BuildInfo
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -45421,7 +45421,7 @@ Types:
       ID: 2619
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
-      GoRuntimeType: 1738176
+      GoRuntimeType: 1737408
       GoKind: 25
       RawFields:
         - Name: Reader
@@ -45434,7 +45434,7 @@ Types:
       ID: 2617
       Name: struct { io.Reader; io.WriterTo }
       ByteSize: 32
-      GoRuntimeType: 1737984
+      GoRuntimeType: 1737216
       GoKind: 25
       RawFields:
         - Name: Reader

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,17 +1,23 @@
 === yield 1 [final=false] ===
 Package: main
-	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
-		Arg: x: []int (declared at line 12, available: [12-12])
-	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
-	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-263], [266-266], [277-277], [280-281], [283-284], [286-287], [289-289], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
-		Var: o: main.outer (declared at line 247, available: )
-		Var: s: []*string (declared at line 258, available: )
-		Var: str: string (declared at line 257, available: [246-314])
-		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
-		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
-		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
-		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [17:17] injectible: [17-17]
+		Arg: x: []int (declared at line 17, available: [17-17])
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [108:138] injectible: [108-110], [112-126], [128-131], [133-133], [137-138]
+		Arg: ctx: context.Context (declared at line 108, available: [108-110])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 109, available: [110-113])
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [82:104] injectible: [82-84], [86-89], [91-96], [98-104]
+		Arg: ctx: context.Context (declared at line 82, available: [82-84])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-86])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [249:320] injectible: [249-251], [254-258], [263-264], [266-269], [272-272], [283-283], [286-287], [289-290], [292-293], [295-295], [300-300], [302-302], [304-305], [307-308], [310-311], [313-317], [319-320]
+		Arg: ctx: context.Context (declared at line 249, available: [249-251])
+		Var: o: main.outer (declared at line 253, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 250, available: [251-269])
+		Var: s: []*string (declared at line 264, available: )
+		Var: str: string (declared at line 263, available: [249-320])
+		Var: circ: main.circularReferenceType (declared at line 285, available: [249-320])
+		Var: s1: main.stringType1 (declared at line 313, available: [308-320])
+		Var: s2: main.stringType2 (declared at line 314, available: [308-320])
+		Var: s2p: *main.stringType2 (declared at line 315, available: [308-320])
 	Function: executeContextFuncs (main.executeContextFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [26:33] injectible: [26-27], [29-29], [31-33]
 		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 27, available: [31-32])
 		Var: ctx: context.Context (declared at line 27, available: [31-32])
@@ -21,14 +27,18 @@ Package: main
 		Var: id: uint64 (declared at line 1360, available: [1360-1361])
 	Function: executeContextImplFuncs (main.executeContextImplFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [61:67] injectible: [61-62], [65-67]
 		Var: c: *main.contextImpl (declared at line 62, available: [61-67])
-	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [113:187] injectible: [113-113], [115-184], [186-187]
-		Var: m: main.manyPointers (declared at line 114, available: [113-187])
-	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:50] injectible: [36-36], [39-40], [42-42], [44-45], [47-47], [49-50]
-		Var: ss: []string (declared at line 39, available: [36-50])
-		Scope: 40-44
-			Var: i: int (declared at line 40, available: [40-42], [44-44])
-		Scope: 45-49
-			Var: i: int (declared at line 45, available: [45-49])
+	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [119:196] injectible: [119-121], [124-193], [195-196]
+		Arg: ctx: context.Context (declared at line 119, available: [119-121])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 120, available: [121-121])
+		Var: m: main.manyPointers (declared at line 123, available: [119-196])
+	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [39:56] injectible: [39-41], [45-46], [48-48], [50-51], [53-53], [55-56]
+		Arg: ctx: context.Context (declared at line 39, available: [39-41])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 40, available: [41-45])
+		Var: ss: []string (declared at line 45, available: [39-56])
+		Scope: 46-50
+			Var: i: int (declared at line 46, available: [46-48], [50-50])
+		Scope: 51-55
+			Var: i: int (declared at line 51, available: [51-55])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -83,10 +93,12 @@ Package: main
 		Arg: acc: string (declared at line 340, available: [340-340])
 		Arg: x: string (declared at line 340, available: [340-340])
 		Arg: ~r0: string (declared at line 340, available: )
-	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106] injectible: [97-98], [100-106]
-		Var: x: int (declared at line 99, available: )
-		Var: y: int (declared at line 100, available: [97-106])
-		Var: a: [5]int (declared at line 98, available: [97-106])
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [100:112] injectible: [100-102], [104-104], [106-112]
+		Arg: ctx: context.Context (declared at line 100, available: [100-102])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 101, available: [102-107])
+		Var: x: int (declared at line 105, available: )
+		Var: y: int (declared at line 106, available: [100-112])
+		Var: a: [5]int (declared at line 104, available: [100-112])
 	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124] injectible: [76-82], [88-112], [117-120], [122-122], [124-124]
 		Var: &one: *int (declared at line 95, available: [76-124])
 		Var: &foo: *string (declared at line 98, available: [76-124])
@@ -142,107 +154,125 @@ Package: main
 			Var: i: int (declared at line 210, available: [210-210], [211-211], [212-212], [214-214])
 			Scope: 210-212
 				Var: key: [4]int (declared at line 211, available: )
-	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
-		Var: x: chan bool (declared at line 52, available: [53-54])
-	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-141], [143-143], [145-145], [147-151], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
-		Var: upp: **int (declared at line 169, available: )
-		Var: self: *main.node (declared at line 172, available: [173-177])
-		Var: swp: main.structWithPointer (declared at line 114, available: )
-		Var: z: main.spws (declared at line 118, available: )
-		Var: r: string (declared at line 117, available: [112-178])
-		Var: ssaw: main.swsp (declared at line 126, available: [112-178])
-		Var: rct: main.reallyComplexType (declared at line 137, available: [112-178])
-		Var: b: main.node (declared at line 145, available: [112-178])
-		Var: stringSlice: []string (declared at line 162, available: [112-178])
-		Var: up: *int (declared at line 168, available: [112-178])
-		Var: aruint: [2]uint (declared at line 159, available: )
-		Var: n: main.nStruct (declared at line 123, available: )
-		Var: u: int (declared at line 167, available: )
-		Var: u64F: uint64 (declared at line 113, available: )
-		Var: uintToPointTo: uint (declared at line 120, available: )
-		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [92:127] injectible: [92-94], [96-96], [109-123], [127-127]
+		Arg: ctx: context.Context (declared at line 92, available: [92-94])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 93, available: [94-96])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [54:62] injectible: [54-56], [58-62]
+		Arg: ctx: context.Context (declared at line 54, available: [54-56])
+		Var: x: chan bool (declared at line 58, available: [59-60])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 55, available: [56-58])
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [117:186] injectible: [117-119], [121-121], [123-123], [125-125], [128-129], [131-134], [138-140], [142-143], [145-149], [151-151], [153-153], [155-159], [163-163], [165-165], [167-168], [170-171], [173-173], [175-176], [178-178], [180-181], [183-186]
+		Arg: ctx: context.Context (declared at line 117, available: [117-119])
+		Var: z: main.spws (declared at line 126, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 118, available: [119-123])
+		Var: upp: **int (declared at line 177, available: )
+		Var: self: *main.node (declared at line 180, available: [181-185])
+		Var: swp: main.structWithPointer (declared at line 122, available: )
+		Var: r: string (declared at line 125, available: [117-186])
+		Var: ssaw: main.swsp (declared at line 134, available: [117-186])
+		Var: rct: main.reallyComplexType (declared at line 145, available: [117-186])
+		Var: b: main.node (declared at line 153, available: [117-186])
+		Var: stringSlice: []string (declared at line 170, available: [117-186])
+		Var: up: *int (declared at line 176, available: [117-186])
+		Var: aruint: [2]uint (declared at line 167, available: )
+		Var: n: main.nStruct (declared at line 131, available: )
+		Var: u: int (declared at line 175, available: )
+		Var: u64F: uint64 (declared at line 121, available: )
+		Var: uintToPointTo: uint (declared at line 128, available: )
+		Var: x: main.structWithTwoValues (declared at line 142, available: )
 	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [29:33] injectible: [29-33]
-		Var: s: *main.Server (declared at line 30, available: )
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
-		Var: originalSlice: []int (declared at line 133, available: )
-		Var: s: []uint (declared at line 142, available: )
-		Var: s2: []uint (declared at line 159, available: )
-		Scope: 143-146
-			Var: i: int (declared at line 143, available: [146-146])
-	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
-	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [65:86] injectible: [65-65], [67-72], [75-77], [81-81], [84-86]
-		Var: abc: string (declared at line 66, available: )
-		Var: uninitializedString: string (declared at line 74, available: )
-		Var: s: string (declared at line 80, available: )
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236] injectible: [135-137], [140-140], [142-143], [145-146], [150-150], [152-160], [172-172], [174-174], [177-182], [190-192], [194-195], [198-198], [200-201], [203-206], [208-208], [210-213], [215-216], [219-220], [222-223], [225-226], [228-229], [231-232], [235-236]
-		Var: ptrRcvr: *main.receiver (declared at line 200, available: )
-		Var: n: main.nStruct (declared at line 139, available: )
-		Var: ns: main.structWithNoStrings (declared at line 148, available: )
-		Var: cs: main.cStruct (declared at line 149, available: )
-		Var: rcvr: main.receiver (declared at line 197, available: )
-		Var: ts: main.threestrings (declared at line 136, available: [135-236])
-		Var: s: main.aStruct (declared at line 142, available: [135-236])
-		Var: b: main.bStruct (declared at line 145, available: [135-236])
-		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
-		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
-		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
-		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
-		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
-		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
-		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
-	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
-		Var: ist: *time.Location (declared at line 48, available: [49-49])
-	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
-		Arg: x: []int (declared at line 22, available: [22-25])
-	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
-		Arg: f: func(int) (declared at line 28, available: [28-29])
+	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [34:41] injectible: [34-36], [38-41]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: s: *main.Server (declared at line 38, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [137:189] injectible: [137-139], [141-143], [145-152], [154-158], [160-160], [162-164], [167-168], [170-181], [183-183], [185-185], [187-189]
+		Arg: ctx: context.Context (declared at line 137, available: [137-139])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 138, available: [139-141])
+		Var: originalSlice: []int (declared at line 141, available: )
+		Var: s: []uint (declared at line 150, available: )
+		Var: s2: []uint (declared at line 167, available: )
+		Scope: 151-154
+			Var: i: int (declared at line 151, available: [154-154])
+	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [34:39] injectible: [34-36], [38-39]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [70:94] injectible: [70-72], [75-80], [83-85], [89-89], [92-94]
+		Arg: ctx: context.Context (declared at line 70, available: [70-72])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 71, available: [72-75])
+		Var: abc: string (declared at line 74, available: )
+		Var: uninitializedString: string (declared at line 82, available: )
+		Var: s: string (declared at line 88, available: )
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [141:245] injectible: [141-143], [145-146], [149-149], [151-152], [154-155], [159-159], [161-169], [181-181], [183-183], [186-191], [199-201], [203-204], [207-207], [209-210], [212-215], [217-217], [219-222], [224-225], [228-229], [231-232], [234-235], [237-238], [240-241], [244-245]
+		Arg: ctx: context.Context (declared at line 141, available: [141-143])
+		Var: rcvr: main.receiver (declared at line 206, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 142, available: [143-146])
+		Var: ptrRcvr: *main.receiver (declared at line 209, available: )
+		Var: n: main.nStruct (declared at line 148, available: )
+		Var: ns: main.structWithNoStrings (declared at line 157, available: )
+		Var: cs: main.cStruct (declared at line 158, available: )
+		Var: ts: main.threestrings (declared at line 145, available: [141-245])
+		Var: s: main.aStruct (declared at line 151, available: [141-245])
+		Var: b: main.bStruct (declared at line 154, available: [141-245])
+		Var: tenStr: main.tenStrings (declared at line 171, available: [141-245])
+		Var: deep: main.deepStruct1 (declared at line 185, available: [141-245])
+		Var: fields: main.lotsOfFields (declared at line 203, available: [141-245])
+		Var: sta: main.structWithTwoArrays (declared at line 212, available: [141-245])
+		Var: .autotmp_121: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_140: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_147: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_152: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_176: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_183: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_188: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_195: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_201: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_206: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_213: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_219: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_22: [0]main.structWithCyclicSlices (declared at line 229, available: [141-245])
+		Var: .autotmp_224: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_236: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_243: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_248: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_255: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_26: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_261: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_266: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_273: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_279: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_284: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_291: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_298: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_304: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_309: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_31: [0][][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_32: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_34: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_41: [0][][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_42: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_44: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_47: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_51: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_56: [0][][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_57: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_59: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_62: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_66: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_70: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_20: [0]uint8 (declared at line 166, available: [141-245])
+		Var: .autotmp_97: main.emptyStruct (declared at line 199, available: [141-245])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [44:65] injectible: [44-46], [49-50], [56-59], [64-65]
+		Arg: ctx: context.Context (declared at line 44, available: [44-46])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 45, available: [46-49])
+		Var: ist: *time.Location (declared at line 56, available: [57-57])
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [27:30] injectible: [27-30]
+		Arg: x: []int (declared at line 27, available: [27-30])
+	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [31:33] injectible: [31-33]
+		Arg: f: func(int) (declared at line 31, available: [31-32])
 	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [109:119] injectible: [109-115], [117-117], [119-119]
 		Arg: entriesCount: int (declared at line 109, available: [109-119])
 		Arg: ~r0: map[string][]main.structWithMap (declared at line 109, available: )
@@ -275,21 +305,23 @@ Package: main
 		Arg: b: <T> (declared at line 113, available: [113-114])
 		Arg: ~r0: <T> (declared at line 113, available: )
 		Arg: ~r1: <T> (declared at line 113, available: )
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:18] injectible: [16-18]
 		Arg: value: int (declared at line 16, available: [16-17])
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:50] injectible: [21-21], [26-26], [29-30], [33-33], [35-35], [37-40], [44-48], [50-50]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [22:50] injectible: [22-22], [27-27], [30-31], [34-34], [36-36], [38-41], [44-48], [50-50]
 		Var: ticker: *time.Ticker (declared at line 44, available: [45-45])
-		Var: service: string (declared at line 29, available: [30-33])
-		Scope: 37-45
-			Var: scanner: *bufio.Scanner (declared at line 37, available: )
+		Var: service: string (declared at line 30, available: [31-34])
+		Var: .autotmp_15: context.backgroundCtx (declared at line 212, available: [22-50])
+		Scope: 38-45
+			Var: scanner: *bufio.Scanner (declared at line 38, available: )
 		Scope: 45-48
 			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 46, available: [45-48])
+			Var: ctx: context.Context (declared at line 46, available: [47-47])
 	Type: main.Pair[...]
 		Field: Key: <T>
 		Field: Value: <T>
@@ -303,10 +335,10 @@ Package: main
 		Field: Total: float64
 	Type: main.Server
 		Field: name: string
-		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [21:26] injectible: [21-23], [25-26]
-			Arg: s: *main.Server (declared at line 21, available: [21-23])
-			Arg: req: *main.Request (declared at line 21, available: [21-26])
-			Arg: ~r0: error (declared at line 21, available: )
+		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [26:31] injectible: [26-28], [30-31]
+			Arg: s: *main.Server (declared at line 26, available: [26-28])
+			Arg: req: *main.Request (declared at line 26, available: [26-31])
+			Arg: ~r0: error (declared at line 26, available: )
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -622,12 +654,12 @@ Package: main
 		Field: aStringPtr: *string
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52] injectible: [52-52]
-			Arg: r: *main.receiver (declared at line 52, available: [52-52])
-			Arg: a: int (declared at line 52, available: [52-52])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56] injectible: [56-56]
-			Arg: r: main.receiver (declared at line 56, available: [56-56])
-			Arg: a: int (declared at line 56, available: [56-56])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [58:58] injectible: [58-58]
+			Arg: r: *main.receiver (declared at line 58, available: [58-58])
+			Arg: a: int (declared at line 58, available: [58-58])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [62:62] injectible: [62-62]
+			Arg: r: main.receiver (declared at line 62, available: [62-62])
+			Arg: a: int (declared at line 62, available: [62-62])
 	Type: main.score
 	Type: main.secondBehavior
 		Field: i: int
@@ -745,14 +777,14 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
-	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [104:107] injectible: [105-107]
-		Var: i: int (declared at line 106, available: [105-106])
+	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [110:113] injectible: [111-113]
+		Var: i: int (declared at line 112, available: [111-112])
 		Arg: id: int (declared at line 0, available: )
-		Var: p: *main.paddedData (declared at line 105, available: )
-	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [23:28] injectible: [23-26], [28-28]
-		Arg: n: int (declared at line 23, available: [23-28])
-		Arg: ~r0: string (declared at line 23, available: )
-		Var: prefix: string (declared at line 24, available: [23-26], [28-28])
+		Var: p: *main.paddedData (declared at line 111, available: )
+	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [26:31] injectible: [26-29], [31-31]
+		Arg: n: int (declared at line 26, available: [26-31])
+		Arg: ~r0: string (declared at line 26, available: )
+		Var: prefix: string (declared at line 27, available: [26-29], [31-31])
 		Var: ~r0.ptr: *uint8 (declared at line 34, available: )
 		Var: ~r0.len: int (declared at line 34, available: )
 	Function: nestedGeneric[...] (main.nestedGeneric[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [203:203] injectible: [203-203]
@@ -764,20 +796,21 @@ Package: main
 		Arg: items: <T> (declared at line 183, available: [183-184])
 		Arg: pred: <T> (declared at line 183, available: [183-184])
 		Arg: ~r0: <T> (declared at line 183, available: )
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
-		Arg: ~r0: uint64 (declared at line 40, available: )
-		Var: n: uint64 (declared at line 45, available: [44-46])
-		Var: b: []uint8 (declared at line 41, available: [44-45])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [43:49] injectible: [43-49]
+		Arg: ~r0: uint64 (declared at line 43, available: )
+		Var: n: uint64 (declared at line 48, available: [47-49])
+		Var: b: []uint8 (declared at line 44, available: [47-48])
 	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:88] injectible: [52-66], [68-69], [71-73], [75-77], [80-88]
+		Arg: ctx: context.Context (declared at line 52, available: [52-88])
 		Var: it: main.iterExample (declared at line 70, available: [52-88])
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 67, available: [52-88])
-	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
-		Arg: x: []int (declared at line 16, available: [16-17])
-		Arg: ~r0: string (declared at line 16, available: )
-	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14] injectible: [12-14]
-	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20] injectible: [18-20]
-	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25] injectible: [24-25]
-		Arg: ~r0: string (declared at line 24, available: )
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [21:22] injectible: [21-22]
+		Arg: x: []int (declared at line 21, available: [21-22])
+		Arg: ~r0: string (declared at line 21, available: )
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [17:19] injectible: [17-19]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [23:25] injectible: [23-25]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [29-30]
+		Arg: ~r0: string (declared at line 29, available: )
 	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55] injectible: [54-55]
 		Arg: a: interface {} (declared at line 54, available: [54-55])
 		Arg: ~r0: string (declared at line 54, available: )
@@ -787,224 +820,224 @@ Package: main
 	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
 		Arg: arg: [3]int (declared at line 297, available: [297-302])
 		Arg: ~r0: [3]int (declared at line 297, available: )
-	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
-		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
-	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
-		Arg: a: [2][2]int (declared at line 70, available: [70-70])
-	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78] injectible: [78-78]
-		Arg: b: [2][2][2]int (declared at line 78, available: [78-78])
+	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [93:93] injectible: [93-93]
+		Arg: a: [2]struct {} (declared at line 93, available: [93-93])
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [76:76] injectible: [76-76]
+		Arg: a: [2][2]int (declared at line 76, available: [76-76])
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [84:84] injectible: [84-84]
+		Arg: b: [2][2][2]int (declared at line 84, available: [84-84])
 	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [42:42] injectible: [42-42]
 		Arg: m: [2]map[string]int (declared at line 42, available: [42-42])
-	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74] injectible: [74-74]
-		Arg: a: [2]string (declared at line 74, available: [74-74])
-	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83] injectible: [83-83]
-		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
-	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
-		Arg: x: *[2]uint (declared at line 59, available: [59-59])
-	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
-		Arg: x: uint64 (declared at line 19, available: [23-23])
-		Arg: ~r0: uint64 (declared at line 19, available: )
-	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
-		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
-	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
-		Arg: x: [2]bool (declared at line 26, available: [26-26])
-	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
-		Arg: a: []uint8 (declared at line 117, available: [117-117])
-		Arg: b: []uint8 (declared at line 117, available: [117-117])
-	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
-		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
-		Arg: a: []uint8 (declared at line 129, available: [129-129])
-		Arg: b: []int (declared at line 129, available: [129-129])
-	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
-		Arg: x: []uint8 (declared at line 77, available: [77-77])
-	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
-		Arg: x: []uint8 (declared at line 81, available: [81-81])
-	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
-		Arg: x: []uint8 (declared at line 85, available: [85-85])
-	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
-		Arg: x: []uint8 (declared at line 89, available: [89-89])
-	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
-		Arg: x: []uint8 (declared at line 93, available: [93-93])
-	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
-		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
-	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
-		Arg: a: int (declared at line 125, available: [125-125])
-		Arg: x: []uint8 (declared at line 125, available: [125-125])
-		Arg: b: string (declared at line 125, available: [125-125])
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [80:80] injectible: [80-80]
+		Arg: a: [2]string (declared at line 80, available: [80-80])
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [89:89] injectible: [89-89]
+		Arg: a: [2]main.nestedStruct (declared at line 88, available: [89-89])
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [64:64] injectible: [64-64]
+		Arg: x: *[2]uint (declared at line 64, available: [64-64])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [26:26] injectible: [26-26]
+		Arg: x: uint64 (declared at line 22, available: [26-26])
+		Arg: ~r0: uint64 (declared at line 22, available: )
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [85:85] injectible: [85-85]
+		Arg: b: main.bigStruct (declared at line 85, available: [85-85])
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [32:32] injectible: [32-32]
+		Arg: x: [2]bool (declared at line 32, available: [32-32])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [122:122] injectible: [122-122]
+		Arg: a: []uint8 (declared at line 122, available: [122-122])
+		Arg: b: []uint8 (declared at line 122, available: [122-122])
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [20:20] injectible: [20-20]
+		Arg: x: [2]uint8 (declared at line 20, available: [20-20])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [134:134] injectible: [134-134]
+		Arg: a: []uint8 (declared at line 134, available: [134-134])
+		Arg: b: []int (declared at line 134, available: [134-134])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [82:82] injectible: [82-82]
+		Arg: x: []uint8 (declared at line 82, available: [82-82])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [86:86] injectible: [86-86]
+		Arg: x: []uint8 (declared at line 86, available: [86-86])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [90:90] injectible: [90-90]
+		Arg: x: []uint8 (declared at line 90, available: [90-90])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [94:94] injectible: [94-94]
+		Arg: x: []uint8 (declared at line 94, available: [94-94])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [98:98] injectible: [98-98]
+		Arg: x: []uint8 (declared at line 98, available: [98-98])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [126:126] injectible: [126-126]
+		Arg: x: [][]uint8 (declared at line 126, available: [126-126])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [130:130] injectible: [130-130]
+		Arg: a: int (declared at line 130, available: [130-130])
+		Arg: x: []uint8 (declared at line 130, available: [130-130])
+		Arg: b: string (declared at line 130, available: [130-130])
 	Function: testCaptureContextImpl (main.testCaptureContextImpl) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [44:44] injectible: [44-44]
 		Arg: c: *main.contextImpl (declared at line 44, available: [44-44])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
-		Arg: c: chan bool (declared at line 30, available: [30-30])
-	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
-		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
-	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
-		Arg: w: uint8 (declared at line 34, available: [34-34])
-		Arg: x: bool (declared at line 34, available: [34-34])
-		Arg: y: float32 (declared at line 34, available: [34-34])
-	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22] injectible: [22-22]
-		Arg: w: uint8 (declared at line 22, available: [22-22])
-		Arg: x: uint8 (declared at line 22, available: [22-22])
-		Arg: y: float32 (declared at line 22, available: [22-22])
-	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38] injectible: [38-38]
-		Arg: w: uint8 (declared at line 38, available: [38-38])
-		Arg: x: int (declared at line 38, available: [38-38])
-		Arg: y: float32 (declared at line 38, available: [38-38])
-	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46] injectible: [46-46]
-		Arg: w: uint8 (declared at line 46, available: [46-46])
-		Arg: x: int16 (declared at line 46, available: [46-46])
-		Arg: y: float32 (declared at line 46, available: [46-46])
-	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50] injectible: [50-50]
-		Arg: w: uint8 (declared at line 50, available: [50-50])
-		Arg: x: int32 (declared at line 50, available: [50-50])
-		Arg: y: float32 (declared at line 50, available: [50-50])
-	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54] injectible: [54-54]
-		Arg: w: uint8 (declared at line 54, available: [54-54])
-		Arg: x: int64 (declared at line 54, available: [54-54])
-		Arg: y: float32 (declared at line 54, available: [54-54])
-	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42] injectible: [42-42]
-		Arg: w: uint8 (declared at line 42, available: [42-42])
-		Arg: x: int8 (declared at line 42, available: [42-42])
-		Arg: y: float32 (declared at line 42, available: [42-42])
-	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26] injectible: [26-26]
-		Arg: w: uint8 (declared at line 26, available: [26-26])
-		Arg: x: int32 (declared at line 26, available: [26-26])
-		Arg: y: float32 (declared at line 26, available: [26-26])
-	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30] injectible: [30-30]
-		Arg: w: uint8 (declared at line 30, available: [30-30])
-		Arg: x: string (declared at line 30, available: [30-30])
-		Arg: y: float32 (declared at line 30, available: [30-30])
-	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58] injectible: [58-58]
-		Arg: w: uint8 (declared at line 58, available: [58-58])
-		Arg: x: uint (declared at line 58, available: [58-58])
-		Arg: y: float32 (declared at line 58, available: [58-58])
-	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66] injectible: [66-66]
-		Arg: w: uint8 (declared at line 66, available: [66-66])
-		Arg: x: uint16 (declared at line 66, available: [66-66])
-		Arg: y: float32 (declared at line 66, available: [66-66])
-	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70] injectible: [70-70]
-		Arg: w: uint8 (declared at line 70, available: [70-70])
-		Arg: x: uint32 (declared at line 70, available: [70-70])
-		Arg: y: float32 (declared at line 70, available: [70-70])
-	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74] injectible: [74-74]
-		Arg: w: uint8 (declared at line 74, available: [74-74])
-		Arg: x: uint64 (declared at line 74, available: [74-74])
-		Arg: y: float32 (declared at line 74, available: [74-74])
-	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62] injectible: [62-62]
-		Arg: w: uint8 (declared at line 62, available: [62-62])
-		Arg: x: uint8 (declared at line 62, available: [62-62])
-		Arg: y: float32 (declared at line 62, available: [62-62])
-	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75] injectible: [75-75]
-		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [33:33] injectible: [33-33]
+		Arg: c: chan bool (declared at line 33, available: [33-33])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93] injectible: [93-93]
+		Arg: x: main.circularReferenceType (declared at line 93, available: [93-93])
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [40:40] injectible: [40-40]
+		Arg: w: uint8 (declared at line 40, available: [40-40])
+		Arg: x: bool (declared at line 40, available: [40-40])
+		Arg: y: float32 (declared at line 40, available: [40-40])
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [28:28] injectible: [28-28]
+		Arg: w: uint8 (declared at line 28, available: [28-28])
+		Arg: x: uint8 (declared at line 28, available: [28-28])
+		Arg: y: float32 (declared at line 28, available: [28-28])
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [44:44] injectible: [44-44]
+		Arg: w: uint8 (declared at line 44, available: [44-44])
+		Arg: x: int (declared at line 44, available: [44-44])
+		Arg: y: float32 (declared at line 44, available: [44-44])
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [52:52] injectible: [52-52]
+		Arg: w: uint8 (declared at line 52, available: [52-52])
+		Arg: x: int16 (declared at line 52, available: [52-52])
+		Arg: y: float32 (declared at line 52, available: [52-52])
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [56:56] injectible: [56-56]
+		Arg: w: uint8 (declared at line 56, available: [56-56])
+		Arg: x: int32 (declared at line 56, available: [56-56])
+		Arg: y: float32 (declared at line 56, available: [56-56])
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [60:60] injectible: [60-60]
+		Arg: w: uint8 (declared at line 60, available: [60-60])
+		Arg: x: int64 (declared at line 60, available: [60-60])
+		Arg: y: float32 (declared at line 60, available: [60-60])
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [48:48] injectible: [48-48]
+		Arg: w: uint8 (declared at line 48, available: [48-48])
+		Arg: x: int8 (declared at line 48, available: [48-48])
+		Arg: y: float32 (declared at line 48, available: [48-48])
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [32:32] injectible: [32-32]
+		Arg: w: uint8 (declared at line 32, available: [32-32])
+		Arg: x: int32 (declared at line 32, available: [32-32])
+		Arg: y: float32 (declared at line 32, available: [32-32])
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [36:36] injectible: [36-36]
+		Arg: w: uint8 (declared at line 36, available: [36-36])
+		Arg: x: string (declared at line 36, available: [36-36])
+		Arg: y: float32 (declared at line 36, available: [36-36])
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [64:64] injectible: [64-64]
+		Arg: w: uint8 (declared at line 64, available: [64-64])
+		Arg: x: uint (declared at line 64, available: [64-64])
+		Arg: y: float32 (declared at line 64, available: [64-64])
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [72:72] injectible: [72-72]
+		Arg: w: uint8 (declared at line 72, available: [72-72])
+		Arg: x: uint16 (declared at line 72, available: [72-72])
+		Arg: y: float32 (declared at line 72, available: [72-72])
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [76:76] injectible: [76-76]
+		Arg: w: uint8 (declared at line 76, available: [76-76])
+		Arg: x: uint32 (declared at line 76, available: [76-76])
+		Arg: y: float32 (declared at line 76, available: [76-76])
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [80:80] injectible: [80-80]
+		Arg: w: uint8 (declared at line 80, available: [80-80])
+		Arg: x: uint64 (declared at line 80, available: [80-80])
+		Arg: y: float32 (declared at line 80, available: [80-80])
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [68:68] injectible: [68-68]
+		Arg: w: uint8 (declared at line 68, available: [68-68])
+		Arg: x: uint8 (declared at line 68, available: [68-68])
+		Arg: y: float32 (declared at line 68, available: [68-68])
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [80:80] injectible: [80-80]
+		Arg: z: *main.reallyComplexType (declared at line 80, available: [80-80])
 	Function: testConflictingReturn (main.testConflictingReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [109:111] injectible: [109-111]
 		Arg: i: int (declared at line 109, available: [109-111])
 		Arg: ~r0: int (declared at line 109, available: )
 		Arg: r0: string (declared at line 109, available: )
-	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
-		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
-		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
-		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
-		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
-		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
-		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
-		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
-		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
-	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
-		Arg: x: []uint8 (declared at line 97, available: [97-97])
-	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
-		Arg: u: []uint (declared at line 33, available: [33-33])
-	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
-		Arg: xs: []main.structWithNoStrings (declared at line 45, available: [45-45])
-		Arg: a: int (declared at line 45, available: [45-45])
-	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [50:50] injectible: [50-50]
-		Arg: x: string (declared at line 50, available: [50-50])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124] injectible: [124-124]
-		Arg: e: main.emptyStruct (declared at line 124, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128] injectible: [128-128]
-		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [114:114] injectible: [114-114]
+		Arg: t: *main.t (declared at line 114, available: [114-114])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: main.deepMap1 (declared at line 203, available: [203-203])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [206:206] injectible: [206-206]
+		Arg: a: *main.deepMap7 (declared at line 206, available: [206-206])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: main.deepPtr1 (declared at line 139, available: [139-139])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142] injectible: [142-142]
+		Arg: a: *main.deepPtr7 (declared at line 142, available: [142-142])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: main.deepSlice1 (declared at line 165, available: [165-165])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [168:168] injectible: [168-168]
+		Arg: a: *main.deepSlice7 (declared at line 168, available: [168-168])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [126:126] injectible: [126-126]
+		Arg: t: main.deepStruct1 (declared at line 126, available: [126-126])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [102:102] injectible: [102-102]
+		Arg: x: []uint8 (declared at line 102, available: [102-102])
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [38:38] injectible: [38-38]
+		Arg: u: []uint (declared at line 38, available: [38-38])
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [50:50] injectible: [50-50]
+		Arg: xs: []main.structWithNoStrings (declared at line 50, available: [50-50])
+		Arg: a: int (declared at line 50, available: [50-50])
+	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [55:55] injectible: [55-55]
+		Arg: x: string (declared at line 55, available: [55-55])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [130:130] injectible: [130-130]
+		Arg: e: main.emptyStruct (declared at line 130, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [134:134] injectible: [134-134]
+		Arg: e: *main.emptyStruct (declared at line 134, available: [134-134])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
-	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [108-110], [112-112]
-		Arg: shouldErr: bool (declared at line 101, available: [101-103])
-		Arg: ~r0: int (declared at line 101, available: )
-		Var: x: int (declared at line 106, available: )
-		Var: err: error (declared at line 102, available: [101-112])
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [104:115] injectible: [104-104], [106-107], [111-113], [115-115]
+		Arg: shouldErr: bool (declared at line 104, available: [104-106])
+		Arg: ~r0: int (declared at line 104, available: )
+		Var: x: int (declared at line 109, available: )
+		Var: err: error (declared at line 105, available: [104-115])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
-	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80] injectible: [79-80]
-		Arg: x: int (declared at line 79, available: [79-80])
-		Arg: ~r0: int (declared at line 79, available: )
-	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93] injectible: [92-93]
-		Arg: a: [5]int (declared at line 92, available: [92-93])
-		Arg: ~r0: int (declared at line 92, available: )
-	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [17:19] injectible: [17-19]
-		Arg: x: int (declared at line 17, available: [17-18])
-		Arg: y: int (declared at line 17, available: [17-18])
-	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [21:25] injectible: [21-25]
-		Arg: x: int (declared at line 21, available: [21-25])
-		Arg: y: int (declared at line 21, available: [21-25])
-	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35] injectible: [32-32], [34-35]
-		Arg: x: int (declared at line 32, available: [32-34])
-	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42] injectible: [37-42]
-		Arg: x: int (declared at line 37, available: [37-38])
-		Arg: y: int (declared at line 37, available: [37-39])
-		Var: z: int (declared at line 38, available: [37-42])
-	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46] injectible: [44-46]
-		Arg: x: int (declared at line 44, available: [44-45])
-	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49] injectible: [49-49]
-	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60] injectible: [52-53], [55-56], [58-60]
-		Var: s: int (declared at line 54, available: [55-58])
-		Scope: 55-58
-			Var: i: int (declared at line 55, available: [55-58])
-	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63] injectible: [63-63]
-	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [66:67] injectible: [67-67]
-	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [13:15] injectible: [14-14]
-		Arg: x: int (declared at line 0, available: [13-14])
-	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [74:75] injectible: [75-75]
-		Arg: x: int (declared at line 0, available: [75-75])
-	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:71] injectible: [71-71]
-		Arg: a: [5]int (declared at line 0, available: [71-71])
-	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38] injectible: [38-38]
-		Arg: x: [2]int16 (declared at line 38, available: [38-38])
-	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42] injectible: [42-42]
-		Arg: x: [2]int32 (declared at line 42, available: [42-42])
-	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46] injectible: [46-46]
-		Arg: x: [2]int64 (declared at line 46, available: [46-46])
-	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34] injectible: [34-34]
-		Arg: x: [2]int8 (declared at line 34, available: [34-34])
-	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30] injectible: [30-30]
-		Arg: x: [2]int (declared at line 30, available: [30-30])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [82:83] injectible: [82-83]
+		Arg: x: int (declared at line 82, available: [82-83])
+		Arg: ~r0: int (declared at line 82, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [95:96] injectible: [95-96]
+		Arg: a: [5]int (declared at line 95, available: [95-96])
+		Arg: ~r0: int (declared at line 95, available: )
+	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [20:22] injectible: [20-22]
+		Arg: x: int (declared at line 20, available: [20-21])
+		Arg: y: int (declared at line 20, available: [20-21])
+	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [24:28] injectible: [24-28]
+		Arg: x: int (declared at line 24, available: [24-28])
+		Arg: y: int (declared at line 24, available: [24-28])
+	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [35:38] injectible: [35-35], [37-38]
+		Arg: x: int (declared at line 35, available: [35-37])
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [40:45] injectible: [40-45]
+		Arg: x: int (declared at line 40, available: [40-41])
+		Arg: y: int (declared at line 40, available: [40-42])
+		Var: z: int (declared at line 41, available: [40-45])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [47:49] injectible: [47-49]
+		Arg: x: int (declared at line 47, available: [47-48])
+	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [51:52] injectible: [52-52]
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [55:63] injectible: [55-56], [58-59], [61-63]
+		Var: s: int (declared at line 57, available: [58-61])
+		Scope: 58-61
+			Var: i: int (declared at line 58, available: [58-61])
+	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [65:66] injectible: [66-66]
+	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [69:70] injectible: [70-70]
+	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [16:18] injectible: [17-17]
+		Arg: x: int (declared at line 0, available: [16-17])
+	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [77:78] injectible: [78-78]
+		Arg: x: int (declared at line 0, available: [78-78])
+	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [73:74] injectible: [74-74]
+		Arg: a: [5]int (declared at line 0, available: [74-74])
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [44:44] injectible: [44-44]
+		Arg: x: [2]int16 (declared at line 44, available: [44-44])
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [48:48] injectible: [48-48]
+		Arg: x: [2]int32 (declared at line 48, available: [48-48])
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [52:52] injectible: [52-52]
+		Arg: x: [2]int64 (declared at line 52, available: [52-52])
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [40:40] injectible: [40-40]
+		Arg: x: [2]int8 (declared at line 40, available: [40-40])
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [36:36] injectible: [36-36]
+		Arg: x: [2]int (declared at line 36, available: [36-36])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50] injectible: [50-50]
 		Arg: b: main.behavior (declared at line 50, available: [50-50])
-	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [94:94] injectible: [94-94]
-		Arg: a: int (declared at line 94, available: [94-94])
-		Arg: b: error (declared at line 94, available: [94-94])
-		Arg: c: uint (declared at line 94, available: [94-94])
-	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
-		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [58:58] injectible: [58-58]
-		Arg: a: string (declared at line 58, available: [58-58])
-		Arg: b: string (declared at line 58, available: [58-58])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [97:97] injectible: [97-97]
+		Arg: a: int (declared at line 97, available: [97-97])
+		Arg: b: error (declared at line 97, available: [97-97])
+		Arg: c: uint (declared at line 97, available: [97-97])
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67] injectible: [67-67]
+		Arg: a: main.interfaceComplexityA (declared at line 67, available: [67-67])
+	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [63:63] injectible: [63-63]
+		Arg: a: string (declared at line 63, available: [63-63])
+		Arg: b: string (declared at line 63, available: [63-63])
 	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
 		Arg: arg: main.largeStruct (declared at line 281, available: [281-291])
 		Arg: ~r0: main.largeStruct (declared at line 281, available: )
-	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
-		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
-		Var: s: int (declared at line 224, available: [237-237], [242-242])
-		Var: aPerArch: int (declared at line 228, available: [223-243])
-		Var: b: int (declared at line 229, available: [223-243])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
-		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [47:47] injectible: [47-47]
+		Arg: a: main.node (declared at line 47, available: [47-47])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [226:246] injectible: [226-226], [233-233], [236-237], [239-242], [244-246]
+		Var: s: int (declared at line 227, available: [240-240], [245-245])
+		Var: aPerArch: int (declared at line 231, available: [226-246])
+		Var: b: int (declared at line 232, available: [226-246])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [138:138] injectible: [138-138]
+		Arg: l: main.lotsOfFields (declared at line 138, available: [138-138])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
 		Arg: a: int (declared at line 328, available: [328-330])
 		Arg: b: int (declared at line 328, available: [328-330])
@@ -1016,10 +1049,10 @@ Package: main
 		Arg: h: int (declared at line 328, available: [328-330])
 		Arg: i: int (declared at line 328, available: [328-330])
 		Arg: ~r0: [2]int (declared at line 328, available: )
-	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [102:102] injectible: [102-102]
-		Arg: m: main.manyPointers (declared at line 102, available: [102-102])
-	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [33:33] injectible: [33-33]
-		Arg: ss: []string (declared at line 33, available: [33-33])
+	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [108:108] injectible: [108-108]
+		Arg: m: main.manyPointers (declared at line 108, available: [108-108])
+	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:36] injectible: [36-36]
+		Arg: ss: []string (declared at line 36, available: [36-36])
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -1058,8 +1091,8 @@ Package: main
 		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
 	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70] injectible: [70-70]
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
-	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
-		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [47:47] injectible: [47-47]
+		Arg: x: string (declared at line 47, available: [47-47])
 	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-349]
 		Arg: a: int (declared at line 337, available: [337-349])
 		Arg: b: int (declared at line 337, available: [337-349])
@@ -1071,17 +1104,17 @@ Package: main
 		Arg: h: int (declared at line 337, available: [337-349])
 		Arg: s: string (declared at line 337, available: [337-349])
 		Arg: ~r0: main.largeStruct (declared at line 337, available: )
-	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [62:62] injectible: [62-62]
-		Arg: x: string (declared at line 62, available: [62-62])
+	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [67:67] injectible: [67-67]
+		Arg: x: string (declared at line 67, available: [67-67])
 	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
 		Arg: a: [2]int (declared at line 364, available: [364-366])
 		Arg: b: [3]int (declared at line 364, available: [364-366])
 		Arg: ~r0: int (declared at line 364, available: )
 		Arg: ~r1: [2]int (declared at line 364, available: )
-	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
-		Arg: o: main.outer (declared at line 72, available: [72-72])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
-		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [75:75] injectible: [75-75]
+		Arg: o: main.outer (declared at line 75, available: [75-75])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [102:102] injectible: [102-102]
+		Arg: b: main.bStruct (declared at line 102, available: [102-102])
 	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
 		Arg: s1: main.largeStruct (declared at line 308, available: [308-320])
 		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
@@ -1090,99 +1123,99 @@ Package: main
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
 		Arg: result2: int (declared at line 95, available: )
-	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
-		Arg: a: bool (declared at line 78, available: [78-78])
-		Arg: b: uint8 (declared at line 78, available: [78-78])
-		Arg: c: int32 (declared at line 78, available: [78-78])
-		Arg: d: uint (declared at line 78, available: [78-78])
-		Arg: e: string (declared at line 78, available: [78-78])
-	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
-		Arg: a: main.tierA (declared at line 68, available: [68-68])
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [84:84] injectible: [84-84]
+		Arg: a: bool (declared at line 84, available: [84-84])
+		Arg: b: uint8 (declared at line 84, available: [84-84])
+		Arg: c: int32 (declared at line 84, available: [84-84])
+		Arg: d: uint (declared at line 84, available: [84-84])
+		Arg: e: string (declared at line 84, available: [84-84])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71] injectible: [71-71]
+		Arg: a: main.tierA (declared at line 71, available: [71-71])
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
 		Arg: i: int (declared at line 88, available: [88-89])
 		Arg: result: int (declared at line 88, available: )
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
-		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
-	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
-		Arg: x: []uint8 (declared at line 101, available: [101-101])
-	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
-		Arg: z: *bool (declared at line 99, available: [99-99])
-		Arg: a: uint (declared at line 99, available: [99-99])
-	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61] injectible: [61-61]
-		Arg: xs: []uint16 (declared at line 61, available: [61-61])
-	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49] injectible: [49-49]
-		Arg: xs: []main.structWithNoStrings (declared at line 49, available: [49-49])
-		Arg: a: int (declared at line 49, available: [49-49])
-	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57] injectible: [57-57]
-		Arg: a: int8 (declared at line 57, available: [57-57])
-		Arg: s: []bool (declared at line 57, available: [57-57])
-		Arg: x: uint (declared at line 57, available: [57-57])
-	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71] injectible: [71-71]
-		Arg: z: uint (declared at line 71, available: [71-71])
-		Arg: x: *main.nStruct (declared at line 71, available: [71-71])
-		Arg: a: int (declared at line 71, available: [71-71])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100] injectible: [100-100]
-		Arg: c: main.cStruct (declared at line 100, available: [100-100])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92] injectible: [92-92]
-		Arg: x: main.nStruct (declared at line 92, available: [92-92])
-	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [38:38] injectible: [38-38]
-		Arg: a: *main.oneStringStruct (declared at line 38, available: [38-38])
-	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95] injectible: [95-95]
-		Arg: a: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: b: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: c: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: d: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: e: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: f: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: g: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: h: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: i: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: j: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: k: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: l: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: m: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: n: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: o: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: p: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: q: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: r: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: s: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: t: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: u: [3]uint32 (declared at line 94, available: [95-95])
-	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18] injectible: [18-18]
-		Arg: a: uint8 (declared at line 15, available: [18-18])
-		Arg: b: uint8 (declared at line 15, available: [18-18])
-		Arg: c: uint8 (declared at line 15, available: [18-18])
-		Arg: d: uint8 (declared at line 15, available: [18-18])
-		Arg: e: uint8 (declared at line 15, available: [18-18])
-		Arg: f: uint8 (declared at line 15, available: [18-18])
-		Arg: g: uint8 (declared at line 15, available: [18-18])
-		Arg: h: uint8 (declared at line 16, available: [18-18])
-		Arg: i: uint8 (declared at line 16, available: [18-18])
-		Arg: j: uint8 (declared at line 16, available: )
-		Arg: k: uint8 (declared at line 16, available: )
-		Arg: l: uint8 (declared at line 16, available: )
-		Arg: m: uint8 (declared at line 16, available: )
-		Arg: n: uint8 (declared at line 16, available: )
-		Arg: o: uint8 (declared at line 17, available: )
-		Arg: p: uint8 (declared at line 17, available: )
-		Arg: q: uint8 (declared at line 17, available: )
-		Arg: r: uint8 (declared at line 17, available: )
-		Arg: s: uint8 (declared at line 17, available: )
-		Arg: t: uint8 (declared at line 17, available: )
-		Arg: u: uint8 (declared at line 17, available: )
-	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51] injectible: [51-51]
-		Arg: a: *main.node (declared at line 51, available: [51-51])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [114:114] injectible: [114-114]
+		Arg: x: *main.anotherStruct (declared at line 114, available: [114-114])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [106:106] injectible: [106-106]
+		Arg: x: []uint8 (declared at line 106, available: [106-106])
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [104:104] injectible: [104-104]
+		Arg: z: *bool (declared at line 104, available: [104-104])
+		Arg: a: uint (declared at line 104, available: [104-104])
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [66:66] injectible: [66-66]
+		Arg: xs: []uint16 (declared at line 66, available: [66-66])
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [54:54] injectible: [54-54]
+		Arg: xs: []main.structWithNoStrings (declared at line 54, available: [54-54])
+		Arg: a: int (declared at line 54, available: [54-54])
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [62:62] injectible: [62-62]
+		Arg: a: int8 (declared at line 62, available: [62-62])
+		Arg: s: []bool (declared at line 62, available: [62-62])
+		Arg: x: uint (declared at line 62, available: [62-62])
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [76:76] injectible: [76-76]
+		Arg: z: uint (declared at line 76, available: [76-76])
+		Arg: x: *main.nStruct (declared at line 76, available: [76-76])
+		Arg: a: int (declared at line 76, available: [76-76])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [106:106] injectible: [106-106]
+		Arg: c: main.cStruct (declared at line 106, available: [106-106])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [98:98] injectible: [98-98]
+		Arg: x: main.nStruct (declared at line 98, available: [98-98])
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [43:43] injectible: [43-43]
+		Arg: a: *main.oneStringStruct (declared at line 43, available: [43-43])
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [101:101] injectible: [101-101]
+		Arg: a: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: b: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: c: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: d: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: e: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: f: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: g: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: h: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: i: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: j: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: k: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: l: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: m: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: n: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: o: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: p: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: q: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: r: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: s: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: t: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: u: [3]uint32 (declared at line 100, available: [101-101])
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [24:24] injectible: [24-24]
+		Arg: a: uint8 (declared at line 21, available: [24-24])
+		Arg: b: uint8 (declared at line 21, available: [24-24])
+		Arg: c: uint8 (declared at line 21, available: [24-24])
+		Arg: d: uint8 (declared at line 21, available: [24-24])
+		Arg: e: uint8 (declared at line 21, available: [24-24])
+		Arg: f: uint8 (declared at line 21, available: [24-24])
+		Arg: g: uint8 (declared at line 21, available: [24-24])
+		Arg: h: uint8 (declared at line 22, available: [24-24])
+		Arg: i: uint8 (declared at line 22, available: [24-24])
+		Arg: j: uint8 (declared at line 22, available: )
+		Arg: k: uint8 (declared at line 22, available: )
+		Arg: l: uint8 (declared at line 22, available: )
+		Arg: m: uint8 (declared at line 22, available: )
+		Arg: n: uint8 (declared at line 22, available: )
+		Arg: o: uint8 (declared at line 23, available: )
+		Arg: p: uint8 (declared at line 23, available: )
+		Arg: q: uint8 (declared at line 23, available: )
+		Arg: r: uint8 (declared at line 23, available: )
+		Arg: s: uint8 (declared at line 23, available: )
+		Arg: t: uint8 (declared at line 23, available: )
+		Arg: u: uint8 (declared at line 23, available: )
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [56:56] injectible: [56-56]
+		Arg: a: *main.node (declared at line 56, available: [56-56])
 	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [46:46] injectible: [46-46]
 		Arg: m: *map[string]int (declared at line 46, available: [46-46])
-	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103] injectible: [103-103]
-		Arg: u: **int (declared at line 103, available: [103-103])
-	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38] injectible: [38-38]
-		Arg: a: *main.structWithTwoValues (declared at line 38, available: [38-38])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76] injectible: [76-76]
-		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
-		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [108:108] injectible: [108-108]
+		Arg: u: **int (declared at line 108, available: [108-108])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [43:43] injectible: [43-43]
+		Arg: a: *main.structWithTwoValues (declared at line 43, available: [43-43])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [82:82] injectible: [82-82]
+		Arg: s: *main.structWithASlice (declared at line 82, available: [82-82])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [86:86] injectible: [86-86]
+		Arg: s: *main.structWithAString (declared at line 86, available: [86-86])
 	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
 		Arg: v: interface {} (declared at line 60, available: [60-72])
 		Arg: ~r0: interface {} (declared at line 60, available: )
@@ -1301,44 +1334,44 @@ Package: main
 		Arg: ~r0: main.structWithArray (declared at line 245, available: )
 	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
 		Arg: ~r0: main.wideStruct (declared at line 225, available: )
-	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
-		Arg: x: [2]int32 (declared at line 18, available: [18-18])
-	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
-		Arg: x: bool (declared at line 19, available: [19-19])
-	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11] injectible: [11-11]
-		Arg: x: uint8 (declared at line 11, available: [11-11])
-	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63] injectible: [63-63]
-		Arg: x: float32 (declared at line 63, available: [63-63])
-	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67] injectible: [67-67]
-		Arg: x: float64 (declared at line 67, available: [67-67])
-	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23] injectible: [23-23]
-		Arg: x: int (declared at line 23, available: [23-23])
-	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31] injectible: [31-31]
-		Arg: x: int16 (declared at line 31, available: [31-31])
-	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35] injectible: [35-35]
-		Arg: x: int32 (declared at line 35, available: [35-35])
-	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39] injectible: [39-39]
-		Arg: x: int64 (declared at line 39, available: [39-39])
-	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27] injectible: [27-27]
-		Arg: x: int8 (declared at line 27, available: [27-27])
-	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15] injectible: [15-15]
-		Arg: x: int32 (declared at line 15, available: [15-15])
-	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [12:12] injectible: [12-12]
-		Arg: x: string (declared at line 12, available: [12-12])
-	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43] injectible: [43-43]
-		Arg: x: uint (declared at line 43, available: [43-43])
-	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51] injectible: [51-51]
-		Arg: x: uint16 (declared at line 51, available: [51-51])
-	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55] injectible: [55-55]
-		Arg: x: uint32 (declared at line 55, available: [55-55])
-	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59] injectible: [59-59]
-		Arg: x: uint64 (declared at line 59, available: [59-59])
-	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47] injectible: [47-47]
-		Arg: x: uint8 (declared at line 47, available: [47-47])
-	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [69:69] injectible: [69-69]
-		Arg: xs: []struct {} (declared at line 69, available: [69-69])
-	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37] injectible: [37-37]
-		Arg: u: [][]uint (declared at line 37, available: [37-37])
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [24:24] injectible: [24-24]
+		Arg: x: [2]int32 (declared at line 24, available: [24-24])
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [25:25] injectible: [25-25]
+		Arg: x: bool (declared at line 25, available: [25-25])
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [17:17] injectible: [17-17]
+		Arg: x: uint8 (declared at line 17, available: [17-17])
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [69:69] injectible: [69-69]
+		Arg: x: float32 (declared at line 69, available: [69-69])
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
+		Arg: x: float64 (declared at line 73, available: [73-73])
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [29:29] injectible: [29-29]
+		Arg: x: int (declared at line 29, available: [29-29])
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [37:37] injectible: [37-37]
+		Arg: x: int16 (declared at line 37, available: [37-37])
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [41:41] injectible: [41-41]
+		Arg: x: int32 (declared at line 41, available: [41-41])
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [45:45] injectible: [45-45]
+		Arg: x: int64 (declared at line 45, available: [45-45])
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [33:33] injectible: [33-33]
+		Arg: x: int8 (declared at line 33, available: [33-33])
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [21:21] injectible: [21-21]
+		Arg: x: int32 (declared at line 21, available: [21-21])
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [17:17] injectible: [17-17]
+		Arg: x: string (declared at line 17, available: [17-17])
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [49:49] injectible: [49-49]
+		Arg: x: uint (declared at line 49, available: [49-49])
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [57:57] injectible: [57-57]
+		Arg: x: uint16 (declared at line 57, available: [57-57])
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [61:61] injectible: [61-61]
+		Arg: x: uint32 (declared at line 61, available: [61-61])
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [65:65] injectible: [65-65]
+		Arg: x: uint64 (declared at line 65, available: [65-65])
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [53:53] injectible: [53-53]
+		Arg: x: uint8 (declared at line 53, available: [53-53])
+	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [74:74] injectible: [74-74]
+		Arg: xs: []struct {} (declared at line 74, available: [74-74])
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [42:42] injectible: [42-42]
+		Arg: u: [][]uint (declared at line 42, available: [42-42])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
 	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
@@ -1351,120 +1384,120 @@ Package: main
 		Arg: ~r0: int (declared at line 356, available: )
 		Arg: ~r1: int (declared at line 356, available: )
 		Arg: ~r2: int (declared at line 356, available: )
-	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
-		Arg: x: [2]string (declared at line 22, available: [22-22])
-	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
-		Arg: z: *string (declared at line 91, available: [91-91])
-	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53] injectible: [53-53]
-		Arg: s: []string (declared at line 53, available: [53-53])
-	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95] injectible: [95-95]
-		Arg: a: *[]string (declared at line 95, available: [95-95])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
-		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
-		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
-		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
-		Arg: x: main.aStruct (declared at line 84, available: [84-84])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]
-		Arg: w: uint8 (declared at line 104, available: [104-104])
-		Arg: x: main.aStruct (declared at line 104, available: [104-104])
-	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67] injectible: [67-67]
-		Arg: x: *main.nStruct (declared at line 67, available: [67-67])
-	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41] injectible: [41-41]
-		Arg: xs: []main.structWithNoStrings (declared at line 41, available: [41-41])
-		Arg: a: int (declared at line 41, available: [41-41])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72] injectible: [72-72]
-		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64] injectible: [64-64]
-		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68] injectible: [68-68]
-		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [28:28] injectible: [28-28]
+		Arg: x: [2]string (declared at line 28, available: [28-28])
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [96:96] injectible: [96-96]
+		Arg: z: *string (declared at line 96, available: [96-96])
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [58:58] injectible: [58-58]
+		Arg: s: []string (declared at line 58, available: [58-58])
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [100:100] injectible: [100-100]
+		Arg: a: *[]string (declared at line 100, available: [100-100])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [122:122] injectible: [122-122]
+		Arg: t: main.threestrings (declared at line 122, available: [122-122])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [217:217] injectible: [217-217]
+		Arg: a: *main.stringType1 (declared at line 217, available: [217-217])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:223] injectible: [223-223]
+		Arg: a: **main.stringType2 (declared at line 223, available: [223-223])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [90:90] injectible: [90-90]
+		Arg: x: main.aStruct (declared at line 90, available: [90-90])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [110:110] injectible: [110-110]
+		Arg: w: uint8 (declared at line 110, available: [110-110])
+		Arg: x: main.aStruct (declared at line 110, available: [110-110])
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [72:72] injectible: [72-72]
+		Arg: x: *main.nStruct (declared at line 72, available: [72-72])
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [46:46] injectible: [46-46]
+		Arg: xs: []main.structWithNoStrings (declared at line 46, available: [46-46])
+		Arg: a: int (declared at line 46, available: [46-46])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [78:78] injectible: [78-78]
+		Arg: s: main.structWithASlice (declared at line 78, available: [78-78])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [70:70] injectible: [70-70]
+		Arg: s: main.structWithASlice (declared at line 70, available: [70-70])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [74:74] injectible: [74-74]
+		Arg: s: main.structWithASlice (declared at line 74, available: [74-74])
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73] injectible: [73-73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
-		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [66:66] injectible: [66-66]
+		Arg: a: main.structWithAnArray (declared at line 66, available: [66-66])
 	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
 		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
 		Arg: ~r0: int (declared at line 372, available: )
 		Arg: ~r1: main.structWithArray (declared at line 372, available: )
 		Var: x: int (declared at line 374, available: [372-379])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
-		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
-	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
-		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
-	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31] injectible: [31-31]
-		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [94:94] injectible: [94-94]
+		Arg: s: main.structWithTwoArrays (declared at line 94, available: [94-94])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [50:50] injectible: [50-50]
+		Arg: a: main.structWithCyclicMaps (declared at line 50, available: [50-50])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [37:37] injectible: [37-37]
+		Arg: a: main.structWithCyclicSlices (declared at line 37, available: [37-37])
 	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18] injectible: [18-18]
 		Arg: s: main.structWithMap (declared at line 18, available: [18-18])
-	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79] injectible: [79-79]
-		Arg: x: main.structWithPointer (declared at line 79, available: [79-79])
-	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87] injectible: [87-87]
-		Arg: z: main.spws (declared at line 87, available: [87-87])
-	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83] injectible: [83-83]
-		Arg: b: main.swsp (declared at line 83, available: [83-83])
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48] injectible: [48-48]
-		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
-	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [73:73] injectible: [73-73]
-		Arg: as: []uint (declared at line 73, available: [73-73])
-		Arg: bs: []uint (declared at line 73, available: [73-73])
-		Arg: cs: []uint (declared at line 73, available: [73-73])
-	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [54:54] injectible: [54-54]
-		Arg: a: string (declared at line 54, available: [54-54])
-		Arg: b: string (declared at line 54, available: [54-54])
-		Arg: c: string (declared at line 54, available: [54-54])
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [84:84] injectible: [84-84]
+		Arg: x: main.structWithPointer (declared at line 84, available: [84-84])
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [92:92] injectible: [92-92]
+		Arg: z: main.spws (declared at line 92, available: [92-92])
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [88:88] injectible: [88-88]
+		Arg: b: main.swsp (declared at line 88, available: [88-88])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [54:54] injectible: [54-54]
+		Arg: a: main.hasUnsupportedFields (declared at line 54, available: [54-54])
+	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [78:78] injectible: [78-78]
+		Arg: as: []uint (declared at line 78, available: [78-78])
+		Arg: bs: []uint (declared at line 78, available: [78-78])
+		Arg: cs: []uint (declared at line 78, available: [78-78])
+	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [59:59] injectible: [59-59]
+		Arg: a: string (declared at line 59, available: [59-59])
+		Arg: b: string (declared at line 59, available: [59-59])
+		Arg: c: string (declared at line 59, available: [59-59])
 	Function: testTakeContext (main.testTakeContext) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [24:24] injectible: [24-24]
 		Arg: ctx: context.Context (declared at line 22, available: [24-24])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112] injectible: [112-112]
-		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
-	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [16:16] injectible: [16-16]
-		Arg: x: string (declared at line 16, available: [16-16])
-		Arg: y: string (declared at line 16, available: [16-16])
-		Arg: z: string (declared at line 16, available: [16-16])
-	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [30:30] injectible: [30-30]
-		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
-	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
-		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
-		Arg: x: time.Time (declared at line 31, available: [31-31])
-	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
-		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
-	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
-		Arg: x: time.Time (declared at line 27, available: [27-27])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
-	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
-		Arg: a: []uint8 (declared at line 113, available: [113-113])
-		Arg: b: []uint8 (declared at line 113, available: [113-113])
-	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
-		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
-	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
-		Arg: x: [2]uint16 (declared at line 58, available: [58-58])
-	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62] injectible: [62-62]
-		Arg: x: [2]uint32 (declared at line 62, available: [62-62])
-	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66] injectible: [66-66]
-		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
-	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
-		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
-	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
-		Arg: x: []uint8 (declared at line 105, available: [105-105])
-	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
-		Arg: x: []uint8 (declared at line 109, available: [109-109])
-	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
-		Arg: x: [2]uint (declared at line 50, available: [50-50])
-	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]
-		Arg: x: *uint (declared at line 63, available: [63-63])
-	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29] injectible: [29-29]
-		Arg: u: []uint (declared at line 29, available: [29-29])
-	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [46:46] injectible: [46-46]
-		Arg: x: string (declared at line 46, available: [46-46])
-	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55] injectible: [55-55]
-		Arg: x: unsafe.Pointer (declared at line 55, available: [55-55])
-	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [99:99] injectible: [99-99]
-		Arg: a: [100]uint (declared at line 99, available: [99-99])
-	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
-		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [118:118] injectible: [118-118]
+		Arg: x: main.tenStrings (declared at line 118, available: [118-118])
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [21:21] injectible: [21-21]
+		Arg: x: string (declared at line 21, available: [21-21])
+		Arg: y: string (declared at line 21, available: [21-21])
+		Arg: z: string (declared at line 21, available: [21-21])
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [35:35] injectible: [35-35]
+		Arg: a: main.threeStringStruct (declared at line 35, available: [35-35])
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [39:39] injectible: [39-39]
+		Arg: a: *main.threeStringStruct (declared at line 39, available: [39-39])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [36:36] injectible: [36-36]
+		Arg: x: time.Time (declared at line 36, available: [36-36])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [40:40] injectible: [40-40]
+		Arg: c: main.timeCapture (declared at line 40, available: [40-40])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [32:32] injectible: [32-32]
+		Arg: x: time.Time (declared at line 32, available: [32-32])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [37:37] injectible: [37-37]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 37, available: [37-37])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [118:118] injectible: [118-118]
+		Arg: a: []uint8 (declared at line 118, available: [118-118])
+		Arg: b: []uint8 (declared at line 118, available: [118-118])
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [79:79] injectible: [79-79]
+		Arg: x: main.typeAlias (declared at line 79, available: [79-79])
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [64:64] injectible: [64-64]
+		Arg: x: [2]uint16 (declared at line 64, available: [64-64])
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [68:68] injectible: [68-68]
+		Arg: x: [2]uint32 (declared at line 68, available: [68-68])
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [72:72] injectible: [72-72]
+		Arg: x: [2]uint64 (declared at line 72, available: [72-72])
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [60:60] injectible: [60-60]
+		Arg: x: [2]uint8 (declared at line 60, available: [60-60])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [110:110] injectible: [110-110]
+		Arg: x: []uint8 (declared at line 110, available: [110-110])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [114:114] injectible: [114-114]
+		Arg: x: []uint8 (declared at line 114, available: [114-114])
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [56:56] injectible: [56-56]
+		Arg: x: [2]uint (declared at line 56, available: [56-56])
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [68:68] injectible: [68-68]
+		Arg: x: *uint (declared at line 68, available: [68-68])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [34:34] injectible: [34-34]
+		Arg: u: []uint (declared at line 34, available: [34-34])
+	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [51:51] injectible: [51-51]
+		Arg: x: string (declared at line 51, available: [51-51])
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [60:60] injectible: [60-60]
+		Arg: x: unsafe.Pointer (declared at line 60, available: [60-60])
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [105:105] injectible: [105-105]
+		Arg: a: [100]uint (declared at line 105, available: [105-105])
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [70:70] injectible: [70-70]
+		Arg: xs: []uint (declared at line 70, available: [70-70])
 	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
 		Arg: a: [0]int (declared at line 385, available: )
 		Arg: b: int (declared at line 385, available: [385-388])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,16 +1,22 @@
 === yield 1 [final=false] ===
 Package: main
-	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
-		Arg: x: []int (declared at line 12, available: [12-12])
-	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
-	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-263], [266-266], [277-277], [280-281], [283-284], [286-287], [289-289], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
-		Var: s: []*string (declared at line 258, available: )
-		Var: str: string (declared at line 257, available: [246-314])
-		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
-		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
-		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
-		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [17:17] injectible: [17-17]
+		Arg: x: []int (declared at line 17, available: [17-17])
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [108:138] injectible: [108-110], [112-126], [128-131], [133-133], [137-138]
+		Arg: ctx: context.Context (declared at line 108, available: [108-110])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 109, available: [110-113])
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [82:104] injectible: [82-84], [86-89], [91-96], [98-104]
+		Arg: ctx: context.Context (declared at line 82, available: [82-84])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-86])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [249:320] injectible: [249-251], [254-258], [263-264], [266-269], [272-272], [283-283], [286-287], [289-290], [292-293], [295-295], [300-300], [302-302], [304-305], [307-308], [310-311], [313-317], [319-320]
+		Arg: ctx: context.Context (declared at line 249, available: [249-251])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 250, available: [251-269])
+		Var: s: []*string (declared at line 264, available: )
+		Var: str: string (declared at line 263, available: [249-320])
+		Var: circ: main.circularReferenceType (declared at line 285, available: [249-320])
+		Var: s1: main.stringType1 (declared at line 313, available: [308-320])
+		Var: s2: main.stringType2 (declared at line 314, available: [308-320])
+		Var: s2p: *main.stringType2 (declared at line 315, available: [308-320])
 	Function: executeContextFuncs (main.executeContextFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [26:33] injectible: [26-27], [29-29], [31-33]
 		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 27, available: [31-32])
 		Var: ctx: context.Context (declared at line 27, available: [31-32])
@@ -20,14 +26,18 @@ Package: main
 		Var: id: uint64 (declared at line 1360, available: [1360-1361])
 	Function: executeContextImplFuncs (main.executeContextImplFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [61:67] injectible: [61-62], [65-67]
 		Var: c: *main.contextImpl (declared at line 62, available: [61-67])
-	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [113:187] injectible: [113-113], [115-184], [186-187]
-		Var: m: main.manyPointers (declared at line 114, available: [113-187])
-	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:50] injectible: [36-36], [39-40], [42-42], [44-45], [47-47], [49-50]
-		Var: ss: []string (declared at line 39, available: [36-50])
-		Scope: 40-44
-			Var: i: int (declared at line 40, available: [40-42], [44-44])
-		Scope: 45-49
-			Var: i: int (declared at line 45, available: [45-49])
+	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [119:196] injectible: [119-121], [124-193], [195-196]
+		Arg: ctx: context.Context (declared at line 119, available: [119-121])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 120, available: [121-121])
+		Var: m: main.manyPointers (declared at line 123, available: [119-196])
+	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [39:56] injectible: [39-41], [45-46], [48-48], [50-51], [53-53], [55-56]
+		Arg: ctx: context.Context (declared at line 39, available: [39-41])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 40, available: [41-45])
+		Var: ss: []string (declared at line 45, available: [39-56])
+		Scope: 46-50
+			Var: i: int (declared at line 46, available: [46-48], [50-50])
+		Scope: 51-55
+			Var: i: int (declared at line 51, available: [51-55])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -82,10 +92,12 @@ Package: main
 		Arg: acc: string (declared at line 340, available: [340-340])
 		Arg: x: string (declared at line 340, available: [340-340])
 		Arg: ~r0: string (declared at line 340, available: )
-	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106] injectible: [97-98], [100-106]
-		Var: x: int (declared at line 99, available: )
-		Var: y: int (declared at line 100, available: [97-106])
-		Var: a: [5]int (declared at line 98, available: [97-106])
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [100:112] injectible: [100-102], [104-104], [106-112]
+		Arg: ctx: context.Context (declared at line 100, available: [100-102])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 101, available: [102-107])
+		Var: x: int (declared at line 105, available: )
+		Var: y: int (declared at line 106, available: [100-112])
+		Var: a: [5]int (declared at line 104, available: [100-112])
 	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124] injectible: [76-82], [88-112], [117-120], [122-122], [124-124]
 		Var: &one: *int (declared at line 95, available: [76-124])
 		Var: &foo: *string (declared at line 98, available: [76-124])
@@ -133,103 +145,121 @@ Package: main
 			Var: i: int (declared at line 210, available: [210-210], [211-211], [212-212], [214-214])
 			Scope: 210-212
 				Var: key: [4]int (declared at line 211, available: )
-	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
-		Var: x: chan bool (declared at line 52, available: [53-54])
-	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-141], [143-143], [145-145], [147-151], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
-		Var: self: *main.node (declared at line 172, available: [173-177])
-		Var: z: main.spws (declared at line 118, available: )
-		Var: r: string (declared at line 117, available: [112-178])
-		Var: ssaw: main.swsp (declared at line 126, available: [112-178])
-		Var: rct: main.reallyComplexType (declared at line 137, available: [112-178])
-		Var: b: main.node (declared at line 145, available: [112-178])
-		Var: stringSlice: []string (declared at line 162, available: [112-178])
-		Var: up: *int (declared at line 168, available: [112-178])
-		Var: aruint: [2]uint (declared at line 159, available: )
-		Var: n: main.nStruct (declared at line 123, available: )
-		Var: u: int (declared at line 167, available: )
-		Var: u64F: uint64 (declared at line 113, available: )
-		Var: uintToPointTo: uint (declared at line 120, available: )
-		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [92:127] injectible: [92-94], [96-96], [109-123], [127-127]
+		Arg: ctx: context.Context (declared at line 92, available: [92-94])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 93, available: [94-96])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [54:62] injectible: [54-56], [58-62]
+		Arg: ctx: context.Context (declared at line 54, available: [54-56])
+		Var: x: chan bool (declared at line 58, available: [59-60])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 55, available: [56-58])
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [117:186] injectible: [117-119], [121-121], [123-123], [125-125], [128-129], [131-134], [138-140], [142-143], [145-149], [151-151], [153-153], [155-159], [163-163], [165-165], [167-168], [170-171], [173-173], [175-176], [178-178], [180-181], [183-186]
+		Arg: ctx: context.Context (declared at line 117, available: [117-119])
+		Var: z: main.spws (declared at line 126, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 118, available: [119-123])
+		Var: self: *main.node (declared at line 180, available: [181-185])
+		Var: r: string (declared at line 125, available: [117-186])
+		Var: ssaw: main.swsp (declared at line 134, available: [117-186])
+		Var: rct: main.reallyComplexType (declared at line 145, available: [117-186])
+		Var: b: main.node (declared at line 153, available: [117-186])
+		Var: stringSlice: []string (declared at line 170, available: [117-186])
+		Var: up: *int (declared at line 176, available: [117-186])
+		Var: aruint: [2]uint (declared at line 167, available: )
+		Var: n: main.nStruct (declared at line 131, available: )
+		Var: u: int (declared at line 175, available: )
+		Var: u64F: uint64 (declared at line 121, available: )
+		Var: uintToPointTo: uint (declared at line 128, available: )
+		Var: x: main.structWithTwoValues (declared at line 142, available: )
 	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [29:33] injectible: [29-33]
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
-		Var: originalSlice: []int (declared at line 133, available: )
-		Var: s: []uint (declared at line 142, available: )
-		Var: s2: []uint (declared at line 159, available: )
-		Scope: 143-146
-			Var: i: int (declared at line 143, available: [146-146])
-	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
-	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [65:86] injectible: [65-65], [67-72], [75-77], [81-81], [84-86]
-		Var: abc: string (declared at line 66, available: )
-		Var: uninitializedString: string (declared at line 74, available: )
-		Var: s: string (declared at line 80, available: )
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236] injectible: [135-137], [140-140], [142-143], [145-146], [150-150], [152-160], [172-172], [174-174], [177-182], [190-192], [194-195], [198-198], [200-201], [203-206], [208-208], [210-213], [215-216], [219-220], [222-223], [225-226], [228-229], [231-232], [235-236]
-		Var: n: main.nStruct (declared at line 139, available: )
-		Var: ns: main.structWithNoStrings (declared at line 148, available: )
-		Var: cs: main.cStruct (declared at line 149, available: )
-		Var: rcvr: main.receiver (declared at line 197, available: )
-		Var: ts: main.threestrings (declared at line 136, available: [135-236])
-		Var: s: main.aStruct (declared at line 142, available: [135-236])
-		Var: b: main.bStruct (declared at line 145, available: [135-236])
-		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
-		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
-		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
-		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
-		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
-		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
-		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
-	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
-		Var: ist: *time.Location (declared at line 48, available: [49-49])
-	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
-		Arg: x: []int (declared at line 22, available: [22-25])
-	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
-		Arg: f: func(int) (declared at line 28, available: [28-29])
+	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [34:41] injectible: [34-36], [38-41]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [137:189] injectible: [137-139], [141-143], [145-152], [154-158], [160-160], [162-164], [167-168], [170-181], [183-183], [185-185], [187-189]
+		Arg: ctx: context.Context (declared at line 137, available: [137-139])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 138, available: [139-141])
+		Var: originalSlice: []int (declared at line 141, available: )
+		Var: s: []uint (declared at line 150, available: )
+		Var: s2: []uint (declared at line 167, available: )
+		Scope: 151-154
+			Var: i: int (declared at line 151, available: [154-154])
+	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [34:39] injectible: [34-36], [38-39]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [70:94] injectible: [70-72], [75-80], [83-85], [89-89], [92-94]
+		Arg: ctx: context.Context (declared at line 70, available: [70-72])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 71, available: [72-75])
+		Var: abc: string (declared at line 74, available: )
+		Var: uninitializedString: string (declared at line 82, available: )
+		Var: s: string (declared at line 88, available: )
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [141:245] injectible: [141-143], [145-146], [149-149], [151-152], [154-155], [159-159], [161-169], [181-181], [183-183], [186-191], [199-201], [203-204], [207-207], [209-210], [212-215], [217-217], [219-222], [224-225], [228-229], [231-232], [234-235], [237-238], [240-241], [244-245]
+		Arg: ctx: context.Context (declared at line 141, available: [141-143])
+		Var: rcvr: main.receiver (declared at line 206, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 142, available: [143-146])
+		Var: n: main.nStruct (declared at line 148, available: )
+		Var: ns: main.structWithNoStrings (declared at line 157, available: )
+		Var: cs: main.cStruct (declared at line 158, available: )
+		Var: ts: main.threestrings (declared at line 145, available: [141-245])
+		Var: s: main.aStruct (declared at line 151, available: [141-245])
+		Var: b: main.bStruct (declared at line 154, available: [141-245])
+		Var: tenStr: main.tenStrings (declared at line 171, available: [141-245])
+		Var: deep: main.deepStruct1 (declared at line 185, available: [141-245])
+		Var: fields: main.lotsOfFields (declared at line 203, available: [141-245])
+		Var: sta: main.structWithTwoArrays (declared at line 212, available: [141-245])
+		Var: .autotmp_121: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_140: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_147: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_152: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_176: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_183: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_188: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_195: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_201: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_206: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_213: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_219: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_22: [0]main.structWithCyclicSlices (declared at line 229, available: [141-245])
+		Var: .autotmp_224: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_236: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_243: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_248: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_255: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_26: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_261: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_266: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_273: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_279: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_284: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_291: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_298: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_304: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_309: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_31: [0][][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_32: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_34: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_41: [0][][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_42: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_44: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_47: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_51: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_56: [0][][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_57: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_59: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_62: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_66: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_70: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_20: [0]uint8 (declared at line 166, available: [141-245])
+		Var: .autotmp_97: main.emptyStruct (declared at line 199, available: [141-245])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [44:65] injectible: [44-46], [49-50], [56-59], [64-65]
+		Arg: ctx: context.Context (declared at line 44, available: [44-46])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 45, available: [46-49])
+		Var: ist: *time.Location (declared at line 56, available: [57-57])
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [27:30] injectible: [27-30]
+		Arg: x: []int (declared at line 27, available: [27-30])
+	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [31:33] injectible: [31-33]
+		Arg: f: func(int) (declared at line 31, available: [31-32])
 	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [109:119] injectible: [109-115], [117-117], [119-119]
 		Arg: entriesCount: int (declared at line 109, available: [109-119])
 		Arg: ~r0: map[string][]main.structWithMap (declared at line 109, available: )
@@ -262,9 +292,9 @@ Package: main
 		Arg: b: <T> (declared at line 113, available: [113-114])
 		Arg: ~r0: <T> (declared at line 113, available: )
 		Arg: ~r1: <T> (declared at line 113, available: )
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:17] injectible: [17-17]
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -272,11 +302,13 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:50] injectible: [21-21], [26-26], [29-30], [33-33], [35-35], [37-40], [44-48], [50-50]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [22:50] injectible: [22-22], [27-27], [30-31], [34-34], [36-36], [38-41], [44-48], [50-50]
 		Var: ticker: *time.Ticker (declared at line 44, available: [45-45])
-		Var: service: string (declared at line 29, available: [30-33])
+		Var: service: string (declared at line 30, available: [31-34])
+		Var: .autotmp_15: context.backgroundCtx (declared at line 216, available: [22-50])
 		Scope: 45-48
 			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 46, available: [45-48])
+			Var: ctx: context.Context (declared at line 46, available: [47-47])
 	Type: main.Pair[...]
 		Field: Key: <T>
 		Field: Value: <T>
@@ -290,10 +322,10 @@ Package: main
 		Field: Total: float64
 	Type: main.Server
 		Field: name: string
-		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [21:26] injectible: [21-23], [25-26]
-			Arg: s: *main.Server (declared at line 21, available: [21-23])
-			Arg: req: *main.Request (declared at line 21, available: [21-26])
-			Arg: ~r0: error (declared at line 21, available: )
+		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [26:31] injectible: [26-28], [30-31]
+			Arg: s: *main.Server (declared at line 26, available: [26-28])
+			Arg: req: *main.Request (declared at line 26, available: [26-31])
+			Arg: ~r0: error (declared at line 26, available: )
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -608,12 +640,12 @@ Package: main
 		Field: aStringPtr: *string
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52] injectible: [52-52]
-			Arg: r: *main.receiver (declared at line 52, available: [52-52])
-			Arg: a: int (declared at line 52, available: [52-52])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56] injectible: [56-56]
-			Arg: r: main.receiver (declared at line 56, available: [56-56])
-			Arg: a: int (declared at line 56, available: [56-56])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [58:58] injectible: [58-58]
+			Arg: r: *main.receiver (declared at line 58, available: [58-58])
+			Arg: a: int (declared at line 58, available: [58-58])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [62:62] injectible: [62-62]
+			Arg: r: main.receiver (declared at line 62, available: [62-62])
+			Arg: a: int (declared at line 62, available: [62-62])
 	Type: main.score
 	Type: main.secondBehavior
 		Field: i: int
@@ -731,14 +763,14 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
-	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [104:107] injectible: [105-107]
-		Var: i: int (declared at line 106, available: [105-106])
+	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [110:113] injectible: [111-113]
+		Var: i: int (declared at line 112, available: [111-112])
 		Arg: id: int (declared at line 0, available: )
-		Var: p: *main.paddedData (declared at line 105, available: )
-	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [23:28] injectible: [23-26], [28-28]
-		Arg: n: int (declared at line 23, available: [23-28])
-		Arg: ~r0: string (declared at line 23, available: )
-		Var: prefix: string (declared at line 24, available: [23-26], [28-28])
+		Var: p: *main.paddedData (declared at line 111, available: )
+	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [26:31] injectible: [26-29], [31-31]
+		Arg: n: int (declared at line 26, available: [26-31])
+		Arg: ~r0: string (declared at line 26, available: )
+		Var: prefix: string (declared at line 27, available: [26-29], [31-31])
 		Var: ~r0.ptr: *uint8 (declared at line 34, available: )
 		Var: ~r0.len: int (declared at line 34, available: )
 	Function: nestedGeneric[...] (main.nestedGeneric[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [203:203] injectible: [203-203]
@@ -750,20 +782,21 @@ Package: main
 		Arg: items: <T> (declared at line 183, available: [183-184])
 		Arg: pred: <T> (declared at line 183, available: [183-184])
 		Arg: ~r0: <T> (declared at line 183, available: )
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
-		Arg: ~r0: uint64 (declared at line 40, available: )
-		Var: n: uint64 (declared at line 45, available: [44-46])
-		Var: b: []uint8 (declared at line 41, available: [44-45])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [43:49] injectible: [43-49]
+		Arg: ~r0: uint64 (declared at line 43, available: )
+		Var: n: uint64 (declared at line 48, available: [47-49])
+		Var: b: []uint8 (declared at line 44, available: [47-48])
 	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:88] injectible: [52-66], [68-69], [71-73], [75-77], [80-88]
+		Arg: ctx: context.Context (declared at line 52, available: [52-88])
 		Var: it: main.iterExample (declared at line 70, available: [52-88])
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 67, available: [52-88])
-	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
-		Arg: x: []int (declared at line 16, available: [16-17])
-		Arg: ~r0: string (declared at line 16, available: )
-	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14] injectible: [12-14]
-	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20] injectible: [18-20]
-	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25] injectible: [24-25]
-		Arg: ~r0: string (declared at line 24, available: )
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [21:22] injectible: [21-22]
+		Arg: x: []int (declared at line 21, available: [21-22])
+		Arg: ~r0: string (declared at line 21, available: )
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [17:19] injectible: [17-19]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [23:25] injectible: [23-25]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [29-30]
+		Arg: ~r0: string (declared at line 29, available: )
 	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55] injectible: [54-55]
 		Arg: a: interface {} (declared at line 54, available: [54-55])
 		Arg: ~r0: string (declared at line 54, available: )
@@ -773,224 +806,224 @@ Package: main
 	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
 		Arg: arg: [3]int (declared at line 297, available: [297-302])
 		Arg: ~r0: [3]int (declared at line 297, available: )
-	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
-		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
-	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
-		Arg: a: [2][2]int (declared at line 70, available: [70-70])
-	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78] injectible: [78-78]
-		Arg: b: [2][2][2]int (declared at line 78, available: [78-78])
+	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [93:93] injectible: [93-93]
+		Arg: a: [2]struct {} (declared at line 93, available: [93-93])
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [76:76] injectible: [76-76]
+		Arg: a: [2][2]int (declared at line 76, available: [76-76])
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [84:84] injectible: [84-84]
+		Arg: b: [2][2][2]int (declared at line 84, available: [84-84])
 	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [42:42] injectible: [42-42]
 		Arg: m: [2]map[string]int (declared at line 42, available: [42-42])
-	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74] injectible: [74-74]
-		Arg: a: [2]string (declared at line 74, available: [74-74])
-	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83] injectible: [83-83]
-		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
-	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
-		Arg: x: *[2]uint (declared at line 59, available: [59-59])
-	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
-		Arg: x: uint64 (declared at line 19, available: [23-23])
-		Arg: ~r0: uint64 (declared at line 19, available: )
-	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
-		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
-	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
-		Arg: x: [2]bool (declared at line 26, available: [26-26])
-	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
-		Arg: a: []uint8 (declared at line 117, available: [117-117])
-		Arg: b: []uint8 (declared at line 117, available: [117-117])
-	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
-		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
-		Arg: a: []uint8 (declared at line 129, available: [129-129])
-		Arg: b: []int (declared at line 129, available: [129-129])
-	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
-		Arg: x: []uint8 (declared at line 77, available: [77-77])
-	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
-		Arg: x: []uint8 (declared at line 81, available: [81-81])
-	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
-		Arg: x: []uint8 (declared at line 85, available: [85-85])
-	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
-		Arg: x: []uint8 (declared at line 89, available: [89-89])
-	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
-		Arg: x: []uint8 (declared at line 93, available: [93-93])
-	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
-		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
-	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
-		Arg: a: int (declared at line 125, available: [125-125])
-		Arg: x: []uint8 (declared at line 125, available: [125-125])
-		Arg: b: string (declared at line 125, available: [125-125])
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [80:80] injectible: [80-80]
+		Arg: a: [2]string (declared at line 80, available: [80-80])
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [89:89] injectible: [89-89]
+		Arg: a: [2]main.nestedStruct (declared at line 88, available: [89-89])
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [64:64] injectible: [64-64]
+		Arg: x: *[2]uint (declared at line 64, available: [64-64])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [26:26] injectible: [26-26]
+		Arg: x: uint64 (declared at line 22, available: [26-26])
+		Arg: ~r0: uint64 (declared at line 22, available: )
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [85:85] injectible: [85-85]
+		Arg: b: main.bigStruct (declared at line 85, available: [85-85])
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [32:32] injectible: [32-32]
+		Arg: x: [2]bool (declared at line 32, available: [32-32])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [122:122] injectible: [122-122]
+		Arg: a: []uint8 (declared at line 122, available: [122-122])
+		Arg: b: []uint8 (declared at line 122, available: [122-122])
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [20:20] injectible: [20-20]
+		Arg: x: [2]uint8 (declared at line 20, available: [20-20])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [134:134] injectible: [134-134]
+		Arg: a: []uint8 (declared at line 134, available: [134-134])
+		Arg: b: []int (declared at line 134, available: [134-134])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [82:82] injectible: [82-82]
+		Arg: x: []uint8 (declared at line 82, available: [82-82])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [86:86] injectible: [86-86]
+		Arg: x: []uint8 (declared at line 86, available: [86-86])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [90:90] injectible: [90-90]
+		Arg: x: []uint8 (declared at line 90, available: [90-90])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [94:94] injectible: [94-94]
+		Arg: x: []uint8 (declared at line 94, available: [94-94])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [98:98] injectible: [98-98]
+		Arg: x: []uint8 (declared at line 98, available: [98-98])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [126:126] injectible: [126-126]
+		Arg: x: [][]uint8 (declared at line 126, available: [126-126])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [130:130] injectible: [130-130]
+		Arg: a: int (declared at line 130, available: [130-130])
+		Arg: x: []uint8 (declared at line 130, available: [130-130])
+		Arg: b: string (declared at line 130, available: [130-130])
 	Function: testCaptureContextImpl (main.testCaptureContextImpl) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [44:44] injectible: [44-44]
 		Arg: c: *main.contextImpl (declared at line 44, available: [44-44])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
-		Arg: c: chan bool (declared at line 30, available: [30-30])
-	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
-		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
-	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
-		Arg: w: uint8 (declared at line 34, available: [34-34])
-		Arg: x: bool (declared at line 34, available: [34-34])
-		Arg: y: float32 (declared at line 34, available: [34-34])
-	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22] injectible: [22-22]
-		Arg: w: uint8 (declared at line 22, available: [22-22])
-		Arg: x: uint8 (declared at line 22, available: [22-22])
-		Arg: y: float32 (declared at line 22, available: [22-22])
-	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38] injectible: [38-38]
-		Arg: w: uint8 (declared at line 38, available: [38-38])
-		Arg: x: int (declared at line 38, available: [38-38])
-		Arg: y: float32 (declared at line 38, available: [38-38])
-	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46] injectible: [46-46]
-		Arg: w: uint8 (declared at line 46, available: [46-46])
-		Arg: x: int16 (declared at line 46, available: [46-46])
-		Arg: y: float32 (declared at line 46, available: [46-46])
-	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50] injectible: [50-50]
-		Arg: w: uint8 (declared at line 50, available: [50-50])
-		Arg: x: int32 (declared at line 50, available: [50-50])
-		Arg: y: float32 (declared at line 50, available: [50-50])
-	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54] injectible: [54-54]
-		Arg: w: uint8 (declared at line 54, available: [54-54])
-		Arg: x: int64 (declared at line 54, available: [54-54])
-		Arg: y: float32 (declared at line 54, available: [54-54])
-	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42] injectible: [42-42]
-		Arg: w: uint8 (declared at line 42, available: [42-42])
-		Arg: x: int8 (declared at line 42, available: [42-42])
-		Arg: y: float32 (declared at line 42, available: [42-42])
-	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26] injectible: [26-26]
-		Arg: w: uint8 (declared at line 26, available: [26-26])
-		Arg: x: int32 (declared at line 26, available: [26-26])
-		Arg: y: float32 (declared at line 26, available: [26-26])
-	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30] injectible: [30-30]
-		Arg: w: uint8 (declared at line 30, available: [30-30])
-		Arg: x: string (declared at line 30, available: [30-30])
-		Arg: y: float32 (declared at line 30, available: [30-30])
-	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58] injectible: [58-58]
-		Arg: w: uint8 (declared at line 58, available: [58-58])
-		Arg: x: uint (declared at line 58, available: [58-58])
-		Arg: y: float32 (declared at line 58, available: [58-58])
-	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66] injectible: [66-66]
-		Arg: w: uint8 (declared at line 66, available: [66-66])
-		Arg: x: uint16 (declared at line 66, available: [66-66])
-		Arg: y: float32 (declared at line 66, available: [66-66])
-	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70] injectible: [70-70]
-		Arg: w: uint8 (declared at line 70, available: [70-70])
-		Arg: x: uint32 (declared at line 70, available: [70-70])
-		Arg: y: float32 (declared at line 70, available: [70-70])
-	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74] injectible: [74-74]
-		Arg: w: uint8 (declared at line 74, available: [74-74])
-		Arg: x: uint64 (declared at line 74, available: [74-74])
-		Arg: y: float32 (declared at line 74, available: [74-74])
-	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62] injectible: [62-62]
-		Arg: w: uint8 (declared at line 62, available: [62-62])
-		Arg: x: uint8 (declared at line 62, available: [62-62])
-		Arg: y: float32 (declared at line 62, available: [62-62])
-	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75] injectible: [75-75]
-		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [33:33] injectible: [33-33]
+		Arg: c: chan bool (declared at line 33, available: [33-33])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93] injectible: [93-93]
+		Arg: x: main.circularReferenceType (declared at line 93, available: [93-93])
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [40:40] injectible: [40-40]
+		Arg: w: uint8 (declared at line 40, available: [40-40])
+		Arg: x: bool (declared at line 40, available: [40-40])
+		Arg: y: float32 (declared at line 40, available: [40-40])
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [28:28] injectible: [28-28]
+		Arg: w: uint8 (declared at line 28, available: [28-28])
+		Arg: x: uint8 (declared at line 28, available: [28-28])
+		Arg: y: float32 (declared at line 28, available: [28-28])
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [44:44] injectible: [44-44]
+		Arg: w: uint8 (declared at line 44, available: [44-44])
+		Arg: x: int (declared at line 44, available: [44-44])
+		Arg: y: float32 (declared at line 44, available: [44-44])
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [52:52] injectible: [52-52]
+		Arg: w: uint8 (declared at line 52, available: [52-52])
+		Arg: x: int16 (declared at line 52, available: [52-52])
+		Arg: y: float32 (declared at line 52, available: [52-52])
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [56:56] injectible: [56-56]
+		Arg: w: uint8 (declared at line 56, available: [56-56])
+		Arg: x: int32 (declared at line 56, available: [56-56])
+		Arg: y: float32 (declared at line 56, available: [56-56])
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [60:60] injectible: [60-60]
+		Arg: w: uint8 (declared at line 60, available: [60-60])
+		Arg: x: int64 (declared at line 60, available: [60-60])
+		Arg: y: float32 (declared at line 60, available: [60-60])
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [48:48] injectible: [48-48]
+		Arg: w: uint8 (declared at line 48, available: [48-48])
+		Arg: x: int8 (declared at line 48, available: [48-48])
+		Arg: y: float32 (declared at line 48, available: [48-48])
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [32:32] injectible: [32-32]
+		Arg: w: uint8 (declared at line 32, available: [32-32])
+		Arg: x: int32 (declared at line 32, available: [32-32])
+		Arg: y: float32 (declared at line 32, available: [32-32])
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [36:36] injectible: [36-36]
+		Arg: w: uint8 (declared at line 36, available: [36-36])
+		Arg: x: string (declared at line 36, available: [36-36])
+		Arg: y: float32 (declared at line 36, available: [36-36])
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [64:64] injectible: [64-64]
+		Arg: w: uint8 (declared at line 64, available: [64-64])
+		Arg: x: uint (declared at line 64, available: [64-64])
+		Arg: y: float32 (declared at line 64, available: [64-64])
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [72:72] injectible: [72-72]
+		Arg: w: uint8 (declared at line 72, available: [72-72])
+		Arg: x: uint16 (declared at line 72, available: [72-72])
+		Arg: y: float32 (declared at line 72, available: [72-72])
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [76:76] injectible: [76-76]
+		Arg: w: uint8 (declared at line 76, available: [76-76])
+		Arg: x: uint32 (declared at line 76, available: [76-76])
+		Arg: y: float32 (declared at line 76, available: [76-76])
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [80:80] injectible: [80-80]
+		Arg: w: uint8 (declared at line 80, available: [80-80])
+		Arg: x: uint64 (declared at line 80, available: [80-80])
+		Arg: y: float32 (declared at line 80, available: [80-80])
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [68:68] injectible: [68-68]
+		Arg: w: uint8 (declared at line 68, available: [68-68])
+		Arg: x: uint8 (declared at line 68, available: [68-68])
+		Arg: y: float32 (declared at line 68, available: [68-68])
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [80:80] injectible: [80-80]
+		Arg: z: *main.reallyComplexType (declared at line 80, available: [80-80])
 	Function: testConflictingReturn (main.testConflictingReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [109:111] injectible: [109-111]
 		Arg: i: int (declared at line 109, available: [109-111])
 		Arg: ~r0: int (declared at line 109, available: )
 		Arg: r0: string (declared at line 109, available: )
-	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
-		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
-		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
-		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
-		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
-		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
-		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
-		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
-		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
-	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
-		Arg: x: []uint8 (declared at line 97, available: [97-97])
-	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
-		Arg: u: []uint (declared at line 33, available: [33-33])
-	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
-		Arg: xs: []main.structWithNoStrings (declared at line 45, available: [45-45])
-		Arg: a: int (declared at line 45, available: [45-45])
-	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [50:50] injectible: [50-50]
-		Arg: x: string (declared at line 50, available: [50-50])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124] injectible: [124-124]
-		Arg: e: main.emptyStruct (declared at line 124, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128] injectible: [128-128]
-		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [114:114] injectible: [114-114]
+		Arg: t: *main.t (declared at line 114, available: [114-114])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: main.deepMap1 (declared at line 203, available: [203-203])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [206:206] injectible: [206-206]
+		Arg: a: *main.deepMap7 (declared at line 206, available: [206-206])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: main.deepPtr1 (declared at line 139, available: [139-139])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142] injectible: [142-142]
+		Arg: a: *main.deepPtr7 (declared at line 142, available: [142-142])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: main.deepSlice1 (declared at line 165, available: [165-165])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [168:168] injectible: [168-168]
+		Arg: a: *main.deepSlice7 (declared at line 168, available: [168-168])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [126:126] injectible: [126-126]
+		Arg: t: main.deepStruct1 (declared at line 126, available: [126-126])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [102:102] injectible: [102-102]
+		Arg: x: []uint8 (declared at line 102, available: [102-102])
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [38:38] injectible: [38-38]
+		Arg: u: []uint (declared at line 38, available: [38-38])
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [50:50] injectible: [50-50]
+		Arg: xs: []main.structWithNoStrings (declared at line 50, available: [50-50])
+		Arg: a: int (declared at line 50, available: [50-50])
+	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [55:55] injectible: [55-55]
+		Arg: x: string (declared at line 55, available: [55-55])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [130:130] injectible: [130-130]
+		Arg: e: main.emptyStruct (declared at line 130, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [134:134] injectible: [134-134]
+		Arg: e: *main.emptyStruct (declared at line 134, available: [134-134])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
-	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [108-110], [112-112]
-		Arg: shouldErr: bool (declared at line 101, available: [101-103])
-		Arg: ~r0: int (declared at line 101, available: )
-		Var: x: int (declared at line 106, available: )
-		Var: err: error (declared at line 102, available: [101-112])
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [104:115] injectible: [104-104], [106-107], [111-113], [115-115]
+		Arg: shouldErr: bool (declared at line 104, available: [104-106])
+		Arg: ~r0: int (declared at line 104, available: )
+		Var: x: int (declared at line 109, available: )
+		Var: err: error (declared at line 105, available: [104-115])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
-	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80] injectible: [79-80]
-		Arg: x: int (declared at line 79, available: [79-80])
-		Arg: ~r0: int (declared at line 79, available: )
-	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93] injectible: [92-93]
-		Arg: a: [5]int (declared at line 92, available: [92-93])
-		Arg: ~r0: int (declared at line 92, available: )
-	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [17:19] injectible: [17-19]
-		Arg: x: int (declared at line 17, available: [17-18])
-		Arg: y: int (declared at line 17, available: [17-18])
-	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [21:25] injectible: [21-25]
-		Arg: x: int (declared at line 21, available: [21-25])
-		Arg: y: int (declared at line 21, available: [21-25])
-	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35] injectible: [32-32], [34-35]
-		Arg: x: int (declared at line 32, available: [32-34])
-	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42] injectible: [37-42]
-		Arg: x: int (declared at line 37, available: [37-38])
-		Arg: y: int (declared at line 37, available: [37-39])
-		Var: z: int (declared at line 38, available: [37-42])
-	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46] injectible: [44-46]
-		Arg: x: int (declared at line 44, available: [44-45])
-	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49] injectible: [49-49]
-	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60] injectible: [52-53], [55-56], [58-60]
-		Var: s: int (declared at line 54, available: [55-58])
-		Scope: 55-58
-			Var: i: int (declared at line 55, available: [55-58])
-	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63] injectible: [63-63]
-	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [66:67] injectible: [67-67]
-	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [13:15] injectible: [14-14]
-		Arg: x: int (declared at line 0, available: [13-14])
-	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [74:75] injectible: [75-75]
-		Arg: x: int (declared at line 0, available: [75-75])
-	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:71] injectible: [71-71]
-		Arg: a: [5]int (declared at line 0, available: [71-71])
-	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38] injectible: [38-38]
-		Arg: x: [2]int16 (declared at line 38, available: [38-38])
-	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42] injectible: [42-42]
-		Arg: x: [2]int32 (declared at line 42, available: [42-42])
-	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46] injectible: [46-46]
-		Arg: x: [2]int64 (declared at line 46, available: [46-46])
-	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34] injectible: [34-34]
-		Arg: x: [2]int8 (declared at line 34, available: [34-34])
-	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30] injectible: [30-30]
-		Arg: x: [2]int (declared at line 30, available: [30-30])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [82:83] injectible: [82-83]
+		Arg: x: int (declared at line 82, available: [82-83])
+		Arg: ~r0: int (declared at line 82, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [95:96] injectible: [95-96]
+		Arg: a: [5]int (declared at line 95, available: [95-96])
+		Arg: ~r0: int (declared at line 95, available: )
+	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [20:22] injectible: [20-22]
+		Arg: x: int (declared at line 20, available: [20-21])
+		Arg: y: int (declared at line 20, available: [20-21])
+	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [24:28] injectible: [24-28]
+		Arg: x: int (declared at line 24, available: [24-28])
+		Arg: y: int (declared at line 24, available: [24-28])
+	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [35:38] injectible: [35-35], [37-38]
+		Arg: x: int (declared at line 35, available: [35-37])
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [40:45] injectible: [40-45]
+		Arg: x: int (declared at line 40, available: [40-41])
+		Arg: y: int (declared at line 40, available: [40-42])
+		Var: z: int (declared at line 41, available: [40-45])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [47:49] injectible: [47-49]
+		Arg: x: int (declared at line 47, available: [47-48])
+	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [51:52] injectible: [52-52]
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [55:63] injectible: [55-56], [58-59], [61-63]
+		Var: s: int (declared at line 57, available: [58-61])
+		Scope: 58-61
+			Var: i: int (declared at line 58, available: [58-61])
+	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [65:66] injectible: [66-66]
+	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [69:70] injectible: [70-70]
+	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [16:18] injectible: [17-17]
+		Arg: x: int (declared at line 0, available: [16-17])
+	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [77:78] injectible: [78-78]
+		Arg: x: int (declared at line 0, available: [78-78])
+	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [73:74] injectible: [74-74]
+		Arg: a: [5]int (declared at line 0, available: [74-74])
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [44:44] injectible: [44-44]
+		Arg: x: [2]int16 (declared at line 44, available: [44-44])
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [48:48] injectible: [48-48]
+		Arg: x: [2]int32 (declared at line 48, available: [48-48])
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [52:52] injectible: [52-52]
+		Arg: x: [2]int64 (declared at line 52, available: [52-52])
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [40:40] injectible: [40-40]
+		Arg: x: [2]int8 (declared at line 40, available: [40-40])
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [36:36] injectible: [36-36]
+		Arg: x: [2]int (declared at line 36, available: [36-36])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50] injectible: [50-50]
 		Arg: b: main.behavior (declared at line 50, available: [50-50])
-	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [94:94] injectible: [94-94]
-		Arg: a: int (declared at line 94, available: [94-94])
-		Arg: b: error (declared at line 94, available: [94-94])
-		Arg: c: uint (declared at line 94, available: [94-94])
-	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
-		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [58:58] injectible: [58-58]
-		Arg: a: string (declared at line 58, available: [58-58])
-		Arg: b: string (declared at line 58, available: [58-58])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [97:97] injectible: [97-97]
+		Arg: a: int (declared at line 97, available: [97-97])
+		Arg: b: error (declared at line 97, available: [97-97])
+		Arg: c: uint (declared at line 97, available: [97-97])
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67] injectible: [67-67]
+		Arg: a: main.interfaceComplexityA (declared at line 67, available: [67-67])
+	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [63:63] injectible: [63-63]
+		Arg: a: string (declared at line 63, available: [63-63])
+		Arg: b: string (declared at line 63, available: [63-63])
 	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
 		Arg: arg: main.largeStruct (declared at line 281, available: [281-291])
 		Arg: ~r0: main.largeStruct (declared at line 281, available: )
-	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
-		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
-		Var: s: int (declared at line 224, available: [237-237], [242-242])
-		Var: aPerArch: int (declared at line 228, available: [223-243])
-		Var: b: int (declared at line 229, available: [223-243])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
-		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [47:47] injectible: [47-47]
+		Arg: a: main.node (declared at line 47, available: [47-47])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [226:246] injectible: [226-226], [233-233], [236-237], [239-242], [244-246]
+		Var: s: int (declared at line 227, available: [240-240], [245-245])
+		Var: aPerArch: int (declared at line 231, available: [226-246])
+		Var: b: int (declared at line 232, available: [226-246])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [138:138] injectible: [138-138]
+		Arg: l: main.lotsOfFields (declared at line 138, available: [138-138])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
 		Arg: a: int (declared at line 328, available: [328-330])
 		Arg: b: int (declared at line 328, available: [328-330])
@@ -1002,10 +1035,10 @@ Package: main
 		Arg: h: int (declared at line 328, available: [328-330])
 		Arg: i: int (declared at line 328, available: [328-330])
 		Arg: ~r0: [2]int (declared at line 328, available: )
-	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [102:102] injectible: [102-102]
-		Arg: m: main.manyPointers (declared at line 102, available: [102-102])
-	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [33:33] injectible: [33-33]
-		Arg: ss: []string (declared at line 33, available: [33-33])
+	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [108:108] injectible: [108-108]
+		Arg: m: main.manyPointers (declared at line 108, available: [108-108])
+	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:36] injectible: [36-36]
+		Arg: ss: []string (declared at line 36, available: [36-36])
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -1044,8 +1077,8 @@ Package: main
 		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
 	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70] injectible: [70-70]
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
-	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
-		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [47:47] injectible: [47-47]
+		Arg: x: string (declared at line 47, available: [47-47])
 	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-349]
 		Arg: a: int (declared at line 337, available: [337-349])
 		Arg: b: int (declared at line 337, available: [337-349])
@@ -1057,17 +1090,17 @@ Package: main
 		Arg: h: int (declared at line 337, available: [337-349])
 		Arg: s: string (declared at line 337, available: [337-349])
 		Arg: ~r0: main.largeStruct (declared at line 337, available: )
-	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [62:62] injectible: [62-62]
-		Arg: x: string (declared at line 62, available: [62-62])
+	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [67:67] injectible: [67-67]
+		Arg: x: string (declared at line 67, available: [67-67])
 	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
 		Arg: a: [2]int (declared at line 364, available: [364-366])
 		Arg: b: [3]int (declared at line 364, available: [364-366])
 		Arg: ~r0: int (declared at line 364, available: )
 		Arg: ~r1: [2]int (declared at line 364, available: )
-	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
-		Arg: o: main.outer (declared at line 72, available: [72-72])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
-		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [75:75] injectible: [75-75]
+		Arg: o: main.outer (declared at line 75, available: [75-75])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [102:102] injectible: [102-102]
+		Arg: b: main.bStruct (declared at line 102, available: [102-102])
 	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
 		Arg: s1: main.largeStruct (declared at line 308, available: [308-320])
 		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
@@ -1076,99 +1109,99 @@ Package: main
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
 		Arg: result2: int (declared at line 95, available: )
-	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
-		Arg: a: bool (declared at line 78, available: [78-78])
-		Arg: b: uint8 (declared at line 78, available: [78-78])
-		Arg: c: int32 (declared at line 78, available: [78-78])
-		Arg: d: uint (declared at line 78, available: [78-78])
-		Arg: e: string (declared at line 78, available: [78-78])
-	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
-		Arg: a: main.tierA (declared at line 68, available: [68-68])
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [84:84] injectible: [84-84]
+		Arg: a: bool (declared at line 84, available: [84-84])
+		Arg: b: uint8 (declared at line 84, available: [84-84])
+		Arg: c: int32 (declared at line 84, available: [84-84])
+		Arg: d: uint (declared at line 84, available: [84-84])
+		Arg: e: string (declared at line 84, available: [84-84])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71] injectible: [71-71]
+		Arg: a: main.tierA (declared at line 71, available: [71-71])
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
 		Arg: i: int (declared at line 88, available: [88-89])
 		Arg: result: int (declared at line 88, available: )
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
-		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
-	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
-		Arg: x: []uint8 (declared at line 101, available: [101-101])
-	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
-		Arg: z: *bool (declared at line 99, available: [99-99])
-		Arg: a: uint (declared at line 99, available: [99-99])
-	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61] injectible: [61-61]
-		Arg: xs: []uint16 (declared at line 61, available: [61-61])
-	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49] injectible: [49-49]
-		Arg: xs: []main.structWithNoStrings (declared at line 49, available: [49-49])
-		Arg: a: int (declared at line 49, available: [49-49])
-	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57] injectible: [57-57]
-		Arg: a: int8 (declared at line 57, available: [57-57])
-		Arg: s: []bool (declared at line 57, available: [57-57])
-		Arg: x: uint (declared at line 57, available: [57-57])
-	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71] injectible: [71-71]
-		Arg: z: uint (declared at line 71, available: [71-71])
-		Arg: x: *main.nStruct (declared at line 71, available: [71-71])
-		Arg: a: int (declared at line 71, available: [71-71])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100] injectible: [100-100]
-		Arg: c: main.cStruct (declared at line 100, available: [100-100])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92] injectible: [92-92]
-		Arg: x: main.nStruct (declared at line 92, available: [92-92])
-	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [38:38] injectible: [38-38]
-		Arg: a: *main.oneStringStruct (declared at line 38, available: [38-38])
-	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95] injectible: [95-95]
-		Arg: a: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: b: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: c: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: d: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: e: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: f: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: g: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: h: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: i: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: j: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: k: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: l: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: m: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: n: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: o: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: p: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: q: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: r: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: s: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: t: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: u: [3]uint32 (declared at line 94, available: [95-95])
-	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18] injectible: [18-18]
-		Arg: a: uint8 (declared at line 15, available: [18-18])
-		Arg: b: uint8 (declared at line 15, available: [18-18])
-		Arg: c: uint8 (declared at line 15, available: [18-18])
-		Arg: d: uint8 (declared at line 15, available: [18-18])
-		Arg: e: uint8 (declared at line 15, available: [18-18])
-		Arg: f: uint8 (declared at line 15, available: [18-18])
-		Arg: g: uint8 (declared at line 15, available: [18-18])
-		Arg: h: uint8 (declared at line 16, available: [18-18])
-		Arg: i: uint8 (declared at line 16, available: [18-18])
-		Arg: j: uint8 (declared at line 16, available: )
-		Arg: k: uint8 (declared at line 16, available: )
-		Arg: l: uint8 (declared at line 16, available: )
-		Arg: m: uint8 (declared at line 16, available: )
-		Arg: n: uint8 (declared at line 16, available: )
-		Arg: o: uint8 (declared at line 17, available: )
-		Arg: p: uint8 (declared at line 17, available: )
-		Arg: q: uint8 (declared at line 17, available: )
-		Arg: r: uint8 (declared at line 17, available: )
-		Arg: s: uint8 (declared at line 17, available: )
-		Arg: t: uint8 (declared at line 17, available: )
-		Arg: u: uint8 (declared at line 17, available: )
-	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51] injectible: [51-51]
-		Arg: a: *main.node (declared at line 51, available: [51-51])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [114:114] injectible: [114-114]
+		Arg: x: *main.anotherStruct (declared at line 114, available: [114-114])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [106:106] injectible: [106-106]
+		Arg: x: []uint8 (declared at line 106, available: [106-106])
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [104:104] injectible: [104-104]
+		Arg: z: *bool (declared at line 104, available: [104-104])
+		Arg: a: uint (declared at line 104, available: [104-104])
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [66:66] injectible: [66-66]
+		Arg: xs: []uint16 (declared at line 66, available: [66-66])
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [54:54] injectible: [54-54]
+		Arg: xs: []main.structWithNoStrings (declared at line 54, available: [54-54])
+		Arg: a: int (declared at line 54, available: [54-54])
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [62:62] injectible: [62-62]
+		Arg: a: int8 (declared at line 62, available: [62-62])
+		Arg: s: []bool (declared at line 62, available: [62-62])
+		Arg: x: uint (declared at line 62, available: [62-62])
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [76:76] injectible: [76-76]
+		Arg: z: uint (declared at line 76, available: [76-76])
+		Arg: x: *main.nStruct (declared at line 76, available: [76-76])
+		Arg: a: int (declared at line 76, available: [76-76])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [106:106] injectible: [106-106]
+		Arg: c: main.cStruct (declared at line 106, available: [106-106])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [98:98] injectible: [98-98]
+		Arg: x: main.nStruct (declared at line 98, available: [98-98])
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [43:43] injectible: [43-43]
+		Arg: a: *main.oneStringStruct (declared at line 43, available: [43-43])
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [101:101] injectible: [101-101]
+		Arg: a: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: b: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: c: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: d: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: e: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: f: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: g: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: h: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: i: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: j: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: k: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: l: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: m: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: n: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: o: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: p: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: q: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: r: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: s: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: t: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: u: [3]uint32 (declared at line 100, available: [101-101])
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [24:24] injectible: [24-24]
+		Arg: a: uint8 (declared at line 21, available: [24-24])
+		Arg: b: uint8 (declared at line 21, available: [24-24])
+		Arg: c: uint8 (declared at line 21, available: [24-24])
+		Arg: d: uint8 (declared at line 21, available: [24-24])
+		Arg: e: uint8 (declared at line 21, available: [24-24])
+		Arg: f: uint8 (declared at line 21, available: [24-24])
+		Arg: g: uint8 (declared at line 21, available: [24-24])
+		Arg: h: uint8 (declared at line 22, available: [24-24])
+		Arg: i: uint8 (declared at line 22, available: [24-24])
+		Arg: j: uint8 (declared at line 22, available: )
+		Arg: k: uint8 (declared at line 22, available: )
+		Arg: l: uint8 (declared at line 22, available: )
+		Arg: m: uint8 (declared at line 22, available: )
+		Arg: n: uint8 (declared at line 22, available: )
+		Arg: o: uint8 (declared at line 23, available: )
+		Arg: p: uint8 (declared at line 23, available: )
+		Arg: q: uint8 (declared at line 23, available: )
+		Arg: r: uint8 (declared at line 23, available: )
+		Arg: s: uint8 (declared at line 23, available: )
+		Arg: t: uint8 (declared at line 23, available: )
+		Arg: u: uint8 (declared at line 23, available: )
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [56:56] injectible: [56-56]
+		Arg: a: *main.node (declared at line 56, available: [56-56])
 	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [46:46] injectible: [46-46]
 		Arg: m: *map[string]int (declared at line 46, available: [46-46])
-	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103] injectible: [103-103]
-		Arg: u: **int (declared at line 103, available: [103-103])
-	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38] injectible: [38-38]
-		Arg: a: *main.structWithTwoValues (declared at line 38, available: [38-38])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76] injectible: [76-76]
-		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
-		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [108:108] injectible: [108-108]
+		Arg: u: **int (declared at line 108, available: [108-108])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [43:43] injectible: [43-43]
+		Arg: a: *main.structWithTwoValues (declared at line 43, available: [43-43])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [82:82] injectible: [82-82]
+		Arg: s: *main.structWithASlice (declared at line 82, available: [82-82])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [86:86] injectible: [86-86]
+		Arg: s: *main.structWithAString (declared at line 86, available: [86-86])
 	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
 		Arg: v: interface {} (declared at line 60, available: [60-72])
 		Arg: ~r0: interface {} (declared at line 60, available: )
@@ -1287,44 +1320,44 @@ Package: main
 		Arg: ~r0: main.structWithArray (declared at line 245, available: )
 	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
 		Arg: ~r0: main.wideStruct (declared at line 225, available: )
-	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
-		Arg: x: [2]int32 (declared at line 18, available: [18-18])
-	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
-		Arg: x: bool (declared at line 19, available: [19-19])
-	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11] injectible: [11-11]
-		Arg: x: uint8 (declared at line 11, available: [11-11])
-	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63] injectible: [63-63]
-		Arg: x: float32 (declared at line 63, available: [63-63])
-	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67] injectible: [67-67]
-		Arg: x: float64 (declared at line 67, available: [67-67])
-	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23] injectible: [23-23]
-		Arg: x: int (declared at line 23, available: [23-23])
-	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31] injectible: [31-31]
-		Arg: x: int16 (declared at line 31, available: [31-31])
-	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35] injectible: [35-35]
-		Arg: x: int32 (declared at line 35, available: [35-35])
-	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39] injectible: [39-39]
-		Arg: x: int64 (declared at line 39, available: [39-39])
-	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27] injectible: [27-27]
-		Arg: x: int8 (declared at line 27, available: [27-27])
-	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15] injectible: [15-15]
-		Arg: x: int32 (declared at line 15, available: [15-15])
-	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [12:12] injectible: [12-12]
-		Arg: x: string (declared at line 12, available: [12-12])
-	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43] injectible: [43-43]
-		Arg: x: uint (declared at line 43, available: [43-43])
-	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51] injectible: [51-51]
-		Arg: x: uint16 (declared at line 51, available: [51-51])
-	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55] injectible: [55-55]
-		Arg: x: uint32 (declared at line 55, available: [55-55])
-	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59] injectible: [59-59]
-		Arg: x: uint64 (declared at line 59, available: [59-59])
-	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47] injectible: [47-47]
-		Arg: x: uint8 (declared at line 47, available: [47-47])
-	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [69:69] injectible: [69-69]
-		Arg: xs: []struct {} (declared at line 69, available: [69-69])
-	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37] injectible: [37-37]
-		Arg: u: [][]uint (declared at line 37, available: [37-37])
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [24:24] injectible: [24-24]
+		Arg: x: [2]int32 (declared at line 24, available: [24-24])
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [25:25] injectible: [25-25]
+		Arg: x: bool (declared at line 25, available: [25-25])
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [17:17] injectible: [17-17]
+		Arg: x: uint8 (declared at line 17, available: [17-17])
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [69:69] injectible: [69-69]
+		Arg: x: float32 (declared at line 69, available: [69-69])
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
+		Arg: x: float64 (declared at line 73, available: [73-73])
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [29:29] injectible: [29-29]
+		Arg: x: int (declared at line 29, available: [29-29])
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [37:37] injectible: [37-37]
+		Arg: x: int16 (declared at line 37, available: [37-37])
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [41:41] injectible: [41-41]
+		Arg: x: int32 (declared at line 41, available: [41-41])
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [45:45] injectible: [45-45]
+		Arg: x: int64 (declared at line 45, available: [45-45])
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [33:33] injectible: [33-33]
+		Arg: x: int8 (declared at line 33, available: [33-33])
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [21:21] injectible: [21-21]
+		Arg: x: int32 (declared at line 21, available: [21-21])
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [17:17] injectible: [17-17]
+		Arg: x: string (declared at line 17, available: [17-17])
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [49:49] injectible: [49-49]
+		Arg: x: uint (declared at line 49, available: [49-49])
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [57:57] injectible: [57-57]
+		Arg: x: uint16 (declared at line 57, available: [57-57])
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [61:61] injectible: [61-61]
+		Arg: x: uint32 (declared at line 61, available: [61-61])
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [65:65] injectible: [65-65]
+		Arg: x: uint64 (declared at line 65, available: [65-65])
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [53:53] injectible: [53-53]
+		Arg: x: uint8 (declared at line 53, available: [53-53])
+	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [74:74] injectible: [74-74]
+		Arg: xs: []struct {} (declared at line 74, available: [74-74])
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [42:42] injectible: [42-42]
+		Arg: u: [][]uint (declared at line 42, available: [42-42])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
 	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
@@ -1337,120 +1370,120 @@ Package: main
 		Arg: ~r0: int (declared at line 356, available: )
 		Arg: ~r1: int (declared at line 356, available: )
 		Arg: ~r2: int (declared at line 356, available: )
-	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
-		Arg: x: [2]string (declared at line 22, available: [22-22])
-	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
-		Arg: z: *string (declared at line 91, available: [91-91])
-	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53] injectible: [53-53]
-		Arg: s: []string (declared at line 53, available: [53-53])
-	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95] injectible: [95-95]
-		Arg: a: *[]string (declared at line 95, available: [95-95])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
-		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
-		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
-		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
-		Arg: x: main.aStruct (declared at line 84, available: [84-84])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]
-		Arg: w: uint8 (declared at line 104, available: [104-104])
-		Arg: x: main.aStruct (declared at line 104, available: [104-104])
-	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67] injectible: [67-67]
-		Arg: x: *main.nStruct (declared at line 67, available: [67-67])
-	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41] injectible: [41-41]
-		Arg: xs: []main.structWithNoStrings (declared at line 41, available: [41-41])
-		Arg: a: int (declared at line 41, available: [41-41])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72] injectible: [72-72]
-		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64] injectible: [64-64]
-		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68] injectible: [68-68]
-		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [28:28] injectible: [28-28]
+		Arg: x: [2]string (declared at line 28, available: [28-28])
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [96:96] injectible: [96-96]
+		Arg: z: *string (declared at line 96, available: [96-96])
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [58:58] injectible: [58-58]
+		Arg: s: []string (declared at line 58, available: [58-58])
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [100:100] injectible: [100-100]
+		Arg: a: *[]string (declared at line 100, available: [100-100])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [122:122] injectible: [122-122]
+		Arg: t: main.threestrings (declared at line 122, available: [122-122])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [217:217] injectible: [217-217]
+		Arg: a: *main.stringType1 (declared at line 217, available: [217-217])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:223] injectible: [223-223]
+		Arg: a: **main.stringType2 (declared at line 223, available: [223-223])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [90:90] injectible: [90-90]
+		Arg: x: main.aStruct (declared at line 90, available: [90-90])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [110:110] injectible: [110-110]
+		Arg: w: uint8 (declared at line 110, available: [110-110])
+		Arg: x: main.aStruct (declared at line 110, available: [110-110])
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [72:72] injectible: [72-72]
+		Arg: x: *main.nStruct (declared at line 72, available: [72-72])
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [46:46] injectible: [46-46]
+		Arg: xs: []main.structWithNoStrings (declared at line 46, available: [46-46])
+		Arg: a: int (declared at line 46, available: [46-46])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [78:78] injectible: [78-78]
+		Arg: s: main.structWithASlice (declared at line 78, available: [78-78])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [70:70] injectible: [70-70]
+		Arg: s: main.structWithASlice (declared at line 70, available: [70-70])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [74:74] injectible: [74-74]
+		Arg: s: main.structWithASlice (declared at line 74, available: [74-74])
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73] injectible: [73-73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
-		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [66:66] injectible: [66-66]
+		Arg: a: main.structWithAnArray (declared at line 66, available: [66-66])
 	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
 		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
 		Arg: ~r0: int (declared at line 372, available: )
 		Arg: ~r1: main.structWithArray (declared at line 372, available: )
 		Var: x: int (declared at line 374, available: [372-379])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
-		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
-	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
-		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
-	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31] injectible: [31-31]
-		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [94:94] injectible: [94-94]
+		Arg: s: main.structWithTwoArrays (declared at line 94, available: [94-94])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [50:50] injectible: [50-50]
+		Arg: a: main.structWithCyclicMaps (declared at line 50, available: [50-50])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [37:37] injectible: [37-37]
+		Arg: a: main.structWithCyclicSlices (declared at line 37, available: [37-37])
 	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18] injectible: [18-18]
 		Arg: s: main.structWithMap (declared at line 18, available: [18-18])
-	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79] injectible: [79-79]
-		Arg: x: main.structWithPointer (declared at line 79, available: [79-79])
-	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87] injectible: [87-87]
-		Arg: z: main.spws (declared at line 87, available: [87-87])
-	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83] injectible: [83-83]
-		Arg: b: main.swsp (declared at line 83, available: [83-83])
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48] injectible: [48-48]
-		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
-	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [73:73] injectible: [73-73]
-		Arg: as: []uint (declared at line 73, available: [73-73])
-		Arg: bs: []uint (declared at line 73, available: [73-73])
-		Arg: cs: []uint (declared at line 73, available: [73-73])
-	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [54:54] injectible: [54-54]
-		Arg: a: string (declared at line 54, available: [54-54])
-		Arg: b: string (declared at line 54, available: [54-54])
-		Arg: c: string (declared at line 54, available: [54-54])
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [84:84] injectible: [84-84]
+		Arg: x: main.structWithPointer (declared at line 84, available: [84-84])
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [92:92] injectible: [92-92]
+		Arg: z: main.spws (declared at line 92, available: [92-92])
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [88:88] injectible: [88-88]
+		Arg: b: main.swsp (declared at line 88, available: [88-88])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [54:54] injectible: [54-54]
+		Arg: a: main.hasUnsupportedFields (declared at line 54, available: [54-54])
+	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [78:78] injectible: [78-78]
+		Arg: as: []uint (declared at line 78, available: [78-78])
+		Arg: bs: []uint (declared at line 78, available: [78-78])
+		Arg: cs: []uint (declared at line 78, available: [78-78])
+	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [59:59] injectible: [59-59]
+		Arg: a: string (declared at line 59, available: [59-59])
+		Arg: b: string (declared at line 59, available: [59-59])
+		Arg: c: string (declared at line 59, available: [59-59])
 	Function: testTakeContext (main.testTakeContext) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [24:24] injectible: [24-24]
 		Arg: ctx: context.Context (declared at line 22, available: [24-24])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112] injectible: [112-112]
-		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
-	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [16:16] injectible: [16-16]
-		Arg: x: string (declared at line 16, available: [16-16])
-		Arg: y: string (declared at line 16, available: [16-16])
-		Arg: z: string (declared at line 16, available: [16-16])
-	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [30:30] injectible: [30-30]
-		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
-	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
-		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
-		Arg: x: time.Time (declared at line 31, available: [31-31])
-	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
-		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
-	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
-		Arg: x: time.Time (declared at line 27, available: [27-27])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
-	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
-		Arg: a: []uint8 (declared at line 113, available: [113-113])
-		Arg: b: []uint8 (declared at line 113, available: [113-113])
-	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
-		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
-	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
-		Arg: x: [2]uint16 (declared at line 58, available: [58-58])
-	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62] injectible: [62-62]
-		Arg: x: [2]uint32 (declared at line 62, available: [62-62])
-	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66] injectible: [66-66]
-		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
-	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
-		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
-	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
-		Arg: x: []uint8 (declared at line 105, available: [105-105])
-	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
-		Arg: x: []uint8 (declared at line 109, available: [109-109])
-	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
-		Arg: x: [2]uint (declared at line 50, available: [50-50])
-	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]
-		Arg: x: *uint (declared at line 63, available: [63-63])
-	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29] injectible: [29-29]
-		Arg: u: []uint (declared at line 29, available: [29-29])
-	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [46:46] injectible: [46-46]
-		Arg: x: string (declared at line 46, available: [46-46])
-	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55] injectible: [55-55]
-		Arg: x: unsafe.Pointer (declared at line 55, available: [55-55])
-	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [99:99] injectible: [99-99]
-		Arg: a: [100]uint (declared at line 99, available: [99-99])
-	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
-		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [118:118] injectible: [118-118]
+		Arg: x: main.tenStrings (declared at line 118, available: [118-118])
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [21:21] injectible: [21-21]
+		Arg: x: string (declared at line 21, available: [21-21])
+		Arg: y: string (declared at line 21, available: [21-21])
+		Arg: z: string (declared at line 21, available: [21-21])
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [35:35] injectible: [35-35]
+		Arg: a: main.threeStringStruct (declared at line 35, available: [35-35])
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [39:39] injectible: [39-39]
+		Arg: a: *main.threeStringStruct (declared at line 39, available: [39-39])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [36:36] injectible: [36-36]
+		Arg: x: time.Time (declared at line 36, available: [36-36])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [40:40] injectible: [40-40]
+		Arg: c: main.timeCapture (declared at line 40, available: [40-40])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [32:32] injectible: [32-32]
+		Arg: x: time.Time (declared at line 32, available: [32-32])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [37:37] injectible: [37-37]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 37, available: [37-37])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [118:118] injectible: [118-118]
+		Arg: a: []uint8 (declared at line 118, available: [118-118])
+		Arg: b: []uint8 (declared at line 118, available: [118-118])
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [79:79] injectible: [79-79]
+		Arg: x: main.typeAlias (declared at line 79, available: [79-79])
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [64:64] injectible: [64-64]
+		Arg: x: [2]uint16 (declared at line 64, available: [64-64])
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [68:68] injectible: [68-68]
+		Arg: x: [2]uint32 (declared at line 68, available: [68-68])
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [72:72] injectible: [72-72]
+		Arg: x: [2]uint64 (declared at line 72, available: [72-72])
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [60:60] injectible: [60-60]
+		Arg: x: [2]uint8 (declared at line 60, available: [60-60])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [110:110] injectible: [110-110]
+		Arg: x: []uint8 (declared at line 110, available: [110-110])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [114:114] injectible: [114-114]
+		Arg: x: []uint8 (declared at line 114, available: [114-114])
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [56:56] injectible: [56-56]
+		Arg: x: [2]uint (declared at line 56, available: [56-56])
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [68:68] injectible: [68-68]
+		Arg: x: *uint (declared at line 68, available: [68-68])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [34:34] injectible: [34-34]
+		Arg: u: []uint (declared at line 34, available: [34-34])
+	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [51:51] injectible: [51-51]
+		Arg: x: string (declared at line 51, available: [51-51])
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [60:60] injectible: [60-60]
+		Arg: x: unsafe.Pointer (declared at line 60, available: [60-60])
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [105:105] injectible: [105-105]
+		Arg: a: [100]uint (declared at line 105, available: [105-105])
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [70:70] injectible: [70-70]
+		Arg: xs: []uint (declared at line 70, available: [70-70])
 	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
 		Arg: a: [0]int (declared at line 385, available: )
 		Arg: b: int (declared at line 385, available: [385-388])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,16 +1,22 @@
 === yield 1 [final=false] ===
 Package: main
-	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
-		Arg: x: []int (declared at line 12, available: [12-12])
-	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
-	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-263], [266-266], [277-277], [280-281], [283-284], [286-287], [289-289], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
-		Var: s: []*string (declared at line 258, available: )
-		Var: str: string (declared at line 257, available: [246-314])
-		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
-		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
-		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
-		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [17:17] injectible: [17-17]
+		Arg: x: []int (declared at line 17, available: [17-17])
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [108:138] injectible: [108-110], [112-126], [128-131], [133-133], [137-138]
+		Arg: ctx: context.Context (declared at line 108, available: [108-110])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 109, available: [110-113])
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [82:104] injectible: [82-84], [86-89], [91-96], [98-104]
+		Arg: ctx: context.Context (declared at line 82, available: [82-84])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-86])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [249:320] injectible: [249-251], [255-258], [263-264], [266-269], [272-272], [283-283], [286-287], [289-290], [292-293], [295-295], [300-300], [302-302], [304-305], [307-308], [310-311], [313-317], [319-320]
+		Arg: ctx: context.Context (declared at line 249, available: [249-251])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 250, available: [251-269])
+		Var: s: []*string (declared at line 264, available: )
+		Var: str: string (declared at line 263, available: [249-320])
+		Var: circ: main.circularReferenceType (declared at line 285, available: [249-320])
+		Var: s1: main.stringType1 (declared at line 313, available: [308-320])
+		Var: s2: main.stringType2 (declared at line 314, available: [308-320])
+		Var: s2p: *main.stringType2 (declared at line 315, available: [308-320])
 	Function: executeContextFuncs (main.executeContextFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [26:33] injectible: [26-27], [29-29], [31-33]
 		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 27, available: [31-32])
 		Var: ctx: context.Context (declared at line 27, available: [31-32])
@@ -19,14 +25,18 @@ Package: main
 		Var: id: uint64 (declared at line 1360, available: [1360-1361])
 	Function: executeContextImplFuncs (main.executeContextImplFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [61:67] injectible: [61-62], [65-67]
 		Var: c: *main.contextImpl (declared at line 62, available: [61-67])
-	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [113:187] injectible: [113-113], [115-184], [186-187]
-		Var: m: main.manyPointers (declared at line 114, available: [113-187])
-	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:50] injectible: [36-36], [39-40], [42-42], [44-45], [47-47], [49-50]
-		Var: ss: []string (declared at line 39, available: [36-50])
-		Scope: 40-44
-			Var: i: int (declared at line 40, available: [40-44])
-		Scope: 45-49
-			Var: i: int (declared at line 45, available: [45-49])
+	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [119:196] injectible: [119-121], [124-193], [195-196]
+		Arg: ctx: context.Context (declared at line 119, available: [119-121])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 120, available: [121-121])
+		Var: m: main.manyPointers (declared at line 123, available: [119-196])
+	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [39:56] injectible: [39-41], [45-46], [48-48], [50-51], [53-53], [55-56]
+		Arg: ctx: context.Context (declared at line 39, available: [39-41])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 40, available: [41-45])
+		Var: ss: []string (declared at line 45, available: [39-56])
+		Scope: 46-50
+			Var: i: int (declared at line 46, available: [46-50])
+		Scope: 51-55
+			Var: i: int (declared at line 51, available: [51-55])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -79,10 +89,12 @@ Package: main
 		Arg: acc: string (declared at line 340, available: [340-340])
 		Arg: x: string (declared at line 340, available: [340-340])
 		Arg: ~r0: string (declared at line 340, available: )
-	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106] injectible: [97-98], [100-106]
-		Var: x: int (declared at line 99, available: )
-		Var: y: int (declared at line 100, available: [97-106])
-		Var: a: [5]int (declared at line 98, available: [97-106])
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [100:112] injectible: [100-102], [104-104], [106-112]
+		Arg: ctx: context.Context (declared at line 100, available: [100-102])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 101, available: [102-107])
+		Var: x: int (declared at line 105, available: )
+		Var: y: int (declared at line 106, available: [100-112])
+		Var: a: [5]int (declared at line 104, available: [100-112])
 	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124] injectible: [76-82], [88-112], [117-120], [122-122], [124-124]
 		Var: &one: *int (declared at line 95, available: [76-124])
 		Var: &foo: *string (declared at line 98, available: [76-124])
@@ -129,103 +141,121 @@ Package: main
 			Var: i: int (declared at line 210, available: [210-210], [212-212], [214-214])
 			Scope: 210-212
 				Var: key: [4]int (declared at line 211, available: )
-	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
-		Var: x: chan bool (declared at line 52, available: [53-54])
-	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-141], [143-143], [145-145], [148-151], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
-		Var: self: *main.node (declared at line 172, available: [173-177])
-		Var: z: main.spws (declared at line 118, available: )
-		Var: r: string (declared at line 117, available: [112-178])
-		Var: ssaw: main.swsp (declared at line 126, available: [112-178])
-		Var: rct: main.reallyComplexType (declared at line 137, available: [112-178])
-		Var: b: main.node (declared at line 145, available: [112-178])
-		Var: stringSlice: []string (declared at line 162, available: [112-178])
-		Var: up: *int (declared at line 168, available: [112-178])
-		Var: aruint: [2]uint (declared at line 159, available: )
-		Var: n: main.nStruct (declared at line 123, available: )
-		Var: u: int (declared at line 167, available: )
-		Var: u64F: uint64 (declared at line 113, available: )
-		Var: uintToPointTo: uint (declared at line 120, available: )
-		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [92:127] injectible: [92-94], [96-96], [109-123], [127-127]
+		Arg: ctx: context.Context (declared at line 92, available: [92-94])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 93, available: [94-96])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [54:62] injectible: [54-56], [58-62]
+		Arg: ctx: context.Context (declared at line 54, available: [54-56])
+		Var: x: chan bool (declared at line 58, available: [59-60])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 55, available: [56-58])
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [117:186] injectible: [117-119], [121-121], [123-123], [125-125], [128-129], [131-134], [138-140], [142-143], [145-149], [151-151], [153-153], [156-159], [163-163], [165-165], [167-168], [170-171], [173-173], [175-176], [178-178], [180-181], [183-186]
+		Arg: ctx: context.Context (declared at line 117, available: [117-119])
+		Var: z: main.spws (declared at line 126, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 118, available: [119-123])
+		Var: self: *main.node (declared at line 180, available: [181-185])
+		Var: r: string (declared at line 125, available: [117-186])
+		Var: ssaw: main.swsp (declared at line 134, available: [117-186])
+		Var: rct: main.reallyComplexType (declared at line 145, available: [117-186])
+		Var: b: main.node (declared at line 153, available: [117-186])
+		Var: stringSlice: []string (declared at line 170, available: [117-186])
+		Var: up: *int (declared at line 176, available: [117-186])
+		Var: aruint: [2]uint (declared at line 167, available: )
+		Var: n: main.nStruct (declared at line 131, available: )
+		Var: u: int (declared at line 175, available: )
+		Var: u64F: uint64 (declared at line 121, available: )
+		Var: uintToPointTo: uint (declared at line 128, available: )
+		Var: x: main.structWithTwoValues (declared at line 142, available: )
 	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [29:33] injectible: [29-33]
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
-		Var: originalSlice: []int (declared at line 133, available: )
-		Var: s: []uint (declared at line 142, available: )
-		Var: s2: []uint (declared at line 159, available: )
-		Scope: 143-146
-			Var: i: int (declared at line 143, available: [146-146])
-	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
-	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [65:86] injectible: [65-65], [67-72], [75-77], [81-81], [84-86]
-		Var: abc: string (declared at line 66, available: )
-		Var: uninitializedString: string (declared at line 74, available: )
-		Var: s: string (declared at line 80, available: )
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236] injectible: [135-137], [140-140], [142-143], [145-146], [150-150], [152-160], [172-172], [174-174], [177-182], [190-192], [194-195], [198-198], [200-201], [203-206], [208-208], [210-213], [215-216], [219-220], [222-223], [225-226], [228-229], [231-232], [235-236]
-		Var: n: main.nStruct (declared at line 139, available: )
-		Var: ns: main.structWithNoStrings (declared at line 148, available: )
-		Var: cs: main.cStruct (declared at line 149, available: )
-		Var: rcvr: main.receiver (declared at line 197, available: )
-		Var: ts: main.threestrings (declared at line 136, available: [135-236])
-		Var: s: main.aStruct (declared at line 142, available: [135-236])
-		Var: b: main.bStruct (declared at line 145, available: [135-236])
-		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
-		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
-		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
-		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
-		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
-		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
-		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
-	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
-		Var: ist: *time.Location (declared at line 48, available: [49-49])
-	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
-		Arg: x: []int (declared at line 22, available: [22-25])
-	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
-		Arg: f: func(int) (declared at line 28, available: [28-29])
+	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [34:41] injectible: [34-36], [38-41]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [137:189] injectible: [137-139], [141-143], [145-152], [154-158], [160-160], [162-164], [167-168], [170-181], [183-183], [185-185], [187-189]
+		Arg: ctx: context.Context (declared at line 137, available: [137-139])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 138, available: [139-141])
+		Var: originalSlice: []int (declared at line 141, available: )
+		Var: s: []uint (declared at line 150, available: )
+		Var: s2: []uint (declared at line 167, available: )
+		Scope: 151-154
+			Var: i: int (declared at line 151, available: [154-154])
+	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [34:39] injectible: [34-36], [38-39]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [70:94] injectible: [70-72], [75-80], [83-85], [89-89], [92-94]
+		Arg: ctx: context.Context (declared at line 70, available: [70-72])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 71, available: [72-75])
+		Var: abc: string (declared at line 74, available: )
+		Var: uninitializedString: string (declared at line 82, available: )
+		Var: s: string (declared at line 88, available: )
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [141:245] injectible: [141-143], [145-146], [149-149], [151-152], [154-155], [159-159], [161-169], [181-181], [183-183], [186-191], [199-201], [203-204], [207-207], [209-210], [212-215], [217-217], [219-222], [224-225], [228-229], [231-232], [234-235], [237-238], [240-241], [244-245]
+		Arg: ctx: context.Context (declared at line 141, available: [141-143])
+		Var: rcvr: main.receiver (declared at line 206, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 142, available: [143-146])
+		Var: n: main.nStruct (declared at line 148, available: )
+		Var: ns: main.structWithNoStrings (declared at line 157, available: )
+		Var: cs: main.cStruct (declared at line 158, available: )
+		Var: ts: main.threestrings (declared at line 145, available: [141-245])
+		Var: s: main.aStruct (declared at line 151, available: [141-245])
+		Var: b: main.bStruct (declared at line 154, available: [141-245])
+		Var: tenStr: main.tenStrings (declared at line 171, available: [141-245])
+		Var: deep: main.deepStruct1 (declared at line 185, available: [141-245])
+		Var: fields: main.lotsOfFields (declared at line 203, available: [141-245])
+		Var: sta: main.structWithTwoArrays (declared at line 212, available: [141-245])
+		Var: .autotmp_121: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_140: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_147: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_152: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_176: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_183: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_188: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_195: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_201: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_206: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_213: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_219: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_22: [0]main.structWithCyclicSlices (declared at line 229, available: [141-245])
+		Var: .autotmp_224: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_236: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_243: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_248: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_255: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_26: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_261: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_266: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_273: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_279: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_284: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_291: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_298: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_304: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_309: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_31: [0][][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_32: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_34: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_41: [0][][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_42: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_44: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_47: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_51: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_56: [0][][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_57: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_59: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_62: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_66: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_70: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_20: [0]uint8 (declared at line 166, available: [141-245])
+		Var: .autotmp_97: main.emptyStruct (declared at line 199, available: [141-245])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [44:65] injectible: [44-46], [49-50], [56-59], [64-65]
+		Arg: ctx: context.Context (declared at line 44, available: [44-46])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 45, available: [46-49])
+		Var: ist: *time.Location (declared at line 56, available: [57-57])
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [27:30] injectible: [27-30]
+		Arg: x: []int (declared at line 27, available: [27-30])
+	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [31:33] injectible: [31-33]
+		Arg: f: func(int) (declared at line 31, available: [31-32])
 	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [109:119] injectible: [109-115], [117-117], [119-119]
 		Arg: entriesCount: int (declared at line 109, available: [109-119])
 		Arg: ~r0: map[string][]main.structWithMap (declared at line 109, available: )
@@ -258,9 +288,9 @@ Package: main
 		Arg: b: <T> (declared at line 113, available: [113-114])
 		Arg: ~r0: <T> (declared at line 113, available: )
 		Arg: ~r1: <T> (declared at line 113, available: )
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:17] injectible: [17-17]
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -268,11 +298,12 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:50] injectible: [21-21], [26-26], [29-30], [33-33], [35-35], [37-40], [44-48], [50-50]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [22:50] injectible: [22-22], [27-27], [30-31], [34-34], [36-36], [38-41], [44-48], [50-50]
 		Var: ticker: *time.Ticker (declared at line 44, available: [45-45])
-		Var: service: string (declared at line 29, available: [30-33])
+		Var: service: string (declared at line 30, available: [31-34])
 		Scope: 45-48
 			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 46, available: [45-48])
+			Var: ctx: context.Context (declared at line 46, available: [47-47])
 	Type: main.Pair[...]
 		Field: Key: <T>
 		Field: Value: <T>
@@ -286,10 +317,10 @@ Package: main
 		Field: Total: float64
 	Type: main.Server
 		Field: name: string
-		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [21:26] injectible: [21-23], [25-26]
-			Arg: s: *main.Server (declared at line 21, available: [21-23])
-			Arg: req: *main.Request (declared at line 21, available: [21-26])
-			Arg: ~r0: error (declared at line 21, available: )
+		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [26:31] injectible: [26-28], [30-31]
+			Arg: s: *main.Server (declared at line 26, available: [26-28])
+			Arg: req: *main.Request (declared at line 26, available: [26-31])
+			Arg: ~r0: error (declared at line 26, available: )
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -600,12 +631,12 @@ Package: main
 		Field: aStringPtr: *string
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52] injectible: [52-52]
-			Arg: r: *main.receiver (declared at line 52, available: [52-52])
-			Arg: a: int (declared at line 52, available: [52-52])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56] injectible: [56-56]
-			Arg: r: main.receiver (declared at line 56, available: [56-56])
-			Arg: a: int (declared at line 56, available: [56-56])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [58:58] injectible: [58-58]
+			Arg: r: *main.receiver (declared at line 58, available: [58-58])
+			Arg: a: int (declared at line 58, available: [58-58])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [62:62] injectible: [62-62]
+			Arg: r: main.receiver (declared at line 62, available: [62-62])
+			Arg: a: int (declared at line 62, available: [62-62])
 	Type: main.score
 	Type: main.secondBehavior
 		Field: i: int
@@ -723,14 +754,14 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
-	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [104:107] injectible: [105-107]
-		Var: i: int (declared at line 106, available: [105-106])
+	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [110:113] injectible: [111-113]
+		Var: i: int (declared at line 112, available: [111-112])
 		Arg: id: int (declared at line 0, available: )
-		Var: p: *main.paddedData (declared at line 105, available: )
-	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [23:28] injectible: [23-26], [28-28]
-		Arg: n: int (declared at line 23, available: [23-28])
-		Arg: ~r0: string (declared at line 23, available: )
-		Var: prefix: string (declared at line 24, available: [23-26], [28-28])
+		Var: p: *main.paddedData (declared at line 111, available: )
+	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [26:31] injectible: [26-29], [31-31]
+		Arg: n: int (declared at line 26, available: [26-31])
+		Arg: ~r0: string (declared at line 26, available: )
+		Var: prefix: string (declared at line 27, available: [26-29], [31-31])
 		Var: ~r0.ptr: *uint8 (declared at line 34, available: )
 		Var: ~r0.len: int (declared at line 34, available: )
 	Function: nestedGeneric[...] (main.nestedGeneric[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [203:203] injectible: [203-203]
@@ -742,20 +773,21 @@ Package: main
 		Arg: items: <T> (declared at line 183, available: [183-184])
 		Arg: pred: <T> (declared at line 183, available: [183-184])
 		Arg: ~r0: <T> (declared at line 183, available: )
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
-		Arg: ~r0: uint64 (declared at line 40, available: )
-		Var: n: uint64 (declared at line 45, available: [44-46])
-		Var: b: []uint8 (declared at line 41, available: [42-45])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [43:49] injectible: [43-49]
+		Arg: ~r0: uint64 (declared at line 43, available: )
+		Var: n: uint64 (declared at line 48, available: [47-49])
+		Var: b: []uint8 (declared at line 44, available: [45-48])
 	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:88] injectible: [52-66], [68-69], [71-73], [75-77], [80-88]
+		Arg: ctx: context.Context (declared at line 52, available: [52-88])
 		Var: it: main.iterExample (declared at line 70, available: [52-88])
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 67, available: [52-88])
-	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
-		Arg: x: []int (declared at line 16, available: [16-17])
-		Arg: ~r0: string (declared at line 16, available: )
-	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14] injectible: [12-14]
-	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20] injectible: [18-20]
-	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25] injectible: [24-25]
-		Arg: ~r0: string (declared at line 24, available: )
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [21:22] injectible: [21-22]
+		Arg: x: []int (declared at line 21, available: [21-22])
+		Arg: ~r0: string (declared at line 21, available: )
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [17:19] injectible: [17-19]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [23:25] injectible: [23-25]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [29-30]
+		Arg: ~r0: string (declared at line 29, available: )
 	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55] injectible: [54-55]
 		Arg: a: interface {} (declared at line 54, available: [54-55])
 		Arg: ~r0: string (declared at line 54, available: )
@@ -765,224 +797,224 @@ Package: main
 	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
 		Arg: arg: [3]int (declared at line 297, available: [297-302])
 		Arg: ~r0: [3]int (declared at line 297, available: )
-	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
-		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
-	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
-		Arg: a: [2][2]int (declared at line 70, available: [70-70])
-	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78] injectible: [78-78]
-		Arg: b: [2][2][2]int (declared at line 78, available: [78-78])
+	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [93:93] injectible: [93-93]
+		Arg: a: [2]struct {} (declared at line 93, available: [93-93])
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [76:76] injectible: [76-76]
+		Arg: a: [2][2]int (declared at line 76, available: [76-76])
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [84:84] injectible: [84-84]
+		Arg: b: [2][2][2]int (declared at line 84, available: [84-84])
 	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [42:42] injectible: [42-42]
 		Arg: m: [2]map[string]int (declared at line 42, available: [42-42])
-	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74] injectible: [74-74]
-		Arg: a: [2]string (declared at line 74, available: [74-74])
-	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83] injectible: [83-83]
-		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
-	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
-		Arg: x: *[2]uint (declared at line 59, available: [59-59])
-	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
-		Arg: x: uint64 (declared at line 19, available: [23-23])
-		Arg: ~r0: uint64 (declared at line 19, available: )
-	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
-		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
-	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
-		Arg: x: [2]bool (declared at line 26, available: [26-26])
-	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
-		Arg: a: []uint8 (declared at line 117, available: [117-117])
-		Arg: b: []uint8 (declared at line 117, available: [117-117])
-	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
-		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
-		Arg: a: []uint8 (declared at line 129, available: [129-129])
-		Arg: b: []int (declared at line 129, available: [129-129])
-	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
-		Arg: x: []uint8 (declared at line 77, available: [77-77])
-	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
-		Arg: x: []uint8 (declared at line 81, available: [81-81])
-	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
-		Arg: x: []uint8 (declared at line 85, available: [85-85])
-	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
-		Arg: x: []uint8 (declared at line 89, available: [89-89])
-	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
-		Arg: x: []uint8 (declared at line 93, available: [93-93])
-	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
-		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
-	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
-		Arg: a: int (declared at line 125, available: [125-125])
-		Arg: x: []uint8 (declared at line 125, available: [125-125])
-		Arg: b: string (declared at line 125, available: [125-125])
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [80:80] injectible: [80-80]
+		Arg: a: [2]string (declared at line 80, available: [80-80])
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [89:89] injectible: [89-89]
+		Arg: a: [2]main.nestedStruct (declared at line 88, available: [89-89])
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [64:64] injectible: [64-64]
+		Arg: x: *[2]uint (declared at line 64, available: [64-64])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [26:26] injectible: [26-26]
+		Arg: x: uint64 (declared at line 22, available: [26-26])
+		Arg: ~r0: uint64 (declared at line 22, available: )
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [85:85] injectible: [85-85]
+		Arg: b: main.bigStruct (declared at line 85, available: [85-85])
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [32:32] injectible: [32-32]
+		Arg: x: [2]bool (declared at line 32, available: [32-32])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [122:122] injectible: [122-122]
+		Arg: a: []uint8 (declared at line 122, available: [122-122])
+		Arg: b: []uint8 (declared at line 122, available: [122-122])
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [20:20] injectible: [20-20]
+		Arg: x: [2]uint8 (declared at line 20, available: [20-20])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [134:134] injectible: [134-134]
+		Arg: a: []uint8 (declared at line 134, available: [134-134])
+		Arg: b: []int (declared at line 134, available: [134-134])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [82:82] injectible: [82-82]
+		Arg: x: []uint8 (declared at line 82, available: [82-82])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [86:86] injectible: [86-86]
+		Arg: x: []uint8 (declared at line 86, available: [86-86])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [90:90] injectible: [90-90]
+		Arg: x: []uint8 (declared at line 90, available: [90-90])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [94:94] injectible: [94-94]
+		Arg: x: []uint8 (declared at line 94, available: [94-94])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [98:98] injectible: [98-98]
+		Arg: x: []uint8 (declared at line 98, available: [98-98])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [126:126] injectible: [126-126]
+		Arg: x: [][]uint8 (declared at line 126, available: [126-126])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [130:130] injectible: [130-130]
+		Arg: a: int (declared at line 130, available: [130-130])
+		Arg: x: []uint8 (declared at line 130, available: [130-130])
+		Arg: b: string (declared at line 130, available: [130-130])
 	Function: testCaptureContextImpl (main.testCaptureContextImpl) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [44:44] injectible: [44-44]
 		Arg: c: *main.contextImpl (declared at line 44, available: [44-44])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
-		Arg: c: chan bool (declared at line 30, available: [30-30])
-	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
-		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
-	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
-		Arg: w: uint8 (declared at line 34, available: [34-34])
-		Arg: x: bool (declared at line 34, available: [34-34])
-		Arg: y: float32 (declared at line 34, available: [34-34])
-	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22] injectible: [22-22]
-		Arg: w: uint8 (declared at line 22, available: [22-22])
-		Arg: x: uint8 (declared at line 22, available: [22-22])
-		Arg: y: float32 (declared at line 22, available: [22-22])
-	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38] injectible: [38-38]
-		Arg: w: uint8 (declared at line 38, available: [38-38])
-		Arg: x: int (declared at line 38, available: [38-38])
-		Arg: y: float32 (declared at line 38, available: [38-38])
-	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46] injectible: [46-46]
-		Arg: w: uint8 (declared at line 46, available: [46-46])
-		Arg: x: int16 (declared at line 46, available: [46-46])
-		Arg: y: float32 (declared at line 46, available: [46-46])
-	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50] injectible: [50-50]
-		Arg: w: uint8 (declared at line 50, available: [50-50])
-		Arg: x: int32 (declared at line 50, available: [50-50])
-		Arg: y: float32 (declared at line 50, available: [50-50])
-	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54] injectible: [54-54]
-		Arg: w: uint8 (declared at line 54, available: [54-54])
-		Arg: x: int64 (declared at line 54, available: [54-54])
-		Arg: y: float32 (declared at line 54, available: [54-54])
-	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42] injectible: [42-42]
-		Arg: w: uint8 (declared at line 42, available: [42-42])
-		Arg: x: int8 (declared at line 42, available: [42-42])
-		Arg: y: float32 (declared at line 42, available: [42-42])
-	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26] injectible: [26-26]
-		Arg: w: uint8 (declared at line 26, available: [26-26])
-		Arg: x: int32 (declared at line 26, available: [26-26])
-		Arg: y: float32 (declared at line 26, available: [26-26])
-	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30] injectible: [30-30]
-		Arg: w: uint8 (declared at line 30, available: [30-30])
-		Arg: x: string (declared at line 30, available: [30-30])
-		Arg: y: float32 (declared at line 30, available: [30-30])
-	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58] injectible: [58-58]
-		Arg: w: uint8 (declared at line 58, available: [58-58])
-		Arg: x: uint (declared at line 58, available: [58-58])
-		Arg: y: float32 (declared at line 58, available: [58-58])
-	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66] injectible: [66-66]
-		Arg: w: uint8 (declared at line 66, available: [66-66])
-		Arg: x: uint16 (declared at line 66, available: [66-66])
-		Arg: y: float32 (declared at line 66, available: [66-66])
-	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70] injectible: [70-70]
-		Arg: w: uint8 (declared at line 70, available: [70-70])
-		Arg: x: uint32 (declared at line 70, available: [70-70])
-		Arg: y: float32 (declared at line 70, available: [70-70])
-	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74] injectible: [74-74]
-		Arg: w: uint8 (declared at line 74, available: [74-74])
-		Arg: x: uint64 (declared at line 74, available: [74-74])
-		Arg: y: float32 (declared at line 74, available: [74-74])
-	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62] injectible: [62-62]
-		Arg: w: uint8 (declared at line 62, available: [62-62])
-		Arg: x: uint8 (declared at line 62, available: [62-62])
-		Arg: y: float32 (declared at line 62, available: [62-62])
-	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75] injectible: [75-75]
-		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [33:33] injectible: [33-33]
+		Arg: c: chan bool (declared at line 33, available: [33-33])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93] injectible: [93-93]
+		Arg: x: main.circularReferenceType (declared at line 93, available: [93-93])
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [40:40] injectible: [40-40]
+		Arg: w: uint8 (declared at line 40, available: [40-40])
+		Arg: x: bool (declared at line 40, available: [40-40])
+		Arg: y: float32 (declared at line 40, available: [40-40])
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [28:28] injectible: [28-28]
+		Arg: w: uint8 (declared at line 28, available: [28-28])
+		Arg: x: uint8 (declared at line 28, available: [28-28])
+		Arg: y: float32 (declared at line 28, available: [28-28])
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [44:44] injectible: [44-44]
+		Arg: w: uint8 (declared at line 44, available: [44-44])
+		Arg: x: int (declared at line 44, available: [44-44])
+		Arg: y: float32 (declared at line 44, available: [44-44])
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [52:52] injectible: [52-52]
+		Arg: w: uint8 (declared at line 52, available: [52-52])
+		Arg: x: int16 (declared at line 52, available: [52-52])
+		Arg: y: float32 (declared at line 52, available: [52-52])
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [56:56] injectible: [56-56]
+		Arg: w: uint8 (declared at line 56, available: [56-56])
+		Arg: x: int32 (declared at line 56, available: [56-56])
+		Arg: y: float32 (declared at line 56, available: [56-56])
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [60:60] injectible: [60-60]
+		Arg: w: uint8 (declared at line 60, available: [60-60])
+		Arg: x: int64 (declared at line 60, available: [60-60])
+		Arg: y: float32 (declared at line 60, available: [60-60])
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [48:48] injectible: [48-48]
+		Arg: w: uint8 (declared at line 48, available: [48-48])
+		Arg: x: int8 (declared at line 48, available: [48-48])
+		Arg: y: float32 (declared at line 48, available: [48-48])
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [32:32] injectible: [32-32]
+		Arg: w: uint8 (declared at line 32, available: [32-32])
+		Arg: x: int32 (declared at line 32, available: [32-32])
+		Arg: y: float32 (declared at line 32, available: [32-32])
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [36:36] injectible: [36-36]
+		Arg: w: uint8 (declared at line 36, available: [36-36])
+		Arg: x: string (declared at line 36, available: [36-36])
+		Arg: y: float32 (declared at line 36, available: [36-36])
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [64:64] injectible: [64-64]
+		Arg: w: uint8 (declared at line 64, available: [64-64])
+		Arg: x: uint (declared at line 64, available: [64-64])
+		Arg: y: float32 (declared at line 64, available: [64-64])
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [72:72] injectible: [72-72]
+		Arg: w: uint8 (declared at line 72, available: [72-72])
+		Arg: x: uint16 (declared at line 72, available: [72-72])
+		Arg: y: float32 (declared at line 72, available: [72-72])
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [76:76] injectible: [76-76]
+		Arg: w: uint8 (declared at line 76, available: [76-76])
+		Arg: x: uint32 (declared at line 76, available: [76-76])
+		Arg: y: float32 (declared at line 76, available: [76-76])
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [80:80] injectible: [80-80]
+		Arg: w: uint8 (declared at line 80, available: [80-80])
+		Arg: x: uint64 (declared at line 80, available: [80-80])
+		Arg: y: float32 (declared at line 80, available: [80-80])
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [68:68] injectible: [68-68]
+		Arg: w: uint8 (declared at line 68, available: [68-68])
+		Arg: x: uint8 (declared at line 68, available: [68-68])
+		Arg: y: float32 (declared at line 68, available: [68-68])
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [80:80] injectible: [80-80]
+		Arg: z: *main.reallyComplexType (declared at line 80, available: [80-80])
 	Function: testConflictingReturn (main.testConflictingReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [109:111] injectible: [109-111]
 		Arg: i: int (declared at line 109, available: [109-111])
 		Arg: ~r0: int (declared at line 109, available: )
 		Arg: r0: string (declared at line 109, available: )
-	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
-		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
-		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
-		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
-		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
-		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
-		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
-		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
-		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
-	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
-		Arg: x: []uint8 (declared at line 97, available: [97-97])
-	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
-		Arg: u: []uint (declared at line 33, available: [33-33])
-	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
-		Arg: xs: []main.structWithNoStrings (declared at line 45, available: [45-45])
-		Arg: a: int (declared at line 45, available: [45-45])
-	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [50:50] injectible: [50-50]
-		Arg: x: string (declared at line 50, available: [50-50])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124] injectible: [124-124]
-		Arg: e: main.emptyStruct (declared at line 124, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128] injectible: [128-128]
-		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [114:114] injectible: [114-114]
+		Arg: t: *main.t (declared at line 114, available: [114-114])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: main.deepMap1 (declared at line 203, available: [203-203])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [206:206] injectible: [206-206]
+		Arg: a: *main.deepMap7 (declared at line 206, available: [206-206])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: main.deepPtr1 (declared at line 139, available: [139-139])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142] injectible: [142-142]
+		Arg: a: *main.deepPtr7 (declared at line 142, available: [142-142])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: main.deepSlice1 (declared at line 165, available: [165-165])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [168:168] injectible: [168-168]
+		Arg: a: *main.deepSlice7 (declared at line 168, available: [168-168])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [126:126] injectible: [126-126]
+		Arg: t: main.deepStruct1 (declared at line 126, available: [126-126])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [102:102] injectible: [102-102]
+		Arg: x: []uint8 (declared at line 102, available: [102-102])
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [38:38] injectible: [38-38]
+		Arg: u: []uint (declared at line 38, available: [38-38])
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [50:50] injectible: [50-50]
+		Arg: xs: []main.structWithNoStrings (declared at line 50, available: [50-50])
+		Arg: a: int (declared at line 50, available: [50-50])
+	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [55:55] injectible: [55-55]
+		Arg: x: string (declared at line 55, available: [55-55])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [130:130] injectible: [130-130]
+		Arg: e: main.emptyStruct (declared at line 130, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [134:134] injectible: [134-134]
+		Arg: e: *main.emptyStruct (declared at line 134, available: [134-134])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
-	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [108-110], [112-112]
-		Arg: shouldErr: bool (declared at line 101, available: [101-103])
-		Arg: ~r0: int (declared at line 101, available: )
-		Var: x: int (declared at line 106, available: )
-		Var: err: error (declared at line 102, available: )
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [104:115] injectible: [104-104], [106-107], [111-113], [115-115]
+		Arg: shouldErr: bool (declared at line 104, available: [104-106])
+		Arg: ~r0: int (declared at line 104, available: )
+		Var: x: int (declared at line 109, available: )
+		Var: err: error (declared at line 105, available: )
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
-	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80] injectible: [79-80]
-		Arg: x: int (declared at line 79, available: [79-80])
-		Arg: ~r0: int (declared at line 79, available: )
-	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93] injectible: [92-93]
-		Arg: a: [5]int (declared at line 92, available: [92-93])
-		Arg: ~r0: int (declared at line 92, available: )
-	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [17:19] injectible: [17-19]
-		Arg: x: int (declared at line 17, available: [17-18])
-		Arg: y: int (declared at line 17, available: [17-18])
-	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [21:25] injectible: [21-25]
-		Arg: x: int (declared at line 21, available: [21-25])
-		Arg: y: int (declared at line 21, available: [21-25])
-	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35] injectible: [32-32], [34-35]
-		Arg: x: int (declared at line 32, available: [32-34])
-	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42] injectible: [37-42]
-		Arg: x: int (declared at line 37, available: [37-38])
-		Arg: y: int (declared at line 37, available: [37-39])
-		Var: z: int (declared at line 38, available: [37-42])
-	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46] injectible: [44-46]
-		Arg: x: int (declared at line 44, available: [44-45])
-	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49] injectible: [49-49]
-	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60] injectible: [52-53], [55-56], [58-60]
-		Var: s: int (declared at line 54, available: [55-55], [56-56], [58-58])
-		Scope: 55-58
-			Var: i: int (declared at line 55, available: [55-55], [56-58])
-	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63] injectible: [63-63]
-	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [66:67] injectible: [67-67]
-	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [13:15] injectible: [14-14]
-		Arg: x: int (declared at line 0, available: [13-14])
-	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [74:75] injectible: [75-75]
-		Arg: x: int (declared at line 0, available: [75-75])
-	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:71] injectible: [71-71]
-		Arg: a: [5]int (declared at line 0, available: [71-71])
-	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38] injectible: [38-38]
-		Arg: x: [2]int16 (declared at line 38, available: [38-38])
-	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42] injectible: [42-42]
-		Arg: x: [2]int32 (declared at line 42, available: [42-42])
-	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46] injectible: [46-46]
-		Arg: x: [2]int64 (declared at line 46, available: [46-46])
-	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34] injectible: [34-34]
-		Arg: x: [2]int8 (declared at line 34, available: [34-34])
-	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30] injectible: [30-30]
-		Arg: x: [2]int (declared at line 30, available: [30-30])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [82:83] injectible: [82-83]
+		Arg: x: int (declared at line 82, available: [82-83])
+		Arg: ~r0: int (declared at line 82, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [95:96] injectible: [95-96]
+		Arg: a: [5]int (declared at line 95, available: [95-96])
+		Arg: ~r0: int (declared at line 95, available: )
+	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [20:22] injectible: [20-22]
+		Arg: x: int (declared at line 20, available: [20-21])
+		Arg: y: int (declared at line 20, available: [20-21])
+	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [24:28] injectible: [24-28]
+		Arg: x: int (declared at line 24, available: [24-28])
+		Arg: y: int (declared at line 24, available: [24-28])
+	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [35:38] injectible: [35-35], [37-38]
+		Arg: x: int (declared at line 35, available: [35-37])
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [40:45] injectible: [40-45]
+		Arg: x: int (declared at line 40, available: [40-41])
+		Arg: y: int (declared at line 40, available: [40-42])
+		Var: z: int (declared at line 41, available: [40-45])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [47:49] injectible: [47-49]
+		Arg: x: int (declared at line 47, available: [47-48])
+	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [51:52] injectible: [52-52]
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [55:63] injectible: [55-56], [58-59], [61-63]
+		Var: s: int (declared at line 57, available: [58-58], [59-59], [61-61])
+		Scope: 58-61
+			Var: i: int (declared at line 58, available: [58-58], [59-61])
+	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [65:66] injectible: [66-66]
+	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [69:70] injectible: [70-70]
+	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [16:18] injectible: [17-17]
+		Arg: x: int (declared at line 0, available: [16-17])
+	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [77:78] injectible: [78-78]
+		Arg: x: int (declared at line 0, available: [78-78])
+	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [73:74] injectible: [74-74]
+		Arg: a: [5]int (declared at line 0, available: [74-74])
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [44:44] injectible: [44-44]
+		Arg: x: [2]int16 (declared at line 44, available: [44-44])
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [48:48] injectible: [48-48]
+		Arg: x: [2]int32 (declared at line 48, available: [48-48])
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [52:52] injectible: [52-52]
+		Arg: x: [2]int64 (declared at line 52, available: [52-52])
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [40:40] injectible: [40-40]
+		Arg: x: [2]int8 (declared at line 40, available: [40-40])
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [36:36] injectible: [36-36]
+		Arg: x: [2]int (declared at line 36, available: [36-36])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50] injectible: [50-50]
 		Arg: b: main.behavior (declared at line 50, available: [50-50])
-	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [94:94] injectible: [94-94]
-		Arg: a: int (declared at line 94, available: [94-94])
-		Arg: b: error (declared at line 94, available: [94-94])
-		Arg: c: uint (declared at line 94, available: [94-94])
-	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
-		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [58:58] injectible: [58-58]
-		Arg: a: string (declared at line 58, available: [58-58])
-		Arg: b: string (declared at line 58, available: [58-58])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [97:97] injectible: [97-97]
+		Arg: a: int (declared at line 97, available: [97-97])
+		Arg: b: error (declared at line 97, available: [97-97])
+		Arg: c: uint (declared at line 97, available: [97-97])
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67] injectible: [67-67]
+		Arg: a: main.interfaceComplexityA (declared at line 67, available: [67-67])
+	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [63:63] injectible: [63-63]
+		Arg: a: string (declared at line 63, available: [63-63])
+		Arg: b: string (declared at line 63, available: [63-63])
 	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
 		Arg: arg: main.largeStruct (declared at line 281, available: [281-291])
 		Arg: ~r0: main.largeStruct (declared at line 281, available: )
-	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
-		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
-		Var: s: int (declared at line 224, available: [237-237], [242-242])
-		Var: aPerArch: int (declared at line 228, available: [223-243])
-		Var: b: int (declared at line 229, available: [223-243])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
-		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [47:47] injectible: [47-47]
+		Arg: a: main.node (declared at line 47, available: [47-47])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [226:246] injectible: [226-226], [233-233], [236-237], [239-242], [244-246]
+		Var: s: int (declared at line 227, available: [240-240], [245-245])
+		Var: aPerArch: int (declared at line 231, available: [226-246])
+		Var: b: int (declared at line 232, available: [226-246])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [138:138] injectible: [138-138]
+		Arg: l: main.lotsOfFields (declared at line 138, available: [138-138])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
 		Arg: a: int (declared at line 328, available: [328-330])
 		Arg: b: int (declared at line 328, available: [328-330])
@@ -994,10 +1026,10 @@ Package: main
 		Arg: h: int (declared at line 328, available: [328-330])
 		Arg: i: int (declared at line 328, available: [328-330])
 		Arg: ~r0: [2]int (declared at line 328, available: )
-	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [102:102] injectible: [102-102]
-		Arg: m: main.manyPointers (declared at line 102, available: [102-102])
-	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [33:33] injectible: [33-33]
-		Arg: ss: []string (declared at line 33, available: [33-33])
+	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [108:108] injectible: [108-108]
+		Arg: m: main.manyPointers (declared at line 108, available: [108-108])
+	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:36] injectible: [36-36]
+		Arg: ss: []string (declared at line 36, available: [36-36])
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -1036,8 +1068,8 @@ Package: main
 		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
 	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70] injectible: [70-70]
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
-	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
-		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [47:47] injectible: [47-47]
+		Arg: x: string (declared at line 47, available: [47-47])
 	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-349]
 		Arg: a: int (declared at line 337, available: [337-349])
 		Arg: b: int (declared at line 337, available: [337-349])
@@ -1049,17 +1081,17 @@ Package: main
 		Arg: h: int (declared at line 337, available: [337-349])
 		Arg: s: string (declared at line 337, available: [337-349])
 		Arg: ~r0: main.largeStruct (declared at line 337, available: )
-	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [62:62] injectible: [62-62]
-		Arg: x: string (declared at line 62, available: [62-62])
+	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [67:67] injectible: [67-67]
+		Arg: x: string (declared at line 67, available: [67-67])
 	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
 		Arg: a: [2]int (declared at line 364, available: [364-366])
 		Arg: b: [3]int (declared at line 364, available: [364-366])
 		Arg: ~r0: int (declared at line 364, available: )
 		Arg: ~r1: [2]int (declared at line 364, available: )
-	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
-		Arg: o: main.outer (declared at line 72, available: [72-72])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
-		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [75:75] injectible: [75-75]
+		Arg: o: main.outer (declared at line 75, available: [75-75])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [102:102] injectible: [102-102]
+		Arg: b: main.bStruct (declared at line 102, available: [102-102])
 	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
 		Arg: s1: main.largeStruct (declared at line 308, available: [308-320])
 		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
@@ -1068,99 +1100,99 @@ Package: main
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
 		Arg: result2: int (declared at line 95, available: )
-	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
-		Arg: a: bool (declared at line 78, available: [78-78])
-		Arg: b: uint8 (declared at line 78, available: [78-78])
-		Arg: c: int32 (declared at line 78, available: [78-78])
-		Arg: d: uint (declared at line 78, available: [78-78])
-		Arg: e: string (declared at line 78, available: [78-78])
-	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
-		Arg: a: main.tierA (declared at line 68, available: [68-68])
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [84:84] injectible: [84-84]
+		Arg: a: bool (declared at line 84, available: [84-84])
+		Arg: b: uint8 (declared at line 84, available: [84-84])
+		Arg: c: int32 (declared at line 84, available: [84-84])
+		Arg: d: uint (declared at line 84, available: [84-84])
+		Arg: e: string (declared at line 84, available: [84-84])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71] injectible: [71-71]
+		Arg: a: main.tierA (declared at line 71, available: [71-71])
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
 		Arg: i: int (declared at line 88, available: [88-89])
 		Arg: result: int (declared at line 88, available: )
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
-		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
-	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
-		Arg: x: []uint8 (declared at line 101, available: [101-101])
-	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
-		Arg: z: *bool (declared at line 99, available: [99-99])
-		Arg: a: uint (declared at line 99, available: [99-99])
-	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61] injectible: [61-61]
-		Arg: xs: []uint16 (declared at line 61, available: [61-61])
-	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49] injectible: [49-49]
-		Arg: xs: []main.structWithNoStrings (declared at line 49, available: [49-49])
-		Arg: a: int (declared at line 49, available: [49-49])
-	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57] injectible: [57-57]
-		Arg: a: int8 (declared at line 57, available: [57-57])
-		Arg: s: []bool (declared at line 57, available: [57-57])
-		Arg: x: uint (declared at line 57, available: [57-57])
-	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71] injectible: [71-71]
-		Arg: z: uint (declared at line 71, available: [71-71])
-		Arg: x: *main.nStruct (declared at line 71, available: [71-71])
-		Arg: a: int (declared at line 71, available: [71-71])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100] injectible: [100-100]
-		Arg: c: main.cStruct (declared at line 100, available: [100-100])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92] injectible: [92-92]
-		Arg: x: main.nStruct (declared at line 92, available: [92-92])
-	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [38:38] injectible: [38-38]
-		Arg: a: *main.oneStringStruct (declared at line 38, available: [38-38])
-	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95] injectible: [95-95]
-		Arg: a: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: b: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: c: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: d: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: e: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: f: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: g: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: h: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: i: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: j: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: k: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: l: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: m: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: n: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: o: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: p: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: q: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: r: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: s: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: t: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: u: [3]uint32 (declared at line 94, available: [95-95])
-	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18] injectible: [18-18]
-		Arg: a: uint8 (declared at line 15, available: [18-18])
-		Arg: b: uint8 (declared at line 15, available: [18-18])
-		Arg: c: uint8 (declared at line 15, available: [18-18])
-		Arg: d: uint8 (declared at line 15, available: [18-18])
-		Arg: e: uint8 (declared at line 15, available: [18-18])
-		Arg: f: uint8 (declared at line 15, available: [18-18])
-		Arg: g: uint8 (declared at line 15, available: [18-18])
-		Arg: h: uint8 (declared at line 16, available: [18-18])
-		Arg: i: uint8 (declared at line 16, available: [18-18])
-		Arg: j: uint8 (declared at line 16, available: )
-		Arg: k: uint8 (declared at line 16, available: )
-		Arg: l: uint8 (declared at line 16, available: )
-		Arg: m: uint8 (declared at line 16, available: )
-		Arg: n: uint8 (declared at line 16, available: )
-		Arg: o: uint8 (declared at line 17, available: )
-		Arg: p: uint8 (declared at line 17, available: )
-		Arg: q: uint8 (declared at line 17, available: )
-		Arg: r: uint8 (declared at line 17, available: )
-		Arg: s: uint8 (declared at line 17, available: )
-		Arg: t: uint8 (declared at line 17, available: )
-		Arg: u: uint8 (declared at line 17, available: )
-	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51] injectible: [51-51]
-		Arg: a: *main.node (declared at line 51, available: [51-51])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [114:114] injectible: [114-114]
+		Arg: x: *main.anotherStruct (declared at line 114, available: [114-114])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [106:106] injectible: [106-106]
+		Arg: x: []uint8 (declared at line 106, available: [106-106])
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [104:104] injectible: [104-104]
+		Arg: z: *bool (declared at line 104, available: [104-104])
+		Arg: a: uint (declared at line 104, available: [104-104])
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [66:66] injectible: [66-66]
+		Arg: xs: []uint16 (declared at line 66, available: [66-66])
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [54:54] injectible: [54-54]
+		Arg: xs: []main.structWithNoStrings (declared at line 54, available: [54-54])
+		Arg: a: int (declared at line 54, available: [54-54])
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [62:62] injectible: [62-62]
+		Arg: a: int8 (declared at line 62, available: [62-62])
+		Arg: s: []bool (declared at line 62, available: [62-62])
+		Arg: x: uint (declared at line 62, available: [62-62])
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [76:76] injectible: [76-76]
+		Arg: z: uint (declared at line 76, available: [76-76])
+		Arg: x: *main.nStruct (declared at line 76, available: [76-76])
+		Arg: a: int (declared at line 76, available: [76-76])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [106:106] injectible: [106-106]
+		Arg: c: main.cStruct (declared at line 106, available: [106-106])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [98:98] injectible: [98-98]
+		Arg: x: main.nStruct (declared at line 98, available: [98-98])
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [43:43] injectible: [43-43]
+		Arg: a: *main.oneStringStruct (declared at line 43, available: [43-43])
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [101:101] injectible: [101-101]
+		Arg: a: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: b: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: c: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: d: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: e: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: f: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: g: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: h: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: i: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: j: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: k: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: l: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: m: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: n: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: o: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: p: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: q: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: r: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: s: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: t: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: u: [3]uint32 (declared at line 100, available: [101-101])
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [24:24] injectible: [24-24]
+		Arg: a: uint8 (declared at line 21, available: [24-24])
+		Arg: b: uint8 (declared at line 21, available: [24-24])
+		Arg: c: uint8 (declared at line 21, available: [24-24])
+		Arg: d: uint8 (declared at line 21, available: [24-24])
+		Arg: e: uint8 (declared at line 21, available: [24-24])
+		Arg: f: uint8 (declared at line 21, available: [24-24])
+		Arg: g: uint8 (declared at line 21, available: [24-24])
+		Arg: h: uint8 (declared at line 22, available: [24-24])
+		Arg: i: uint8 (declared at line 22, available: [24-24])
+		Arg: j: uint8 (declared at line 22, available: )
+		Arg: k: uint8 (declared at line 22, available: )
+		Arg: l: uint8 (declared at line 22, available: )
+		Arg: m: uint8 (declared at line 22, available: )
+		Arg: n: uint8 (declared at line 22, available: )
+		Arg: o: uint8 (declared at line 23, available: )
+		Arg: p: uint8 (declared at line 23, available: )
+		Arg: q: uint8 (declared at line 23, available: )
+		Arg: r: uint8 (declared at line 23, available: )
+		Arg: s: uint8 (declared at line 23, available: )
+		Arg: t: uint8 (declared at line 23, available: )
+		Arg: u: uint8 (declared at line 23, available: )
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [56:56] injectible: [56-56]
+		Arg: a: *main.node (declared at line 56, available: [56-56])
 	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [46:46] injectible: [46-46]
 		Arg: m: *map[string]int (declared at line 46, available: [46-46])
-	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103] injectible: [103-103]
-		Arg: u: **int (declared at line 103, available: [103-103])
-	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38] injectible: [38-38]
-		Arg: a: *main.structWithTwoValues (declared at line 38, available: [38-38])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76] injectible: [76-76]
-		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
-		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [108:108] injectible: [108-108]
+		Arg: u: **int (declared at line 108, available: [108-108])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [43:43] injectible: [43-43]
+		Arg: a: *main.structWithTwoValues (declared at line 43, available: [43-43])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [82:82] injectible: [82-82]
+		Arg: s: *main.structWithASlice (declared at line 82, available: [82-82])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [86:86] injectible: [86-86]
+		Arg: s: *main.structWithAString (declared at line 86, available: [86-86])
 	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
 		Arg: v: interface {} (declared at line 60, available: [60-72])
 		Arg: ~r0: interface {} (declared at line 60, available: )
@@ -1279,44 +1311,44 @@ Package: main
 		Arg: ~r0: main.structWithArray (declared at line 245, available: )
 	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
 		Arg: ~r0: main.wideStruct (declared at line 225, available: )
-	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
-		Arg: x: [2]int32 (declared at line 18, available: [18-18])
-	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
-		Arg: x: bool (declared at line 19, available: [19-19])
-	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11] injectible: [11-11]
-		Arg: x: uint8 (declared at line 11, available: [11-11])
-	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63] injectible: [63-63]
-		Arg: x: float32 (declared at line 63, available: [63-63])
-	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67] injectible: [67-67]
-		Arg: x: float64 (declared at line 67, available: [67-67])
-	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23] injectible: [23-23]
-		Arg: x: int (declared at line 23, available: [23-23])
-	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31] injectible: [31-31]
-		Arg: x: int16 (declared at line 31, available: [31-31])
-	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35] injectible: [35-35]
-		Arg: x: int32 (declared at line 35, available: [35-35])
-	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39] injectible: [39-39]
-		Arg: x: int64 (declared at line 39, available: [39-39])
-	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27] injectible: [27-27]
-		Arg: x: int8 (declared at line 27, available: [27-27])
-	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15] injectible: [15-15]
-		Arg: x: int32 (declared at line 15, available: [15-15])
-	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [12:12] injectible: [12-12]
-		Arg: x: string (declared at line 12, available: [12-12])
-	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43] injectible: [43-43]
-		Arg: x: uint (declared at line 43, available: [43-43])
-	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51] injectible: [51-51]
-		Arg: x: uint16 (declared at line 51, available: [51-51])
-	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55] injectible: [55-55]
-		Arg: x: uint32 (declared at line 55, available: [55-55])
-	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59] injectible: [59-59]
-		Arg: x: uint64 (declared at line 59, available: [59-59])
-	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47] injectible: [47-47]
-		Arg: x: uint8 (declared at line 47, available: [47-47])
-	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [69:69] injectible: [69-69]
-		Arg: xs: []struct {} (declared at line 69, available: [69-69])
-	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37] injectible: [37-37]
-		Arg: u: [][]uint (declared at line 37, available: [37-37])
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [24:24] injectible: [24-24]
+		Arg: x: [2]int32 (declared at line 24, available: [24-24])
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [25:25] injectible: [25-25]
+		Arg: x: bool (declared at line 25, available: [25-25])
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [17:17] injectible: [17-17]
+		Arg: x: uint8 (declared at line 17, available: [17-17])
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [69:69] injectible: [69-69]
+		Arg: x: float32 (declared at line 69, available: [69-69])
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
+		Arg: x: float64 (declared at line 73, available: [73-73])
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [29:29] injectible: [29-29]
+		Arg: x: int (declared at line 29, available: [29-29])
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [37:37] injectible: [37-37]
+		Arg: x: int16 (declared at line 37, available: [37-37])
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [41:41] injectible: [41-41]
+		Arg: x: int32 (declared at line 41, available: [41-41])
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [45:45] injectible: [45-45]
+		Arg: x: int64 (declared at line 45, available: [45-45])
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [33:33] injectible: [33-33]
+		Arg: x: int8 (declared at line 33, available: [33-33])
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [21:21] injectible: [21-21]
+		Arg: x: int32 (declared at line 21, available: [21-21])
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [17:17] injectible: [17-17]
+		Arg: x: string (declared at line 17, available: [17-17])
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [49:49] injectible: [49-49]
+		Arg: x: uint (declared at line 49, available: [49-49])
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [57:57] injectible: [57-57]
+		Arg: x: uint16 (declared at line 57, available: [57-57])
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [61:61] injectible: [61-61]
+		Arg: x: uint32 (declared at line 61, available: [61-61])
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [65:65] injectible: [65-65]
+		Arg: x: uint64 (declared at line 65, available: [65-65])
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [53:53] injectible: [53-53]
+		Arg: x: uint8 (declared at line 53, available: [53-53])
+	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [74:74] injectible: [74-74]
+		Arg: xs: []struct {} (declared at line 74, available: [74-74])
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [42:42] injectible: [42-42]
+		Arg: u: [][]uint (declared at line 42, available: [42-42])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
 	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
@@ -1329,120 +1361,120 @@ Package: main
 		Arg: ~r0: int (declared at line 356, available: )
 		Arg: ~r1: int (declared at line 356, available: )
 		Arg: ~r2: int (declared at line 356, available: )
-	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
-		Arg: x: [2]string (declared at line 22, available: [22-22])
-	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
-		Arg: z: *string (declared at line 91, available: [91-91])
-	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53] injectible: [53-53]
-		Arg: s: []string (declared at line 53, available: [53-53])
-	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95] injectible: [95-95]
-		Arg: a: *[]string (declared at line 95, available: [95-95])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
-		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
-		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
-		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
-		Arg: x: main.aStruct (declared at line 84, available: [84-84])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]
-		Arg: w: uint8 (declared at line 104, available: [104-104])
-		Arg: x: main.aStruct (declared at line 104, available: [104-104])
-	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67] injectible: [67-67]
-		Arg: x: *main.nStruct (declared at line 67, available: [67-67])
-	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41] injectible: [41-41]
-		Arg: xs: []main.structWithNoStrings (declared at line 41, available: [41-41])
-		Arg: a: int (declared at line 41, available: [41-41])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72] injectible: [72-72]
-		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64] injectible: [64-64]
-		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68] injectible: [68-68]
-		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [28:28] injectible: [28-28]
+		Arg: x: [2]string (declared at line 28, available: [28-28])
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [96:96] injectible: [96-96]
+		Arg: z: *string (declared at line 96, available: [96-96])
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [58:58] injectible: [58-58]
+		Arg: s: []string (declared at line 58, available: [58-58])
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [100:100] injectible: [100-100]
+		Arg: a: *[]string (declared at line 100, available: [100-100])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [122:122] injectible: [122-122]
+		Arg: t: main.threestrings (declared at line 122, available: [122-122])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [217:217] injectible: [217-217]
+		Arg: a: *main.stringType1 (declared at line 217, available: [217-217])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:223] injectible: [223-223]
+		Arg: a: **main.stringType2 (declared at line 223, available: [223-223])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [90:90] injectible: [90-90]
+		Arg: x: main.aStruct (declared at line 90, available: [90-90])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [110:110] injectible: [110-110]
+		Arg: w: uint8 (declared at line 110, available: [110-110])
+		Arg: x: main.aStruct (declared at line 110, available: [110-110])
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [72:72] injectible: [72-72]
+		Arg: x: *main.nStruct (declared at line 72, available: [72-72])
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [46:46] injectible: [46-46]
+		Arg: xs: []main.structWithNoStrings (declared at line 46, available: [46-46])
+		Arg: a: int (declared at line 46, available: [46-46])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [78:78] injectible: [78-78]
+		Arg: s: main.structWithASlice (declared at line 78, available: [78-78])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [70:70] injectible: [70-70]
+		Arg: s: main.structWithASlice (declared at line 70, available: [70-70])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [74:74] injectible: [74-74]
+		Arg: s: main.structWithASlice (declared at line 74, available: [74-74])
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73] injectible: [73-73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
-		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [66:66] injectible: [66-66]
+		Arg: a: main.structWithAnArray (declared at line 66, available: [66-66])
 	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
 		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
 		Arg: ~r0: int (declared at line 372, available: )
 		Arg: ~r1: main.structWithArray (declared at line 372, available: )
 		Var: x: int (declared at line 374, available: [372-379])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
-		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
-	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
-		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
-	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31] injectible: [31-31]
-		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [94:94] injectible: [94-94]
+		Arg: s: main.structWithTwoArrays (declared at line 94, available: [94-94])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [50:50] injectible: [50-50]
+		Arg: a: main.structWithCyclicMaps (declared at line 50, available: [50-50])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [37:37] injectible: [37-37]
+		Arg: a: main.structWithCyclicSlices (declared at line 37, available: [37-37])
 	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18] injectible: [18-18]
 		Arg: s: main.structWithMap (declared at line 18, available: [18-18])
-	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79] injectible: [79-79]
-		Arg: x: main.structWithPointer (declared at line 79, available: [79-79])
-	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87] injectible: [87-87]
-		Arg: z: main.spws (declared at line 87, available: [87-87])
-	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83] injectible: [83-83]
-		Arg: b: main.swsp (declared at line 83, available: [83-83])
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48] injectible: [48-48]
-		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
-	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [73:73] injectible: [73-73]
-		Arg: as: []uint (declared at line 73, available: [73-73])
-		Arg: bs: []uint (declared at line 73, available: [73-73])
-		Arg: cs: []uint (declared at line 73, available: [73-73])
-	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [54:54] injectible: [54-54]
-		Arg: a: string (declared at line 54, available: [54-54])
-		Arg: b: string (declared at line 54, available: [54-54])
-		Arg: c: string (declared at line 54, available: [54-54])
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [84:84] injectible: [84-84]
+		Arg: x: main.structWithPointer (declared at line 84, available: [84-84])
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [92:92] injectible: [92-92]
+		Arg: z: main.spws (declared at line 92, available: [92-92])
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [88:88] injectible: [88-88]
+		Arg: b: main.swsp (declared at line 88, available: [88-88])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [54:54] injectible: [54-54]
+		Arg: a: main.hasUnsupportedFields (declared at line 54, available: [54-54])
+	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [78:78] injectible: [78-78]
+		Arg: as: []uint (declared at line 78, available: [78-78])
+		Arg: bs: []uint (declared at line 78, available: [78-78])
+		Arg: cs: []uint (declared at line 78, available: [78-78])
+	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [59:59] injectible: [59-59]
+		Arg: a: string (declared at line 59, available: [59-59])
+		Arg: b: string (declared at line 59, available: [59-59])
+		Arg: c: string (declared at line 59, available: [59-59])
 	Function: testTakeContext (main.testTakeContext) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [24:24] injectible: [24-24]
 		Arg: ctx: context.Context (declared at line 22, available: [24-24])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112] injectible: [112-112]
-		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
-	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [16:16] injectible: [16-16]
-		Arg: x: string (declared at line 16, available: [16-16])
-		Arg: y: string (declared at line 16, available: [16-16])
-		Arg: z: string (declared at line 16, available: [16-16])
-	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [30:30] injectible: [30-30]
-		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
-	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
-		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
-		Arg: x: time.Time (declared at line 31, available: [31-31])
-	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
-		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
-	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
-		Arg: x: time.Time (declared at line 27, available: [27-27])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
-	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
-		Arg: a: []uint8 (declared at line 113, available: [113-113])
-		Arg: b: []uint8 (declared at line 113, available: [113-113])
-	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
-		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
-	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
-		Arg: x: [2]uint16 (declared at line 58, available: [58-58])
-	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62] injectible: [62-62]
-		Arg: x: [2]uint32 (declared at line 62, available: [62-62])
-	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66] injectible: [66-66]
-		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
-	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
-		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
-	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
-		Arg: x: []uint8 (declared at line 105, available: [105-105])
-	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
-		Arg: x: []uint8 (declared at line 109, available: [109-109])
-	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
-		Arg: x: [2]uint (declared at line 50, available: [50-50])
-	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]
-		Arg: x: *uint (declared at line 63, available: [63-63])
-	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29] injectible: [29-29]
-		Arg: u: []uint (declared at line 29, available: [29-29])
-	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [46:46] injectible: [46-46]
-		Arg: x: string (declared at line 46, available: [46-46])
-	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55] injectible: [55-55]
-		Arg: x: unsafe.Pointer (declared at line 55, available: [55-55])
-	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [99:99] injectible: [99-99]
-		Arg: a: [100]uint (declared at line 99, available: [99-99])
-	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
-		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [118:118] injectible: [118-118]
+		Arg: x: main.tenStrings (declared at line 118, available: [118-118])
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [21:21] injectible: [21-21]
+		Arg: x: string (declared at line 21, available: [21-21])
+		Arg: y: string (declared at line 21, available: [21-21])
+		Arg: z: string (declared at line 21, available: [21-21])
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [35:35] injectible: [35-35]
+		Arg: a: main.threeStringStruct (declared at line 35, available: [35-35])
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [39:39] injectible: [39-39]
+		Arg: a: *main.threeStringStruct (declared at line 39, available: [39-39])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [36:36] injectible: [36-36]
+		Arg: x: time.Time (declared at line 36, available: [36-36])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [40:40] injectible: [40-40]
+		Arg: c: main.timeCapture (declared at line 40, available: [40-40])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [32:32] injectible: [32-32]
+		Arg: x: time.Time (declared at line 32, available: [32-32])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [37:37] injectible: [37-37]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 37, available: [37-37])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [118:118] injectible: [118-118]
+		Arg: a: []uint8 (declared at line 118, available: [118-118])
+		Arg: b: []uint8 (declared at line 118, available: [118-118])
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [79:79] injectible: [79-79]
+		Arg: x: main.typeAlias (declared at line 79, available: [79-79])
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [64:64] injectible: [64-64]
+		Arg: x: [2]uint16 (declared at line 64, available: [64-64])
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [68:68] injectible: [68-68]
+		Arg: x: [2]uint32 (declared at line 68, available: [68-68])
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [72:72] injectible: [72-72]
+		Arg: x: [2]uint64 (declared at line 72, available: [72-72])
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [60:60] injectible: [60-60]
+		Arg: x: [2]uint8 (declared at line 60, available: [60-60])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [110:110] injectible: [110-110]
+		Arg: x: []uint8 (declared at line 110, available: [110-110])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [114:114] injectible: [114-114]
+		Arg: x: []uint8 (declared at line 114, available: [114-114])
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [56:56] injectible: [56-56]
+		Arg: x: [2]uint (declared at line 56, available: [56-56])
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [68:68] injectible: [68-68]
+		Arg: x: *uint (declared at line 68, available: [68-68])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [34:34] injectible: [34-34]
+		Arg: u: []uint (declared at line 34, available: [34-34])
+	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [51:51] injectible: [51-51]
+		Arg: x: string (declared at line 51, available: [51-51])
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [60:60] injectible: [60-60]
+		Arg: x: unsafe.Pointer (declared at line 60, available: [60-60])
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [105:105] injectible: [105-105]
+		Arg: a: [100]uint (declared at line 105, available: [105-105])
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [70:70] injectible: [70-70]
+		Arg: xs: []uint (declared at line 70, available: [70-70])
 	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
 		Arg: a: [0]int (declared at line 385, available: )
 		Arg: b: int (declared at line 385, available: [385-388])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,16 +1,22 @@
 === yield 1 [final=false] ===
 Package: main
-	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
-		Arg: x: []int (declared at line 12, available: [12-12])
-	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
-	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-263], [266-266], [277-277], [280-281], [283-283], [287-287], [289-289], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
-		Var: s: []*string (declared at line 258, available: )
-		Var: str: string (declared at line 257, available: [246-314])
-		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
-		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
-		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
-		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [17:17] injectible: [17-17]
+		Arg: x: []int (declared at line 17, available: [17-17])
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [108:138] injectible: [108-110], [112-126], [128-131], [133-133], [137-138]
+		Arg: ctx: context.Context (declared at line 108, available: [108-110])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 109, available: [110-113])
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [82:104] injectible: [82-84], [86-89], [91-96], [98-104]
+		Arg: ctx: context.Context (declared at line 82, available: [82-84])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-86])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [249:320] injectible: [249-251], [255-258], [263-264], [266-269], [272-272], [283-283], [286-287], [289-289], [293-293], [295-295], [300-300], [302-302], [304-305], [307-308], [310-311], [313-317], [319-320]
+		Arg: ctx: context.Context (declared at line 249, available: [249-251])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 250, available: [251-269])
+		Var: s: []*string (declared at line 264, available: )
+		Var: str: string (declared at line 263, available: [249-320])
+		Var: circ: main.circularReferenceType (declared at line 285, available: [249-320])
+		Var: s1: main.stringType1 (declared at line 313, available: [308-320])
+		Var: s2: main.stringType2 (declared at line 314, available: [308-320])
+		Var: s2p: *main.stringType2 (declared at line 315, available: [308-320])
 	Function: executeContextFuncs (main.executeContextFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [26:33] injectible: [26-27], [29-29], [31-33]
 		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 27, available: [31-32])
 		Var: ctx: context.Context (declared at line 27, available: [31-32])
@@ -19,14 +25,18 @@ Package: main
 		Var: id: uint64 (declared at line 1360, available: [1360-1361])
 	Function: executeContextImplFuncs (main.executeContextImplFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [61:67] injectible: [61-62], [65-67]
 		Var: c: *main.contextImpl (declared at line 62, available: [61-67])
-	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [113:187] injectible: [113-113], [115-184], [186-187]
-		Var: m: main.manyPointers (declared at line 114, available: [113-187])
-	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:50] injectible: [36-36], [39-40], [42-42], [44-45], [47-47], [49-50]
-		Var: ss: []string (declared at line 39, available: [36-50])
-		Scope: 40-44
-			Var: i: int (declared at line 40, available: [40-44])
-		Scope: 44-49
-			Var: i: int (declared at line 45, available: [47-47], [49-49])
+	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [119:196] injectible: [119-121], [124-193], [195-196]
+		Arg: ctx: context.Context (declared at line 119, available: [119-121])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 120, available: [121-121])
+		Var: m: main.manyPointers (declared at line 123, available: [119-196])
+	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [39:56] injectible: [39-41], [45-46], [48-48], [50-51], [53-53], [55-56]
+		Arg: ctx: context.Context (declared at line 39, available: [39-41])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 40, available: [41-45])
+		Var: ss: []string (declared at line 45, available: [39-56])
+		Scope: 46-50
+			Var: i: int (declared at line 46, available: [46-50])
+		Scope: 50-55
+			Var: i: int (declared at line 51, available: [53-53], [55-55])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -79,10 +89,12 @@ Package: main
 		Arg: acc: string (declared at line 340, available: [340-340])
 		Arg: x: string (declared at line 340, available: [340-340])
 		Arg: ~r0: string (declared at line 340, available: )
-	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106] injectible: [97-98], [100-106]
-		Var: x: int (declared at line 99, available: )
-		Var: y: int (declared at line 100, available: [97-106])
-		Var: a: [5]int (declared at line 98, available: [97-106])
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [100:112] injectible: [100-102], [104-104], [106-112]
+		Arg: ctx: context.Context (declared at line 100, available: [100-102])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 101, available: [102-107])
+		Var: x: int (declared at line 105, available: )
+		Var: y: int (declared at line 106, available: [100-112])
+		Var: a: [5]int (declared at line 104, available: [100-112])
 	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124] injectible: [76-82], [88-112], [117-120], [122-122], [124-124]
 		Var: &one: *int (declared at line 95, available: [76-124])
 		Var: &foo: *string (declared at line 98, available: [76-124])
@@ -129,103 +141,121 @@ Package: main
 			Var: i: int (declared at line 210, available: [210-210], [212-212], [214-214])
 			Scope: 210-212
 				Var: key: [4]int (declared at line 211, available: )
-	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
-		Var: x: chan bool (declared at line 52, available: [53-54])
-	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-141], [143-143], [145-145], [148-151], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
-		Var: self: *main.node (declared at line 172, available: [173-177])
-		Var: z: main.spws (declared at line 118, available: )
-		Var: r: string (declared at line 117, available: [112-178])
-		Var: ssaw: main.swsp (declared at line 126, available: [112-178])
-		Var: rct: main.reallyComplexType (declared at line 137, available: [112-178])
-		Var: b: main.node (declared at line 145, available: [112-178])
-		Var: stringSlice: []string (declared at line 162, available: [112-178])
-		Var: up: *int (declared at line 168, available: [112-178])
-		Var: aruint: [2]uint (declared at line 159, available: )
-		Var: n: main.nStruct (declared at line 123, available: )
-		Var: u: int (declared at line 167, available: )
-		Var: u64F: uint64 (declared at line 113, available: )
-		Var: uintToPointTo: uint (declared at line 120, available: )
-		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [92:127] injectible: [92-94], [96-96], [109-123], [127-127]
+		Arg: ctx: context.Context (declared at line 92, available: [92-94])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 93, available: [94-96])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [54:62] injectible: [54-56], [58-62]
+		Arg: ctx: context.Context (declared at line 54, available: [54-56])
+		Var: x: chan bool (declared at line 58, available: [59-60])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 55, available: [56-58])
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [117:186] injectible: [117-119], [121-121], [123-123], [125-125], [128-129], [131-134], [138-140], [142-143], [145-149], [151-151], [153-153], [156-159], [163-163], [165-165], [167-168], [170-171], [173-173], [175-176], [178-178], [180-181], [183-186]
+		Arg: ctx: context.Context (declared at line 117, available: [117-119])
+		Var: z: main.spws (declared at line 126, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 118, available: [119-123])
+		Var: self: *main.node (declared at line 180, available: [181-185])
+		Var: r: string (declared at line 125, available: [117-186])
+		Var: ssaw: main.swsp (declared at line 134, available: [117-186])
+		Var: rct: main.reallyComplexType (declared at line 145, available: [117-186])
+		Var: b: main.node (declared at line 153, available: [117-186])
+		Var: stringSlice: []string (declared at line 170, available: [117-186])
+		Var: up: *int (declared at line 176, available: [117-186])
+		Var: aruint: [2]uint (declared at line 167, available: )
+		Var: n: main.nStruct (declared at line 131, available: )
+		Var: u: int (declared at line 175, available: )
+		Var: u64F: uint64 (declared at line 121, available: )
+		Var: uintToPointTo: uint (declared at line 128, available: )
+		Var: x: main.structWithTwoValues (declared at line 142, available: )
 	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [29:33] injectible: [29-33]
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
-		Var: originalSlice: []int (declared at line 133, available: )
-		Var: s: []uint (declared at line 142, available: )
-		Var: s2: []uint (declared at line 159, available: )
-		Scope: 143-146
-			Var: i: int (declared at line 143, available: [146-146])
-	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
-	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [65:86] injectible: [65-65], [67-72], [75-77], [81-81], [84-86]
-		Var: abc: string (declared at line 66, available: )
-		Var: uninitializedString: string (declared at line 74, available: )
-		Var: s: string (declared at line 80, available: )
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236] injectible: [135-137], [140-140], [142-143], [145-146], [150-150], [152-160], [172-172], [174-174], [177-182], [190-192], [194-195], [198-198], [200-201], [203-206], [208-208], [210-213], [215-216], [220-220], [222-223], [225-226], [228-229], [231-232], [235-236]
-		Var: n: main.nStruct (declared at line 139, available: )
-		Var: ns: main.structWithNoStrings (declared at line 148, available: )
-		Var: cs: main.cStruct (declared at line 149, available: )
-		Var: rcvr: main.receiver (declared at line 197, available: )
-		Var: ts: main.threestrings (declared at line 136, available: [135-236])
-		Var: s: main.aStruct (declared at line 142, available: [135-236])
-		Var: b: main.bStruct (declared at line 145, available: [135-236])
-		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
-		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
-		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
-		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
-		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
-		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
-		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
-	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
-		Var: ist: *time.Location (declared at line 48, available: [49-49])
-	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
-		Arg: x: []int (declared at line 22, available: [22-25])
-	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
-		Arg: f: func(int) (declared at line 28, available: [28-29])
+	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [34:41] injectible: [34-36], [38-41]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [137:189] injectible: [137-139], [141-143], [145-152], [154-158], [160-160], [162-164], [167-168], [170-181], [183-183], [185-185], [187-189]
+		Arg: ctx: context.Context (declared at line 137, available: [137-139])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 138, available: [139-141])
+		Var: originalSlice: []int (declared at line 141, available: )
+		Var: s: []uint (declared at line 150, available: )
+		Var: s2: []uint (declared at line 167, available: )
+		Scope: 151-154
+			Var: i: int (declared at line 151, available: [154-154])
+	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [34:39] injectible: [34-36], [38-39]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [70:94] injectible: [70-72], [75-80], [83-85], [89-89], [92-94]
+		Arg: ctx: context.Context (declared at line 70, available: [70-72])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 71, available: [72-75])
+		Var: abc: string (declared at line 74, available: )
+		Var: uninitializedString: string (declared at line 82, available: )
+		Var: s: string (declared at line 88, available: )
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [141:245] injectible: [141-143], [145-146], [149-149], [151-152], [154-155], [159-159], [161-169], [181-181], [183-183], [186-191], [199-201], [203-204], [207-207], [209-210], [212-215], [217-217], [219-222], [224-225], [229-229], [231-232], [234-235], [237-238], [240-241], [244-245]
+		Arg: ctx: context.Context (declared at line 141, available: [141-143])
+		Var: rcvr: main.receiver (declared at line 206, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 142, available: [143-146])
+		Var: n: main.nStruct (declared at line 148, available: )
+		Var: ns: main.structWithNoStrings (declared at line 157, available: )
+		Var: cs: main.cStruct (declared at line 158, available: )
+		Var: ts: main.threestrings (declared at line 145, available: [141-245])
+		Var: s: main.aStruct (declared at line 151, available: [141-245])
+		Var: b: main.bStruct (declared at line 154, available: [141-245])
+		Var: tenStr: main.tenStrings (declared at line 171, available: [141-245])
+		Var: deep: main.deepStruct1 (declared at line 185, available: [141-245])
+		Var: fields: main.lotsOfFields (declared at line 203, available: [141-245])
+		Var: sta: main.structWithTwoArrays (declared at line 212, available: [141-245])
+		Var: .autotmp_121: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_140: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_147: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_152: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_176: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_183: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_188: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_195: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_201: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_206: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_213: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_219: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_22: [0]main.structWithCyclicSlices (declared at line 229, available: [141-245])
+		Var: .autotmp_224: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_236: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_243: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_248: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_255: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_26: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_261: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_266: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_273: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_279: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_284: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_291: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_298: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_304: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_309: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_31: [0][][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_32: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_34: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_41: [0][][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_42: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_44: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_47: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_51: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_56: [0][][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_57: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_59: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_62: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_66: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_70: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_20: [0]uint8 (declared at line 166, available: [141-245])
+		Var: .autotmp_97: main.emptyStruct (declared at line 199, available: [141-245])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [44:65] injectible: [44-46], [49-50], [56-59], [64-65]
+		Arg: ctx: context.Context (declared at line 44, available: [44-46])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 45, available: [46-49])
+		Var: ist: *time.Location (declared at line 56, available: [57-57])
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [27:30] injectible: [27-30]
+		Arg: x: []int (declared at line 27, available: [27-30])
+	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [31:33] injectible: [31-33]
+		Arg: f: func(int) (declared at line 31, available: [31-32])
 	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [109:119] injectible: [109-115], [117-117], [119-119]
 		Arg: entriesCount: int (declared at line 109, available: [109-119])
 		Arg: ~r0: map[string][]main.structWithMap (declared at line 109, available: )
@@ -258,9 +288,9 @@ Package: main
 		Arg: b: <T> (declared at line 113, available: [113-114])
 		Arg: ~r0: <T> (declared at line 113, available: )
 		Arg: ~r1: <T> (declared at line 113, available: )
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:17] injectible: [17-17]
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -268,11 +298,12 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:50] injectible: [21-21], [26-26], [29-30], [33-33], [35-35], [37-40], [44-48], [50-50]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [22:50] injectible: [22-22], [27-27], [30-31], [34-34], [36-36], [38-41], [44-48], [50-50]
 		Var: ticker: *time.Ticker (declared at line 44, available: [45-45])
-		Var: service: string (declared at line 29, available: [30-33])
+		Var: service: string (declared at line 30, available: [31-34])
 		Scope: 45-48
 			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 46, available: [45-48])
+			Var: ctx: context.Context (declared at line 46, available: [47-47])
 	Type: main.Pair[...]
 		Field: Key: <T>
 		Field: Value: <T>
@@ -286,10 +317,10 @@ Package: main
 		Field: Total: float64
 	Type: main.Server
 		Field: name: string
-		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [21:26] injectible: [21-23], [25-26]
-			Arg: s: *main.Server (declared at line 21, available: [21-23])
-			Arg: req: *main.Request (declared at line 21, available: [21-26])
-			Arg: ~r0: error (declared at line 21, available: )
+		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [26:31] injectible: [26-28], [30-31]
+			Arg: s: *main.Server (declared at line 26, available: [26-28])
+			Arg: req: *main.Request (declared at line 26, available: [26-31])
+			Arg: ~r0: error (declared at line 26, available: )
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -604,12 +635,12 @@ Package: main
 		Field: aStringPtr: *string
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52] injectible: [52-52]
-			Arg: r: *main.receiver (declared at line 52, available: [52-52])
-			Arg: a: int (declared at line 52, available: [52-52])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56] injectible: [56-56]
-			Arg: r: main.receiver (declared at line 56, available: [56-56])
-			Arg: a: int (declared at line 56, available: [56-56])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [58:58] injectible: [58-58]
+			Arg: r: *main.receiver (declared at line 58, available: [58-58])
+			Arg: a: int (declared at line 58, available: [58-58])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [62:62] injectible: [62-62]
+			Arg: r: main.receiver (declared at line 62, available: [62-62])
+			Arg: a: int (declared at line 62, available: [62-62])
 	Type: main.score
 	Type: main.secondBehavior
 		Field: i: int
@@ -727,14 +758,14 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
-	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [104:107] injectible: [105-107]
-		Var: i: int (declared at line 106, available: [105-105])
+	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [110:113] injectible: [111-113]
+		Var: i: int (declared at line 112, available: [111-111])
 		Arg: id: int (declared at line 0, available: )
-		Var: p: *main.paddedData (declared at line 105, available: )
-	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [23:28] injectible: [23-26], [28-28]
-		Arg: n: int (declared at line 23, available: [23-28])
-		Arg: ~r0: string (declared at line 23, available: )
-		Var: prefix: string (declared at line 24, available: [23-26], [28-28])
+		Var: p: *main.paddedData (declared at line 111, available: )
+	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [26:31] injectible: [26-29], [31-31]
+		Arg: n: int (declared at line 26, available: [26-31])
+		Arg: ~r0: string (declared at line 26, available: )
+		Var: prefix: string (declared at line 27, available: [26-29], [31-31])
 		Var: ~r0.ptr: *uint8 (declared at line 50, available: )
 		Var: ~r0.len: int (declared at line 50, available: )
 	Function: nestedGeneric[...] (main.nestedGeneric[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [203:203] injectible: [203-203]
@@ -746,20 +777,21 @@ Package: main
 		Arg: items: <T> (declared at line 183, available: [183-184])
 		Arg: pred: <T> (declared at line 183, available: [183-184])
 		Arg: ~r0: <T> (declared at line 183, available: )
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
-		Arg: ~r0: uint64 (declared at line 40, available: )
-		Var: n: uint64 (declared at line 45, available: [44-46])
-		Var: b: []uint8 (declared at line 41, available: [42-45])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [43:49] injectible: [43-49]
+		Arg: ~r0: uint64 (declared at line 43, available: )
+		Var: n: uint64 (declared at line 48, available: [47-49])
+		Var: b: []uint8 (declared at line 44, available: [45-48])
 	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:88] injectible: [52-66], [68-69], [71-73], [75-77], [80-88]
+		Arg: ctx: context.Context (declared at line 52, available: [52-88])
 		Var: it: main.iterExample (declared at line 70, available: [52-88])
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 67, available: [52-88])
-	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
-		Arg: x: []int (declared at line 16, available: [16-17])
-		Arg: ~r0: string (declared at line 16, available: )
-	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14] injectible: [12-14]
-	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20] injectible: [18-20]
-	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25] injectible: [24-25]
-		Arg: ~r0: string (declared at line 24, available: )
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [21:22] injectible: [21-22]
+		Arg: x: []int (declared at line 21, available: [21-22])
+		Arg: ~r0: string (declared at line 21, available: )
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [17:19] injectible: [17-19]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [23:25] injectible: [23-25]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [29-30]
+		Arg: ~r0: string (declared at line 29, available: )
 	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55] injectible: [54-55]
 		Arg: a: interface {} (declared at line 54, available: [54-55])
 		Arg: ~r0: string (declared at line 54, available: )
@@ -769,224 +801,224 @@ Package: main
 	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
 		Arg: arg: [3]int (declared at line 297, available: [297-302])
 		Arg: ~r0: [3]int (declared at line 297, available: )
-	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
-		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
-	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
-		Arg: a: [2][2]int (declared at line 70, available: [70-70])
-	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78] injectible: [78-78]
-		Arg: b: [2][2][2]int (declared at line 78, available: [78-78])
+	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [93:93] injectible: [93-93]
+		Arg: a: [2]struct {} (declared at line 93, available: [93-93])
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [76:76] injectible: [76-76]
+		Arg: a: [2][2]int (declared at line 76, available: [76-76])
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [84:84] injectible: [84-84]
+		Arg: b: [2][2][2]int (declared at line 84, available: [84-84])
 	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [42:42] injectible: [42-42]
 		Arg: m: [2]map[string]int (declared at line 42, available: [42-42])
-	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74] injectible: [74-74]
-		Arg: a: [2]string (declared at line 74, available: [74-74])
-	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83] injectible: [83-83]
-		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
-	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
-		Arg: x: *[2]uint (declared at line 59, available: [59-59])
-	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
-		Arg: x: uint64 (declared at line 19, available: [23-23])
-		Arg: ~r0: uint64 (declared at line 19, available: )
-	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
-		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
-	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
-		Arg: x: [2]bool (declared at line 26, available: [26-26])
-	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
-		Arg: a: []uint8 (declared at line 117, available: [117-117])
-		Arg: b: []uint8 (declared at line 117, available: [117-117])
-	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
-		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
-		Arg: a: []uint8 (declared at line 129, available: [129-129])
-		Arg: b: []int (declared at line 129, available: [129-129])
-	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
-		Arg: x: []uint8 (declared at line 77, available: [77-77])
-	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
-		Arg: x: []uint8 (declared at line 81, available: [81-81])
-	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
-		Arg: x: []uint8 (declared at line 85, available: [85-85])
-	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
-		Arg: x: []uint8 (declared at line 89, available: [89-89])
-	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
-		Arg: x: []uint8 (declared at line 93, available: [93-93])
-	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
-		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
-	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
-		Arg: a: int (declared at line 125, available: [125-125])
-		Arg: x: []uint8 (declared at line 125, available: [125-125])
-		Arg: b: string (declared at line 125, available: [125-125])
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [80:80] injectible: [80-80]
+		Arg: a: [2]string (declared at line 80, available: [80-80])
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [89:89] injectible: [89-89]
+		Arg: a: [2]main.nestedStruct (declared at line 88, available: [89-89])
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [64:64] injectible: [64-64]
+		Arg: x: *[2]uint (declared at line 64, available: [64-64])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [26:26] injectible: [26-26]
+		Arg: x: uint64 (declared at line 22, available: [26-26])
+		Arg: ~r0: uint64 (declared at line 22, available: )
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [85:85] injectible: [85-85]
+		Arg: b: main.bigStruct (declared at line 85, available: [85-85])
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [32:32] injectible: [32-32]
+		Arg: x: [2]bool (declared at line 32, available: [32-32])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [122:122] injectible: [122-122]
+		Arg: a: []uint8 (declared at line 122, available: [122-122])
+		Arg: b: []uint8 (declared at line 122, available: [122-122])
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [20:20] injectible: [20-20]
+		Arg: x: [2]uint8 (declared at line 20, available: [20-20])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [134:134] injectible: [134-134]
+		Arg: a: []uint8 (declared at line 134, available: [134-134])
+		Arg: b: []int (declared at line 134, available: [134-134])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [82:82] injectible: [82-82]
+		Arg: x: []uint8 (declared at line 82, available: [82-82])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [86:86] injectible: [86-86]
+		Arg: x: []uint8 (declared at line 86, available: [86-86])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [90:90] injectible: [90-90]
+		Arg: x: []uint8 (declared at line 90, available: [90-90])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [94:94] injectible: [94-94]
+		Arg: x: []uint8 (declared at line 94, available: [94-94])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [98:98] injectible: [98-98]
+		Arg: x: []uint8 (declared at line 98, available: [98-98])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [126:126] injectible: [126-126]
+		Arg: x: [][]uint8 (declared at line 126, available: [126-126])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [130:130] injectible: [130-130]
+		Arg: a: int (declared at line 130, available: [130-130])
+		Arg: x: []uint8 (declared at line 130, available: [130-130])
+		Arg: b: string (declared at line 130, available: [130-130])
 	Function: testCaptureContextImpl (main.testCaptureContextImpl) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [44:44] injectible: [44-44]
 		Arg: c: *main.contextImpl (declared at line 44, available: [44-44])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
-		Arg: c: chan bool (declared at line 30, available: [30-30])
-	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
-		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
-	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
-		Arg: w: uint8 (declared at line 34, available: [34-34])
-		Arg: x: bool (declared at line 34, available: [34-34])
-		Arg: y: float32 (declared at line 34, available: [34-34])
-	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22] injectible: [22-22]
-		Arg: w: uint8 (declared at line 22, available: [22-22])
-		Arg: x: uint8 (declared at line 22, available: [22-22])
-		Arg: y: float32 (declared at line 22, available: [22-22])
-	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38] injectible: [38-38]
-		Arg: w: uint8 (declared at line 38, available: [38-38])
-		Arg: x: int (declared at line 38, available: [38-38])
-		Arg: y: float32 (declared at line 38, available: [38-38])
-	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46] injectible: [46-46]
-		Arg: w: uint8 (declared at line 46, available: [46-46])
-		Arg: x: int16 (declared at line 46, available: [46-46])
-		Arg: y: float32 (declared at line 46, available: [46-46])
-	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50] injectible: [50-50]
-		Arg: w: uint8 (declared at line 50, available: [50-50])
-		Arg: x: int32 (declared at line 50, available: [50-50])
-		Arg: y: float32 (declared at line 50, available: [50-50])
-	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54] injectible: [54-54]
-		Arg: w: uint8 (declared at line 54, available: [54-54])
-		Arg: x: int64 (declared at line 54, available: [54-54])
-		Arg: y: float32 (declared at line 54, available: [54-54])
-	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42] injectible: [42-42]
-		Arg: w: uint8 (declared at line 42, available: [42-42])
-		Arg: x: int8 (declared at line 42, available: [42-42])
-		Arg: y: float32 (declared at line 42, available: [42-42])
-	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26] injectible: [26-26]
-		Arg: w: uint8 (declared at line 26, available: [26-26])
-		Arg: x: int32 (declared at line 26, available: [26-26])
-		Arg: y: float32 (declared at line 26, available: [26-26])
-	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30] injectible: [30-30]
-		Arg: w: uint8 (declared at line 30, available: [30-30])
-		Arg: x: string (declared at line 30, available: [30-30])
-		Arg: y: float32 (declared at line 30, available: [30-30])
-	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58] injectible: [58-58]
-		Arg: w: uint8 (declared at line 58, available: [58-58])
-		Arg: x: uint (declared at line 58, available: [58-58])
-		Arg: y: float32 (declared at line 58, available: [58-58])
-	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66] injectible: [66-66]
-		Arg: w: uint8 (declared at line 66, available: [66-66])
-		Arg: x: uint16 (declared at line 66, available: [66-66])
-		Arg: y: float32 (declared at line 66, available: [66-66])
-	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70] injectible: [70-70]
-		Arg: w: uint8 (declared at line 70, available: [70-70])
-		Arg: x: uint32 (declared at line 70, available: [70-70])
-		Arg: y: float32 (declared at line 70, available: [70-70])
-	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74] injectible: [74-74]
-		Arg: w: uint8 (declared at line 74, available: [74-74])
-		Arg: x: uint64 (declared at line 74, available: [74-74])
-		Arg: y: float32 (declared at line 74, available: [74-74])
-	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62] injectible: [62-62]
-		Arg: w: uint8 (declared at line 62, available: [62-62])
-		Arg: x: uint8 (declared at line 62, available: [62-62])
-		Arg: y: float32 (declared at line 62, available: [62-62])
-	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75] injectible: [75-75]
-		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [33:33] injectible: [33-33]
+		Arg: c: chan bool (declared at line 33, available: [33-33])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93] injectible: [93-93]
+		Arg: x: main.circularReferenceType (declared at line 93, available: [93-93])
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [40:40] injectible: [40-40]
+		Arg: w: uint8 (declared at line 40, available: [40-40])
+		Arg: x: bool (declared at line 40, available: [40-40])
+		Arg: y: float32 (declared at line 40, available: [40-40])
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [28:28] injectible: [28-28]
+		Arg: w: uint8 (declared at line 28, available: [28-28])
+		Arg: x: uint8 (declared at line 28, available: [28-28])
+		Arg: y: float32 (declared at line 28, available: [28-28])
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [44:44] injectible: [44-44]
+		Arg: w: uint8 (declared at line 44, available: [44-44])
+		Arg: x: int (declared at line 44, available: [44-44])
+		Arg: y: float32 (declared at line 44, available: [44-44])
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [52:52] injectible: [52-52]
+		Arg: w: uint8 (declared at line 52, available: [52-52])
+		Arg: x: int16 (declared at line 52, available: [52-52])
+		Arg: y: float32 (declared at line 52, available: [52-52])
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [56:56] injectible: [56-56]
+		Arg: w: uint8 (declared at line 56, available: [56-56])
+		Arg: x: int32 (declared at line 56, available: [56-56])
+		Arg: y: float32 (declared at line 56, available: [56-56])
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [60:60] injectible: [60-60]
+		Arg: w: uint8 (declared at line 60, available: [60-60])
+		Arg: x: int64 (declared at line 60, available: [60-60])
+		Arg: y: float32 (declared at line 60, available: [60-60])
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [48:48] injectible: [48-48]
+		Arg: w: uint8 (declared at line 48, available: [48-48])
+		Arg: x: int8 (declared at line 48, available: [48-48])
+		Arg: y: float32 (declared at line 48, available: [48-48])
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [32:32] injectible: [32-32]
+		Arg: w: uint8 (declared at line 32, available: [32-32])
+		Arg: x: int32 (declared at line 32, available: [32-32])
+		Arg: y: float32 (declared at line 32, available: [32-32])
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [36:36] injectible: [36-36]
+		Arg: w: uint8 (declared at line 36, available: [36-36])
+		Arg: x: string (declared at line 36, available: [36-36])
+		Arg: y: float32 (declared at line 36, available: [36-36])
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [64:64] injectible: [64-64]
+		Arg: w: uint8 (declared at line 64, available: [64-64])
+		Arg: x: uint (declared at line 64, available: [64-64])
+		Arg: y: float32 (declared at line 64, available: [64-64])
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [72:72] injectible: [72-72]
+		Arg: w: uint8 (declared at line 72, available: [72-72])
+		Arg: x: uint16 (declared at line 72, available: [72-72])
+		Arg: y: float32 (declared at line 72, available: [72-72])
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [76:76] injectible: [76-76]
+		Arg: w: uint8 (declared at line 76, available: [76-76])
+		Arg: x: uint32 (declared at line 76, available: [76-76])
+		Arg: y: float32 (declared at line 76, available: [76-76])
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [80:80] injectible: [80-80]
+		Arg: w: uint8 (declared at line 80, available: [80-80])
+		Arg: x: uint64 (declared at line 80, available: [80-80])
+		Arg: y: float32 (declared at line 80, available: [80-80])
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [68:68] injectible: [68-68]
+		Arg: w: uint8 (declared at line 68, available: [68-68])
+		Arg: x: uint8 (declared at line 68, available: [68-68])
+		Arg: y: float32 (declared at line 68, available: [68-68])
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [80:80] injectible: [80-80]
+		Arg: z: *main.reallyComplexType (declared at line 80, available: [80-80])
 	Function: testConflictingReturn (main.testConflictingReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [109:111] injectible: [109-111]
 		Arg: i: int (declared at line 109, available: [109-111])
 		Arg: ~r0: int (declared at line 109, available: )
 		Arg: r0: string (declared at line 109, available: )
-	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
-		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
-		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
-		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
-		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
-		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
-		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
-		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
-		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
-	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
-		Arg: x: []uint8 (declared at line 97, available: [97-97])
-	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
-		Arg: u: []uint (declared at line 33, available: [33-33])
-	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
-		Arg: xs: []main.structWithNoStrings (declared at line 45, available: [45-45])
-		Arg: a: int (declared at line 45, available: [45-45])
-	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [50:50] injectible: [50-50]
-		Arg: x: string (declared at line 50, available: [50-50])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124] injectible: [124-124]
-		Arg: e: main.emptyStruct (declared at line 124, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128] injectible: [128-128]
-		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [114:114] injectible: [114-114]
+		Arg: t: *main.t (declared at line 114, available: [114-114])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: main.deepMap1 (declared at line 203, available: [203-203])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [206:206] injectible: [206-206]
+		Arg: a: *main.deepMap7 (declared at line 206, available: [206-206])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: main.deepPtr1 (declared at line 139, available: [139-139])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142] injectible: [142-142]
+		Arg: a: *main.deepPtr7 (declared at line 142, available: [142-142])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: main.deepSlice1 (declared at line 165, available: [165-165])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [168:168] injectible: [168-168]
+		Arg: a: *main.deepSlice7 (declared at line 168, available: [168-168])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [126:126] injectible: [126-126]
+		Arg: t: main.deepStruct1 (declared at line 126, available: [126-126])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [102:102] injectible: [102-102]
+		Arg: x: []uint8 (declared at line 102, available: [102-102])
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [38:38] injectible: [38-38]
+		Arg: u: []uint (declared at line 38, available: [38-38])
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [50:50] injectible: [50-50]
+		Arg: xs: []main.structWithNoStrings (declared at line 50, available: [50-50])
+		Arg: a: int (declared at line 50, available: [50-50])
+	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [55:55] injectible: [55-55]
+		Arg: x: string (declared at line 55, available: [55-55])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [130:130] injectible: [130-130]
+		Arg: e: main.emptyStruct (declared at line 130, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [134:134] injectible: [134-134]
+		Arg: e: *main.emptyStruct (declared at line 134, available: [134-134])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
-	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [106-106], [108-110], [112-112]
-		Arg: shouldErr: bool (declared at line 101, available: [101-103])
-		Arg: ~r0: int (declared at line 101, available: )
-		Var: x: int (declared at line 106, available: )
-		Var: err: error (declared at line 102, available: [108-108])
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [104:115] injectible: [104-104], [106-107], [109-109], [111-113], [115-115]
+		Arg: shouldErr: bool (declared at line 104, available: [104-106])
+		Arg: ~r0: int (declared at line 104, available: )
+		Var: x: int (declared at line 109, available: )
+		Var: err: error (declared at line 105, available: [111-111])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
-	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80] injectible: [79-80]
-		Arg: x: int (declared at line 79, available: [79-80])
-		Arg: ~r0: int (declared at line 79, available: )
-	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93] injectible: [92-93]
-		Arg: a: [5]int (declared at line 92, available: [92-93])
-		Arg: ~r0: int (declared at line 92, available: )
-	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [17:19] injectible: [17-19]
-		Arg: x: int (declared at line 17, available: [17-18])
-		Arg: y: int (declared at line 17, available: [17-18])
-	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [21:25] injectible: [21-25]
-		Arg: x: int (declared at line 21, available: [21-25])
-		Arg: y: int (declared at line 21, available: [21-25])
-	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35] injectible: [32-32], [34-35]
-		Arg: x: int (declared at line 32, available: [32-34])
-	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42] injectible: [37-42]
-		Arg: x: int (declared at line 37, available: [37-38])
-		Arg: y: int (declared at line 37, available: [37-39])
-		Var: z: int (declared at line 38, available: [37-42])
-	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46] injectible: [44-46]
-		Arg: x: int (declared at line 44, available: [44-45])
-	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49] injectible: [49-49]
-	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60] injectible: [52-53], [55-56], [58-60]
-		Var: s: int (declared at line 54, available: [55-55], [56-56], [58-58])
-		Scope: 55-58
-			Var: i: int (declared at line 55, available: [55-55], [56-56], [58-58])
-	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63] injectible: [63-63]
-	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [66:67] injectible: [67-67]
-	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [13:15] injectible: [14-14]
-		Arg: x: int (declared at line 0, available: [13-14])
-	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [74:75] injectible: [75-75]
-		Arg: x: int (declared at line 0, available: [75-75])
-	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:71] injectible: [71-71]
-		Arg: a: [5]int (declared at line 0, available: [71-71])
-	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38] injectible: [38-38]
-		Arg: x: [2]int16 (declared at line 38, available: [38-38])
-	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42] injectible: [42-42]
-		Arg: x: [2]int32 (declared at line 42, available: [42-42])
-	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46] injectible: [46-46]
-		Arg: x: [2]int64 (declared at line 46, available: [46-46])
-	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34] injectible: [34-34]
-		Arg: x: [2]int8 (declared at line 34, available: [34-34])
-	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30] injectible: [30-30]
-		Arg: x: [2]int (declared at line 30, available: [30-30])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [82:83] injectible: [82-83]
+		Arg: x: int (declared at line 82, available: [82-83])
+		Arg: ~r0: int (declared at line 82, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [95:96] injectible: [95-96]
+		Arg: a: [5]int (declared at line 95, available: [95-96])
+		Arg: ~r0: int (declared at line 95, available: )
+	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [20:22] injectible: [20-22]
+		Arg: x: int (declared at line 20, available: [20-21])
+		Arg: y: int (declared at line 20, available: [20-21])
+	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [24:28] injectible: [24-28]
+		Arg: x: int (declared at line 24, available: [24-28])
+		Arg: y: int (declared at line 24, available: [24-28])
+	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [35:38] injectible: [35-35], [37-38]
+		Arg: x: int (declared at line 35, available: [35-37])
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [40:45] injectible: [40-45]
+		Arg: x: int (declared at line 40, available: [40-41])
+		Arg: y: int (declared at line 40, available: [40-42])
+		Var: z: int (declared at line 41, available: [40-45])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [47:49] injectible: [47-49]
+		Arg: x: int (declared at line 47, available: [47-48])
+	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [51:52] injectible: [52-52]
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [55:63] injectible: [55-56], [58-59], [61-63]
+		Var: s: int (declared at line 57, available: [58-58], [59-59], [61-61])
+		Scope: 58-61
+			Var: i: int (declared at line 58, available: [58-58], [59-59], [61-61])
+	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [65:66] injectible: [66-66]
+	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [69:70] injectible: [70-70]
+	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [16:18] injectible: [17-17]
+		Arg: x: int (declared at line 0, available: [16-17])
+	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [77:78] injectible: [78-78]
+		Arg: x: int (declared at line 0, available: [78-78])
+	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [73:74] injectible: [74-74]
+		Arg: a: [5]int (declared at line 0, available: [74-74])
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [44:44] injectible: [44-44]
+		Arg: x: [2]int16 (declared at line 44, available: [44-44])
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [48:48] injectible: [48-48]
+		Arg: x: [2]int32 (declared at line 48, available: [48-48])
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [52:52] injectible: [52-52]
+		Arg: x: [2]int64 (declared at line 52, available: [52-52])
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [40:40] injectible: [40-40]
+		Arg: x: [2]int8 (declared at line 40, available: [40-40])
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [36:36] injectible: [36-36]
+		Arg: x: [2]int (declared at line 36, available: [36-36])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50] injectible: [50-50]
 		Arg: b: main.behavior (declared at line 50, available: [50-50])
-	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [94:94] injectible: [94-94]
-		Arg: a: int (declared at line 94, available: [94-94])
-		Arg: b: error (declared at line 94, available: [94-94])
-		Arg: c: uint (declared at line 94, available: [94-94])
-	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
-		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [58:58] injectible: [58-58]
-		Arg: a: string (declared at line 58, available: [58-58])
-		Arg: b: string (declared at line 58, available: [58-58])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [97:97] injectible: [97-97]
+		Arg: a: int (declared at line 97, available: [97-97])
+		Arg: b: error (declared at line 97, available: [97-97])
+		Arg: c: uint (declared at line 97, available: [97-97])
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67] injectible: [67-67]
+		Arg: a: main.interfaceComplexityA (declared at line 67, available: [67-67])
+	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [63:63] injectible: [63-63]
+		Arg: a: string (declared at line 63, available: [63-63])
+		Arg: b: string (declared at line 63, available: [63-63])
 	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
 		Arg: arg: main.largeStruct (declared at line 281, available: [281-291])
 		Arg: ~r0: main.largeStruct (declared at line 281, available: )
-	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
-		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
-		Var: s: int (declared at line 224, available: [237-237], [242-242])
-		Var: aPerArch: int (declared at line 228, available: [223-243])
-		Var: b: int (declared at line 229, available: [223-243])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
-		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [47:47] injectible: [47-47]
+		Arg: a: main.node (declared at line 47, available: [47-47])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [226:246] injectible: [226-226], [233-233], [236-237], [239-242], [244-246]
+		Var: s: int (declared at line 227, available: [240-240], [245-245])
+		Var: aPerArch: int (declared at line 231, available: [226-246])
+		Var: b: int (declared at line 232, available: [226-246])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [138:138] injectible: [138-138]
+		Arg: l: main.lotsOfFields (declared at line 138, available: [138-138])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
 		Arg: a: int (declared at line 328, available: [328-330])
 		Arg: b: int (declared at line 328, available: [328-330])
@@ -998,10 +1030,10 @@ Package: main
 		Arg: h: int (declared at line 328, available: [328-330])
 		Arg: i: int (declared at line 328, available: [328-330])
 		Arg: ~r0: [2]int (declared at line 328, available: )
-	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [102:102] injectible: [102-102]
-		Arg: m: main.manyPointers (declared at line 102, available: [102-102])
-	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [33:33] injectible: [33-33]
-		Arg: ss: []string (declared at line 33, available: [33-33])
+	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [108:108] injectible: [108-108]
+		Arg: m: main.manyPointers (declared at line 108, available: [108-108])
+	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:36] injectible: [36-36]
+		Arg: ss: []string (declared at line 36, available: [36-36])
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -1040,8 +1072,8 @@ Package: main
 		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
 	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70] injectible: [70-70]
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
-	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
-		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [47:47] injectible: [47-47]
+		Arg: x: string (declared at line 47, available: [47-47])
 	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-349]
 		Arg: a: int (declared at line 337, available: [337-349])
 		Arg: b: int (declared at line 337, available: [337-349])
@@ -1053,17 +1085,17 @@ Package: main
 		Arg: h: int (declared at line 337, available: [337-349])
 		Arg: s: string (declared at line 337, available: [337-349])
 		Arg: ~r0: main.largeStruct (declared at line 337, available: )
-	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [62:62] injectible: [62-62]
-		Arg: x: string (declared at line 62, available: [62-62])
+	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [67:67] injectible: [67-67]
+		Arg: x: string (declared at line 67, available: [67-67])
 	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
 		Arg: a: [2]int (declared at line 364, available: [364-366])
 		Arg: b: [3]int (declared at line 364, available: [364-366])
 		Arg: ~r0: int (declared at line 364, available: )
 		Arg: ~r1: [2]int (declared at line 364, available: )
-	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
-		Arg: o: main.outer (declared at line 72, available: [72-72])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
-		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [75:75] injectible: [75-75]
+		Arg: o: main.outer (declared at line 75, available: [75-75])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [102:102] injectible: [102-102]
+		Arg: b: main.bStruct (declared at line 102, available: [102-102])
 	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
 		Arg: s1: main.largeStruct (declared at line 308, available: [308-320])
 		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
@@ -1072,99 +1104,99 @@ Package: main
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
 		Arg: result2: int (declared at line 95, available: )
-	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
-		Arg: a: bool (declared at line 78, available: [78-78])
-		Arg: b: uint8 (declared at line 78, available: [78-78])
-		Arg: c: int32 (declared at line 78, available: [78-78])
-		Arg: d: uint (declared at line 78, available: [78-78])
-		Arg: e: string (declared at line 78, available: [78-78])
-	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
-		Arg: a: main.tierA (declared at line 68, available: [68-68])
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [84:84] injectible: [84-84]
+		Arg: a: bool (declared at line 84, available: [84-84])
+		Arg: b: uint8 (declared at line 84, available: [84-84])
+		Arg: c: int32 (declared at line 84, available: [84-84])
+		Arg: d: uint (declared at line 84, available: [84-84])
+		Arg: e: string (declared at line 84, available: [84-84])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71] injectible: [71-71]
+		Arg: a: main.tierA (declared at line 71, available: [71-71])
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
 		Arg: i: int (declared at line 88, available: [88-89])
 		Arg: result: int (declared at line 88, available: )
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
-		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
-	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
-		Arg: x: []uint8 (declared at line 101, available: [101-101])
-	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
-		Arg: z: *bool (declared at line 99, available: [99-99])
-		Arg: a: uint (declared at line 99, available: [99-99])
-	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61] injectible: [61-61]
-		Arg: xs: []uint16 (declared at line 61, available: [61-61])
-	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49] injectible: [49-49]
-		Arg: xs: []main.structWithNoStrings (declared at line 49, available: [49-49])
-		Arg: a: int (declared at line 49, available: [49-49])
-	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57] injectible: [57-57]
-		Arg: a: int8 (declared at line 57, available: [57-57])
-		Arg: s: []bool (declared at line 57, available: [57-57])
-		Arg: x: uint (declared at line 57, available: [57-57])
-	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71] injectible: [71-71]
-		Arg: z: uint (declared at line 71, available: [71-71])
-		Arg: x: *main.nStruct (declared at line 71, available: [71-71])
-		Arg: a: int (declared at line 71, available: [71-71])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100] injectible: [100-100]
-		Arg: c: main.cStruct (declared at line 100, available: [100-100])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92] injectible: [92-92]
-		Arg: x: main.nStruct (declared at line 92, available: [92-92])
-	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [38:38] injectible: [38-38]
-		Arg: a: *main.oneStringStruct (declared at line 38, available: [38-38])
-	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95] injectible: [95-95]
-		Arg: a: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: b: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: c: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: d: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: e: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: f: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: g: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: h: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: i: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: j: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: k: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: l: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: m: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: n: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: o: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: p: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: q: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: r: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: s: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: t: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: u: [3]uint32 (declared at line 94, available: [95-95])
-	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18] injectible: [18-18]
-		Arg: a: uint8 (declared at line 15, available: [18-18])
-		Arg: b: uint8 (declared at line 15, available: [18-18])
-		Arg: c: uint8 (declared at line 15, available: [18-18])
-		Arg: d: uint8 (declared at line 15, available: [18-18])
-		Arg: e: uint8 (declared at line 15, available: [18-18])
-		Arg: f: uint8 (declared at line 15, available: [18-18])
-		Arg: g: uint8 (declared at line 15, available: [18-18])
-		Arg: h: uint8 (declared at line 16, available: [18-18])
-		Arg: i: uint8 (declared at line 16, available: [18-18])
-		Arg: j: uint8 (declared at line 16, available: )
-		Arg: k: uint8 (declared at line 16, available: )
-		Arg: l: uint8 (declared at line 16, available: )
-		Arg: m: uint8 (declared at line 16, available: )
-		Arg: n: uint8 (declared at line 16, available: )
-		Arg: o: uint8 (declared at line 17, available: )
-		Arg: p: uint8 (declared at line 17, available: )
-		Arg: q: uint8 (declared at line 17, available: )
-		Arg: r: uint8 (declared at line 17, available: )
-		Arg: s: uint8 (declared at line 17, available: )
-		Arg: t: uint8 (declared at line 17, available: )
-		Arg: u: uint8 (declared at line 17, available: )
-	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51] injectible: [51-51]
-		Arg: a: *main.node (declared at line 51, available: [51-51])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [114:114] injectible: [114-114]
+		Arg: x: *main.anotherStruct (declared at line 114, available: [114-114])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [106:106] injectible: [106-106]
+		Arg: x: []uint8 (declared at line 106, available: [106-106])
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [104:104] injectible: [104-104]
+		Arg: z: *bool (declared at line 104, available: [104-104])
+		Arg: a: uint (declared at line 104, available: [104-104])
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [66:66] injectible: [66-66]
+		Arg: xs: []uint16 (declared at line 66, available: [66-66])
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [54:54] injectible: [54-54]
+		Arg: xs: []main.structWithNoStrings (declared at line 54, available: [54-54])
+		Arg: a: int (declared at line 54, available: [54-54])
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [62:62] injectible: [62-62]
+		Arg: a: int8 (declared at line 62, available: [62-62])
+		Arg: s: []bool (declared at line 62, available: [62-62])
+		Arg: x: uint (declared at line 62, available: [62-62])
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [76:76] injectible: [76-76]
+		Arg: z: uint (declared at line 76, available: [76-76])
+		Arg: x: *main.nStruct (declared at line 76, available: [76-76])
+		Arg: a: int (declared at line 76, available: [76-76])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [106:106] injectible: [106-106]
+		Arg: c: main.cStruct (declared at line 106, available: [106-106])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [98:98] injectible: [98-98]
+		Arg: x: main.nStruct (declared at line 98, available: [98-98])
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [43:43] injectible: [43-43]
+		Arg: a: *main.oneStringStruct (declared at line 43, available: [43-43])
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [101:101] injectible: [101-101]
+		Arg: a: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: b: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: c: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: d: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: e: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: f: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: g: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: h: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: i: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: j: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: k: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: l: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: m: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: n: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: o: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: p: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: q: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: r: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: s: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: t: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: u: [3]uint32 (declared at line 100, available: [101-101])
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [24:24] injectible: [24-24]
+		Arg: a: uint8 (declared at line 21, available: [24-24])
+		Arg: b: uint8 (declared at line 21, available: [24-24])
+		Arg: c: uint8 (declared at line 21, available: [24-24])
+		Arg: d: uint8 (declared at line 21, available: [24-24])
+		Arg: e: uint8 (declared at line 21, available: [24-24])
+		Arg: f: uint8 (declared at line 21, available: [24-24])
+		Arg: g: uint8 (declared at line 21, available: [24-24])
+		Arg: h: uint8 (declared at line 22, available: [24-24])
+		Arg: i: uint8 (declared at line 22, available: [24-24])
+		Arg: j: uint8 (declared at line 22, available: )
+		Arg: k: uint8 (declared at line 22, available: )
+		Arg: l: uint8 (declared at line 22, available: )
+		Arg: m: uint8 (declared at line 22, available: )
+		Arg: n: uint8 (declared at line 22, available: )
+		Arg: o: uint8 (declared at line 23, available: )
+		Arg: p: uint8 (declared at line 23, available: )
+		Arg: q: uint8 (declared at line 23, available: )
+		Arg: r: uint8 (declared at line 23, available: )
+		Arg: s: uint8 (declared at line 23, available: )
+		Arg: t: uint8 (declared at line 23, available: )
+		Arg: u: uint8 (declared at line 23, available: )
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [56:56] injectible: [56-56]
+		Arg: a: *main.node (declared at line 56, available: [56-56])
 	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [46:46] injectible: [46-46]
 		Arg: m: *map[string]int (declared at line 46, available: [46-46])
-	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103] injectible: [103-103]
-		Arg: u: **int (declared at line 103, available: [103-103])
-	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38] injectible: [38-38]
-		Arg: a: *main.structWithTwoValues (declared at line 38, available: [38-38])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76] injectible: [76-76]
-		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
-		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [108:108] injectible: [108-108]
+		Arg: u: **int (declared at line 108, available: [108-108])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [43:43] injectible: [43-43]
+		Arg: a: *main.structWithTwoValues (declared at line 43, available: [43-43])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [82:82] injectible: [82-82]
+		Arg: s: *main.structWithASlice (declared at line 82, available: [82-82])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [86:86] injectible: [86-86]
+		Arg: s: *main.structWithAString (declared at line 86, available: [86-86])
 	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
 		Arg: v: interface {} (declared at line 60, available: [60-72])
 		Arg: ~r0: interface {} (declared at line 60, available: )
@@ -1283,44 +1315,44 @@ Package: main
 		Arg: ~r0: main.structWithArray (declared at line 245, available: )
 	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
 		Arg: ~r0: main.wideStruct (declared at line 225, available: )
-	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
-		Arg: x: [2]int32 (declared at line 18, available: [18-18])
-	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
-		Arg: x: bool (declared at line 19, available: [19-19])
-	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11] injectible: [11-11]
-		Arg: x: uint8 (declared at line 11, available: [11-11])
-	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63] injectible: [63-63]
-		Arg: x: float32 (declared at line 63, available: [63-63])
-	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67] injectible: [67-67]
-		Arg: x: float64 (declared at line 67, available: [67-67])
-	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23] injectible: [23-23]
-		Arg: x: int (declared at line 23, available: [23-23])
-	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31] injectible: [31-31]
-		Arg: x: int16 (declared at line 31, available: [31-31])
-	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35] injectible: [35-35]
-		Arg: x: int32 (declared at line 35, available: [35-35])
-	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39] injectible: [39-39]
-		Arg: x: int64 (declared at line 39, available: [39-39])
-	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27] injectible: [27-27]
-		Arg: x: int8 (declared at line 27, available: [27-27])
-	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15] injectible: [15-15]
-		Arg: x: int32 (declared at line 15, available: [15-15])
-	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [12:12] injectible: [12-12]
-		Arg: x: string (declared at line 12, available: [12-12])
-	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43] injectible: [43-43]
-		Arg: x: uint (declared at line 43, available: [43-43])
-	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51] injectible: [51-51]
-		Arg: x: uint16 (declared at line 51, available: [51-51])
-	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55] injectible: [55-55]
-		Arg: x: uint32 (declared at line 55, available: [55-55])
-	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59] injectible: [59-59]
-		Arg: x: uint64 (declared at line 59, available: [59-59])
-	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47] injectible: [47-47]
-		Arg: x: uint8 (declared at line 47, available: [47-47])
-	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [69:69] injectible: [69-69]
-		Arg: xs: []struct {} (declared at line 69, available: [69-69])
-	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37] injectible: [37-37]
-		Arg: u: [][]uint (declared at line 37, available: [37-37])
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [24:24] injectible: [24-24]
+		Arg: x: [2]int32 (declared at line 24, available: [24-24])
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [25:25] injectible: [25-25]
+		Arg: x: bool (declared at line 25, available: [25-25])
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [17:17] injectible: [17-17]
+		Arg: x: uint8 (declared at line 17, available: [17-17])
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [69:69] injectible: [69-69]
+		Arg: x: float32 (declared at line 69, available: [69-69])
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
+		Arg: x: float64 (declared at line 73, available: [73-73])
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [29:29] injectible: [29-29]
+		Arg: x: int (declared at line 29, available: [29-29])
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [37:37] injectible: [37-37]
+		Arg: x: int16 (declared at line 37, available: [37-37])
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [41:41] injectible: [41-41]
+		Arg: x: int32 (declared at line 41, available: [41-41])
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [45:45] injectible: [45-45]
+		Arg: x: int64 (declared at line 45, available: [45-45])
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [33:33] injectible: [33-33]
+		Arg: x: int8 (declared at line 33, available: [33-33])
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [21:21] injectible: [21-21]
+		Arg: x: int32 (declared at line 21, available: [21-21])
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [17:17] injectible: [17-17]
+		Arg: x: string (declared at line 17, available: [17-17])
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [49:49] injectible: [49-49]
+		Arg: x: uint (declared at line 49, available: [49-49])
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [57:57] injectible: [57-57]
+		Arg: x: uint16 (declared at line 57, available: [57-57])
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [61:61] injectible: [61-61]
+		Arg: x: uint32 (declared at line 61, available: [61-61])
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [65:65] injectible: [65-65]
+		Arg: x: uint64 (declared at line 65, available: [65-65])
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [53:53] injectible: [53-53]
+		Arg: x: uint8 (declared at line 53, available: [53-53])
+	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [74:74] injectible: [74-74]
+		Arg: xs: []struct {} (declared at line 74, available: [74-74])
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [42:42] injectible: [42-42]
+		Arg: u: [][]uint (declared at line 42, available: [42-42])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
 	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
@@ -1333,120 +1365,120 @@ Package: main
 		Arg: ~r0: int (declared at line 356, available: )
 		Arg: ~r1: int (declared at line 356, available: )
 		Arg: ~r2: int (declared at line 356, available: )
-	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
-		Arg: x: [2]string (declared at line 22, available: [22-22])
-	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
-		Arg: z: *string (declared at line 91, available: [91-91])
-	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53] injectible: [53-53]
-		Arg: s: []string (declared at line 53, available: [53-53])
-	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95] injectible: [95-95]
-		Arg: a: *[]string (declared at line 95, available: [95-95])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
-		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
-		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
-		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
-		Arg: x: main.aStruct (declared at line 84, available: [84-84])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]
-		Arg: w: uint8 (declared at line 104, available: [104-104])
-		Arg: x: main.aStruct (declared at line 104, available: [104-104])
-	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67] injectible: [67-67]
-		Arg: x: *main.nStruct (declared at line 67, available: [67-67])
-	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41] injectible: [41-41]
-		Arg: xs: []main.structWithNoStrings (declared at line 41, available: [41-41])
-		Arg: a: int (declared at line 41, available: [41-41])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72] injectible: [72-72]
-		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64] injectible: [64-64]
-		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68] injectible: [68-68]
-		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [28:28] injectible: [28-28]
+		Arg: x: [2]string (declared at line 28, available: [28-28])
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [96:96] injectible: [96-96]
+		Arg: z: *string (declared at line 96, available: [96-96])
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [58:58] injectible: [58-58]
+		Arg: s: []string (declared at line 58, available: [58-58])
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [100:100] injectible: [100-100]
+		Arg: a: *[]string (declared at line 100, available: [100-100])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [122:122] injectible: [122-122]
+		Arg: t: main.threestrings (declared at line 122, available: [122-122])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [217:217] injectible: [217-217]
+		Arg: a: *main.stringType1 (declared at line 217, available: [217-217])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:223] injectible: [223-223]
+		Arg: a: **main.stringType2 (declared at line 223, available: [223-223])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [90:90] injectible: [90-90]
+		Arg: x: main.aStruct (declared at line 90, available: [90-90])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [110:110] injectible: [110-110]
+		Arg: w: uint8 (declared at line 110, available: [110-110])
+		Arg: x: main.aStruct (declared at line 110, available: [110-110])
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [72:72] injectible: [72-72]
+		Arg: x: *main.nStruct (declared at line 72, available: [72-72])
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [46:46] injectible: [46-46]
+		Arg: xs: []main.structWithNoStrings (declared at line 46, available: [46-46])
+		Arg: a: int (declared at line 46, available: [46-46])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [78:78] injectible: [78-78]
+		Arg: s: main.structWithASlice (declared at line 78, available: [78-78])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [70:70] injectible: [70-70]
+		Arg: s: main.structWithASlice (declared at line 70, available: [70-70])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [74:74] injectible: [74-74]
+		Arg: s: main.structWithASlice (declared at line 74, available: [74-74])
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73] injectible: [73-73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
-		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [66:66] injectible: [66-66]
+		Arg: a: main.structWithAnArray (declared at line 66, available: [66-66])
 	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
 		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
 		Arg: ~r0: int (declared at line 372, available: )
 		Arg: ~r1: main.structWithArray (declared at line 372, available: )
 		Var: x: int (declared at line 374, available: [372-379])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
-		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
-	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
-		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
-	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31] injectible: [31-31]
-		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [94:94] injectible: [94-94]
+		Arg: s: main.structWithTwoArrays (declared at line 94, available: [94-94])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [50:50] injectible: [50-50]
+		Arg: a: main.structWithCyclicMaps (declared at line 50, available: [50-50])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [37:37] injectible: [37-37]
+		Arg: a: main.structWithCyclicSlices (declared at line 37, available: [37-37])
 	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18] injectible: [18-18]
 		Arg: s: main.structWithMap (declared at line 18, available: [18-18])
-	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79] injectible: [79-79]
-		Arg: x: main.structWithPointer (declared at line 79, available: [79-79])
-	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87] injectible: [87-87]
-		Arg: z: main.spws (declared at line 87, available: [87-87])
-	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83] injectible: [83-83]
-		Arg: b: main.swsp (declared at line 83, available: [83-83])
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48] injectible: [48-48]
-		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
-	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [73:73] injectible: [73-73]
-		Arg: as: []uint (declared at line 73, available: [73-73])
-		Arg: bs: []uint (declared at line 73, available: [73-73])
-		Arg: cs: []uint (declared at line 73, available: [73-73])
-	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [54:54] injectible: [54-54]
-		Arg: a: string (declared at line 54, available: [54-54])
-		Arg: b: string (declared at line 54, available: [54-54])
-		Arg: c: string (declared at line 54, available: [54-54])
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [84:84] injectible: [84-84]
+		Arg: x: main.structWithPointer (declared at line 84, available: [84-84])
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [92:92] injectible: [92-92]
+		Arg: z: main.spws (declared at line 92, available: [92-92])
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [88:88] injectible: [88-88]
+		Arg: b: main.swsp (declared at line 88, available: [88-88])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [54:54] injectible: [54-54]
+		Arg: a: main.hasUnsupportedFields (declared at line 54, available: [54-54])
+	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [78:78] injectible: [78-78]
+		Arg: as: []uint (declared at line 78, available: [78-78])
+		Arg: bs: []uint (declared at line 78, available: [78-78])
+		Arg: cs: []uint (declared at line 78, available: [78-78])
+	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [59:59] injectible: [59-59]
+		Arg: a: string (declared at line 59, available: [59-59])
+		Arg: b: string (declared at line 59, available: [59-59])
+		Arg: c: string (declared at line 59, available: [59-59])
 	Function: testTakeContext (main.testTakeContext) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [24:24] injectible: [24-24]
 		Arg: ctx: context.Context (declared at line 22, available: [24-24])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112] injectible: [112-112]
-		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
-	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [16:16] injectible: [16-16]
-		Arg: x: string (declared at line 16, available: [16-16])
-		Arg: y: string (declared at line 16, available: [16-16])
-		Arg: z: string (declared at line 16, available: [16-16])
-	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [30:30] injectible: [30-30]
-		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
-	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
-		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
-		Arg: x: time.Time (declared at line 31, available: [31-31])
-	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
-		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
-	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
-		Arg: x: time.Time (declared at line 27, available: [27-27])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
-	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
-		Arg: a: []uint8 (declared at line 113, available: [113-113])
-		Arg: b: []uint8 (declared at line 113, available: [113-113])
-	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
-		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
-	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
-		Arg: x: [2]uint16 (declared at line 58, available: [58-58])
-	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62] injectible: [62-62]
-		Arg: x: [2]uint32 (declared at line 62, available: [62-62])
-	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66] injectible: [66-66]
-		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
-	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
-		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
-	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
-		Arg: x: []uint8 (declared at line 105, available: [105-105])
-	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
-		Arg: x: []uint8 (declared at line 109, available: [109-109])
-	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
-		Arg: x: [2]uint (declared at line 50, available: [50-50])
-	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]
-		Arg: x: *uint (declared at line 63, available: [63-63])
-	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29] injectible: [29-29]
-		Arg: u: []uint (declared at line 29, available: [29-29])
-	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [46:46] injectible: [46-46]
-		Arg: x: string (declared at line 46, available: [46-46])
-	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55] injectible: [55-55]
-		Arg: x: unsafe.Pointer (declared at line 55, available: [55-55])
-	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [99:99] injectible: [99-99]
-		Arg: a: [100]uint (declared at line 99, available: [99-99])
-	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
-		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [118:118] injectible: [118-118]
+		Arg: x: main.tenStrings (declared at line 118, available: [118-118])
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [21:21] injectible: [21-21]
+		Arg: x: string (declared at line 21, available: [21-21])
+		Arg: y: string (declared at line 21, available: [21-21])
+		Arg: z: string (declared at line 21, available: [21-21])
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [35:35] injectible: [35-35]
+		Arg: a: main.threeStringStruct (declared at line 35, available: [35-35])
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [39:39] injectible: [39-39]
+		Arg: a: *main.threeStringStruct (declared at line 39, available: [39-39])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [36:36] injectible: [36-36]
+		Arg: x: time.Time (declared at line 36, available: [36-36])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [40:40] injectible: [40-40]
+		Arg: c: main.timeCapture (declared at line 40, available: [40-40])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [32:32] injectible: [32-32]
+		Arg: x: time.Time (declared at line 32, available: [32-32])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [37:37] injectible: [37-37]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 37, available: [37-37])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [118:118] injectible: [118-118]
+		Arg: a: []uint8 (declared at line 118, available: [118-118])
+		Arg: b: []uint8 (declared at line 118, available: [118-118])
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [79:79] injectible: [79-79]
+		Arg: x: main.typeAlias (declared at line 79, available: [79-79])
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [64:64] injectible: [64-64]
+		Arg: x: [2]uint16 (declared at line 64, available: [64-64])
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [68:68] injectible: [68-68]
+		Arg: x: [2]uint32 (declared at line 68, available: [68-68])
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [72:72] injectible: [72-72]
+		Arg: x: [2]uint64 (declared at line 72, available: [72-72])
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [60:60] injectible: [60-60]
+		Arg: x: [2]uint8 (declared at line 60, available: [60-60])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [110:110] injectible: [110-110]
+		Arg: x: []uint8 (declared at line 110, available: [110-110])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [114:114] injectible: [114-114]
+		Arg: x: []uint8 (declared at line 114, available: [114-114])
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [56:56] injectible: [56-56]
+		Arg: x: [2]uint (declared at line 56, available: [56-56])
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [68:68] injectible: [68-68]
+		Arg: x: *uint (declared at line 68, available: [68-68])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [34:34] injectible: [34-34]
+		Arg: u: []uint (declared at line 34, available: [34-34])
+	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [51:51] injectible: [51-51]
+		Arg: x: string (declared at line 51, available: [51-51])
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [60:60] injectible: [60-60]
+		Arg: x: unsafe.Pointer (declared at line 60, available: [60-60])
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [105:105] injectible: [105-105]
+		Arg: a: [100]uint (declared at line 105, available: [105-105])
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [70:70] injectible: [70-70]
+		Arg: xs: []uint (declared at line 70, available: [70-70])
 	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
 		Arg: a: [0]int (declared at line 385, available: )
 		Arg: b: int (declared at line 385, available: [385-388])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,17 +1,23 @@
 === yield 1 [final=false] ===
 Package: main
-	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
-		Arg: x: []int (declared at line 12, available: [12-12])
-	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
-	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-263], [266-266], [277-277], [280-281], [283-284], [286-287], [289-289], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
-		Var: o: main.outer (declared at line 247, available: )
-		Var: s: []*string (declared at line 258, available: )
-		Var: str: string (declared at line 257, available: [246-314])
-		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
-		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
-		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
-		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [17:17] injectible: [17-17]
+		Arg: x: []int (declared at line 17, available: [17-17])
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [108:138] injectible: [108-110], [112-126], [128-131], [133-133], [137-138]
+		Arg: ctx: context.Context (declared at line 108, available: [108-110])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 109, available: [110-113])
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [82:104] injectible: [82-84], [86-89], [91-96], [98-104]
+		Arg: ctx: context.Context (declared at line 82, available: [82-84])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-86])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [249:320] injectible: [249-251], [254-258], [263-264], [266-269], [272-272], [283-283], [286-287], [289-290], [292-293], [295-295], [300-300], [302-302], [304-305], [307-308], [310-311], [313-317], [319-320]
+		Arg: ctx: context.Context (declared at line 249, available: [249-251])
+		Var: o: main.outer (declared at line 253, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 250, available: [251-269])
+		Var: s: []*string (declared at line 264, available: )
+		Var: str: string (declared at line 263, available: [249-320])
+		Var: circ: main.circularReferenceType (declared at line 285, available: [249-320])
+		Var: s1: main.stringType1 (declared at line 313, available: [308-320])
+		Var: s2: main.stringType2 (declared at line 314, available: [308-320])
+		Var: s2p: *main.stringType2 (declared at line 315, available: [308-320])
 	Function: executeContextFuncs (main.executeContextFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [26:33] injectible: [26-27], [29-29], [31-33]
 		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 27, available: [31-32])
 		Var: ctx: context.Context (declared at line 27, available: [31-32])
@@ -21,14 +27,18 @@ Package: main
 		Var: id: uint64 (declared at line 1360, available: [1360-1361])
 	Function: executeContextImplFuncs (main.executeContextImplFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [61:67] injectible: [61-62], [65-67]
 		Var: c: *main.contextImpl (declared at line 62, available: [61-67])
-	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [113:187] injectible: [113-113], [115-184], [186-187]
-		Var: m: main.manyPointers (declared at line 114, available: [113-187])
-	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:50] injectible: [36-36], [39-40], [42-42], [44-45], [47-47], [49-50]
-		Var: ss: []string (declared at line 39, available: [36-50])
-		Scope: 40-44
-			Var: i: int (declared at line 40, available: [40-42], [44-44])
-		Scope: 45-49
-			Var: i: int (declared at line 45, available: [45-49])
+	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [119:196] injectible: [119-121], [124-193], [195-196]
+		Arg: ctx: context.Context (declared at line 119, available: [119-121])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 120, available: [121-121])
+		Var: m: main.manyPointers (declared at line 123, available: [119-196])
+	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [39:56] injectible: [39-41], [45-46], [48-48], [50-51], [53-53], [55-56]
+		Arg: ctx: context.Context (declared at line 39, available: [39-41])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 40, available: [41-45])
+		Var: ss: []string (declared at line 45, available: [39-56])
+		Scope: 46-50
+			Var: i: int (declared at line 46, available: [46-48], [50-50])
+		Scope: 51-55
+			Var: i: int (declared at line 51, available: [51-55])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -83,10 +93,12 @@ Package: main
 		Arg: acc: string (declared at line 340, available: [340-340])
 		Arg: x: string (declared at line 340, available: [340-340])
 		Arg: ~r0: string (declared at line 340, available: )
-	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106] injectible: [97-98], [100-106]
-		Var: x: int (declared at line 99, available: )
-		Var: y: int (declared at line 100, available: [97-106])
-		Var: a: [5]int (declared at line 98, available: [97-106])
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [100:112] injectible: [100-102], [104-104], [106-112]
+		Arg: ctx: context.Context (declared at line 100, available: [100-102])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 101, available: [102-107])
+		Var: x: int (declared at line 105, available: )
+		Var: y: int (declared at line 106, available: [100-112])
+		Var: a: [5]int (declared at line 104, available: [100-112])
 	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124] injectible: [76-82], [88-112], [117-120], [122-122], [124-124]
 		Var: &one: *int (declared at line 95, available: [76-124])
 		Var: &foo: *string (declared at line 98, available: [76-124])
@@ -142,107 +154,125 @@ Package: main
 			Var: i: int (declared at line 210, available: [210-210], [211-212], [214-214])
 			Scope: 210-212
 				Var: key: [4]int (declared at line 211, available: )
-	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
-		Var: x: chan bool (declared at line 52, available: [53-54])
-	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-141], [143-143], [145-145], [147-151], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
-		Var: upp: **int (declared at line 169, available: )
-		Var: self: *main.node (declared at line 172, available: [173-177])
-		Var: swp: main.structWithPointer (declared at line 114, available: )
-		Var: z: main.spws (declared at line 118, available: )
-		Var: r: string (declared at line 117, available: [112-178])
-		Var: ssaw: main.swsp (declared at line 126, available: [112-178])
-		Var: rct: main.reallyComplexType (declared at line 137, available: [112-178])
-		Var: b: main.node (declared at line 145, available: [112-178])
-		Var: stringSlice: []string (declared at line 162, available: [112-178])
-		Var: up: *int (declared at line 168, available: [112-178])
-		Var: aruint: [2]uint (declared at line 159, available: )
-		Var: n: main.nStruct (declared at line 123, available: )
-		Var: u: int (declared at line 167, available: )
-		Var: u64F: uint64 (declared at line 113, available: )
-		Var: uintToPointTo: uint (declared at line 120, available: )
-		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [92:127] injectible: [92-94], [96-96], [109-123], [127-127]
+		Arg: ctx: context.Context (declared at line 92, available: [92-94])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 93, available: [94-96])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [54:62] injectible: [54-56], [58-62]
+		Arg: ctx: context.Context (declared at line 54, available: [54-56])
+		Var: x: chan bool (declared at line 58, available: [59-60])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 55, available: [56-58])
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [117:186] injectible: [117-119], [121-121], [123-123], [125-125], [128-129], [131-134], [138-140], [142-143], [145-149], [151-151], [153-153], [155-159], [163-163], [165-165], [167-168], [170-171], [173-173], [175-176], [178-178], [180-181], [183-186]
+		Arg: ctx: context.Context (declared at line 117, available: [117-119])
+		Var: z: main.spws (declared at line 126, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 118, available: [119-123])
+		Var: upp: **int (declared at line 177, available: )
+		Var: self: *main.node (declared at line 180, available: [181-185])
+		Var: swp: main.structWithPointer (declared at line 122, available: )
+		Var: r: string (declared at line 125, available: [117-186])
+		Var: ssaw: main.swsp (declared at line 134, available: [117-186])
+		Var: rct: main.reallyComplexType (declared at line 145, available: [117-186])
+		Var: b: main.node (declared at line 153, available: [117-186])
+		Var: stringSlice: []string (declared at line 170, available: [117-186])
+		Var: up: *int (declared at line 176, available: [117-186])
+		Var: aruint: [2]uint (declared at line 167, available: )
+		Var: n: main.nStruct (declared at line 131, available: )
+		Var: u: int (declared at line 175, available: )
+		Var: u64F: uint64 (declared at line 121, available: )
+		Var: uintToPointTo: uint (declared at line 128, available: )
+		Var: x: main.structWithTwoValues (declared at line 142, available: )
 	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [29:33] injectible: [29-33]
-		Var: s: *main.Server (declared at line 30, available: )
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
-		Var: originalSlice: []int (declared at line 133, available: )
-		Var: s: []uint (declared at line 142, available: )
-		Var: s2: []uint (declared at line 159, available: )
-		Scope: 143-146
-			Var: i: int (declared at line 143, available: [146-146])
-	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
-	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [65:86] injectible: [65-65], [67-72], [75-77], [81-81], [84-86]
-		Var: abc: string (declared at line 66, available: )
-		Var: uninitializedString: string (declared at line 74, available: )
-		Var: s: string (declared at line 80, available: )
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236] injectible: [135-137], [140-140], [142-143], [145-146], [150-150], [152-160], [172-172], [174-174], [177-182], [190-192], [194-195], [198-198], [200-201], [203-206], [208-208], [210-213], [215-216], [219-220], [222-223], [225-226], [228-229], [231-232], [235-236]
-		Var: ptrRcvr: *main.receiver (declared at line 200, available: )
-		Var: n: main.nStruct (declared at line 139, available: )
-		Var: ns: main.structWithNoStrings (declared at line 148, available: )
-		Var: cs: main.cStruct (declared at line 149, available: )
-		Var: rcvr: main.receiver (declared at line 197, available: )
-		Var: ts: main.threestrings (declared at line 136, available: [135-236])
-		Var: s: main.aStruct (declared at line 142, available: [135-236])
-		Var: b: main.bStruct (declared at line 145, available: [135-236])
-		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
-		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
-		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
-		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
-		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
-		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
-		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
-	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
-		Var: ist: *time.Location (declared at line 48, available: [49-49])
-	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
-		Arg: x: []int (declared at line 22, available: [22-25])
-	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
-		Arg: f: func(int) (declared at line 28, available: [28-29])
+	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [34:41] injectible: [34-36], [38-41]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: s: *main.Server (declared at line 38, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [137:189] injectible: [137-139], [141-143], [145-152], [154-158], [160-160], [162-164], [167-168], [170-181], [183-183], [185-185], [187-189]
+		Arg: ctx: context.Context (declared at line 137, available: [137-139])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 138, available: [139-141])
+		Var: originalSlice: []int (declared at line 141, available: )
+		Var: s: []uint (declared at line 150, available: )
+		Var: s2: []uint (declared at line 167, available: )
+		Scope: 151-154
+			Var: i: int (declared at line 151, available: [154-154])
+	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [34:39] injectible: [34-36], [38-39]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [70:94] injectible: [70-72], [75-80], [83-85], [89-89], [92-94]
+		Arg: ctx: context.Context (declared at line 70, available: [70-72])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 71, available: [72-75])
+		Var: abc: string (declared at line 74, available: )
+		Var: uninitializedString: string (declared at line 82, available: )
+		Var: s: string (declared at line 88, available: )
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [141:245] injectible: [141-143], [145-146], [149-149], [151-152], [154-155], [159-159], [161-169], [181-181], [183-183], [186-191], [199-201], [203-204], [207-207], [209-210], [212-215], [217-217], [219-222], [224-225], [228-229], [231-232], [234-235], [237-238], [240-241], [244-245]
+		Arg: ctx: context.Context (declared at line 141, available: [141-143])
+		Var: rcvr: main.receiver (declared at line 206, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 142, available: [143-146])
+		Var: ptrRcvr: *main.receiver (declared at line 209, available: )
+		Var: n: main.nStruct (declared at line 148, available: )
+		Var: ns: main.structWithNoStrings (declared at line 157, available: )
+		Var: cs: main.cStruct (declared at line 158, available: )
+		Var: ts: main.threestrings (declared at line 145, available: [141-245])
+		Var: s: main.aStruct (declared at line 151, available: [141-245])
+		Var: b: main.bStruct (declared at line 154, available: [141-245])
+		Var: tenStr: main.tenStrings (declared at line 171, available: [141-245])
+		Var: deep: main.deepStruct1 (declared at line 185, available: [141-245])
+		Var: fields: main.lotsOfFields (declared at line 203, available: [141-245])
+		Var: sta: main.structWithTwoArrays (declared at line 212, available: [141-245])
+		Var: .autotmp_121: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_140: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_147: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_152: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_176: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_183: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_188: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_195: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_201: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_206: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_213: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_219: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_22: [0]main.structWithCyclicSlices (declared at line 229, available: [141-245])
+		Var: .autotmp_224: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_236: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_243: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_248: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_255: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_26: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_261: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_266: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_273: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_279: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_284: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_291: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_298: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_304: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_309: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_31: [0][][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_32: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_34: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_41: [0][][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_42: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_44: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_47: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_51: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_56: [0][][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_57: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_59: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_62: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_66: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_70: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_20: [0]uint8 (declared at line 166, available: [141-245])
+		Var: .autotmp_97: main.emptyStruct (declared at line 199, available: [141-245])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [44:65] injectible: [44-46], [49-50], [56-59], [64-65]
+		Arg: ctx: context.Context (declared at line 44, available: [44-46])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 45, available: [46-49])
+		Var: ist: *time.Location (declared at line 56, available: [57-57])
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [27:30] injectible: [27-30]
+		Arg: x: []int (declared at line 27, available: [27-30])
+	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [31:33] injectible: [31-33]
+		Arg: f: func(int) (declared at line 31, available: [31-32])
 	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [109:119] injectible: [109-115], [117-117], [119-119]
 		Arg: entriesCount: int (declared at line 109, available: [109-119])
 		Arg: ~r0: map[string][]main.structWithMap (declared at line 109, available: )
@@ -277,21 +307,23 @@ Package: main
 		Arg: b: <T> (declared at line 113, available: [113-114])
 		Arg: ~r0: <T> (declared at line 113, available: )
 		Arg: ~r1: <T> (declared at line 113, available: )
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:18] injectible: [16-18]
 		Arg: value: int (declared at line 16, available: [16-17])
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:50] injectible: [21-21], [26-26], [29-30], [33-33], [35-35], [37-40], [44-48], [50-50]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [22:50] injectible: [22-22], [27-27], [30-31], [34-34], [36-36], [38-41], [44-48], [50-50]
 		Var: ticker: *time.Ticker (declared at line 44, available: [45-45])
-		Var: service: string (declared at line 29, available: [30-33])
-		Scope: 37-45
-			Var: scanner: *bufio.Scanner (declared at line 37, available: )
+		Var: service: string (declared at line 30, available: [31-34])
+		Var: .autotmp_15: context.backgroundCtx (declared at line 212, available: [22-50])
+		Scope: 38-45
+			Var: scanner: *bufio.Scanner (declared at line 38, available: )
 		Scope: 45-48
 			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 46, available: [45-48])
+			Var: ctx: context.Context (declared at line 46, available: [47-47])
 	Type: main.Pair[...]
 		Field: Key: <T>
 		Field: Value: <T>
@@ -305,10 +337,10 @@ Package: main
 		Field: Total: float64
 	Type: main.Server
 		Field: name: string
-		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [21:26] injectible: [21-23], [25-26]
-			Arg: s: *main.Server (declared at line 21, available: [21-23])
-			Arg: req: *main.Request (declared at line 21, available: [21-26])
-			Arg: ~r0: error (declared at line 21, available: )
+		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [26:31] injectible: [26-28], [30-31]
+			Arg: s: *main.Server (declared at line 26, available: [26-28])
+			Arg: req: *main.Request (declared at line 26, available: [26-31])
+			Arg: ~r0: error (declared at line 26, available: )
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -624,12 +656,12 @@ Package: main
 		Field: aStringPtr: *string
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52] injectible: [52-52]
-			Arg: r: *main.receiver (declared at line 52, available: [52-52])
-			Arg: a: int (declared at line 52, available: [52-52])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56] injectible: [56-56]
-			Arg: r: main.receiver (declared at line 56, available: [56-56])
-			Arg: a: int (declared at line 56, available: [56-56])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [58:58] injectible: [58-58]
+			Arg: r: *main.receiver (declared at line 58, available: [58-58])
+			Arg: a: int (declared at line 58, available: [58-58])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [62:62] injectible: [62-62]
+			Arg: r: main.receiver (declared at line 62, available: [62-62])
+			Arg: a: int (declared at line 62, available: [62-62])
 	Type: main.score
 	Type: main.secondBehavior
 		Field: i: int
@@ -747,14 +779,14 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
-	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [104:107] injectible: [105-107]
-		Var: i: int (declared at line 106, available: [105-105])
+	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [110:113] injectible: [111-113]
+		Var: i: int (declared at line 112, available: [111-111])
 		Arg: id: int (declared at line 0, available: )
-		Var: p: *main.paddedData (declared at line 105, available: )
-	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [23:28] injectible: [23-26], [28-28]
-		Arg: n: int (declared at line 23, available: [23-28])
-		Arg: ~r0: string (declared at line 23, available: )
-		Var: prefix: string (declared at line 24, available: [25-26], [28-28])
+		Var: p: *main.paddedData (declared at line 111, available: )
+	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [26:31] injectible: [26-29], [31-31]
+		Arg: n: int (declared at line 26, available: [26-31])
+		Arg: ~r0: string (declared at line 26, available: )
+		Var: prefix: string (declared at line 27, available: [28-29], [31-31])
 		Var: ~r0.ptr: *uint8 (declared at line 34, available: )
 		Var: ~r0.len: int (declared at line 34, available: )
 	Function: nestedGeneric[...] (main.nestedGeneric[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [203:203] injectible: [203-203]
@@ -766,20 +798,21 @@ Package: main
 		Arg: items: <T> (declared at line 183, available: [183-184])
 		Arg: pred: <T> (declared at line 183, available: [183-184])
 		Arg: ~r0: <T> (declared at line 183, available: )
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
-		Arg: ~r0: uint64 (declared at line 40, available: )
-		Var: n: uint64 (declared at line 45, available: [44-46])
-		Var: b: []uint8 (declared at line 41, available: [44-45])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [43:49] injectible: [43-49]
+		Arg: ~r0: uint64 (declared at line 43, available: )
+		Var: n: uint64 (declared at line 48, available: [47-49])
+		Var: b: []uint8 (declared at line 44, available: [47-48])
 	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:88] injectible: [52-66], [68-69], [71-73], [75-77], [80-88]
+		Arg: ctx: context.Context (declared at line 52, available: [52-88])
 		Var: it: main.iterExample (declared at line 70, available: [52-88])
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 67, available: [52-88])
-	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
-		Arg: x: []int (declared at line 16, available: [16-17])
-		Arg: ~r0: string (declared at line 16, available: )
-	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14] injectible: [12-14]
-	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20] injectible: [18-20]
-	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25] injectible: [24-25]
-		Arg: ~r0: string (declared at line 24, available: )
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [21:22] injectible: [21-22]
+		Arg: x: []int (declared at line 21, available: [21-22])
+		Arg: ~r0: string (declared at line 21, available: )
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [17:19] injectible: [17-19]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [23:25] injectible: [23-25]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [29-30]
+		Arg: ~r0: string (declared at line 29, available: )
 	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55] injectible: [54-55]
 		Arg: a: interface {} (declared at line 54, available: [54-55])
 		Arg: ~r0: string (declared at line 54, available: )
@@ -789,225 +822,225 @@ Package: main
 	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
 		Arg: arg: [3]int (declared at line 297, available: [297-302])
 		Arg: ~r0: [3]int (declared at line 297, available: )
-	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
-		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
-	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
-		Arg: a: [2][2]int (declared at line 70, available: [70-70])
-	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78] injectible: [78-78]
-		Arg: b: [2][2][2]int (declared at line 78, available: [78-78])
+	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [93:93] injectible: [93-93]
+		Arg: a: [2]struct {} (declared at line 93, available: [93-93])
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [76:76] injectible: [76-76]
+		Arg: a: [2][2]int (declared at line 76, available: [76-76])
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [84:84] injectible: [84-84]
+		Arg: b: [2][2][2]int (declared at line 84, available: [84-84])
 	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [42:42] injectible: [42-42]
 		Arg: m: [2]map[string]int (declared at line 42, available: [42-42])
-	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74] injectible: [74-74]
-		Arg: a: [2]string (declared at line 74, available: [74-74])
-	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83] injectible: [83-83]
-		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
-	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
-		Arg: x: *[2]uint (declared at line 59, available: [59-59])
-	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
-		Arg: x: uint64 (declared at line 19, available: [23-23])
-		Arg: ~r0: uint64 (declared at line 19, available: )
-	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
-		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
-	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
-		Arg: x: [2]bool (declared at line 26, available: [26-26])
-	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
-		Arg: a: []uint8 (declared at line 117, available: [117-117])
-		Arg: b: []uint8 (declared at line 117, available: [117-117])
-	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
-		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
-		Arg: a: []uint8 (declared at line 129, available: [129-129])
-		Arg: b: []int (declared at line 129, available: [129-129])
-	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
-		Arg: x: []uint8 (declared at line 77, available: [77-77])
-	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
-		Arg: x: []uint8 (declared at line 81, available: [81-81])
-	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
-		Arg: x: []uint8 (declared at line 85, available: [85-85])
-	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
-		Arg: x: []uint8 (declared at line 89, available: [89-89])
-	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
-		Arg: x: []uint8 (declared at line 93, available: [93-93])
-	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
-		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
-	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
-		Arg: a: int (declared at line 125, available: [125-125])
-		Arg: x: []uint8 (declared at line 125, available: [125-125])
-		Arg: b: string (declared at line 125, available: [125-125])
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [80:80] injectible: [80-80]
+		Arg: a: [2]string (declared at line 80, available: [80-80])
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [89:89] injectible: [89-89]
+		Arg: a: [2]main.nestedStruct (declared at line 88, available: [89-89])
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [64:64] injectible: [64-64]
+		Arg: x: *[2]uint (declared at line 64, available: [64-64])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [26:26] injectible: [26-26]
+		Arg: x: uint64 (declared at line 22, available: [26-26])
+		Arg: ~r0: uint64 (declared at line 22, available: )
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [85:85] injectible: [85-85]
+		Arg: b: main.bigStruct (declared at line 85, available: [85-85])
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [32:32] injectible: [32-32]
+		Arg: x: [2]bool (declared at line 32, available: [32-32])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [122:122] injectible: [122-122]
+		Arg: a: []uint8 (declared at line 122, available: [122-122])
+		Arg: b: []uint8 (declared at line 122, available: [122-122])
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [20:20] injectible: [20-20]
+		Arg: x: [2]uint8 (declared at line 20, available: [20-20])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [134:134] injectible: [134-134]
+		Arg: a: []uint8 (declared at line 134, available: [134-134])
+		Arg: b: []int (declared at line 134, available: [134-134])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [82:82] injectible: [82-82]
+		Arg: x: []uint8 (declared at line 82, available: [82-82])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [86:86] injectible: [86-86]
+		Arg: x: []uint8 (declared at line 86, available: [86-86])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [90:90] injectible: [90-90]
+		Arg: x: []uint8 (declared at line 90, available: [90-90])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [94:94] injectible: [94-94]
+		Arg: x: []uint8 (declared at line 94, available: [94-94])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [98:98] injectible: [98-98]
+		Arg: x: []uint8 (declared at line 98, available: [98-98])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [126:126] injectible: [126-126]
+		Arg: x: [][]uint8 (declared at line 126, available: [126-126])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [130:130] injectible: [130-130]
+		Arg: a: int (declared at line 130, available: [130-130])
+		Arg: x: []uint8 (declared at line 130, available: [130-130])
+		Arg: b: string (declared at line 130, available: [130-130])
 	Function: testCaptureContextImpl (main.testCaptureContextImpl) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [44:44] injectible: [44-44]
 		Arg: c: *main.contextImpl (declared at line 44, available: [44-44])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
-		Arg: c: chan bool (declared at line 30, available: [30-30])
-	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
-		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
-	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
-		Arg: w: uint8 (declared at line 34, available: [34-34])
-		Arg: x: bool (declared at line 34, available: [34-34])
-		Arg: y: float32 (declared at line 34, available: [34-34])
-	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22] injectible: [22-22]
-		Arg: w: uint8 (declared at line 22, available: [22-22])
-		Arg: x: uint8 (declared at line 22, available: [22-22])
-		Arg: y: float32 (declared at line 22, available: [22-22])
-	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38] injectible: [38-38]
-		Arg: w: uint8 (declared at line 38, available: [38-38])
-		Arg: x: int (declared at line 38, available: [38-38])
-		Arg: y: float32 (declared at line 38, available: [38-38])
-	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46] injectible: [46-46]
-		Arg: w: uint8 (declared at line 46, available: [46-46])
-		Arg: x: int16 (declared at line 46, available: [46-46])
-		Arg: y: float32 (declared at line 46, available: [46-46])
-	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50] injectible: [50-50]
-		Arg: w: uint8 (declared at line 50, available: [50-50])
-		Arg: x: int32 (declared at line 50, available: [50-50])
-		Arg: y: float32 (declared at line 50, available: [50-50])
-	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54] injectible: [54-54]
-		Arg: w: uint8 (declared at line 54, available: [54-54])
-		Arg: x: int64 (declared at line 54, available: [54-54])
-		Arg: y: float32 (declared at line 54, available: [54-54])
-	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42] injectible: [42-42]
-		Arg: w: uint8 (declared at line 42, available: [42-42])
-		Arg: x: int8 (declared at line 42, available: [42-42])
-		Arg: y: float32 (declared at line 42, available: [42-42])
-	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26] injectible: [26-26]
-		Arg: w: uint8 (declared at line 26, available: [26-26])
-		Arg: x: int32 (declared at line 26, available: [26-26])
-		Arg: y: float32 (declared at line 26, available: [26-26])
-	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30] injectible: [30-30]
-		Arg: w: uint8 (declared at line 30, available: [30-30])
-		Arg: x: string (declared at line 30, available: [30-30])
-		Arg: y: float32 (declared at line 30, available: [30-30])
-	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58] injectible: [58-58]
-		Arg: w: uint8 (declared at line 58, available: [58-58])
-		Arg: x: uint (declared at line 58, available: [58-58])
-		Arg: y: float32 (declared at line 58, available: [58-58])
-	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66] injectible: [66-66]
-		Arg: w: uint8 (declared at line 66, available: [66-66])
-		Arg: x: uint16 (declared at line 66, available: [66-66])
-		Arg: y: float32 (declared at line 66, available: [66-66])
-	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70] injectible: [70-70]
-		Arg: w: uint8 (declared at line 70, available: [70-70])
-		Arg: x: uint32 (declared at line 70, available: [70-70])
-		Arg: y: float32 (declared at line 70, available: [70-70])
-	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74] injectible: [74-74]
-		Arg: w: uint8 (declared at line 74, available: [74-74])
-		Arg: x: uint64 (declared at line 74, available: [74-74])
-		Arg: y: float32 (declared at line 74, available: [74-74])
-	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62] injectible: [62-62]
-		Arg: w: uint8 (declared at line 62, available: [62-62])
-		Arg: x: uint8 (declared at line 62, available: [62-62])
-		Arg: y: float32 (declared at line 62, available: [62-62])
-	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75] injectible: [75-75]
-		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [33:33] injectible: [33-33]
+		Arg: c: chan bool (declared at line 33, available: [33-33])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93] injectible: [93-93]
+		Arg: x: main.circularReferenceType (declared at line 93, available: [93-93])
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [40:40] injectible: [40-40]
+		Arg: w: uint8 (declared at line 40, available: [40-40])
+		Arg: x: bool (declared at line 40, available: [40-40])
+		Arg: y: float32 (declared at line 40, available: [40-40])
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [28:28] injectible: [28-28]
+		Arg: w: uint8 (declared at line 28, available: [28-28])
+		Arg: x: uint8 (declared at line 28, available: [28-28])
+		Arg: y: float32 (declared at line 28, available: [28-28])
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [44:44] injectible: [44-44]
+		Arg: w: uint8 (declared at line 44, available: [44-44])
+		Arg: x: int (declared at line 44, available: [44-44])
+		Arg: y: float32 (declared at line 44, available: [44-44])
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [52:52] injectible: [52-52]
+		Arg: w: uint8 (declared at line 52, available: [52-52])
+		Arg: x: int16 (declared at line 52, available: [52-52])
+		Arg: y: float32 (declared at line 52, available: [52-52])
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [56:56] injectible: [56-56]
+		Arg: w: uint8 (declared at line 56, available: [56-56])
+		Arg: x: int32 (declared at line 56, available: [56-56])
+		Arg: y: float32 (declared at line 56, available: [56-56])
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [60:60] injectible: [60-60]
+		Arg: w: uint8 (declared at line 60, available: [60-60])
+		Arg: x: int64 (declared at line 60, available: [60-60])
+		Arg: y: float32 (declared at line 60, available: [60-60])
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [48:48] injectible: [48-48]
+		Arg: w: uint8 (declared at line 48, available: [48-48])
+		Arg: x: int8 (declared at line 48, available: [48-48])
+		Arg: y: float32 (declared at line 48, available: [48-48])
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [32:32] injectible: [32-32]
+		Arg: w: uint8 (declared at line 32, available: [32-32])
+		Arg: x: int32 (declared at line 32, available: [32-32])
+		Arg: y: float32 (declared at line 32, available: [32-32])
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [36:36] injectible: [36-36]
+		Arg: w: uint8 (declared at line 36, available: [36-36])
+		Arg: x: string (declared at line 36, available: [36-36])
+		Arg: y: float32 (declared at line 36, available: [36-36])
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [64:64] injectible: [64-64]
+		Arg: w: uint8 (declared at line 64, available: [64-64])
+		Arg: x: uint (declared at line 64, available: [64-64])
+		Arg: y: float32 (declared at line 64, available: [64-64])
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [72:72] injectible: [72-72]
+		Arg: w: uint8 (declared at line 72, available: [72-72])
+		Arg: x: uint16 (declared at line 72, available: [72-72])
+		Arg: y: float32 (declared at line 72, available: [72-72])
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [76:76] injectible: [76-76]
+		Arg: w: uint8 (declared at line 76, available: [76-76])
+		Arg: x: uint32 (declared at line 76, available: [76-76])
+		Arg: y: float32 (declared at line 76, available: [76-76])
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [80:80] injectible: [80-80]
+		Arg: w: uint8 (declared at line 80, available: [80-80])
+		Arg: x: uint64 (declared at line 80, available: [80-80])
+		Arg: y: float32 (declared at line 80, available: [80-80])
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [68:68] injectible: [68-68]
+		Arg: w: uint8 (declared at line 68, available: [68-68])
+		Arg: x: uint8 (declared at line 68, available: [68-68])
+		Arg: y: float32 (declared at line 68, available: [68-68])
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [80:80] injectible: [80-80]
+		Arg: z: *main.reallyComplexType (declared at line 80, available: [80-80])
 	Function: testConflictingReturn (main.testConflictingReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [109:111] injectible: [109-111]
 		Arg: i: int (declared at line 109, available: [109-111])
 		Arg: ~r0: int (declared at line 109, available: )
 		Arg: r0: string (declared at line 109, available: )
-	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
-		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
-		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
-		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
-		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
-		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
-		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
-		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
-		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
-	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
-		Arg: x: []uint8 (declared at line 97, available: [97-97])
-	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
-		Arg: u: []uint (declared at line 33, available: [33-33])
-	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
-		Arg: xs: []main.structWithNoStrings (declared at line 45, available: [45-45])
-		Arg: a: int (declared at line 45, available: [45-45])
-	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [50:50] injectible: [50-50]
-		Arg: x: string (declared at line 50, available: [50-50])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124] injectible: [124-124]
-		Arg: e: main.emptyStruct (declared at line 124, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128] injectible: [128-128]
-		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [114:114] injectible: [114-114]
+		Arg: t: *main.t (declared at line 114, available: [114-114])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: main.deepMap1 (declared at line 203, available: [203-203])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [206:206] injectible: [206-206]
+		Arg: a: *main.deepMap7 (declared at line 206, available: [206-206])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: main.deepPtr1 (declared at line 139, available: [139-139])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142] injectible: [142-142]
+		Arg: a: *main.deepPtr7 (declared at line 142, available: [142-142])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: main.deepSlice1 (declared at line 165, available: [165-165])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [168:168] injectible: [168-168]
+		Arg: a: *main.deepSlice7 (declared at line 168, available: [168-168])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [126:126] injectible: [126-126]
+		Arg: t: main.deepStruct1 (declared at line 126, available: [126-126])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [102:102] injectible: [102-102]
+		Arg: x: []uint8 (declared at line 102, available: [102-102])
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [38:38] injectible: [38-38]
+		Arg: u: []uint (declared at line 38, available: [38-38])
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [50:50] injectible: [50-50]
+		Arg: xs: []main.structWithNoStrings (declared at line 50, available: [50-50])
+		Arg: a: int (declared at line 50, available: [50-50])
+	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [55:55] injectible: [55-55]
+		Arg: x: string (declared at line 55, available: [55-55])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [130:130] injectible: [130-130]
+		Arg: e: main.emptyStruct (declared at line 130, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [134:134] injectible: [134-134]
+		Arg: e: *main.emptyStruct (declared at line 134, available: [134-134])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
-	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [108-110], [112-112]
-		Arg: shouldErr: bool (declared at line 101, available: [101-103])
-		Arg: ~r0: int (declared at line 101, available: )
-		Var: x: int (declared at line 106, available: )
-		Var: err: error (declared at line 102, available: [101-112])
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [104:115] injectible: [104-104], [106-107], [111-113], [115-115]
+		Arg: shouldErr: bool (declared at line 104, available: [104-106])
+		Arg: ~r0: int (declared at line 104, available: )
+		Var: x: int (declared at line 109, available: )
+		Var: err: error (declared at line 105, available: [104-115])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
-	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80] injectible: [79-80]
-		Arg: x: int (declared at line 79, available: [79-80])
-		Arg: ~r0: int (declared at line 79, available: )
-	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93] injectible: [92-93]
-		Arg: a: [5]int (declared at line 92, available: [92-93])
-		Arg: ~r0: int (declared at line 92, available: )
-	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [17:19] injectible: [17-19]
-		Arg: x: int (declared at line 17, available: [17-18])
-		Arg: y: int (declared at line 17, available: [17-18])
-	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [21:25] injectible: [21-25]
-		Arg: x: int (declared at line 21, available: [21-25])
-		Arg: y: int (declared at line 21, available: [21-25])
-	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35] injectible: [32-32], [34-35]
-		Arg: x: int (declared at line 32, available: [32-34])
-	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42] injectible: [37-42]
-		Arg: x: int (declared at line 37, available: [37-38])
-		Arg: y: int (declared at line 37, available: [37-39])
-		Var: z: int (declared at line 38, available: [37-42])
-	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46] injectible: [44-46]
-		Arg: x: int (declared at line 44, available: [44-45])
-	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49] injectible: [49-49]
-	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60] injectible: [52-53], [55-56], [58-60]
-		Var: s: int (declared at line 54, available: [55-58])
-		Scope: 55-58
-			Var: i: int (declared at line 55, available: [55-58])
-	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63] injectible: [63-63]
-	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [66:67] injectible: [67-67]
-	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [13:15] injectible: [14-14]
-		Arg: x: int (declared at line 0, available: [13-14])
-	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [74:75] injectible: [75-75]
-		Arg: x: int (declared at line 0, available: [75-75])
-	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:71] injectible: [71-71]
-		Arg: a: [5]int (declared at line 0, available: [71-71])
-	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38] injectible: [38-38]
-		Arg: x: [2]int16 (declared at line 38, available: [38-38])
-	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42] injectible: [42-42]
-		Arg: x: [2]int32 (declared at line 42, available: [42-42])
-	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46] injectible: [46-46]
-		Arg: x: [2]int64 (declared at line 46, available: [46-46])
-	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34] injectible: [34-34]
-		Arg: x: [2]int8 (declared at line 34, available: [34-34])
-	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30] injectible: [30-30]
-		Arg: x: [2]int (declared at line 30, available: [30-30])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [82:83] injectible: [82-83]
+		Arg: x: int (declared at line 82, available: [82-83])
+		Arg: ~r0: int (declared at line 82, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [95:96] injectible: [95-96]
+		Arg: a: [5]int (declared at line 95, available: [95-96])
+		Arg: ~r0: int (declared at line 95, available: )
+	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [20:22] injectible: [20-22]
+		Arg: x: int (declared at line 20, available: [20-21])
+		Arg: y: int (declared at line 20, available: [20-21])
+	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [24:28] injectible: [24-28]
+		Arg: x: int (declared at line 24, available: [24-28])
+		Arg: y: int (declared at line 24, available: [24-28])
+	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [35:38] injectible: [35-35], [37-38]
+		Arg: x: int (declared at line 35, available: [35-37])
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [40:45] injectible: [40-45]
+		Arg: x: int (declared at line 40, available: [40-41])
+		Arg: y: int (declared at line 40, available: [40-42])
+		Var: z: int (declared at line 41, available: [40-45])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [47:49] injectible: [47-49]
+		Arg: x: int (declared at line 47, available: [47-48])
+	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [51:52] injectible: [52-52]
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [55:63] injectible: [55-56], [58-59], [61-63]
+		Var: s: int (declared at line 57, available: [58-61])
+		Scope: 58-61
+			Var: i: int (declared at line 58, available: [58-61])
+	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [65:66] injectible: [66-66]
+	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [69:70] injectible: [70-70]
+	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [16:18] injectible: [17-17]
+		Arg: x: int (declared at line 0, available: [16-17])
+	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [77:78] injectible: [78-78]
+		Arg: x: int (declared at line 0, available: [78-78])
+	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [73:74] injectible: [74-74]
+		Arg: a: [5]int (declared at line 0, available: [74-74])
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [44:44] injectible: [44-44]
+		Arg: x: [2]int16 (declared at line 44, available: [44-44])
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [48:48] injectible: [48-48]
+		Arg: x: [2]int32 (declared at line 48, available: [48-48])
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [52:52] injectible: [52-52]
+		Arg: x: [2]int64 (declared at line 52, available: [52-52])
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [40:40] injectible: [40-40]
+		Arg: x: [2]int8 (declared at line 40, available: [40-40])
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [36:36] injectible: [36-36]
+		Arg: x: [2]int (declared at line 36, available: [36-36])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50] injectible: [50-50]
 		Arg: b: main.behavior (declared at line 50, available: [50-50])
-	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [94:94] injectible: [94-94]
-		Arg: a: int (declared at line 94, available: [94-94])
-		Arg: b: error (declared at line 94, available: [94-94])
-		Arg: c: uint (declared at line 94, available: [94-94])
-	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
-		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [58:58] injectible: [58-58]
-		Arg: a: string (declared at line 58, available: [58-58])
-		Arg: b: string (declared at line 58, available: [58-58])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [97:97] injectible: [97-97]
+		Arg: a: int (declared at line 97, available: [97-97])
+		Arg: b: error (declared at line 97, available: [97-97])
+		Arg: c: uint (declared at line 97, available: [97-97])
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67] injectible: [67-67]
+		Arg: a: main.interfaceComplexityA (declared at line 67, available: [67-67])
+	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [63:63] injectible: [63-63]
+		Arg: a: string (declared at line 63, available: [63-63])
+		Arg: b: string (declared at line 63, available: [63-63])
 	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
 		Arg: arg: main.largeStruct (declared at line 281, available: [281-282])
 		Arg: ~r0: main.largeStruct (declared at line 281, available: )
 		Arg: ~r0: main.largeStruct (declared at line 281, available: )
-	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
-		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
-		Var: s: int (declared at line 224, available: [237-237], [242-242])
-		Var: aPerArch: int (declared at line 228, available: [223-243])
-		Var: b: int (declared at line 229, available: [223-243])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
-		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [47:47] injectible: [47-47]
+		Arg: a: main.node (declared at line 47, available: [47-47])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [226:246] injectible: [226-226], [233-233], [236-237], [239-242], [244-246]
+		Var: s: int (declared at line 227, available: [240-240], [245-245])
+		Var: aPerArch: int (declared at line 231, available: [226-246])
+		Var: b: int (declared at line 232, available: [226-246])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [138:138] injectible: [138-138]
+		Arg: l: main.lotsOfFields (declared at line 138, available: [138-138])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
 		Arg: a: int (declared at line 328, available: [328-330])
 		Arg: b: int (declared at line 328, available: [328-330])
@@ -1019,10 +1052,10 @@ Package: main
 		Arg: h: int (declared at line 328, available: [328-330])
 		Arg: i: int (declared at line 328, available: [328-330])
 		Arg: ~r0: [2]int (declared at line 328, available: )
-	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [102:102] injectible: [102-102]
-		Arg: m: main.manyPointers (declared at line 102, available: [102-102])
-	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [33:33] injectible: [33-33]
-		Arg: ss: []string (declared at line 33, available: [33-33])
+	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [108:108] injectible: [108-108]
+		Arg: m: main.manyPointers (declared at line 108, available: [108-108])
+	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:36] injectible: [36-36]
+		Arg: ss: []string (declared at line 36, available: [36-36])
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -1061,8 +1094,8 @@ Package: main
 		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
 	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70] injectible: [70-70]
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
-	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
-		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [47:47] injectible: [47-47]
+		Arg: x: string (declared at line 47, available: [47-47])
 	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-349]
 		Arg: a: int (declared at line 337, available: [337-349])
 		Arg: b: int (declared at line 337, available: [337-349])
@@ -1075,17 +1108,17 @@ Package: main
 		Arg: s: string (declared at line 337, available: [337-349])
 		Arg: ~r0: main.largeStruct (declared at line 337, available: )
 		Arg: ~r0: main.largeStruct (declared at line 337, available: )
-	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [62:62] injectible: [62-62]
-		Arg: x: string (declared at line 62, available: [62-62])
+	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [67:67] injectible: [67-67]
+		Arg: x: string (declared at line 67, available: [67-67])
 	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
 		Arg: a: [2]int (declared at line 364, available: [364-366])
 		Arg: b: [3]int (declared at line 364, available: [364-366])
 		Arg: ~r0: int (declared at line 364, available: )
 		Arg: ~r1: [2]int (declared at line 364, available: )
-	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
-		Arg: o: main.outer (declared at line 72, available: [72-72])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
-		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [75:75] injectible: [75-75]
+		Arg: o: main.outer (declared at line 75, available: [75-75])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [102:102] injectible: [102-102]
+		Arg: b: main.bStruct (declared at line 102, available: [102-102])
 	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
 		Arg: s1: main.largeStruct (declared at line 308, available: [308-309])
 		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
@@ -1095,99 +1128,99 @@ Package: main
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
 		Arg: result2: int (declared at line 95, available: )
-	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
-		Arg: a: bool (declared at line 78, available: [78-78])
-		Arg: b: uint8 (declared at line 78, available: [78-78])
-		Arg: c: int32 (declared at line 78, available: [78-78])
-		Arg: d: uint (declared at line 78, available: [78-78])
-		Arg: e: string (declared at line 78, available: [78-78])
-	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
-		Arg: a: main.tierA (declared at line 68, available: [68-68])
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [84:84] injectible: [84-84]
+		Arg: a: bool (declared at line 84, available: [84-84])
+		Arg: b: uint8 (declared at line 84, available: [84-84])
+		Arg: c: int32 (declared at line 84, available: [84-84])
+		Arg: d: uint (declared at line 84, available: [84-84])
+		Arg: e: string (declared at line 84, available: [84-84])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71] injectible: [71-71]
+		Arg: a: main.tierA (declared at line 71, available: [71-71])
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
 		Arg: i: int (declared at line 88, available: [88-89])
 		Arg: result: int (declared at line 88, available: )
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
-		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
-	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
-		Arg: x: []uint8 (declared at line 101, available: [101-101])
-	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
-		Arg: z: *bool (declared at line 99, available: [99-99])
-		Arg: a: uint (declared at line 99, available: [99-99])
-	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61] injectible: [61-61]
-		Arg: xs: []uint16 (declared at line 61, available: [61-61])
-	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49] injectible: [49-49]
-		Arg: xs: []main.structWithNoStrings (declared at line 49, available: [49-49])
-		Arg: a: int (declared at line 49, available: [49-49])
-	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57] injectible: [57-57]
-		Arg: a: int8 (declared at line 57, available: [57-57])
-		Arg: s: []bool (declared at line 57, available: [57-57])
-		Arg: x: uint (declared at line 57, available: [57-57])
-	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71] injectible: [71-71]
-		Arg: z: uint (declared at line 71, available: [71-71])
-		Arg: x: *main.nStruct (declared at line 71, available: [71-71])
-		Arg: a: int (declared at line 71, available: [71-71])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100] injectible: [100-100]
-		Arg: c: main.cStruct (declared at line 100, available: [100-100])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92] injectible: [92-92]
-		Arg: x: main.nStruct (declared at line 92, available: [92-92])
-	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [38:38] injectible: [38-38]
-		Arg: a: *main.oneStringStruct (declared at line 38, available: [38-38])
-	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95] injectible: [95-95]
-		Arg: a: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: b: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: c: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: d: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: e: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: f: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: g: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: h: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: i: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: j: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: k: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: l: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: m: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: n: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: o: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: p: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: q: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: r: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: s: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: t: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: u: [3]uint32 (declared at line 94, available: [95-95])
-	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18] injectible: [18-18]
-		Arg: a: uint8 (declared at line 15, available: [18-18])
-		Arg: b: uint8 (declared at line 15, available: [18-18])
-		Arg: c: uint8 (declared at line 15, available: [18-18])
-		Arg: d: uint8 (declared at line 15, available: [18-18])
-		Arg: e: uint8 (declared at line 15, available: [18-18])
-		Arg: f: uint8 (declared at line 15, available: [18-18])
-		Arg: g: uint8 (declared at line 15, available: [18-18])
-		Arg: h: uint8 (declared at line 16, available: [18-18])
-		Arg: i: uint8 (declared at line 16, available: [18-18])
-		Arg: j: uint8 (declared at line 16, available: [18-18])
-		Arg: k: uint8 (declared at line 16, available: [18-18])
-		Arg: l: uint8 (declared at line 16, available: [18-18])
-		Arg: m: uint8 (declared at line 16, available: [18-18])
-		Arg: n: uint8 (declared at line 16, available: [18-18])
-		Arg: o: uint8 (declared at line 17, available: [18-18])
-		Arg: p: uint8 (declared at line 17, available: [18-18])
-		Arg: q: uint8 (declared at line 17, available: )
-		Arg: r: uint8 (declared at line 17, available: )
-		Arg: s: uint8 (declared at line 17, available: )
-		Arg: t: uint8 (declared at line 17, available: )
-		Arg: u: uint8 (declared at line 17, available: )
-	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51] injectible: [51-51]
-		Arg: a: *main.node (declared at line 51, available: [51-51])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [114:114] injectible: [114-114]
+		Arg: x: *main.anotherStruct (declared at line 114, available: [114-114])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [106:106] injectible: [106-106]
+		Arg: x: []uint8 (declared at line 106, available: [106-106])
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [104:104] injectible: [104-104]
+		Arg: z: *bool (declared at line 104, available: [104-104])
+		Arg: a: uint (declared at line 104, available: [104-104])
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [66:66] injectible: [66-66]
+		Arg: xs: []uint16 (declared at line 66, available: [66-66])
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [54:54] injectible: [54-54]
+		Arg: xs: []main.structWithNoStrings (declared at line 54, available: [54-54])
+		Arg: a: int (declared at line 54, available: [54-54])
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [62:62] injectible: [62-62]
+		Arg: a: int8 (declared at line 62, available: [62-62])
+		Arg: s: []bool (declared at line 62, available: [62-62])
+		Arg: x: uint (declared at line 62, available: [62-62])
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [76:76] injectible: [76-76]
+		Arg: z: uint (declared at line 76, available: [76-76])
+		Arg: x: *main.nStruct (declared at line 76, available: [76-76])
+		Arg: a: int (declared at line 76, available: [76-76])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [106:106] injectible: [106-106]
+		Arg: c: main.cStruct (declared at line 106, available: [106-106])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [98:98] injectible: [98-98]
+		Arg: x: main.nStruct (declared at line 98, available: [98-98])
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [43:43] injectible: [43-43]
+		Arg: a: *main.oneStringStruct (declared at line 43, available: [43-43])
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [101:101] injectible: [101-101]
+		Arg: a: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: b: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: c: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: d: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: e: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: f: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: g: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: h: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: i: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: j: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: k: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: l: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: m: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: n: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: o: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: p: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: q: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: r: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: s: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: t: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: u: [3]uint32 (declared at line 100, available: [101-101])
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [24:24] injectible: [24-24]
+		Arg: a: uint8 (declared at line 21, available: [24-24])
+		Arg: b: uint8 (declared at line 21, available: [24-24])
+		Arg: c: uint8 (declared at line 21, available: [24-24])
+		Arg: d: uint8 (declared at line 21, available: [24-24])
+		Arg: e: uint8 (declared at line 21, available: [24-24])
+		Arg: f: uint8 (declared at line 21, available: [24-24])
+		Arg: g: uint8 (declared at line 21, available: [24-24])
+		Arg: h: uint8 (declared at line 22, available: [24-24])
+		Arg: i: uint8 (declared at line 22, available: [24-24])
+		Arg: j: uint8 (declared at line 22, available: [24-24])
+		Arg: k: uint8 (declared at line 22, available: [24-24])
+		Arg: l: uint8 (declared at line 22, available: [24-24])
+		Arg: m: uint8 (declared at line 22, available: [24-24])
+		Arg: n: uint8 (declared at line 22, available: [24-24])
+		Arg: o: uint8 (declared at line 23, available: [24-24])
+		Arg: p: uint8 (declared at line 23, available: [24-24])
+		Arg: q: uint8 (declared at line 23, available: )
+		Arg: r: uint8 (declared at line 23, available: )
+		Arg: s: uint8 (declared at line 23, available: )
+		Arg: t: uint8 (declared at line 23, available: )
+		Arg: u: uint8 (declared at line 23, available: )
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [56:56] injectible: [56-56]
+		Arg: a: *main.node (declared at line 56, available: [56-56])
 	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [46:46] injectible: [46-46]
 		Arg: m: *map[string]int (declared at line 46, available: [46-46])
-	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103] injectible: [103-103]
-		Arg: u: **int (declared at line 103, available: [103-103])
-	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38] injectible: [38-38]
-		Arg: a: *main.structWithTwoValues (declared at line 38, available: [38-38])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76] injectible: [76-76]
-		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
-		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [108:108] injectible: [108-108]
+		Arg: u: **int (declared at line 108, available: [108-108])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [43:43] injectible: [43-43]
+		Arg: a: *main.structWithTwoValues (declared at line 43, available: [43-43])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [82:82] injectible: [82-82]
+		Arg: s: *main.structWithASlice (declared at line 82, available: [82-82])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [86:86] injectible: [86-86]
+		Arg: s: *main.structWithAString (declared at line 86, available: [86-86])
 	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
 		Arg: v: interface {} (declared at line 60, available: [60-72])
 		Arg: ~r0: interface {} (declared at line 60, available: )
@@ -1308,44 +1341,44 @@ Package: main
 	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
 		Arg: ~r0: main.wideStruct (declared at line 225, available: )
 		Arg: ~r0: main.wideStruct (declared at line 225, available: )
-	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
-		Arg: x: [2]int32 (declared at line 18, available: [18-18])
-	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
-		Arg: x: bool (declared at line 19, available: [19-19])
-	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11] injectible: [11-11]
-		Arg: x: uint8 (declared at line 11, available: [11-11])
-	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63] injectible: [63-63]
-		Arg: x: float32 (declared at line 63, available: [63-63])
-	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67] injectible: [67-67]
-		Arg: x: float64 (declared at line 67, available: [67-67])
-	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23] injectible: [23-23]
-		Arg: x: int (declared at line 23, available: [23-23])
-	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31] injectible: [31-31]
-		Arg: x: int16 (declared at line 31, available: [31-31])
-	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35] injectible: [35-35]
-		Arg: x: int32 (declared at line 35, available: [35-35])
-	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39] injectible: [39-39]
-		Arg: x: int64 (declared at line 39, available: [39-39])
-	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27] injectible: [27-27]
-		Arg: x: int8 (declared at line 27, available: [27-27])
-	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15] injectible: [15-15]
-		Arg: x: int32 (declared at line 15, available: [15-15])
-	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [12:12] injectible: [12-12]
-		Arg: x: string (declared at line 12, available: [12-12])
-	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43] injectible: [43-43]
-		Arg: x: uint (declared at line 43, available: [43-43])
-	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51] injectible: [51-51]
-		Arg: x: uint16 (declared at line 51, available: [51-51])
-	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55] injectible: [55-55]
-		Arg: x: uint32 (declared at line 55, available: [55-55])
-	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59] injectible: [59-59]
-		Arg: x: uint64 (declared at line 59, available: [59-59])
-	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47] injectible: [47-47]
-		Arg: x: uint8 (declared at line 47, available: [47-47])
-	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [69:69] injectible: [69-69]
-		Arg: xs: []struct {} (declared at line 69, available: [69-69])
-	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37] injectible: [37-37]
-		Arg: u: [][]uint (declared at line 37, available: [37-37])
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [24:24] injectible: [24-24]
+		Arg: x: [2]int32 (declared at line 24, available: [24-24])
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [25:25] injectible: [25-25]
+		Arg: x: bool (declared at line 25, available: [25-25])
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [17:17] injectible: [17-17]
+		Arg: x: uint8 (declared at line 17, available: [17-17])
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [69:69] injectible: [69-69]
+		Arg: x: float32 (declared at line 69, available: [69-69])
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
+		Arg: x: float64 (declared at line 73, available: [73-73])
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [29:29] injectible: [29-29]
+		Arg: x: int (declared at line 29, available: [29-29])
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [37:37] injectible: [37-37]
+		Arg: x: int16 (declared at line 37, available: [37-37])
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [41:41] injectible: [41-41]
+		Arg: x: int32 (declared at line 41, available: [41-41])
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [45:45] injectible: [45-45]
+		Arg: x: int64 (declared at line 45, available: [45-45])
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [33:33] injectible: [33-33]
+		Arg: x: int8 (declared at line 33, available: [33-33])
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [21:21] injectible: [21-21]
+		Arg: x: int32 (declared at line 21, available: [21-21])
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [17:17] injectible: [17-17]
+		Arg: x: string (declared at line 17, available: [17-17])
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [49:49] injectible: [49-49]
+		Arg: x: uint (declared at line 49, available: [49-49])
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [57:57] injectible: [57-57]
+		Arg: x: uint16 (declared at line 57, available: [57-57])
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [61:61] injectible: [61-61]
+		Arg: x: uint32 (declared at line 61, available: [61-61])
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [65:65] injectible: [65-65]
+		Arg: x: uint64 (declared at line 65, available: [65-65])
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [53:53] injectible: [53-53]
+		Arg: x: uint8 (declared at line 53, available: [53-53])
+	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [74:74] injectible: [74-74]
+		Arg: xs: []struct {} (declared at line 74, available: [74-74])
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [42:42] injectible: [42-42]
+		Arg: u: [][]uint (declared at line 42, available: [42-42])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
 	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
@@ -1358,120 +1391,120 @@ Package: main
 		Arg: ~r0: int (declared at line 356, available: )
 		Arg: ~r1: int (declared at line 356, available: )
 		Arg: ~r2: int (declared at line 356, available: )
-	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
-		Arg: x: [2]string (declared at line 22, available: [22-22])
-	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
-		Arg: z: *string (declared at line 91, available: [91-91])
-	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53] injectible: [53-53]
-		Arg: s: []string (declared at line 53, available: [53-53])
-	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95] injectible: [95-95]
-		Arg: a: *[]string (declared at line 95, available: [95-95])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
-		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
-		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
-		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
-		Arg: x: main.aStruct (declared at line 84, available: [84-84])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]
-		Arg: w: uint8 (declared at line 104, available: [104-104])
-		Arg: x: main.aStruct (declared at line 104, available: [104-104])
-	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67] injectible: [67-67]
-		Arg: x: *main.nStruct (declared at line 67, available: [67-67])
-	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41] injectible: [41-41]
-		Arg: xs: []main.structWithNoStrings (declared at line 41, available: [41-41])
-		Arg: a: int (declared at line 41, available: [41-41])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72] injectible: [72-72]
-		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64] injectible: [64-64]
-		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68] injectible: [68-68]
-		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [28:28] injectible: [28-28]
+		Arg: x: [2]string (declared at line 28, available: [28-28])
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [96:96] injectible: [96-96]
+		Arg: z: *string (declared at line 96, available: [96-96])
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [58:58] injectible: [58-58]
+		Arg: s: []string (declared at line 58, available: [58-58])
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [100:100] injectible: [100-100]
+		Arg: a: *[]string (declared at line 100, available: [100-100])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [122:122] injectible: [122-122]
+		Arg: t: main.threestrings (declared at line 122, available: [122-122])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [217:217] injectible: [217-217]
+		Arg: a: *main.stringType1 (declared at line 217, available: [217-217])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:223] injectible: [223-223]
+		Arg: a: **main.stringType2 (declared at line 223, available: [223-223])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [90:90] injectible: [90-90]
+		Arg: x: main.aStruct (declared at line 90, available: [90-90])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [110:110] injectible: [110-110]
+		Arg: w: uint8 (declared at line 110, available: [110-110])
+		Arg: x: main.aStruct (declared at line 110, available: [110-110])
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [72:72] injectible: [72-72]
+		Arg: x: *main.nStruct (declared at line 72, available: [72-72])
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [46:46] injectible: [46-46]
+		Arg: xs: []main.structWithNoStrings (declared at line 46, available: [46-46])
+		Arg: a: int (declared at line 46, available: [46-46])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [78:78] injectible: [78-78]
+		Arg: s: main.structWithASlice (declared at line 78, available: [78-78])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [70:70] injectible: [70-70]
+		Arg: s: main.structWithASlice (declared at line 70, available: [70-70])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [74:74] injectible: [74-74]
+		Arg: s: main.structWithASlice (declared at line 74, available: [74-74])
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73] injectible: [73-73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
-		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [66:66] injectible: [66-66]
+		Arg: a: main.structWithAnArray (declared at line 66, available: [66-66])
 	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
 		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
 		Arg: ~r0: int (declared at line 372, available: )
 		Arg: ~r1: main.structWithArray (declared at line 372, available: )
 		Var: x: int (declared at line 374, available: [372-379])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
-		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
-	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
-		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
-	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31] injectible: [31-31]
-		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [94:94] injectible: [94-94]
+		Arg: s: main.structWithTwoArrays (declared at line 94, available: [94-94])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [50:50] injectible: [50-50]
+		Arg: a: main.structWithCyclicMaps (declared at line 50, available: [50-50])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [37:37] injectible: [37-37]
+		Arg: a: main.structWithCyclicSlices (declared at line 37, available: [37-37])
 	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18] injectible: [18-18]
 		Arg: s: main.structWithMap (declared at line 18, available: [18-18])
-	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79] injectible: [79-79]
-		Arg: x: main.structWithPointer (declared at line 79, available: [79-79])
-	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87] injectible: [87-87]
-		Arg: z: main.spws (declared at line 87, available: [87-87])
-	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83] injectible: [83-83]
-		Arg: b: main.swsp (declared at line 83, available: [83-83])
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48] injectible: [48-48]
-		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
-	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [73:73] injectible: [73-73]
-		Arg: as: []uint (declared at line 73, available: [73-73])
-		Arg: bs: []uint (declared at line 73, available: [73-73])
-		Arg: cs: []uint (declared at line 73, available: [73-73])
-	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [54:54] injectible: [54-54]
-		Arg: a: string (declared at line 54, available: [54-54])
-		Arg: b: string (declared at line 54, available: [54-54])
-		Arg: c: string (declared at line 54, available: [54-54])
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [84:84] injectible: [84-84]
+		Arg: x: main.structWithPointer (declared at line 84, available: [84-84])
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [92:92] injectible: [92-92]
+		Arg: z: main.spws (declared at line 92, available: [92-92])
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [88:88] injectible: [88-88]
+		Arg: b: main.swsp (declared at line 88, available: [88-88])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [54:54] injectible: [54-54]
+		Arg: a: main.hasUnsupportedFields (declared at line 54, available: [54-54])
+	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [78:78] injectible: [78-78]
+		Arg: as: []uint (declared at line 78, available: [78-78])
+		Arg: bs: []uint (declared at line 78, available: [78-78])
+		Arg: cs: []uint (declared at line 78, available: [78-78])
+	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [59:59] injectible: [59-59]
+		Arg: a: string (declared at line 59, available: [59-59])
+		Arg: b: string (declared at line 59, available: [59-59])
+		Arg: c: string (declared at line 59, available: [59-59])
 	Function: testTakeContext (main.testTakeContext) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [24:24] injectible: [24-24]
 		Arg: ctx: context.Context (declared at line 22, available: [24-24])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112] injectible: [112-112]
-		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
-	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [16:16] injectible: [16-16]
-		Arg: x: string (declared at line 16, available: [16-16])
-		Arg: y: string (declared at line 16, available: [16-16])
-		Arg: z: string (declared at line 16, available: [16-16])
-	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [30:30] injectible: [30-30]
-		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
-	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
-		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
-		Arg: x: time.Time (declared at line 31, available: [31-31])
-	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
-		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
-	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
-		Arg: x: time.Time (declared at line 27, available: [27-27])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
-	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
-		Arg: a: []uint8 (declared at line 113, available: [113-113])
-		Arg: b: []uint8 (declared at line 113, available: [113-113])
-	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
-		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
-	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
-		Arg: x: [2]uint16 (declared at line 58, available: [58-58])
-	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62] injectible: [62-62]
-		Arg: x: [2]uint32 (declared at line 62, available: [62-62])
-	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66] injectible: [66-66]
-		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
-	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
-		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
-	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
-		Arg: x: []uint8 (declared at line 105, available: [105-105])
-	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
-		Arg: x: []uint8 (declared at line 109, available: [109-109])
-	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
-		Arg: x: [2]uint (declared at line 50, available: [50-50])
-	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]
-		Arg: x: *uint (declared at line 63, available: [63-63])
-	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29] injectible: [29-29]
-		Arg: u: []uint (declared at line 29, available: [29-29])
-	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [46:46] injectible: [46-46]
-		Arg: x: string (declared at line 46, available: [46-46])
-	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55] injectible: [55-55]
-		Arg: x: unsafe.Pointer (declared at line 55, available: [55-55])
-	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [99:99] injectible: [99-99]
-		Arg: a: [100]uint (declared at line 99, available: [99-99])
-	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
-		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [118:118] injectible: [118-118]
+		Arg: x: main.tenStrings (declared at line 118, available: [118-118])
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [21:21] injectible: [21-21]
+		Arg: x: string (declared at line 21, available: [21-21])
+		Arg: y: string (declared at line 21, available: [21-21])
+		Arg: z: string (declared at line 21, available: [21-21])
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [35:35] injectible: [35-35]
+		Arg: a: main.threeStringStruct (declared at line 35, available: [35-35])
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [39:39] injectible: [39-39]
+		Arg: a: *main.threeStringStruct (declared at line 39, available: [39-39])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [36:36] injectible: [36-36]
+		Arg: x: time.Time (declared at line 36, available: [36-36])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [40:40] injectible: [40-40]
+		Arg: c: main.timeCapture (declared at line 40, available: [40-40])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [32:32] injectible: [32-32]
+		Arg: x: time.Time (declared at line 32, available: [32-32])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [37:37] injectible: [37-37]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 37, available: [37-37])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [118:118] injectible: [118-118]
+		Arg: a: []uint8 (declared at line 118, available: [118-118])
+		Arg: b: []uint8 (declared at line 118, available: [118-118])
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [79:79] injectible: [79-79]
+		Arg: x: main.typeAlias (declared at line 79, available: [79-79])
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [64:64] injectible: [64-64]
+		Arg: x: [2]uint16 (declared at line 64, available: [64-64])
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [68:68] injectible: [68-68]
+		Arg: x: [2]uint32 (declared at line 68, available: [68-68])
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [72:72] injectible: [72-72]
+		Arg: x: [2]uint64 (declared at line 72, available: [72-72])
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [60:60] injectible: [60-60]
+		Arg: x: [2]uint8 (declared at line 60, available: [60-60])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [110:110] injectible: [110-110]
+		Arg: x: []uint8 (declared at line 110, available: [110-110])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [114:114] injectible: [114-114]
+		Arg: x: []uint8 (declared at line 114, available: [114-114])
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [56:56] injectible: [56-56]
+		Arg: x: [2]uint (declared at line 56, available: [56-56])
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [68:68] injectible: [68-68]
+		Arg: x: *uint (declared at line 68, available: [68-68])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [34:34] injectible: [34-34]
+		Arg: u: []uint (declared at line 34, available: [34-34])
+	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [51:51] injectible: [51-51]
+		Arg: x: string (declared at line 51, available: [51-51])
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [60:60] injectible: [60-60]
+		Arg: x: unsafe.Pointer (declared at line 60, available: [60-60])
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [105:105] injectible: [105-105]
+		Arg: a: [100]uint (declared at line 105, available: [105-105])
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [70:70] injectible: [70-70]
+		Arg: xs: []uint (declared at line 70, available: [70-70])
 	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
 		Arg: a: [0]int (declared at line 385, available: )
 		Arg: b: int (declared at line 385, available: [385-388])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,16 +1,22 @@
 === yield 1 [final=false] ===
 Package: main
-	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
-		Arg: x: []int (declared at line 12, available: [12-12])
-	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
-	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-263], [266-266], [277-277], [280-281], [283-284], [286-287], [289-289], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
-		Var: s: []*string (declared at line 258, available: )
-		Var: str: string (declared at line 257, available: [246-314])
-		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
-		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
-		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
-		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [17:17] injectible: [17-17]
+		Arg: x: []int (declared at line 17, available: [17-17])
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [108:138] injectible: [108-110], [112-126], [128-131], [133-133], [137-138]
+		Arg: ctx: context.Context (declared at line 108, available: [108-110])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 109, available: [110-113])
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [82:104] injectible: [82-84], [86-89], [91-96], [98-104]
+		Arg: ctx: context.Context (declared at line 82, available: [82-84])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-86])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [249:320] injectible: [249-251], [254-258], [263-264], [266-269], [272-272], [283-283], [286-287], [289-290], [292-293], [295-295], [300-300], [302-302], [304-305], [307-308], [310-311], [313-317], [319-320]
+		Arg: ctx: context.Context (declared at line 249, available: [249-251])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 250, available: [251-269])
+		Var: s: []*string (declared at line 264, available: )
+		Var: str: string (declared at line 263, available: [249-320])
+		Var: circ: main.circularReferenceType (declared at line 285, available: [249-320])
+		Var: s1: main.stringType1 (declared at line 313, available: [308-320])
+		Var: s2: main.stringType2 (declared at line 314, available: [308-320])
+		Var: s2p: *main.stringType2 (declared at line 315, available: [308-320])
 	Function: executeContextFuncs (main.executeContextFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [26:33] injectible: [26-27], [29-29], [31-33]
 		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 27, available: [31-32])
 		Var: ctx: context.Context (declared at line 27, available: [31-32])
@@ -20,14 +26,18 @@ Package: main
 		Var: id: uint64 (declared at line 1360, available: [1360-1361])
 	Function: executeContextImplFuncs (main.executeContextImplFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [61:67] injectible: [61-62], [65-67]
 		Var: c: *main.contextImpl (declared at line 62, available: [61-67])
-	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [113:187] injectible: [113-113], [115-184], [186-187]
-		Var: m: main.manyPointers (declared at line 114, available: [113-187])
-	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:50] injectible: [36-36], [39-40], [42-42], [44-45], [47-47], [49-50]
-		Var: ss: []string (declared at line 39, available: [36-50])
-		Scope: 40-44
-			Var: i: int (declared at line 40, available: [40-42], [44-44])
-		Scope: 45-49
-			Var: i: int (declared at line 45, available: [45-49])
+	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [119:196] injectible: [119-121], [124-193], [195-196]
+		Arg: ctx: context.Context (declared at line 119, available: [119-121])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 120, available: [121-121])
+		Var: m: main.manyPointers (declared at line 123, available: [119-196])
+	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [39:56] injectible: [39-41], [45-46], [48-48], [50-51], [53-53], [55-56]
+		Arg: ctx: context.Context (declared at line 39, available: [39-41])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 40, available: [41-45])
+		Var: ss: []string (declared at line 45, available: [39-56])
+		Scope: 46-50
+			Var: i: int (declared at line 46, available: [46-48], [50-50])
+		Scope: 51-55
+			Var: i: int (declared at line 51, available: [51-55])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -82,10 +92,12 @@ Package: main
 		Arg: acc: string (declared at line 340, available: [340-340])
 		Arg: x: string (declared at line 340, available: [340-340])
 		Arg: ~r0: string (declared at line 340, available: )
-	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106] injectible: [97-98], [100-106]
-		Var: x: int (declared at line 99, available: )
-		Var: y: int (declared at line 100, available: [97-106])
-		Var: a: [5]int (declared at line 98, available: [97-106])
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [100:112] injectible: [100-102], [104-104], [106-112]
+		Arg: ctx: context.Context (declared at line 100, available: [100-102])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 101, available: [102-107])
+		Var: x: int (declared at line 105, available: )
+		Var: y: int (declared at line 106, available: [100-112])
+		Var: a: [5]int (declared at line 104, available: [100-112])
 	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124] injectible: [76-82], [88-112], [117-120], [122-122], [124-124]
 		Var: &one: *int (declared at line 95, available: [76-124])
 		Var: &foo: *string (declared at line 98, available: [76-124])
@@ -133,103 +145,121 @@ Package: main
 			Var: i: int (declared at line 210, available: [210-210], [211-212], [214-214])
 			Scope: 210-212
 				Var: key: [4]int (declared at line 211, available: )
-	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
-		Var: x: chan bool (declared at line 52, available: [53-54])
-	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-141], [143-143], [145-145], [147-151], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
-		Var: self: *main.node (declared at line 172, available: [173-177])
-		Var: z: main.spws (declared at line 118, available: )
-		Var: r: string (declared at line 117, available: [112-178])
-		Var: ssaw: main.swsp (declared at line 126, available: [112-178])
-		Var: rct: main.reallyComplexType (declared at line 137, available: [112-178])
-		Var: b: main.node (declared at line 145, available: [112-178])
-		Var: stringSlice: []string (declared at line 162, available: [112-178])
-		Var: up: *int (declared at line 168, available: [112-178])
-		Var: aruint: [2]uint (declared at line 159, available: )
-		Var: n: main.nStruct (declared at line 123, available: )
-		Var: u: int (declared at line 167, available: )
-		Var: u64F: uint64 (declared at line 113, available: )
-		Var: uintToPointTo: uint (declared at line 120, available: )
-		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [92:127] injectible: [92-94], [96-96], [109-123], [127-127]
+		Arg: ctx: context.Context (declared at line 92, available: [92-94])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 93, available: [94-96])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [54:62] injectible: [54-56], [58-62]
+		Arg: ctx: context.Context (declared at line 54, available: [54-56])
+		Var: x: chan bool (declared at line 58, available: [59-60])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 55, available: [56-58])
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [117:186] injectible: [117-119], [121-121], [123-123], [125-125], [128-129], [131-134], [138-140], [142-143], [145-149], [151-151], [153-153], [155-159], [163-163], [165-165], [167-168], [170-171], [173-173], [175-176], [178-178], [180-181], [183-186]
+		Arg: ctx: context.Context (declared at line 117, available: [117-119])
+		Var: z: main.spws (declared at line 126, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 118, available: [119-123])
+		Var: self: *main.node (declared at line 180, available: [181-185])
+		Var: r: string (declared at line 125, available: [117-186])
+		Var: ssaw: main.swsp (declared at line 134, available: [117-186])
+		Var: rct: main.reallyComplexType (declared at line 145, available: [117-186])
+		Var: b: main.node (declared at line 153, available: [117-186])
+		Var: stringSlice: []string (declared at line 170, available: [117-186])
+		Var: up: *int (declared at line 176, available: [117-186])
+		Var: aruint: [2]uint (declared at line 167, available: )
+		Var: n: main.nStruct (declared at line 131, available: )
+		Var: u: int (declared at line 175, available: )
+		Var: u64F: uint64 (declared at line 121, available: )
+		Var: uintToPointTo: uint (declared at line 128, available: )
+		Var: x: main.structWithTwoValues (declared at line 142, available: )
 	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [29:33] injectible: [29-33]
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
-		Var: originalSlice: []int (declared at line 133, available: )
-		Var: s: []uint (declared at line 142, available: )
-		Var: s2: []uint (declared at line 159, available: )
-		Scope: 143-146
-			Var: i: int (declared at line 143, available: [146-146])
-	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
-	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [65:86] injectible: [65-65], [67-72], [75-77], [81-81], [84-86]
-		Var: abc: string (declared at line 66, available: )
-		Var: uninitializedString: string (declared at line 74, available: )
-		Var: s: string (declared at line 80, available: )
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236] injectible: [135-137], [140-140], [142-143], [145-146], [150-150], [152-160], [172-172], [174-174], [177-182], [190-192], [194-195], [198-198], [200-201], [203-206], [208-208], [210-213], [215-216], [219-220], [222-223], [225-226], [228-229], [231-232], [235-236]
-		Var: n: main.nStruct (declared at line 139, available: )
-		Var: ns: main.structWithNoStrings (declared at line 148, available: )
-		Var: cs: main.cStruct (declared at line 149, available: )
-		Var: rcvr: main.receiver (declared at line 197, available: )
-		Var: ts: main.threestrings (declared at line 136, available: [135-236])
-		Var: s: main.aStruct (declared at line 142, available: [135-236])
-		Var: b: main.bStruct (declared at line 145, available: [135-236])
-		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
-		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
-		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
-		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
-		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
-		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
-		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
-	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
-		Var: ist: *time.Location (declared at line 48, available: [49-49])
-	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
-		Arg: x: []int (declared at line 22, available: [22-25])
-	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
-		Arg: f: func(int) (declared at line 28, available: [28-29])
+	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [34:41] injectible: [34-36], [38-41]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [137:189] injectible: [137-139], [141-143], [145-152], [154-158], [160-160], [162-164], [167-168], [170-181], [183-183], [185-185], [187-189]
+		Arg: ctx: context.Context (declared at line 137, available: [137-139])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 138, available: [139-141])
+		Var: originalSlice: []int (declared at line 141, available: )
+		Var: s: []uint (declared at line 150, available: )
+		Var: s2: []uint (declared at line 167, available: )
+		Scope: 151-154
+			Var: i: int (declared at line 151, available: [154-154])
+	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [34:39] injectible: [34-36], [38-39]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [70:94] injectible: [70-72], [75-80], [83-85], [89-89], [92-94]
+		Arg: ctx: context.Context (declared at line 70, available: [70-72])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 71, available: [72-75])
+		Var: abc: string (declared at line 74, available: )
+		Var: uninitializedString: string (declared at line 82, available: )
+		Var: s: string (declared at line 88, available: )
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [141:245] injectible: [141-143], [145-146], [149-149], [151-152], [154-155], [159-159], [161-169], [181-181], [183-183], [186-191], [199-201], [203-204], [207-207], [209-210], [212-215], [217-217], [219-222], [224-225], [228-229], [231-232], [234-235], [237-238], [240-241], [244-245]
+		Arg: ctx: context.Context (declared at line 141, available: [141-143])
+		Var: rcvr: main.receiver (declared at line 206, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 142, available: [143-146])
+		Var: n: main.nStruct (declared at line 148, available: )
+		Var: ns: main.structWithNoStrings (declared at line 157, available: )
+		Var: cs: main.cStruct (declared at line 158, available: )
+		Var: ts: main.threestrings (declared at line 145, available: [141-245])
+		Var: s: main.aStruct (declared at line 151, available: [141-245])
+		Var: b: main.bStruct (declared at line 154, available: [141-245])
+		Var: tenStr: main.tenStrings (declared at line 171, available: [141-245])
+		Var: deep: main.deepStruct1 (declared at line 185, available: [141-245])
+		Var: fields: main.lotsOfFields (declared at line 203, available: [141-245])
+		Var: sta: main.structWithTwoArrays (declared at line 212, available: [141-245])
+		Var: .autotmp_121: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_140: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_147: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_152: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_176: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_183: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_188: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_195: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_201: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_206: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_213: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_219: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_22: [0]main.structWithCyclicSlices (declared at line 229, available: [141-245])
+		Var: .autotmp_224: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_236: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_243: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_248: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_255: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_26: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_261: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_266: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_273: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_279: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_284: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_291: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_298: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_304: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_309: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_31: [0][][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_32: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_34: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_41: [0][][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_42: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_44: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_47: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_51: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_56: [0][][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_57: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_59: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_62: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_66: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_70: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_20: [0]uint8 (declared at line 166, available: [141-245])
+		Var: .autotmp_97: main.emptyStruct (declared at line 199, available: [141-245])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [44:65] injectible: [44-46], [49-50], [56-59], [64-65]
+		Arg: ctx: context.Context (declared at line 44, available: [44-46])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 45, available: [46-49])
+		Var: ist: *time.Location (declared at line 56, available: [57-57])
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [27:30] injectible: [27-30]
+		Arg: x: []int (declared at line 27, available: [27-30])
+	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [31:33] injectible: [31-33]
+		Arg: f: func(int) (declared at line 31, available: [31-32])
 	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [109:119] injectible: [109-115], [117-117], [119-119]
 		Arg: entriesCount: int (declared at line 109, available: [109-119])
 		Arg: ~r0: map[string][]main.structWithMap (declared at line 109, available: )
@@ -264,9 +294,9 @@ Package: main
 		Arg: b: <T> (declared at line 113, available: [113-114])
 		Arg: ~r0: <T> (declared at line 113, available: )
 		Arg: ~r1: <T> (declared at line 113, available: )
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:17] injectible: [17-17]
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -274,11 +304,13 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:50] injectible: [21-21], [26-26], [29-30], [33-33], [35-35], [37-40], [44-48], [50-50]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [22:50] injectible: [22-22], [27-27], [30-31], [34-34], [36-36], [38-41], [44-48], [50-50]
 		Var: ticker: *time.Ticker (declared at line 44, available: [45-45])
-		Var: service: string (declared at line 29, available: [30-33])
+		Var: service: string (declared at line 30, available: [31-34])
+		Var: .autotmp_15: context.backgroundCtx (declared at line 216, available: [22-50])
 		Scope: 45-48
 			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 46, available: [45-48])
+			Var: ctx: context.Context (declared at line 46, available: [47-47])
 	Type: main.Pair[...]
 		Field: Key: <T>
 		Field: Value: <T>
@@ -292,10 +324,10 @@ Package: main
 		Field: Total: float64
 	Type: main.Server
 		Field: name: string
-		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [21:26] injectible: [21-23], [25-26]
-			Arg: s: *main.Server (declared at line 21, available: [21-23])
-			Arg: req: *main.Request (declared at line 21, available: [21-26])
-			Arg: ~r0: error (declared at line 21, available: )
+		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [26:31] injectible: [26-28], [30-31]
+			Arg: s: *main.Server (declared at line 26, available: [26-28])
+			Arg: req: *main.Request (declared at line 26, available: [26-31])
+			Arg: ~r0: error (declared at line 26, available: )
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -610,12 +642,12 @@ Package: main
 		Field: aStringPtr: *string
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52] injectible: [52-52]
-			Arg: r: *main.receiver (declared at line 52, available: [52-52])
-			Arg: a: int (declared at line 52, available: [52-52])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56] injectible: [56-56]
-			Arg: r: main.receiver (declared at line 56, available: [56-56])
-			Arg: a: int (declared at line 56, available: [56-56])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [58:58] injectible: [58-58]
+			Arg: r: *main.receiver (declared at line 58, available: [58-58])
+			Arg: a: int (declared at line 58, available: [58-58])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [62:62] injectible: [62-62]
+			Arg: r: main.receiver (declared at line 62, available: [62-62])
+			Arg: a: int (declared at line 62, available: [62-62])
 	Type: main.score
 	Type: main.secondBehavior
 		Field: i: int
@@ -733,14 +765,14 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
-	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [104:107] injectible: [105-107]
-		Var: i: int (declared at line 106, available: [105-105])
+	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [110:113] injectible: [111-113]
+		Var: i: int (declared at line 112, available: [111-111])
 		Arg: id: int (declared at line 0, available: )
-		Var: p: *main.paddedData (declared at line 105, available: )
-	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [23:28] injectible: [23-26], [28-28]
-		Arg: n: int (declared at line 23, available: [23-28])
-		Arg: ~r0: string (declared at line 23, available: )
-		Var: prefix: string (declared at line 24, available: [25-26], [28-28])
+		Var: p: *main.paddedData (declared at line 111, available: )
+	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [26:31] injectible: [26-29], [31-31]
+		Arg: n: int (declared at line 26, available: [26-31])
+		Arg: ~r0: string (declared at line 26, available: )
+		Var: prefix: string (declared at line 27, available: [28-29], [31-31])
 		Var: ~r0.ptr: *uint8 (declared at line 34, available: )
 		Var: ~r0.len: int (declared at line 34, available: )
 	Function: nestedGeneric[...] (main.nestedGeneric[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [203:203] injectible: [203-203]
@@ -752,20 +784,21 @@ Package: main
 		Arg: items: <T> (declared at line 183, available: [183-184])
 		Arg: pred: <T> (declared at line 183, available: [183-184])
 		Arg: ~r0: <T> (declared at line 183, available: )
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
-		Arg: ~r0: uint64 (declared at line 40, available: )
-		Var: n: uint64 (declared at line 45, available: [44-46])
-		Var: b: []uint8 (declared at line 41, available: [44-45])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [43:49] injectible: [43-49]
+		Arg: ~r0: uint64 (declared at line 43, available: )
+		Var: n: uint64 (declared at line 48, available: [47-49])
+		Var: b: []uint8 (declared at line 44, available: [47-48])
 	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:88] injectible: [52-66], [68-69], [71-73], [75-77], [80-88]
+		Arg: ctx: context.Context (declared at line 52, available: [52-88])
 		Var: it: main.iterExample (declared at line 70, available: [52-88])
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 67, available: [52-88])
-	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
-		Arg: x: []int (declared at line 16, available: [16-17])
-		Arg: ~r0: string (declared at line 16, available: )
-	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14] injectible: [12-14]
-	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20] injectible: [18-20]
-	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25] injectible: [24-25]
-		Arg: ~r0: string (declared at line 24, available: )
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [21:22] injectible: [21-22]
+		Arg: x: []int (declared at line 21, available: [21-22])
+		Arg: ~r0: string (declared at line 21, available: )
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [17:19] injectible: [17-19]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [23:25] injectible: [23-25]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [29-30]
+		Arg: ~r0: string (declared at line 29, available: )
 	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55] injectible: [54-55]
 		Arg: a: interface {} (declared at line 54, available: [54-55])
 		Arg: ~r0: string (declared at line 54, available: )
@@ -775,225 +808,225 @@ Package: main
 	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
 		Arg: arg: [3]int (declared at line 297, available: [297-302])
 		Arg: ~r0: [3]int (declared at line 297, available: )
-	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
-		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
-	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
-		Arg: a: [2][2]int (declared at line 70, available: [70-70])
-	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78] injectible: [78-78]
-		Arg: b: [2][2][2]int (declared at line 78, available: [78-78])
+	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [93:93] injectible: [93-93]
+		Arg: a: [2]struct {} (declared at line 93, available: [93-93])
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [76:76] injectible: [76-76]
+		Arg: a: [2][2]int (declared at line 76, available: [76-76])
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [84:84] injectible: [84-84]
+		Arg: b: [2][2][2]int (declared at line 84, available: [84-84])
 	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [42:42] injectible: [42-42]
 		Arg: m: [2]map[string]int (declared at line 42, available: [42-42])
-	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74] injectible: [74-74]
-		Arg: a: [2]string (declared at line 74, available: [74-74])
-	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83] injectible: [83-83]
-		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
-	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
-		Arg: x: *[2]uint (declared at line 59, available: [59-59])
-	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
-		Arg: x: uint64 (declared at line 19, available: [23-23])
-		Arg: ~r0: uint64 (declared at line 19, available: )
-	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
-		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
-	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
-		Arg: x: [2]bool (declared at line 26, available: [26-26])
-	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
-		Arg: a: []uint8 (declared at line 117, available: [117-117])
-		Arg: b: []uint8 (declared at line 117, available: [117-117])
-	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
-		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
-		Arg: a: []uint8 (declared at line 129, available: [129-129])
-		Arg: b: []int (declared at line 129, available: [129-129])
-	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
-		Arg: x: []uint8 (declared at line 77, available: [77-77])
-	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
-		Arg: x: []uint8 (declared at line 81, available: [81-81])
-	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
-		Arg: x: []uint8 (declared at line 85, available: [85-85])
-	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
-		Arg: x: []uint8 (declared at line 89, available: [89-89])
-	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
-		Arg: x: []uint8 (declared at line 93, available: [93-93])
-	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
-		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
-	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
-		Arg: a: int (declared at line 125, available: [125-125])
-		Arg: x: []uint8 (declared at line 125, available: [125-125])
-		Arg: b: string (declared at line 125, available: [125-125])
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [80:80] injectible: [80-80]
+		Arg: a: [2]string (declared at line 80, available: [80-80])
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [89:89] injectible: [89-89]
+		Arg: a: [2]main.nestedStruct (declared at line 88, available: [89-89])
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [64:64] injectible: [64-64]
+		Arg: x: *[2]uint (declared at line 64, available: [64-64])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [26:26] injectible: [26-26]
+		Arg: x: uint64 (declared at line 22, available: [26-26])
+		Arg: ~r0: uint64 (declared at line 22, available: )
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [85:85] injectible: [85-85]
+		Arg: b: main.bigStruct (declared at line 85, available: [85-85])
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [32:32] injectible: [32-32]
+		Arg: x: [2]bool (declared at line 32, available: [32-32])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [122:122] injectible: [122-122]
+		Arg: a: []uint8 (declared at line 122, available: [122-122])
+		Arg: b: []uint8 (declared at line 122, available: [122-122])
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [20:20] injectible: [20-20]
+		Arg: x: [2]uint8 (declared at line 20, available: [20-20])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [134:134] injectible: [134-134]
+		Arg: a: []uint8 (declared at line 134, available: [134-134])
+		Arg: b: []int (declared at line 134, available: [134-134])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [82:82] injectible: [82-82]
+		Arg: x: []uint8 (declared at line 82, available: [82-82])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [86:86] injectible: [86-86]
+		Arg: x: []uint8 (declared at line 86, available: [86-86])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [90:90] injectible: [90-90]
+		Arg: x: []uint8 (declared at line 90, available: [90-90])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [94:94] injectible: [94-94]
+		Arg: x: []uint8 (declared at line 94, available: [94-94])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [98:98] injectible: [98-98]
+		Arg: x: []uint8 (declared at line 98, available: [98-98])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [126:126] injectible: [126-126]
+		Arg: x: [][]uint8 (declared at line 126, available: [126-126])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [130:130] injectible: [130-130]
+		Arg: a: int (declared at line 130, available: [130-130])
+		Arg: x: []uint8 (declared at line 130, available: [130-130])
+		Arg: b: string (declared at line 130, available: [130-130])
 	Function: testCaptureContextImpl (main.testCaptureContextImpl) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [44:44] injectible: [44-44]
 		Arg: c: *main.contextImpl (declared at line 44, available: [44-44])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
-		Arg: c: chan bool (declared at line 30, available: [30-30])
-	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
-		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
-	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
-		Arg: w: uint8 (declared at line 34, available: [34-34])
-		Arg: x: bool (declared at line 34, available: [34-34])
-		Arg: y: float32 (declared at line 34, available: [34-34])
-	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22] injectible: [22-22]
-		Arg: w: uint8 (declared at line 22, available: [22-22])
-		Arg: x: uint8 (declared at line 22, available: [22-22])
-		Arg: y: float32 (declared at line 22, available: [22-22])
-	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38] injectible: [38-38]
-		Arg: w: uint8 (declared at line 38, available: [38-38])
-		Arg: x: int (declared at line 38, available: [38-38])
-		Arg: y: float32 (declared at line 38, available: [38-38])
-	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46] injectible: [46-46]
-		Arg: w: uint8 (declared at line 46, available: [46-46])
-		Arg: x: int16 (declared at line 46, available: [46-46])
-		Arg: y: float32 (declared at line 46, available: [46-46])
-	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50] injectible: [50-50]
-		Arg: w: uint8 (declared at line 50, available: [50-50])
-		Arg: x: int32 (declared at line 50, available: [50-50])
-		Arg: y: float32 (declared at line 50, available: [50-50])
-	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54] injectible: [54-54]
-		Arg: w: uint8 (declared at line 54, available: [54-54])
-		Arg: x: int64 (declared at line 54, available: [54-54])
-		Arg: y: float32 (declared at line 54, available: [54-54])
-	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42] injectible: [42-42]
-		Arg: w: uint8 (declared at line 42, available: [42-42])
-		Arg: x: int8 (declared at line 42, available: [42-42])
-		Arg: y: float32 (declared at line 42, available: [42-42])
-	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26] injectible: [26-26]
-		Arg: w: uint8 (declared at line 26, available: [26-26])
-		Arg: x: int32 (declared at line 26, available: [26-26])
-		Arg: y: float32 (declared at line 26, available: [26-26])
-	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30] injectible: [30-30]
-		Arg: w: uint8 (declared at line 30, available: [30-30])
-		Arg: x: string (declared at line 30, available: [30-30])
-		Arg: y: float32 (declared at line 30, available: [30-30])
-	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58] injectible: [58-58]
-		Arg: w: uint8 (declared at line 58, available: [58-58])
-		Arg: x: uint (declared at line 58, available: [58-58])
-		Arg: y: float32 (declared at line 58, available: [58-58])
-	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66] injectible: [66-66]
-		Arg: w: uint8 (declared at line 66, available: [66-66])
-		Arg: x: uint16 (declared at line 66, available: [66-66])
-		Arg: y: float32 (declared at line 66, available: [66-66])
-	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70] injectible: [70-70]
-		Arg: w: uint8 (declared at line 70, available: [70-70])
-		Arg: x: uint32 (declared at line 70, available: [70-70])
-		Arg: y: float32 (declared at line 70, available: [70-70])
-	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74] injectible: [74-74]
-		Arg: w: uint8 (declared at line 74, available: [74-74])
-		Arg: x: uint64 (declared at line 74, available: [74-74])
-		Arg: y: float32 (declared at line 74, available: [74-74])
-	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62] injectible: [62-62]
-		Arg: w: uint8 (declared at line 62, available: [62-62])
-		Arg: x: uint8 (declared at line 62, available: [62-62])
-		Arg: y: float32 (declared at line 62, available: [62-62])
-	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75] injectible: [75-75]
-		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [33:33] injectible: [33-33]
+		Arg: c: chan bool (declared at line 33, available: [33-33])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93] injectible: [93-93]
+		Arg: x: main.circularReferenceType (declared at line 93, available: [93-93])
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [40:40] injectible: [40-40]
+		Arg: w: uint8 (declared at line 40, available: [40-40])
+		Arg: x: bool (declared at line 40, available: [40-40])
+		Arg: y: float32 (declared at line 40, available: [40-40])
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [28:28] injectible: [28-28]
+		Arg: w: uint8 (declared at line 28, available: [28-28])
+		Arg: x: uint8 (declared at line 28, available: [28-28])
+		Arg: y: float32 (declared at line 28, available: [28-28])
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [44:44] injectible: [44-44]
+		Arg: w: uint8 (declared at line 44, available: [44-44])
+		Arg: x: int (declared at line 44, available: [44-44])
+		Arg: y: float32 (declared at line 44, available: [44-44])
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [52:52] injectible: [52-52]
+		Arg: w: uint8 (declared at line 52, available: [52-52])
+		Arg: x: int16 (declared at line 52, available: [52-52])
+		Arg: y: float32 (declared at line 52, available: [52-52])
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [56:56] injectible: [56-56]
+		Arg: w: uint8 (declared at line 56, available: [56-56])
+		Arg: x: int32 (declared at line 56, available: [56-56])
+		Arg: y: float32 (declared at line 56, available: [56-56])
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [60:60] injectible: [60-60]
+		Arg: w: uint8 (declared at line 60, available: [60-60])
+		Arg: x: int64 (declared at line 60, available: [60-60])
+		Arg: y: float32 (declared at line 60, available: [60-60])
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [48:48] injectible: [48-48]
+		Arg: w: uint8 (declared at line 48, available: [48-48])
+		Arg: x: int8 (declared at line 48, available: [48-48])
+		Arg: y: float32 (declared at line 48, available: [48-48])
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [32:32] injectible: [32-32]
+		Arg: w: uint8 (declared at line 32, available: [32-32])
+		Arg: x: int32 (declared at line 32, available: [32-32])
+		Arg: y: float32 (declared at line 32, available: [32-32])
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [36:36] injectible: [36-36]
+		Arg: w: uint8 (declared at line 36, available: [36-36])
+		Arg: x: string (declared at line 36, available: [36-36])
+		Arg: y: float32 (declared at line 36, available: [36-36])
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [64:64] injectible: [64-64]
+		Arg: w: uint8 (declared at line 64, available: [64-64])
+		Arg: x: uint (declared at line 64, available: [64-64])
+		Arg: y: float32 (declared at line 64, available: [64-64])
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [72:72] injectible: [72-72]
+		Arg: w: uint8 (declared at line 72, available: [72-72])
+		Arg: x: uint16 (declared at line 72, available: [72-72])
+		Arg: y: float32 (declared at line 72, available: [72-72])
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [76:76] injectible: [76-76]
+		Arg: w: uint8 (declared at line 76, available: [76-76])
+		Arg: x: uint32 (declared at line 76, available: [76-76])
+		Arg: y: float32 (declared at line 76, available: [76-76])
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [80:80] injectible: [80-80]
+		Arg: w: uint8 (declared at line 80, available: [80-80])
+		Arg: x: uint64 (declared at line 80, available: [80-80])
+		Arg: y: float32 (declared at line 80, available: [80-80])
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [68:68] injectible: [68-68]
+		Arg: w: uint8 (declared at line 68, available: [68-68])
+		Arg: x: uint8 (declared at line 68, available: [68-68])
+		Arg: y: float32 (declared at line 68, available: [68-68])
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [80:80] injectible: [80-80]
+		Arg: z: *main.reallyComplexType (declared at line 80, available: [80-80])
 	Function: testConflictingReturn (main.testConflictingReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [109:111] injectible: [109-111]
 		Arg: i: int (declared at line 109, available: [109-111])
 		Arg: ~r0: int (declared at line 109, available: )
 		Arg: r0: string (declared at line 109, available: )
-	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
-		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
-		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
-		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
-		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
-		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
-		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
-		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
-		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
-	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
-		Arg: x: []uint8 (declared at line 97, available: [97-97])
-	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
-		Arg: u: []uint (declared at line 33, available: [33-33])
-	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
-		Arg: xs: []main.structWithNoStrings (declared at line 45, available: [45-45])
-		Arg: a: int (declared at line 45, available: [45-45])
-	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [50:50] injectible: [50-50]
-		Arg: x: string (declared at line 50, available: [50-50])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124] injectible: [124-124]
-		Arg: e: main.emptyStruct (declared at line 124, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128] injectible: [128-128]
-		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [114:114] injectible: [114-114]
+		Arg: t: *main.t (declared at line 114, available: [114-114])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: main.deepMap1 (declared at line 203, available: [203-203])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [206:206] injectible: [206-206]
+		Arg: a: *main.deepMap7 (declared at line 206, available: [206-206])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: main.deepPtr1 (declared at line 139, available: [139-139])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142] injectible: [142-142]
+		Arg: a: *main.deepPtr7 (declared at line 142, available: [142-142])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: main.deepSlice1 (declared at line 165, available: [165-165])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [168:168] injectible: [168-168]
+		Arg: a: *main.deepSlice7 (declared at line 168, available: [168-168])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [126:126] injectible: [126-126]
+		Arg: t: main.deepStruct1 (declared at line 126, available: [126-126])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [102:102] injectible: [102-102]
+		Arg: x: []uint8 (declared at line 102, available: [102-102])
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [38:38] injectible: [38-38]
+		Arg: u: []uint (declared at line 38, available: [38-38])
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [50:50] injectible: [50-50]
+		Arg: xs: []main.structWithNoStrings (declared at line 50, available: [50-50])
+		Arg: a: int (declared at line 50, available: [50-50])
+	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [55:55] injectible: [55-55]
+		Arg: x: string (declared at line 55, available: [55-55])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [130:130] injectible: [130-130]
+		Arg: e: main.emptyStruct (declared at line 130, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [134:134] injectible: [134-134]
+		Arg: e: *main.emptyStruct (declared at line 134, available: [134-134])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
-	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [108-110], [112-112]
-		Arg: shouldErr: bool (declared at line 101, available: [101-103])
-		Arg: ~r0: int (declared at line 101, available: )
-		Var: x: int (declared at line 106, available: )
-		Var: err: error (declared at line 102, available: [101-112])
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [104:115] injectible: [104-104], [106-107], [111-113], [115-115]
+		Arg: shouldErr: bool (declared at line 104, available: [104-106])
+		Arg: ~r0: int (declared at line 104, available: )
+		Var: x: int (declared at line 109, available: )
+		Var: err: error (declared at line 105, available: [104-115])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
-	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80] injectible: [79-80]
-		Arg: x: int (declared at line 79, available: [79-80])
-		Arg: ~r0: int (declared at line 79, available: )
-	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93] injectible: [92-93]
-		Arg: a: [5]int (declared at line 92, available: [92-93])
-		Arg: ~r0: int (declared at line 92, available: )
-	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [17:19] injectible: [17-19]
-		Arg: x: int (declared at line 17, available: [17-18])
-		Arg: y: int (declared at line 17, available: [17-18])
-	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [21:25] injectible: [21-25]
-		Arg: x: int (declared at line 21, available: [21-25])
-		Arg: y: int (declared at line 21, available: [21-25])
-	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35] injectible: [32-32], [34-35]
-		Arg: x: int (declared at line 32, available: [32-34])
-	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42] injectible: [37-42]
-		Arg: x: int (declared at line 37, available: [37-38])
-		Arg: y: int (declared at line 37, available: [37-39])
-		Var: z: int (declared at line 38, available: [37-42])
-	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46] injectible: [44-46]
-		Arg: x: int (declared at line 44, available: [44-45])
-	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49] injectible: [49-49]
-	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60] injectible: [52-53], [55-56], [58-60]
-		Var: s: int (declared at line 54, available: [55-58])
-		Scope: 55-58
-			Var: i: int (declared at line 55, available: [55-58])
-	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63] injectible: [63-63]
-	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [66:67] injectible: [67-67]
-	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [13:15] injectible: [14-14]
-		Arg: x: int (declared at line 0, available: [13-14])
-	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [74:75] injectible: [75-75]
-		Arg: x: int (declared at line 0, available: [75-75])
-	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:71] injectible: [71-71]
-		Arg: a: [5]int (declared at line 0, available: [71-71])
-	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38] injectible: [38-38]
-		Arg: x: [2]int16 (declared at line 38, available: [38-38])
-	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42] injectible: [42-42]
-		Arg: x: [2]int32 (declared at line 42, available: [42-42])
-	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46] injectible: [46-46]
-		Arg: x: [2]int64 (declared at line 46, available: [46-46])
-	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34] injectible: [34-34]
-		Arg: x: [2]int8 (declared at line 34, available: [34-34])
-	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30] injectible: [30-30]
-		Arg: x: [2]int (declared at line 30, available: [30-30])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [82:83] injectible: [82-83]
+		Arg: x: int (declared at line 82, available: [82-83])
+		Arg: ~r0: int (declared at line 82, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [95:96] injectible: [95-96]
+		Arg: a: [5]int (declared at line 95, available: [95-96])
+		Arg: ~r0: int (declared at line 95, available: )
+	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [20:22] injectible: [20-22]
+		Arg: x: int (declared at line 20, available: [20-21])
+		Arg: y: int (declared at line 20, available: [20-21])
+	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [24:28] injectible: [24-28]
+		Arg: x: int (declared at line 24, available: [24-28])
+		Arg: y: int (declared at line 24, available: [24-28])
+	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [35:38] injectible: [35-35], [37-38]
+		Arg: x: int (declared at line 35, available: [35-37])
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [40:45] injectible: [40-45]
+		Arg: x: int (declared at line 40, available: [40-41])
+		Arg: y: int (declared at line 40, available: [40-42])
+		Var: z: int (declared at line 41, available: [40-45])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [47:49] injectible: [47-49]
+		Arg: x: int (declared at line 47, available: [47-48])
+	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [51:52] injectible: [52-52]
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [55:63] injectible: [55-56], [58-59], [61-63]
+		Var: s: int (declared at line 57, available: [58-61])
+		Scope: 58-61
+			Var: i: int (declared at line 58, available: [58-61])
+	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [65:66] injectible: [66-66]
+	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [69:70] injectible: [70-70]
+	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [16:18] injectible: [17-17]
+		Arg: x: int (declared at line 0, available: [16-17])
+	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [77:78] injectible: [78-78]
+		Arg: x: int (declared at line 0, available: [78-78])
+	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [73:74] injectible: [74-74]
+		Arg: a: [5]int (declared at line 0, available: [74-74])
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [44:44] injectible: [44-44]
+		Arg: x: [2]int16 (declared at line 44, available: [44-44])
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [48:48] injectible: [48-48]
+		Arg: x: [2]int32 (declared at line 48, available: [48-48])
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [52:52] injectible: [52-52]
+		Arg: x: [2]int64 (declared at line 52, available: [52-52])
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [40:40] injectible: [40-40]
+		Arg: x: [2]int8 (declared at line 40, available: [40-40])
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [36:36] injectible: [36-36]
+		Arg: x: [2]int (declared at line 36, available: [36-36])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50] injectible: [50-50]
 		Arg: b: main.behavior (declared at line 50, available: [50-50])
-	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [94:94] injectible: [94-94]
-		Arg: a: int (declared at line 94, available: [94-94])
-		Arg: b: error (declared at line 94, available: [94-94])
-		Arg: c: uint (declared at line 94, available: [94-94])
-	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
-		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [58:58] injectible: [58-58]
-		Arg: a: string (declared at line 58, available: [58-58])
-		Arg: b: string (declared at line 58, available: [58-58])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [97:97] injectible: [97-97]
+		Arg: a: int (declared at line 97, available: [97-97])
+		Arg: b: error (declared at line 97, available: [97-97])
+		Arg: c: uint (declared at line 97, available: [97-97])
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67] injectible: [67-67]
+		Arg: a: main.interfaceComplexityA (declared at line 67, available: [67-67])
+	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [63:63] injectible: [63-63]
+		Arg: a: string (declared at line 63, available: [63-63])
+		Arg: b: string (declared at line 63, available: [63-63])
 	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
 		Arg: arg: main.largeStruct (declared at line 281, available: [281-282])
 		Arg: ~r0: main.largeStruct (declared at line 281, available: )
 		Arg: ~r0: main.largeStruct (declared at line 281, available: )
-	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
-		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
-		Var: s: int (declared at line 224, available: [237-237], [242-242])
-		Var: aPerArch: int (declared at line 228, available: [223-243])
-		Var: b: int (declared at line 229, available: [223-243])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
-		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [47:47] injectible: [47-47]
+		Arg: a: main.node (declared at line 47, available: [47-47])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [226:246] injectible: [226-226], [233-233], [236-237], [239-242], [244-246]
+		Var: s: int (declared at line 227, available: [240-240], [245-245])
+		Var: aPerArch: int (declared at line 231, available: [226-246])
+		Var: b: int (declared at line 232, available: [226-246])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [138:138] injectible: [138-138]
+		Arg: l: main.lotsOfFields (declared at line 138, available: [138-138])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
 		Arg: a: int (declared at line 328, available: [328-330])
 		Arg: b: int (declared at line 328, available: [328-330])
@@ -1005,10 +1038,10 @@ Package: main
 		Arg: h: int (declared at line 328, available: [328-330])
 		Arg: i: int (declared at line 328, available: [328-330])
 		Arg: ~r0: [2]int (declared at line 328, available: )
-	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [102:102] injectible: [102-102]
-		Arg: m: main.manyPointers (declared at line 102, available: [102-102])
-	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [33:33] injectible: [33-33]
-		Arg: ss: []string (declared at line 33, available: [33-33])
+	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [108:108] injectible: [108-108]
+		Arg: m: main.manyPointers (declared at line 108, available: [108-108])
+	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:36] injectible: [36-36]
+		Arg: ss: []string (declared at line 36, available: [36-36])
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -1047,8 +1080,8 @@ Package: main
 		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
 	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70] injectible: [70-70]
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
-	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
-		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [47:47] injectible: [47-47]
+		Arg: x: string (declared at line 47, available: [47-47])
 	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-349]
 		Arg: a: int (declared at line 337, available: [337-349])
 		Arg: b: int (declared at line 337, available: [337-349])
@@ -1061,17 +1094,17 @@ Package: main
 		Arg: s: string (declared at line 337, available: [337-349])
 		Arg: ~r0: main.largeStruct (declared at line 337, available: )
 		Arg: ~r0: main.largeStruct (declared at line 337, available: )
-	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [62:62] injectible: [62-62]
-		Arg: x: string (declared at line 62, available: [62-62])
+	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [67:67] injectible: [67-67]
+		Arg: x: string (declared at line 67, available: [67-67])
 	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
 		Arg: a: [2]int (declared at line 364, available: [364-366])
 		Arg: b: [3]int (declared at line 364, available: [364-366])
 		Arg: ~r0: int (declared at line 364, available: )
 		Arg: ~r1: [2]int (declared at line 364, available: )
-	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
-		Arg: o: main.outer (declared at line 72, available: [72-72])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
-		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [75:75] injectible: [75-75]
+		Arg: o: main.outer (declared at line 75, available: [75-75])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [102:102] injectible: [102-102]
+		Arg: b: main.bStruct (declared at line 102, available: [102-102])
 	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
 		Arg: s1: main.largeStruct (declared at line 308, available: [308-309])
 		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
@@ -1081,99 +1114,99 @@ Package: main
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
 		Arg: result2: int (declared at line 95, available: )
-	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
-		Arg: a: bool (declared at line 78, available: [78-78])
-		Arg: b: uint8 (declared at line 78, available: [78-78])
-		Arg: c: int32 (declared at line 78, available: [78-78])
-		Arg: d: uint (declared at line 78, available: [78-78])
-		Arg: e: string (declared at line 78, available: [78-78])
-	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
-		Arg: a: main.tierA (declared at line 68, available: [68-68])
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [84:84] injectible: [84-84]
+		Arg: a: bool (declared at line 84, available: [84-84])
+		Arg: b: uint8 (declared at line 84, available: [84-84])
+		Arg: c: int32 (declared at line 84, available: [84-84])
+		Arg: d: uint (declared at line 84, available: [84-84])
+		Arg: e: string (declared at line 84, available: [84-84])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71] injectible: [71-71]
+		Arg: a: main.tierA (declared at line 71, available: [71-71])
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
 		Arg: i: int (declared at line 88, available: [88-89])
 		Arg: result: int (declared at line 88, available: )
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
-		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
-	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
-		Arg: x: []uint8 (declared at line 101, available: [101-101])
-	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
-		Arg: z: *bool (declared at line 99, available: [99-99])
-		Arg: a: uint (declared at line 99, available: [99-99])
-	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61] injectible: [61-61]
-		Arg: xs: []uint16 (declared at line 61, available: [61-61])
-	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49] injectible: [49-49]
-		Arg: xs: []main.structWithNoStrings (declared at line 49, available: [49-49])
-		Arg: a: int (declared at line 49, available: [49-49])
-	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57] injectible: [57-57]
-		Arg: a: int8 (declared at line 57, available: [57-57])
-		Arg: s: []bool (declared at line 57, available: [57-57])
-		Arg: x: uint (declared at line 57, available: [57-57])
-	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71] injectible: [71-71]
-		Arg: z: uint (declared at line 71, available: [71-71])
-		Arg: x: *main.nStruct (declared at line 71, available: [71-71])
-		Arg: a: int (declared at line 71, available: [71-71])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100] injectible: [100-100]
-		Arg: c: main.cStruct (declared at line 100, available: [100-100])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92] injectible: [92-92]
-		Arg: x: main.nStruct (declared at line 92, available: [92-92])
-	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [38:38] injectible: [38-38]
-		Arg: a: *main.oneStringStruct (declared at line 38, available: [38-38])
-	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95] injectible: [95-95]
-		Arg: a: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: b: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: c: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: d: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: e: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: f: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: g: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: h: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: i: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: j: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: k: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: l: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: m: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: n: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: o: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: p: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: q: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: r: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: s: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: t: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: u: [3]uint32 (declared at line 94, available: [95-95])
-	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18] injectible: [18-18]
-		Arg: a: uint8 (declared at line 15, available: [18-18])
-		Arg: b: uint8 (declared at line 15, available: [18-18])
-		Arg: c: uint8 (declared at line 15, available: [18-18])
-		Arg: d: uint8 (declared at line 15, available: [18-18])
-		Arg: e: uint8 (declared at line 15, available: [18-18])
-		Arg: f: uint8 (declared at line 15, available: [18-18])
-		Arg: g: uint8 (declared at line 15, available: [18-18])
-		Arg: h: uint8 (declared at line 16, available: [18-18])
-		Arg: i: uint8 (declared at line 16, available: [18-18])
-		Arg: j: uint8 (declared at line 16, available: [18-18])
-		Arg: k: uint8 (declared at line 16, available: [18-18])
-		Arg: l: uint8 (declared at line 16, available: [18-18])
-		Arg: m: uint8 (declared at line 16, available: [18-18])
-		Arg: n: uint8 (declared at line 16, available: [18-18])
-		Arg: o: uint8 (declared at line 17, available: [18-18])
-		Arg: p: uint8 (declared at line 17, available: [18-18])
-		Arg: q: uint8 (declared at line 17, available: )
-		Arg: r: uint8 (declared at line 17, available: )
-		Arg: s: uint8 (declared at line 17, available: )
-		Arg: t: uint8 (declared at line 17, available: )
-		Arg: u: uint8 (declared at line 17, available: )
-	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51] injectible: [51-51]
-		Arg: a: *main.node (declared at line 51, available: [51-51])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [114:114] injectible: [114-114]
+		Arg: x: *main.anotherStruct (declared at line 114, available: [114-114])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [106:106] injectible: [106-106]
+		Arg: x: []uint8 (declared at line 106, available: [106-106])
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [104:104] injectible: [104-104]
+		Arg: z: *bool (declared at line 104, available: [104-104])
+		Arg: a: uint (declared at line 104, available: [104-104])
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [66:66] injectible: [66-66]
+		Arg: xs: []uint16 (declared at line 66, available: [66-66])
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [54:54] injectible: [54-54]
+		Arg: xs: []main.structWithNoStrings (declared at line 54, available: [54-54])
+		Arg: a: int (declared at line 54, available: [54-54])
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [62:62] injectible: [62-62]
+		Arg: a: int8 (declared at line 62, available: [62-62])
+		Arg: s: []bool (declared at line 62, available: [62-62])
+		Arg: x: uint (declared at line 62, available: [62-62])
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [76:76] injectible: [76-76]
+		Arg: z: uint (declared at line 76, available: [76-76])
+		Arg: x: *main.nStruct (declared at line 76, available: [76-76])
+		Arg: a: int (declared at line 76, available: [76-76])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [106:106] injectible: [106-106]
+		Arg: c: main.cStruct (declared at line 106, available: [106-106])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [98:98] injectible: [98-98]
+		Arg: x: main.nStruct (declared at line 98, available: [98-98])
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [43:43] injectible: [43-43]
+		Arg: a: *main.oneStringStruct (declared at line 43, available: [43-43])
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [101:101] injectible: [101-101]
+		Arg: a: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: b: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: c: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: d: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: e: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: f: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: g: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: h: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: i: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: j: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: k: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: l: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: m: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: n: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: o: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: p: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: q: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: r: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: s: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: t: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: u: [3]uint32 (declared at line 100, available: [101-101])
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [24:24] injectible: [24-24]
+		Arg: a: uint8 (declared at line 21, available: [24-24])
+		Arg: b: uint8 (declared at line 21, available: [24-24])
+		Arg: c: uint8 (declared at line 21, available: [24-24])
+		Arg: d: uint8 (declared at line 21, available: [24-24])
+		Arg: e: uint8 (declared at line 21, available: [24-24])
+		Arg: f: uint8 (declared at line 21, available: [24-24])
+		Arg: g: uint8 (declared at line 21, available: [24-24])
+		Arg: h: uint8 (declared at line 22, available: [24-24])
+		Arg: i: uint8 (declared at line 22, available: [24-24])
+		Arg: j: uint8 (declared at line 22, available: [24-24])
+		Arg: k: uint8 (declared at line 22, available: [24-24])
+		Arg: l: uint8 (declared at line 22, available: [24-24])
+		Arg: m: uint8 (declared at line 22, available: [24-24])
+		Arg: n: uint8 (declared at line 22, available: [24-24])
+		Arg: o: uint8 (declared at line 23, available: [24-24])
+		Arg: p: uint8 (declared at line 23, available: [24-24])
+		Arg: q: uint8 (declared at line 23, available: )
+		Arg: r: uint8 (declared at line 23, available: )
+		Arg: s: uint8 (declared at line 23, available: )
+		Arg: t: uint8 (declared at line 23, available: )
+		Arg: u: uint8 (declared at line 23, available: )
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [56:56] injectible: [56-56]
+		Arg: a: *main.node (declared at line 56, available: [56-56])
 	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [46:46] injectible: [46-46]
 		Arg: m: *map[string]int (declared at line 46, available: [46-46])
-	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103] injectible: [103-103]
-		Arg: u: **int (declared at line 103, available: [103-103])
-	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38] injectible: [38-38]
-		Arg: a: *main.structWithTwoValues (declared at line 38, available: [38-38])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76] injectible: [76-76]
-		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
-		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [108:108] injectible: [108-108]
+		Arg: u: **int (declared at line 108, available: [108-108])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [43:43] injectible: [43-43]
+		Arg: a: *main.structWithTwoValues (declared at line 43, available: [43-43])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [82:82] injectible: [82-82]
+		Arg: s: *main.structWithASlice (declared at line 82, available: [82-82])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [86:86] injectible: [86-86]
+		Arg: s: *main.structWithAString (declared at line 86, available: [86-86])
 	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
 		Arg: v: interface {} (declared at line 60, available: [60-72])
 		Arg: ~r0: interface {} (declared at line 60, available: )
@@ -1294,44 +1327,44 @@ Package: main
 	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
 		Arg: ~r0: main.wideStruct (declared at line 225, available: )
 		Arg: ~r0: main.wideStruct (declared at line 225, available: )
-	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
-		Arg: x: [2]int32 (declared at line 18, available: [18-18])
-	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
-		Arg: x: bool (declared at line 19, available: [19-19])
-	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11] injectible: [11-11]
-		Arg: x: uint8 (declared at line 11, available: [11-11])
-	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63] injectible: [63-63]
-		Arg: x: float32 (declared at line 63, available: [63-63])
-	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67] injectible: [67-67]
-		Arg: x: float64 (declared at line 67, available: [67-67])
-	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23] injectible: [23-23]
-		Arg: x: int (declared at line 23, available: [23-23])
-	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31] injectible: [31-31]
-		Arg: x: int16 (declared at line 31, available: [31-31])
-	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35] injectible: [35-35]
-		Arg: x: int32 (declared at line 35, available: [35-35])
-	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39] injectible: [39-39]
-		Arg: x: int64 (declared at line 39, available: [39-39])
-	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27] injectible: [27-27]
-		Arg: x: int8 (declared at line 27, available: [27-27])
-	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15] injectible: [15-15]
-		Arg: x: int32 (declared at line 15, available: [15-15])
-	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [12:12] injectible: [12-12]
-		Arg: x: string (declared at line 12, available: [12-12])
-	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43] injectible: [43-43]
-		Arg: x: uint (declared at line 43, available: [43-43])
-	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51] injectible: [51-51]
-		Arg: x: uint16 (declared at line 51, available: [51-51])
-	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55] injectible: [55-55]
-		Arg: x: uint32 (declared at line 55, available: [55-55])
-	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59] injectible: [59-59]
-		Arg: x: uint64 (declared at line 59, available: [59-59])
-	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47] injectible: [47-47]
-		Arg: x: uint8 (declared at line 47, available: [47-47])
-	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [69:69] injectible: [69-69]
-		Arg: xs: []struct {} (declared at line 69, available: [69-69])
-	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37] injectible: [37-37]
-		Arg: u: [][]uint (declared at line 37, available: [37-37])
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [24:24] injectible: [24-24]
+		Arg: x: [2]int32 (declared at line 24, available: [24-24])
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [25:25] injectible: [25-25]
+		Arg: x: bool (declared at line 25, available: [25-25])
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [17:17] injectible: [17-17]
+		Arg: x: uint8 (declared at line 17, available: [17-17])
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [69:69] injectible: [69-69]
+		Arg: x: float32 (declared at line 69, available: [69-69])
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
+		Arg: x: float64 (declared at line 73, available: [73-73])
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [29:29] injectible: [29-29]
+		Arg: x: int (declared at line 29, available: [29-29])
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [37:37] injectible: [37-37]
+		Arg: x: int16 (declared at line 37, available: [37-37])
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [41:41] injectible: [41-41]
+		Arg: x: int32 (declared at line 41, available: [41-41])
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [45:45] injectible: [45-45]
+		Arg: x: int64 (declared at line 45, available: [45-45])
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [33:33] injectible: [33-33]
+		Arg: x: int8 (declared at line 33, available: [33-33])
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [21:21] injectible: [21-21]
+		Arg: x: int32 (declared at line 21, available: [21-21])
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [17:17] injectible: [17-17]
+		Arg: x: string (declared at line 17, available: [17-17])
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [49:49] injectible: [49-49]
+		Arg: x: uint (declared at line 49, available: [49-49])
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [57:57] injectible: [57-57]
+		Arg: x: uint16 (declared at line 57, available: [57-57])
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [61:61] injectible: [61-61]
+		Arg: x: uint32 (declared at line 61, available: [61-61])
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [65:65] injectible: [65-65]
+		Arg: x: uint64 (declared at line 65, available: [65-65])
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [53:53] injectible: [53-53]
+		Arg: x: uint8 (declared at line 53, available: [53-53])
+	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [74:74] injectible: [74-74]
+		Arg: xs: []struct {} (declared at line 74, available: [74-74])
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [42:42] injectible: [42-42]
+		Arg: u: [][]uint (declared at line 42, available: [42-42])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
 	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
@@ -1344,120 +1377,120 @@ Package: main
 		Arg: ~r0: int (declared at line 356, available: )
 		Arg: ~r1: int (declared at line 356, available: )
 		Arg: ~r2: int (declared at line 356, available: )
-	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
-		Arg: x: [2]string (declared at line 22, available: [22-22])
-	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
-		Arg: z: *string (declared at line 91, available: [91-91])
-	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53] injectible: [53-53]
-		Arg: s: []string (declared at line 53, available: [53-53])
-	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95] injectible: [95-95]
-		Arg: a: *[]string (declared at line 95, available: [95-95])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
-		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
-		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
-		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
-		Arg: x: main.aStruct (declared at line 84, available: [84-84])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]
-		Arg: w: uint8 (declared at line 104, available: [104-104])
-		Arg: x: main.aStruct (declared at line 104, available: [104-104])
-	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67] injectible: [67-67]
-		Arg: x: *main.nStruct (declared at line 67, available: [67-67])
-	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41] injectible: [41-41]
-		Arg: xs: []main.structWithNoStrings (declared at line 41, available: [41-41])
-		Arg: a: int (declared at line 41, available: [41-41])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72] injectible: [72-72]
-		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64] injectible: [64-64]
-		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68] injectible: [68-68]
-		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [28:28] injectible: [28-28]
+		Arg: x: [2]string (declared at line 28, available: [28-28])
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [96:96] injectible: [96-96]
+		Arg: z: *string (declared at line 96, available: [96-96])
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [58:58] injectible: [58-58]
+		Arg: s: []string (declared at line 58, available: [58-58])
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [100:100] injectible: [100-100]
+		Arg: a: *[]string (declared at line 100, available: [100-100])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [122:122] injectible: [122-122]
+		Arg: t: main.threestrings (declared at line 122, available: [122-122])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [217:217] injectible: [217-217]
+		Arg: a: *main.stringType1 (declared at line 217, available: [217-217])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:223] injectible: [223-223]
+		Arg: a: **main.stringType2 (declared at line 223, available: [223-223])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [90:90] injectible: [90-90]
+		Arg: x: main.aStruct (declared at line 90, available: [90-90])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [110:110] injectible: [110-110]
+		Arg: w: uint8 (declared at line 110, available: [110-110])
+		Arg: x: main.aStruct (declared at line 110, available: [110-110])
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [72:72] injectible: [72-72]
+		Arg: x: *main.nStruct (declared at line 72, available: [72-72])
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [46:46] injectible: [46-46]
+		Arg: xs: []main.structWithNoStrings (declared at line 46, available: [46-46])
+		Arg: a: int (declared at line 46, available: [46-46])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [78:78] injectible: [78-78]
+		Arg: s: main.structWithASlice (declared at line 78, available: [78-78])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [70:70] injectible: [70-70]
+		Arg: s: main.structWithASlice (declared at line 70, available: [70-70])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [74:74] injectible: [74-74]
+		Arg: s: main.structWithASlice (declared at line 74, available: [74-74])
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73] injectible: [73-73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
-		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [66:66] injectible: [66-66]
+		Arg: a: main.structWithAnArray (declared at line 66, available: [66-66])
 	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
 		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
 		Arg: ~r0: int (declared at line 372, available: )
 		Arg: ~r1: main.structWithArray (declared at line 372, available: )
 		Var: x: int (declared at line 374, available: [372-379])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
-		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
-	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
-		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
-	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31] injectible: [31-31]
-		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [94:94] injectible: [94-94]
+		Arg: s: main.structWithTwoArrays (declared at line 94, available: [94-94])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [50:50] injectible: [50-50]
+		Arg: a: main.structWithCyclicMaps (declared at line 50, available: [50-50])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [37:37] injectible: [37-37]
+		Arg: a: main.structWithCyclicSlices (declared at line 37, available: [37-37])
 	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18] injectible: [18-18]
 		Arg: s: main.structWithMap (declared at line 18, available: [18-18])
-	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79] injectible: [79-79]
-		Arg: x: main.structWithPointer (declared at line 79, available: [79-79])
-	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87] injectible: [87-87]
-		Arg: z: main.spws (declared at line 87, available: [87-87])
-	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83] injectible: [83-83]
-		Arg: b: main.swsp (declared at line 83, available: [83-83])
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48] injectible: [48-48]
-		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
-	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [73:73] injectible: [73-73]
-		Arg: as: []uint (declared at line 73, available: [73-73])
-		Arg: bs: []uint (declared at line 73, available: [73-73])
-		Arg: cs: []uint (declared at line 73, available: [73-73])
-	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [54:54] injectible: [54-54]
-		Arg: a: string (declared at line 54, available: [54-54])
-		Arg: b: string (declared at line 54, available: [54-54])
-		Arg: c: string (declared at line 54, available: [54-54])
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [84:84] injectible: [84-84]
+		Arg: x: main.structWithPointer (declared at line 84, available: [84-84])
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [92:92] injectible: [92-92]
+		Arg: z: main.spws (declared at line 92, available: [92-92])
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [88:88] injectible: [88-88]
+		Arg: b: main.swsp (declared at line 88, available: [88-88])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [54:54] injectible: [54-54]
+		Arg: a: main.hasUnsupportedFields (declared at line 54, available: [54-54])
+	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [78:78] injectible: [78-78]
+		Arg: as: []uint (declared at line 78, available: [78-78])
+		Arg: bs: []uint (declared at line 78, available: [78-78])
+		Arg: cs: []uint (declared at line 78, available: [78-78])
+	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [59:59] injectible: [59-59]
+		Arg: a: string (declared at line 59, available: [59-59])
+		Arg: b: string (declared at line 59, available: [59-59])
+		Arg: c: string (declared at line 59, available: [59-59])
 	Function: testTakeContext (main.testTakeContext) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [24:24] injectible: [24-24]
 		Arg: ctx: context.Context (declared at line 22, available: [24-24])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112] injectible: [112-112]
-		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
-	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [16:16] injectible: [16-16]
-		Arg: x: string (declared at line 16, available: [16-16])
-		Arg: y: string (declared at line 16, available: [16-16])
-		Arg: z: string (declared at line 16, available: [16-16])
-	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [30:30] injectible: [30-30]
-		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
-	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
-		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
-		Arg: x: time.Time (declared at line 31, available: [31-31])
-	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
-		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
-	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
-		Arg: x: time.Time (declared at line 27, available: [27-27])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
-	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
-		Arg: a: []uint8 (declared at line 113, available: [113-113])
-		Arg: b: []uint8 (declared at line 113, available: [113-113])
-	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
-		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
-	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
-		Arg: x: [2]uint16 (declared at line 58, available: [58-58])
-	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62] injectible: [62-62]
-		Arg: x: [2]uint32 (declared at line 62, available: [62-62])
-	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66] injectible: [66-66]
-		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
-	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
-		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
-	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
-		Arg: x: []uint8 (declared at line 105, available: [105-105])
-	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
-		Arg: x: []uint8 (declared at line 109, available: [109-109])
-	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
-		Arg: x: [2]uint (declared at line 50, available: [50-50])
-	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]
-		Arg: x: *uint (declared at line 63, available: [63-63])
-	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29] injectible: [29-29]
-		Arg: u: []uint (declared at line 29, available: [29-29])
-	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [46:46] injectible: [46-46]
-		Arg: x: string (declared at line 46, available: [46-46])
-	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55] injectible: [55-55]
-		Arg: x: unsafe.Pointer (declared at line 55, available: [55-55])
-	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [99:99] injectible: [99-99]
-		Arg: a: [100]uint (declared at line 99, available: [99-99])
-	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
-		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [118:118] injectible: [118-118]
+		Arg: x: main.tenStrings (declared at line 118, available: [118-118])
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [21:21] injectible: [21-21]
+		Arg: x: string (declared at line 21, available: [21-21])
+		Arg: y: string (declared at line 21, available: [21-21])
+		Arg: z: string (declared at line 21, available: [21-21])
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [35:35] injectible: [35-35]
+		Arg: a: main.threeStringStruct (declared at line 35, available: [35-35])
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [39:39] injectible: [39-39]
+		Arg: a: *main.threeStringStruct (declared at line 39, available: [39-39])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [36:36] injectible: [36-36]
+		Arg: x: time.Time (declared at line 36, available: [36-36])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [40:40] injectible: [40-40]
+		Arg: c: main.timeCapture (declared at line 40, available: [40-40])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [32:32] injectible: [32-32]
+		Arg: x: time.Time (declared at line 32, available: [32-32])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [37:37] injectible: [37-37]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 37, available: [37-37])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [118:118] injectible: [118-118]
+		Arg: a: []uint8 (declared at line 118, available: [118-118])
+		Arg: b: []uint8 (declared at line 118, available: [118-118])
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [79:79] injectible: [79-79]
+		Arg: x: main.typeAlias (declared at line 79, available: [79-79])
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [64:64] injectible: [64-64]
+		Arg: x: [2]uint16 (declared at line 64, available: [64-64])
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [68:68] injectible: [68-68]
+		Arg: x: [2]uint32 (declared at line 68, available: [68-68])
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [72:72] injectible: [72-72]
+		Arg: x: [2]uint64 (declared at line 72, available: [72-72])
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [60:60] injectible: [60-60]
+		Arg: x: [2]uint8 (declared at line 60, available: [60-60])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [110:110] injectible: [110-110]
+		Arg: x: []uint8 (declared at line 110, available: [110-110])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [114:114] injectible: [114-114]
+		Arg: x: []uint8 (declared at line 114, available: [114-114])
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [56:56] injectible: [56-56]
+		Arg: x: [2]uint (declared at line 56, available: [56-56])
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [68:68] injectible: [68-68]
+		Arg: x: *uint (declared at line 68, available: [68-68])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [34:34] injectible: [34-34]
+		Arg: u: []uint (declared at line 34, available: [34-34])
+	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [51:51] injectible: [51-51]
+		Arg: x: string (declared at line 51, available: [51-51])
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [60:60] injectible: [60-60]
+		Arg: x: unsafe.Pointer (declared at line 60, available: [60-60])
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [105:105] injectible: [105-105]
+		Arg: a: [100]uint (declared at line 105, available: [105-105])
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [70:70] injectible: [70-70]
+		Arg: xs: []uint (declared at line 70, available: [70-70])
 	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
 		Arg: a: [0]int (declared at line 385, available: )
 		Arg: b: int (declared at line 385, available: [385-388])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,16 +1,22 @@
 === yield 1 [final=false] ===
 Package: main
-	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
-		Arg: x: []int (declared at line 12, available: [12-12])
-	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
-	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-261], [263-263], [266-266], [277-277], [280-281], [283-284], [286-287], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
-		Var: s: []*string (declared at line 258, available: )
-		Var: str: string (declared at line 257, available: [246-314])
-		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
-		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
-		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
-		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [17:17] injectible: [17-17]
+		Arg: x: []int (declared at line 17, available: [17-17])
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [108:138] injectible: [108-110], [112-126], [128-131], [133-133], [137-138]
+		Arg: ctx: context.Context (declared at line 108, available: [108-110])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 109, available: [110-113])
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [82:104] injectible: [82-84], [86-89], [91-96], [98-104]
+		Arg: ctx: context.Context (declared at line 82, available: [82-84])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-86])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [249:320] injectible: [249-251], [255-258], [263-264], [266-269], [272-272], [283-283], [286-287], [289-290], [292-293], [295-295], [300-300], [302-302], [304-305], [307-308], [310-311], [313-317], [319-320]
+		Arg: ctx: context.Context (declared at line 249, available: [249-251])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 250, available: [251-272])
+		Var: s: []*string (declared at line 264, available: )
+		Var: str: string (declared at line 263, available: [249-320])
+		Var: circ: main.circularReferenceType (declared at line 285, available: [249-320])
+		Var: s1: main.stringType1 (declared at line 313, available: [308-320])
+		Var: s2: main.stringType2 (declared at line 314, available: [308-320])
+		Var: s2p: *main.stringType2 (declared at line 315, available: [308-320])
 	Function: executeContextFuncs (main.executeContextFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [26:33] injectible: [26-27], [29-29], [31-33]
 		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 27, available: [31-32])
 		Var: ctx: context.Context (declared at line 27, available: [31-32])
@@ -19,14 +25,18 @@ Package: main
 		Var: id: uint64 (declared at line 1360, available: [1360-1361])
 	Function: executeContextImplFuncs (main.executeContextImplFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [61:67] injectible: [61-62], [65-67]
 		Var: c: *main.contextImpl (declared at line 62, available: [61-67])
-	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [113:187] injectible: [113-113], [115-184], [186-187]
-		Var: m: main.manyPointers (declared at line 114, available: [113-187])
-	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:50] injectible: [36-36], [39-40], [42-42], [44-45], [47-47], [49-50]
-		Var: ss: []string (declared at line 39, available: [36-50])
-		Scope: 39-44
-			Var: i: int (declared at line 40, available: [40-44])
-		Scope: 45-49
-			Var: i: int (declared at line 45, available: [45-49])
+	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [119:196] injectible: [119-121], [124-193], [195-196]
+		Arg: ctx: context.Context (declared at line 119, available: [119-121])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 120, available: [121-121])
+		Var: m: main.manyPointers (declared at line 123, available: [119-196])
+	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [39:56] injectible: [39-41], [45-46], [48-48], [50-51], [53-53], [55-56]
+		Arg: ctx: context.Context (declared at line 39, available: [39-41])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 40, available: [41-48])
+		Var: ss: []string (declared at line 45, available: [39-56])
+		Scope: 45-50
+			Var: i: int (declared at line 46, available: [46-50])
+		Scope: 51-55
+			Var: i: int (declared at line 51, available: [51-55])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -79,10 +89,12 @@ Package: main
 		Arg: acc: string (declared at line 340, available: [340-340])
 		Arg: x: string (declared at line 340, available: [340-340])
 		Arg: ~r0: string (declared at line 340, available: )
-	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106] injectible: [97-98], [100-106]
-		Var: x: int (declared at line 99, available: )
-		Var: y: int (declared at line 100, available: [97-106])
-		Var: a: [5]int (declared at line 98, available: [97-106])
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [100:112] injectible: [100-102], [104-104], [106-112]
+		Arg: ctx: context.Context (declared at line 100, available: [100-102])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 101, available: [102-107])
+		Var: x: int (declared at line 105, available: )
+		Var: y: int (declared at line 106, available: [100-112])
+		Var: a: [5]int (declared at line 104, available: [100-112])
 	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124] injectible: [76-82], [88-112], [117-120], [122-122], [124-124]
 		Var: &one: *int (declared at line 95, available: [76-124])
 		Var: &foo: *string (declared at line 98, available: [76-124])
@@ -129,103 +141,121 @@ Package: main
 			Var: i: int (declared at line 210, available: [123-219])
 			Scope: 210-212
 				Var: key: [4]int (declared at line 211, available: )
-	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
-		Var: x: chan bool (declared at line 52, available: [53-54])
-	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-140], [143-143], [145-145], [148-150], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
-		Var: self: *main.node (declared at line 172, available: [173-177])
-		Var: z: main.spws (declared at line 118, available: )
-		Var: r: string (declared at line 117, available: [112-178])
-		Var: ssaw: main.swsp (declared at line 126, available: [112-178])
-		Var: rct: main.reallyComplexType (declared at line 137, available: [112-178])
-		Var: b: main.node (declared at line 145, available: [112-178])
-		Var: stringSlice: []string (declared at line 162, available: [112-178])
-		Var: up: *int (declared at line 168, available: [112-178])
-		Var: aruint: [2]uint (declared at line 159, available: )
-		Var: n: main.nStruct (declared at line 123, available: )
-		Var: u: int (declared at line 167, available: )
-		Var: u64F: uint64 (declared at line 113, available: )
-		Var: uintToPointTo: uint (declared at line 120, available: )
-		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [92:127] injectible: [92-94], [96-96], [109-123], [127-127]
+		Arg: ctx: context.Context (declared at line 92, available: [92-94])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 93, available: [94-96])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [54:62] injectible: [54-56], [58-62]
+		Arg: ctx: context.Context (declared at line 54, available: [54-56])
+		Var: x: chan bool (declared at line 58, available: [59-60])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 55, available: [56-58])
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [117:186] injectible: [117-119], [121-121], [123-123], [125-125], [128-129], [131-134], [138-140], [142-143], [145-148], [151-151], [153-153], [156-158], [163-163], [165-165], [167-168], [170-171], [173-173], [175-176], [178-178], [180-181], [183-186]
+		Arg: ctx: context.Context (declared at line 117, available: [117-119])
+		Var: z: main.spws (declared at line 126, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 118, available: [119-123])
+		Var: self: *main.node (declared at line 180, available: [181-185])
+		Var: r: string (declared at line 125, available: [117-186])
+		Var: ssaw: main.swsp (declared at line 134, available: [117-186])
+		Var: rct: main.reallyComplexType (declared at line 145, available: [117-186])
+		Var: b: main.node (declared at line 153, available: [117-186])
+		Var: stringSlice: []string (declared at line 170, available: [117-186])
+		Var: up: *int (declared at line 176, available: [117-186])
+		Var: aruint: [2]uint (declared at line 167, available: )
+		Var: n: main.nStruct (declared at line 131, available: )
+		Var: u: int (declared at line 175, available: )
+		Var: u64F: uint64 (declared at line 121, available: )
+		Var: uintToPointTo: uint (declared at line 128, available: )
+		Var: x: main.structWithTwoValues (declared at line 142, available: )
 	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [29:33] injectible: [29-33]
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
-		Var: originalSlice: []int (declared at line 133, available: )
-		Var: s: []uint (declared at line 142, available: )
-		Var: s2: []uint (declared at line 159, available: )
-		Scope: 143-146
-			Var: i: int (declared at line 143, available: [146-146])
-	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
-	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [65:86] injectible: [65-65], [67-72], [75-77], [81-81], [84-86]
-		Var: abc: string (declared at line 66, available: )
-		Var: uninitializedString: string (declared at line 74, available: )
-		Var: s: string (declared at line 80, available: )
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236] injectible: [135-137], [140-140], [142-143], [145-146], [150-150], [152-160], [172-172], [174-174], [177-182], [190-192], [194-195], [198-198], [200-201], [203-206], [208-208], [210-213], [215-216], [219-220], [222-223], [225-226], [228-229], [231-232], [235-236]
-		Var: n: main.nStruct (declared at line 139, available: )
-		Var: ns: main.structWithNoStrings (declared at line 148, available: )
-		Var: cs: main.cStruct (declared at line 149, available: )
-		Var: rcvr: main.receiver (declared at line 197, available: )
-		Var: ts: main.threestrings (declared at line 136, available: [135-236])
-		Var: s: main.aStruct (declared at line 142, available: [135-236])
-		Var: b: main.bStruct (declared at line 145, available: [135-236])
-		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
-		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
-		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
-		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
-		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
-		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
-		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
-	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
-		Var: ist: *time.Location (declared at line 48, available: [49-50])
-	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
-		Arg: x: []int (declared at line 22, available: [22-23], [24-24], [25-25])
-	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
-		Arg: f: func(int) (declared at line 28, available: [28-29])
+	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [34:41] injectible: [34-36], [38-41]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [137:189] injectible: [137-139], [141-143], [145-152], [154-158], [160-160], [162-164], [167-168], [170-181], [183-183], [185-185], [187-189]
+		Arg: ctx: context.Context (declared at line 137, available: [137-139])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 138, available: [139-141])
+		Var: originalSlice: []int (declared at line 141, available: )
+		Var: s: []uint (declared at line 150, available: )
+		Var: s2: []uint (declared at line 167, available: )
+		Scope: 151-154
+			Var: i: int (declared at line 151, available: [154-154])
+	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [34:39] injectible: [34-36], [38-39]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [70:94] injectible: [70-72], [75-80], [83-85], [89-89], [92-94]
+		Arg: ctx: context.Context (declared at line 70, available: [70-72])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 71, available: [72-75])
+		Var: abc: string (declared at line 74, available: )
+		Var: uninitializedString: string (declared at line 82, available: )
+		Var: s: string (declared at line 88, available: )
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [141:245] injectible: [141-143], [145-146], [149-149], [151-152], [154-155], [159-159], [161-169], [181-181], [183-183], [186-191], [199-201], [203-204], [207-207], [209-210], [212-215], [217-217], [219-222], [224-225], [228-229], [231-232], [234-235], [237-238], [240-241], [244-245]
+		Arg: ctx: context.Context (declared at line 141, available: [141-143])
+		Var: rcvr: main.receiver (declared at line 206, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 142, available: [143-149])
+		Var: n: main.nStruct (declared at line 148, available: )
+		Var: ns: main.structWithNoStrings (declared at line 157, available: )
+		Var: cs: main.cStruct (declared at line 158, available: )
+		Var: ts: main.threestrings (declared at line 145, available: [141-245])
+		Var: s: main.aStruct (declared at line 151, available: [141-245])
+		Var: b: main.bStruct (declared at line 154, available: [141-245])
+		Var: tenStr: main.tenStrings (declared at line 171, available: [141-245])
+		Var: deep: main.deepStruct1 (declared at line 185, available: [141-245])
+		Var: fields: main.lotsOfFields (declared at line 203, available: [141-245])
+		Var: sta: main.structWithTwoArrays (declared at line 212, available: [141-245])
+		Var: .autotmp_121: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_140: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_147: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_152: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_176: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_183: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_188: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_195: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_201: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_206: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_213: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_219: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_22: [0]main.structWithCyclicSlices (declared at line 229, available: [141-245])
+		Var: .autotmp_224: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_236: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_243: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_248: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_255: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_26: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_261: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_266: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_273: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_279: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_284: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_291: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_298: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_304: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_309: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_31: [0][][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_32: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_34: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_41: [0][][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_42: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_44: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_47: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_51: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_56: [0][][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_57: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_59: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_62: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_66: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_70: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_20: [0]uint8 (declared at line 166, available: [141-245])
+		Var: .autotmp_97: main.emptyStruct (declared at line 199, available: [141-245])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [44:65] injectible: [44-46], [49-50], [56-59], [64-65]
+		Arg: ctx: context.Context (declared at line 44, available: [44-46])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 45, available: [46-50])
+		Var: ist: *time.Location (declared at line 56, available: [57-58])
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [27:30] injectible: [27-30]
+		Arg: x: []int (declared at line 27, available: [27-28], [29-29], [30-30])
+	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [31:33] injectible: [31-33]
+		Arg: f: func(int) (declared at line 31, available: [31-32])
 	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [109:119] injectible: [109-115], [117-117], [119-119]
 		Arg: entriesCount: int (declared at line 109, available: [109-119])
 		Arg: ~r0: map[string][]main.structWithMap (declared at line 109, available: )
@@ -260,9 +290,9 @@ Package: main
 		Arg: b: <T> (declared at line 113, available: [113-114])
 		Arg: ~r0: <T> (declared at line 113, available: )
 		Arg: ~r1: <T> (declared at line 113, available: )
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:17] injectible: [17-17]
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -270,11 +300,12 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:50] injectible: [21-21], [26-26], [29-30], [33-33], [35-35], [37-40], [44-48], [50-50]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [22:50] injectible: [22-22], [27-27], [30-31], [34-34], [36-36], [38-41], [44-48], [50-50]
 		Var: ticker: *time.Ticker (declared at line 44, available: [45-45])
-		Var: service: string (declared at line 29, available: [30-33])
+		Var: service: string (declared at line 30, available: [31-34])
 		Scope: 45-48
 			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 46, available: [45-48])
+			Var: ctx: context.Context (declared at line 46, available: [47-47])
 	Type: main.Pair[...]
 		Field: Key: <T>
 		Field: Value: <T>
@@ -288,10 +319,10 @@ Package: main
 		Field: Total: float64
 	Type: main.Server
 		Field: name: string
-		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [21:26] injectible: [21-23], [25-26]
-			Arg: s: *main.Server (declared at line 21, available: [21-23])
-			Arg: req: *main.Request (declared at line 21, available: [21-26])
-			Arg: ~r0: error (declared at line 21, available: )
+		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [26:31] injectible: [26-28], [30-31]
+			Arg: s: *main.Server (declared at line 26, available: [26-28])
+			Arg: req: *main.Request (declared at line 26, available: [26-31])
+			Arg: ~r0: error (declared at line 26, available: )
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [988-989])
@@ -602,12 +633,12 @@ Package: main
 		Field: aStringPtr: *string
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52] injectible: [52-52]
-			Arg: r: *main.receiver (declared at line 52, available: [52-52])
-			Arg: a: int (declared at line 52, available: [52-52])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56] injectible: [56-56]
-			Arg: r: main.receiver (declared at line 56, available: [56-56])
-			Arg: a: int (declared at line 56, available: [56-56])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [58:58] injectible: [58-58]
+			Arg: r: *main.receiver (declared at line 58, available: [58-58])
+			Arg: a: int (declared at line 58, available: [58-58])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [62:62] injectible: [62-62]
+			Arg: r: main.receiver (declared at line 62, available: [62-62])
+			Arg: a: int (declared at line 62, available: [62-62])
 	Type: main.score
 	Type: main.secondBehavior
 		Field: i: int
@@ -725,14 +756,14 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
-	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [104:107] injectible: [105-107]
-		Var: i: int (declared at line 106, available: [105-105])
-		Arg: id: int (declared at line 0, available: [105-107])
-		Var: p: *main.paddedData (declared at line 105, available: )
-	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [23:28] injectible: [23-26], [28-28]
-		Arg: n: int (declared at line 23, available: [23-28])
-		Arg: ~r0: string (declared at line 23, available: )
-		Var: prefix: string (declared at line 24, available: [25-26], [28-28])
+	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [110:113] injectible: [111-113]
+		Var: i: int (declared at line 112, available: [111-111])
+		Arg: id: int (declared at line 0, available: )
+		Var: p: *main.paddedData (declared at line 111, available: )
+	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [26:31] injectible: [26-29], [31-31]
+		Arg: n: int (declared at line 26, available: [26-31])
+		Arg: ~r0: string (declared at line 26, available: )
+		Var: prefix: string (declared at line 27, available: [28-29], [31-31])
 		Var: ~r0.ptr: *uint8 (declared at line 34, available: )
 		Var: ~r0.len: int (declared at line 34, available: )
 	Function: nestedGeneric[...] (main.nestedGeneric[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [203:203] injectible: [203-203]
@@ -744,20 +775,21 @@ Package: main
 		Arg: items: <T> (declared at line 183, available: [183-184])
 		Arg: pred: <T> (declared at line 183, available: [183-184])
 		Arg: ~r0: <T> (declared at line 183, available: )
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
-		Arg: ~r0: uint64 (declared at line 40, available: )
-		Var: n: uint64 (declared at line 45, available: [44-46])
-		Var: b: []uint8 (declared at line 41, available: [42-45])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [43:49] injectible: [43-49]
+		Arg: ~r0: uint64 (declared at line 43, available: )
+		Var: n: uint64 (declared at line 48, available: [47-49])
+		Var: b: []uint8 (declared at line 44, available: [45-48])
 	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:88] injectible: [52-66], [68-69], [71-73], [75-77], [80-88]
+		Arg: ctx: context.Context (declared at line 52, available: [52-88])
 		Var: it: main.iterExample (declared at line 70, available: [52-88])
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 67, available: [52-88])
-	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
-		Arg: x: []int (declared at line 16, available: [16-17])
-		Arg: ~r0: string (declared at line 16, available: )
-	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14] injectible: [12-14]
-	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20] injectible: [18-20]
-	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25] injectible: [24-25]
-		Arg: ~r0: string (declared at line 24, available: )
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [21:22] injectible: [21-22]
+		Arg: x: []int (declared at line 21, available: [21-22])
+		Arg: ~r0: string (declared at line 21, available: )
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [17:19] injectible: [17-19]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [23:25] injectible: [23-25]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [29-30]
+		Arg: ~r0: string (declared at line 29, available: )
 	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55] injectible: [54-55]
 		Arg: a: interface {} (declared at line 54, available: [54-55])
 		Arg: ~r0: string (declared at line 54, available: )
@@ -767,225 +799,225 @@ Package: main
 	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
 		Arg: arg: [3]int (declared at line 297, available: [297-302])
 		Arg: ~r0: [3]int (declared at line 297, available: )
-	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
-		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
-	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
-		Arg: a: [2][2]int (declared at line 70, available: [70-70])
-	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78] injectible: [78-78]
-		Arg: b: [2][2][2]int (declared at line 78, available: [78-78])
+	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [93:93] injectible: [93-93]
+		Arg: a: [2]struct {} (declared at line 93, available: [93-93])
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [76:76] injectible: [76-76]
+		Arg: a: [2][2]int (declared at line 76, available: [76-76])
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [84:84] injectible: [84-84]
+		Arg: b: [2][2][2]int (declared at line 84, available: [84-84])
 	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [42:42] injectible: [42-42]
 		Arg: m: [2]map[string]int (declared at line 42, available: [42-42])
-	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74] injectible: [74-74]
-		Arg: a: [2]string (declared at line 74, available: [74-74])
-	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83] injectible: [83-83]
-		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
-	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
-		Arg: x: *[2]uint (declared at line 59, available: [59-59])
-	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
-		Arg: x: uint64 (declared at line 19, available: [23-23])
-		Arg: ~r0: uint64 (declared at line 19, available: )
-	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
-		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
-	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
-		Arg: x: [2]bool (declared at line 26, available: [26-26])
-	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
-		Arg: a: []uint8 (declared at line 117, available: [117-117])
-		Arg: b: []uint8 (declared at line 117, available: [117-117])
-	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
-		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
-		Arg: a: []uint8 (declared at line 129, available: [129-129])
-		Arg: b: []int (declared at line 129, available: [129-129])
-	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
-		Arg: x: []uint8 (declared at line 77, available: [77-77])
-	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
-		Arg: x: []uint8 (declared at line 81, available: [81-81])
-	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
-		Arg: x: []uint8 (declared at line 85, available: [85-85])
-	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
-		Arg: x: []uint8 (declared at line 89, available: [89-89])
-	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
-		Arg: x: []uint8 (declared at line 93, available: [93-93])
-	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
-		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
-	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
-		Arg: a: int (declared at line 125, available: [125-125])
-		Arg: x: []uint8 (declared at line 125, available: [125-125])
-		Arg: b: string (declared at line 125, available: [125-125])
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [80:80] injectible: [80-80]
+		Arg: a: [2]string (declared at line 80, available: [80-80])
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [89:89] injectible: [89-89]
+		Arg: a: [2]main.nestedStruct (declared at line 88, available: [89-89])
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [64:64] injectible: [64-64]
+		Arg: x: *[2]uint (declared at line 64, available: [64-64])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [26:26] injectible: [26-26]
+		Arg: x: uint64 (declared at line 22, available: [26-26])
+		Arg: ~r0: uint64 (declared at line 22, available: )
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [85:85] injectible: [85-85]
+		Arg: b: main.bigStruct (declared at line 85, available: [85-85])
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [32:32] injectible: [32-32]
+		Arg: x: [2]bool (declared at line 32, available: [32-32])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [122:122] injectible: [122-122]
+		Arg: a: []uint8 (declared at line 122, available: [122-122])
+		Arg: b: []uint8 (declared at line 122, available: [122-122])
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [20:20] injectible: [20-20]
+		Arg: x: [2]uint8 (declared at line 20, available: [20-20])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [134:134] injectible: [134-134]
+		Arg: a: []uint8 (declared at line 134, available: [134-134])
+		Arg: b: []int (declared at line 134, available: [134-134])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [82:82] injectible: [82-82]
+		Arg: x: []uint8 (declared at line 82, available: [82-82])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [86:86] injectible: [86-86]
+		Arg: x: []uint8 (declared at line 86, available: [86-86])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [90:90] injectible: [90-90]
+		Arg: x: []uint8 (declared at line 90, available: [90-90])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [94:94] injectible: [94-94]
+		Arg: x: []uint8 (declared at line 94, available: [94-94])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [98:98] injectible: [98-98]
+		Arg: x: []uint8 (declared at line 98, available: [98-98])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [126:126] injectible: [126-126]
+		Arg: x: [][]uint8 (declared at line 126, available: [126-126])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [130:130] injectible: [130-130]
+		Arg: a: int (declared at line 130, available: [130-130])
+		Arg: x: []uint8 (declared at line 130, available: [130-130])
+		Arg: b: string (declared at line 130, available: [130-130])
 	Function: testCaptureContextImpl (main.testCaptureContextImpl) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [44:44] injectible: [44-44]
 		Arg: c: *main.contextImpl (declared at line 44, available: [44-44])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
-		Arg: c: chan bool (declared at line 30, available: [30-30])
-	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
-		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
-	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
-		Arg: w: uint8 (declared at line 34, available: [34-34])
-		Arg: x: bool (declared at line 34, available: [34-34])
-		Arg: y: float32 (declared at line 34, available: [34-34])
-	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22] injectible: [22-22]
-		Arg: w: uint8 (declared at line 22, available: [22-22])
-		Arg: x: uint8 (declared at line 22, available: [22-22])
-		Arg: y: float32 (declared at line 22, available: [22-22])
-	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38] injectible: [38-38]
-		Arg: w: uint8 (declared at line 38, available: [38-38])
-		Arg: x: int (declared at line 38, available: [38-38])
-		Arg: y: float32 (declared at line 38, available: [38-38])
-	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46] injectible: [46-46]
-		Arg: w: uint8 (declared at line 46, available: [46-46])
-		Arg: x: int16 (declared at line 46, available: [46-46])
-		Arg: y: float32 (declared at line 46, available: [46-46])
-	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50] injectible: [50-50]
-		Arg: w: uint8 (declared at line 50, available: [50-50])
-		Arg: x: int32 (declared at line 50, available: [50-50])
-		Arg: y: float32 (declared at line 50, available: [50-50])
-	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54] injectible: [54-54]
-		Arg: w: uint8 (declared at line 54, available: [54-54])
-		Arg: x: int64 (declared at line 54, available: [54-54])
-		Arg: y: float32 (declared at line 54, available: [54-54])
-	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42] injectible: [42-42]
-		Arg: w: uint8 (declared at line 42, available: [42-42])
-		Arg: x: int8 (declared at line 42, available: [42-42])
-		Arg: y: float32 (declared at line 42, available: [42-42])
-	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26] injectible: [26-26]
-		Arg: w: uint8 (declared at line 26, available: [26-26])
-		Arg: x: int32 (declared at line 26, available: [26-26])
-		Arg: y: float32 (declared at line 26, available: [26-26])
-	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30] injectible: [30-30]
-		Arg: w: uint8 (declared at line 30, available: [30-30])
-		Arg: x: string (declared at line 30, available: [30-30])
-		Arg: y: float32 (declared at line 30, available: [30-30])
-	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58] injectible: [58-58]
-		Arg: w: uint8 (declared at line 58, available: [58-58])
-		Arg: x: uint (declared at line 58, available: [58-58])
-		Arg: y: float32 (declared at line 58, available: [58-58])
-	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66] injectible: [66-66]
-		Arg: w: uint8 (declared at line 66, available: [66-66])
-		Arg: x: uint16 (declared at line 66, available: [66-66])
-		Arg: y: float32 (declared at line 66, available: [66-66])
-	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70] injectible: [70-70]
-		Arg: w: uint8 (declared at line 70, available: [70-70])
-		Arg: x: uint32 (declared at line 70, available: [70-70])
-		Arg: y: float32 (declared at line 70, available: [70-70])
-	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74] injectible: [74-74]
-		Arg: w: uint8 (declared at line 74, available: [74-74])
-		Arg: x: uint64 (declared at line 74, available: [74-74])
-		Arg: y: float32 (declared at line 74, available: [74-74])
-	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62] injectible: [62-62]
-		Arg: w: uint8 (declared at line 62, available: [62-62])
-		Arg: x: uint8 (declared at line 62, available: [62-62])
-		Arg: y: float32 (declared at line 62, available: [62-62])
-	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75] injectible: [75-75]
-		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [33:33] injectible: [33-33]
+		Arg: c: chan bool (declared at line 33, available: [33-33])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93] injectible: [93-93]
+		Arg: x: main.circularReferenceType (declared at line 93, available: [93-93])
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [40:40] injectible: [40-40]
+		Arg: w: uint8 (declared at line 40, available: [40-40])
+		Arg: x: bool (declared at line 40, available: [40-40])
+		Arg: y: float32 (declared at line 40, available: [40-40])
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [28:28] injectible: [28-28]
+		Arg: w: uint8 (declared at line 28, available: [28-28])
+		Arg: x: uint8 (declared at line 28, available: [28-28])
+		Arg: y: float32 (declared at line 28, available: [28-28])
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [44:44] injectible: [44-44]
+		Arg: w: uint8 (declared at line 44, available: [44-44])
+		Arg: x: int (declared at line 44, available: [44-44])
+		Arg: y: float32 (declared at line 44, available: [44-44])
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [52:52] injectible: [52-52]
+		Arg: w: uint8 (declared at line 52, available: [52-52])
+		Arg: x: int16 (declared at line 52, available: [52-52])
+		Arg: y: float32 (declared at line 52, available: [52-52])
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [56:56] injectible: [56-56]
+		Arg: w: uint8 (declared at line 56, available: [56-56])
+		Arg: x: int32 (declared at line 56, available: [56-56])
+		Arg: y: float32 (declared at line 56, available: [56-56])
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [60:60] injectible: [60-60]
+		Arg: w: uint8 (declared at line 60, available: [60-60])
+		Arg: x: int64 (declared at line 60, available: [60-60])
+		Arg: y: float32 (declared at line 60, available: [60-60])
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [48:48] injectible: [48-48]
+		Arg: w: uint8 (declared at line 48, available: [48-48])
+		Arg: x: int8 (declared at line 48, available: [48-48])
+		Arg: y: float32 (declared at line 48, available: [48-48])
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [32:32] injectible: [32-32]
+		Arg: w: uint8 (declared at line 32, available: [32-32])
+		Arg: x: int32 (declared at line 32, available: [32-32])
+		Arg: y: float32 (declared at line 32, available: [32-32])
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [36:36] injectible: [36-36]
+		Arg: w: uint8 (declared at line 36, available: [36-36])
+		Arg: x: string (declared at line 36, available: [36-36])
+		Arg: y: float32 (declared at line 36, available: [36-36])
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [64:64] injectible: [64-64]
+		Arg: w: uint8 (declared at line 64, available: [64-64])
+		Arg: x: uint (declared at line 64, available: [64-64])
+		Arg: y: float32 (declared at line 64, available: [64-64])
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [72:72] injectible: [72-72]
+		Arg: w: uint8 (declared at line 72, available: [72-72])
+		Arg: x: uint16 (declared at line 72, available: [72-72])
+		Arg: y: float32 (declared at line 72, available: [72-72])
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [76:76] injectible: [76-76]
+		Arg: w: uint8 (declared at line 76, available: [76-76])
+		Arg: x: uint32 (declared at line 76, available: [76-76])
+		Arg: y: float32 (declared at line 76, available: [76-76])
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [80:80] injectible: [80-80]
+		Arg: w: uint8 (declared at line 80, available: [80-80])
+		Arg: x: uint64 (declared at line 80, available: [80-80])
+		Arg: y: float32 (declared at line 80, available: [80-80])
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [68:68] injectible: [68-68]
+		Arg: w: uint8 (declared at line 68, available: [68-68])
+		Arg: x: uint8 (declared at line 68, available: [68-68])
+		Arg: y: float32 (declared at line 68, available: [68-68])
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [80:80] injectible: [80-80]
+		Arg: z: *main.reallyComplexType (declared at line 80, available: [80-80])
 	Function: testConflictingReturn (main.testConflictingReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [109:111] injectible: [109-111]
 		Arg: i: int (declared at line 109, available: [109-111])
 		Arg: ~r0: int (declared at line 109, available: )
 		Arg: r0: string (declared at line 109, available: )
-	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
-		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
-		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
-		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
-		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
-		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
-		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
-		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
-		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
-	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
-		Arg: x: []uint8 (declared at line 97, available: [97-97])
-	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
-		Arg: u: []uint (declared at line 33, available: [33-33])
-	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
-		Arg: xs: []main.structWithNoStrings (declared at line 45, available: [45-45])
-		Arg: a: int (declared at line 45, available: [45-45])
-	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [50:50] injectible: [50-50]
-		Arg: x: string (declared at line 50, available: [50-50])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124] injectible: [124-124]
-		Arg: e: main.emptyStruct (declared at line 124, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128] injectible: [128-128]
-		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [114:114] injectible: [114-114]
+		Arg: t: *main.t (declared at line 114, available: [114-114])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: main.deepMap1 (declared at line 203, available: [203-203])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [206:206] injectible: [206-206]
+		Arg: a: *main.deepMap7 (declared at line 206, available: [206-206])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: main.deepPtr1 (declared at line 139, available: [139-139])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142] injectible: [142-142]
+		Arg: a: *main.deepPtr7 (declared at line 142, available: [142-142])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: main.deepSlice1 (declared at line 165, available: [165-165])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [168:168] injectible: [168-168]
+		Arg: a: *main.deepSlice7 (declared at line 168, available: [168-168])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [126:126] injectible: [126-126]
+		Arg: t: main.deepStruct1 (declared at line 126, available: [126-126])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [102:102] injectible: [102-102]
+		Arg: x: []uint8 (declared at line 102, available: [102-102])
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [38:38] injectible: [38-38]
+		Arg: u: []uint (declared at line 38, available: [38-38])
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [50:50] injectible: [50-50]
+		Arg: xs: []main.structWithNoStrings (declared at line 50, available: [50-50])
+		Arg: a: int (declared at line 50, available: [50-50])
+	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [55:55] injectible: [55-55]
+		Arg: x: string (declared at line 55, available: [55-55])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [130:130] injectible: [130-130]
+		Arg: e: main.emptyStruct (declared at line 130, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [134:134] injectible: [134-134]
+		Arg: e: *main.emptyStruct (declared at line 134, available: [134-134])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
-	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [108-110], [112-112]
-		Arg: shouldErr: bool (declared at line 101, available: [101-108])
-		Arg: ~r0: int (declared at line 101, available: )
-		Var: x: int (declared at line 106, available: )
-		Var: err: error (declared at line 102, available: )
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [104:115] injectible: [104-104], [106-107], [111-113], [115-115]
+		Arg: shouldErr: bool (declared at line 104, available: [104-111])
+		Arg: ~r0: int (declared at line 104, available: )
+		Var: x: int (declared at line 109, available: )
+		Var: err: error (declared at line 105, available: )
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
-	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80] injectible: [79-80]
-		Arg: x: int (declared at line 79, available: [79-80])
-		Arg: ~r0: int (declared at line 79, available: )
-	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93] injectible: [92-93]
-		Arg: a: [5]int (declared at line 92, available: [92-93])
-		Arg: ~r0: int (declared at line 92, available: )
-	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [17:19] injectible: [17-19]
-		Arg: x: int (declared at line 17, available: [17-18])
-		Arg: y: int (declared at line 17, available: [17-18])
-	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [21:25] injectible: [21-25]
-		Arg: x: int (declared at line 21, available: [21-25])
-		Arg: y: int (declared at line 21, available: [21-25])
-	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35] injectible: [32-32], [34-35]
-		Arg: x: int (declared at line 32, available: [32-34])
-	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42] injectible: [37-42]
-		Arg: x: int (declared at line 37, available: [37-38])
-		Arg: y: int (declared at line 37, available: [37-39])
-		Var: z: int (declared at line 38, available: [37-42])
-	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46] injectible: [44-46]
-		Arg: x: int (declared at line 44, available: [44-45])
-	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49] injectible: [49-49]
-	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60] injectible: [52-53], [55-56], [58-60]
-		Var: s: int (declared at line 54, available: [55-58])
-		Scope: 55-58
-			Var: i: int (declared at line 55, available: [55-58])
-	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63] injectible: [63-63]
-	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [66:67] injectible: [67-67]
-	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [13:15] injectible: [14-14]
-		Arg: x: int (declared at line 0, available: [13-14])
-	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [74:75] injectible: [75-75]
-		Arg: x: int (declared at line 0, available: [75-75])
-	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:71] injectible: [71-71]
-		Arg: a: [5]int (declared at line 0, available: [71-71])
-	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38] injectible: [38-38]
-		Arg: x: [2]int16 (declared at line 38, available: [38-38])
-	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42] injectible: [42-42]
-		Arg: x: [2]int32 (declared at line 42, available: [42-42])
-	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46] injectible: [46-46]
-		Arg: x: [2]int64 (declared at line 46, available: [46-46])
-	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34] injectible: [34-34]
-		Arg: x: [2]int8 (declared at line 34, available: [34-34])
-	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30] injectible: [30-30]
-		Arg: x: [2]int (declared at line 30, available: [30-30])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [82:83] injectible: [82-83]
+		Arg: x: int (declared at line 82, available: [82-83])
+		Arg: ~r0: int (declared at line 82, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [95:96] injectible: [95-96]
+		Arg: a: [5]int (declared at line 95, available: [95-96])
+		Arg: ~r0: int (declared at line 95, available: )
+	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [20:22] injectible: [20-22]
+		Arg: x: int (declared at line 20, available: [20-21])
+		Arg: y: int (declared at line 20, available: [20-21])
+	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [24:28] injectible: [24-28]
+		Arg: x: int (declared at line 24, available: [24-28])
+		Arg: y: int (declared at line 24, available: [24-28])
+	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [35:38] injectible: [35-35], [37-38]
+		Arg: x: int (declared at line 35, available: [35-37])
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [40:45] injectible: [40-45]
+		Arg: x: int (declared at line 40, available: [40-41])
+		Arg: y: int (declared at line 40, available: [40-42])
+		Var: z: int (declared at line 41, available: [40-45])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [47:49] injectible: [47-49]
+		Arg: x: int (declared at line 47, available: [47-48])
+	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [51:52] injectible: [52-52]
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [55:63] injectible: [55-56], [58-59], [61-63]
+		Var: s: int (declared at line 57, available: [58-61])
+		Scope: 58-61
+			Var: i: int (declared at line 58, available: [58-61])
+	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [65:66] injectible: [66-66]
+	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [69:70] injectible: [70-70]
+	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [16:18] injectible: [17-17]
+		Arg: x: int (declared at line 0, available: [16-17])
+	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [77:78] injectible: [78-78]
+		Arg: x: int (declared at line 0, available: [78-78])
+	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [73:74] injectible: [74-74]
+		Arg: a: [5]int (declared at line 0, available: [74-74])
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [44:44] injectible: [44-44]
+		Arg: x: [2]int16 (declared at line 44, available: [44-44])
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [48:48] injectible: [48-48]
+		Arg: x: [2]int32 (declared at line 48, available: [48-48])
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [52:52] injectible: [52-52]
+		Arg: x: [2]int64 (declared at line 52, available: [52-52])
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [40:40] injectible: [40-40]
+		Arg: x: [2]int8 (declared at line 40, available: [40-40])
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [36:36] injectible: [36-36]
+		Arg: x: [2]int (declared at line 36, available: [36-36])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50] injectible: [50-50]
 		Arg: b: main.behavior (declared at line 50, available: [50-50])
-	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [94:94] injectible: [94-94]
-		Arg: a: int (declared at line 94, available: [94-94])
-		Arg: b: error (declared at line 94, available: [94-94])
-		Arg: c: uint (declared at line 94, available: [94-94])
-	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
-		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [58:58] injectible: [58-58]
-		Arg: a: string (declared at line 58, available: [58-58])
-		Arg: b: string (declared at line 58, available: [58-58])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [97:97] injectible: [97-97]
+		Arg: a: int (declared at line 97, available: [97-97])
+		Arg: b: error (declared at line 97, available: [97-97])
+		Arg: c: uint (declared at line 97, available: [97-97])
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67] injectible: [67-67]
+		Arg: a: main.interfaceComplexityA (declared at line 67, available: [67-67])
+	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [63:63] injectible: [63-63]
+		Arg: a: string (declared at line 63, available: [63-63])
+		Arg: b: string (declared at line 63, available: [63-63])
 	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
 		Arg: arg: main.largeStruct (declared at line 281, available: [281-282])
 		Arg: ~r0: main.largeStruct (declared at line 281, available: )
 		Arg: ~r0: main.largeStruct (declared at line 281, available: )
-	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
-		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
-		Var: s: int (declared at line 224, available: [237-237], [242-242])
-		Var: aPerArch: int (declared at line 228, available: [223-243])
-		Var: b: int (declared at line 229, available: [223-243])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
-		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [47:47] injectible: [47-47]
+		Arg: a: main.node (declared at line 47, available: [47-47])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [226:246] injectible: [226-226], [233-233], [236-237], [239-242], [244-246]
+		Var: s: int (declared at line 227, available: [240-240], [245-245])
+		Var: aPerArch: int (declared at line 231, available: [226-246])
+		Var: b: int (declared at line 232, available: [226-246])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [138:138] injectible: [138-138]
+		Arg: l: main.lotsOfFields (declared at line 138, available: [138-138])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
 		Arg: a: int (declared at line 328, available: [328-330])
 		Arg: b: int (declared at line 328, available: [328-330])
@@ -997,10 +1029,10 @@ Package: main
 		Arg: h: int (declared at line 328, available: [328-330])
 		Arg: i: int (declared at line 328, available: [328-330])
 		Arg: ~r0: [2]int (declared at line 328, available: )
-	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [102:102] injectible: [102-102]
-		Arg: m: main.manyPointers (declared at line 102, available: [102-102])
-	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [33:33] injectible: [33-33]
-		Arg: ss: []string (declared at line 33, available: [33-33])
+	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [108:108] injectible: [108-108]
+		Arg: m: main.manyPointers (declared at line 108, available: [108-108])
+	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:36] injectible: [36-36]
+		Arg: ss: []string (declared at line 36, available: [36-36])
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -1039,8 +1071,8 @@ Package: main
 		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
 	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70] injectible: [70-70]
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
-	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
-		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [47:47] injectible: [47-47]
+		Arg: x: string (declared at line 47, available: [47-47])
 	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-347], [349-349]
 		Arg: a: int (declared at line 337, available: [337-349])
 		Arg: b: int (declared at line 337, available: [337-349])
@@ -1053,17 +1085,17 @@ Package: main
 		Arg: s: string (declared at line 337, available: [337-349])
 		Arg: ~r0: main.largeStruct (declared at line 337, available: )
 		Arg: ~r0: main.largeStruct (declared at line 337, available: )
-	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [62:62] injectible: [62-62]
-		Arg: x: string (declared at line 62, available: [62-62])
+	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [67:67] injectible: [67-67]
+		Arg: x: string (declared at line 67, available: [67-67])
 	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
 		Arg: a: [2]int (declared at line 364, available: [364-366])
 		Arg: b: [3]int (declared at line 364, available: [364-366])
 		Arg: ~r0: int (declared at line 364, available: )
 		Arg: ~r1: [2]int (declared at line 364, available: )
-	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
-		Arg: o: main.outer (declared at line 72, available: [72-72])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
-		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [75:75] injectible: [75-75]
+		Arg: o: main.outer (declared at line 75, available: [75-75])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [102:102] injectible: [102-102]
+		Arg: b: main.bStruct (declared at line 102, available: [102-102])
 	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
 		Arg: s1: main.largeStruct (declared at line 308, available: [308-309])
 		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
@@ -1073,99 +1105,99 @@ Package: main
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
 		Arg: result2: int (declared at line 95, available: )
-	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
-		Arg: a: bool (declared at line 78, available: [78-78])
-		Arg: b: uint8 (declared at line 78, available: [78-78])
-		Arg: c: int32 (declared at line 78, available: [78-78])
-		Arg: d: uint (declared at line 78, available: [78-78])
-		Arg: e: string (declared at line 78, available: [78-78])
-	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
-		Arg: a: main.tierA (declared at line 68, available: [68-68])
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [84:84] injectible: [84-84]
+		Arg: a: bool (declared at line 84, available: [84-84])
+		Arg: b: uint8 (declared at line 84, available: [84-84])
+		Arg: c: int32 (declared at line 84, available: [84-84])
+		Arg: d: uint (declared at line 84, available: [84-84])
+		Arg: e: string (declared at line 84, available: [84-84])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71] injectible: [71-71]
+		Arg: a: main.tierA (declared at line 71, available: [71-71])
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
 		Arg: i: int (declared at line 88, available: [88-89])
 		Arg: result: int (declared at line 88, available: )
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
-		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
-	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
-		Arg: x: []uint8 (declared at line 101, available: [101-101])
-	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
-		Arg: z: *bool (declared at line 99, available: [99-99])
-		Arg: a: uint (declared at line 99, available: [99-99])
-	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61] injectible: [61-61]
-		Arg: xs: []uint16 (declared at line 61, available: [61-61])
-	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49] injectible: [49-49]
-		Arg: xs: []main.structWithNoStrings (declared at line 49, available: [49-49])
-		Arg: a: int (declared at line 49, available: [49-49])
-	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57] injectible: [57-57]
-		Arg: a: int8 (declared at line 57, available: [57-57])
-		Arg: s: []bool (declared at line 57, available: [57-57])
-		Arg: x: uint (declared at line 57, available: [57-57])
-	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71] injectible: [71-71]
-		Arg: z: uint (declared at line 71, available: [71-71])
-		Arg: x: *main.nStruct (declared at line 71, available: [71-71])
-		Arg: a: int (declared at line 71, available: [71-71])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100] injectible: [100-100]
-		Arg: c: main.cStruct (declared at line 100, available: [100-100])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92] injectible: [92-92]
-		Arg: x: main.nStruct (declared at line 92, available: [92-92])
-	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [38:38] injectible: [38-38]
-		Arg: a: *main.oneStringStruct (declared at line 38, available: [38-38])
-	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95] injectible: [95-95]
-		Arg: a: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: b: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: c: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: d: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: e: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: f: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: g: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: h: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: i: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: j: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: k: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: l: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: m: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: n: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: o: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: p: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: q: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: r: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: s: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: t: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: u: [3]uint32 (declared at line 94, available: [95-95])
-	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18] injectible: [18-18]
-		Arg: a: uint8 (declared at line 15, available: [18-18])
-		Arg: b: uint8 (declared at line 15, available: [18-18])
-		Arg: c: uint8 (declared at line 15, available: [18-18])
-		Arg: d: uint8 (declared at line 15, available: [18-18])
-		Arg: e: uint8 (declared at line 15, available: [18-18])
-		Arg: f: uint8 (declared at line 15, available: [18-18])
-		Arg: g: uint8 (declared at line 15, available: [18-18])
-		Arg: h: uint8 (declared at line 16, available: [18-18])
-		Arg: i: uint8 (declared at line 16, available: [18-18])
-		Arg: j: uint8 (declared at line 16, available: [18-18])
-		Arg: k: uint8 (declared at line 16, available: [18-18])
-		Arg: l: uint8 (declared at line 16, available: [18-18])
-		Arg: m: uint8 (declared at line 16, available: [18-18])
-		Arg: n: uint8 (declared at line 16, available: [18-18])
-		Arg: o: uint8 (declared at line 17, available: [18-18])
-		Arg: p: uint8 (declared at line 17, available: [18-18])
-		Arg: q: uint8 (declared at line 17, available: )
-		Arg: r: uint8 (declared at line 17, available: )
-		Arg: s: uint8 (declared at line 17, available: )
-		Arg: t: uint8 (declared at line 17, available: )
-		Arg: u: uint8 (declared at line 17, available: )
-	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51] injectible: [51-51]
-		Arg: a: *main.node (declared at line 51, available: [51-51])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [114:114] injectible: [114-114]
+		Arg: x: *main.anotherStruct (declared at line 114, available: [114-114])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [106:106] injectible: [106-106]
+		Arg: x: []uint8 (declared at line 106, available: [106-106])
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [104:104] injectible: [104-104]
+		Arg: z: *bool (declared at line 104, available: [104-104])
+		Arg: a: uint (declared at line 104, available: [104-104])
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [66:66] injectible: [66-66]
+		Arg: xs: []uint16 (declared at line 66, available: [66-66])
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [54:54] injectible: [54-54]
+		Arg: xs: []main.structWithNoStrings (declared at line 54, available: [54-54])
+		Arg: a: int (declared at line 54, available: [54-54])
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [62:62] injectible: [62-62]
+		Arg: a: int8 (declared at line 62, available: [62-62])
+		Arg: s: []bool (declared at line 62, available: [62-62])
+		Arg: x: uint (declared at line 62, available: [62-62])
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [76:76] injectible: [76-76]
+		Arg: z: uint (declared at line 76, available: [76-76])
+		Arg: x: *main.nStruct (declared at line 76, available: [76-76])
+		Arg: a: int (declared at line 76, available: [76-76])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [106:106] injectible: [106-106]
+		Arg: c: main.cStruct (declared at line 106, available: [106-106])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [98:98] injectible: [98-98]
+		Arg: x: main.nStruct (declared at line 98, available: [98-98])
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [43:43] injectible: [43-43]
+		Arg: a: *main.oneStringStruct (declared at line 43, available: [43-43])
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [101:101] injectible: [101-101]
+		Arg: a: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: b: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: c: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: d: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: e: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: f: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: g: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: h: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: i: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: j: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: k: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: l: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: m: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: n: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: o: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: p: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: q: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: r: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: s: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: t: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: u: [3]uint32 (declared at line 100, available: [101-101])
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [24:24] injectible: [24-24]
+		Arg: a: uint8 (declared at line 21, available: [24-24])
+		Arg: b: uint8 (declared at line 21, available: [24-24])
+		Arg: c: uint8 (declared at line 21, available: [24-24])
+		Arg: d: uint8 (declared at line 21, available: [24-24])
+		Arg: e: uint8 (declared at line 21, available: [24-24])
+		Arg: f: uint8 (declared at line 21, available: [24-24])
+		Arg: g: uint8 (declared at line 21, available: [24-24])
+		Arg: h: uint8 (declared at line 22, available: [24-24])
+		Arg: i: uint8 (declared at line 22, available: [24-24])
+		Arg: j: uint8 (declared at line 22, available: [24-24])
+		Arg: k: uint8 (declared at line 22, available: [24-24])
+		Arg: l: uint8 (declared at line 22, available: [24-24])
+		Arg: m: uint8 (declared at line 22, available: [24-24])
+		Arg: n: uint8 (declared at line 22, available: [24-24])
+		Arg: o: uint8 (declared at line 23, available: [24-24])
+		Arg: p: uint8 (declared at line 23, available: [24-24])
+		Arg: q: uint8 (declared at line 23, available: )
+		Arg: r: uint8 (declared at line 23, available: )
+		Arg: s: uint8 (declared at line 23, available: )
+		Arg: t: uint8 (declared at line 23, available: )
+		Arg: u: uint8 (declared at line 23, available: )
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [56:56] injectible: [56-56]
+		Arg: a: *main.node (declared at line 56, available: [56-56])
 	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [46:46] injectible: [46-46]
 		Arg: m: *map[string]int (declared at line 46, available: [46-46])
-	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103] injectible: [103-103]
-		Arg: u: **int (declared at line 103, available: [103-103])
-	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38] injectible: [38-38]
-		Arg: a: *main.structWithTwoValues (declared at line 38, available: [38-38])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76] injectible: [76-76]
-		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
-		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [108:108] injectible: [108-108]
+		Arg: u: **int (declared at line 108, available: [108-108])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [43:43] injectible: [43-43]
+		Arg: a: *main.structWithTwoValues (declared at line 43, available: [43-43])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [82:82] injectible: [82-82]
+		Arg: s: *main.structWithASlice (declared at line 82, available: [82-82])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [86:86] injectible: [86-86]
+		Arg: s: *main.structWithAString (declared at line 86, available: [86-86])
 	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
 		Arg: v: interface {} (declared at line 60, available: [60-72])
 		Arg: ~r0: interface {} (declared at line 60, available: )
@@ -1286,44 +1318,44 @@ Package: main
 	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
 		Arg: ~r0: main.wideStruct (declared at line 225, available: )
 		Arg: ~r0: main.wideStruct (declared at line 225, available: )
-	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
-		Arg: x: [2]int32 (declared at line 18, available: [18-18])
-	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
-		Arg: x: bool (declared at line 19, available: [19-19])
-	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11] injectible: [11-11]
-		Arg: x: uint8 (declared at line 11, available: [11-11])
-	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63] injectible: [63-63]
-		Arg: x: float32 (declared at line 63, available: [63-63])
-	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67] injectible: [67-67]
-		Arg: x: float64 (declared at line 67, available: [67-67])
-	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23] injectible: [23-23]
-		Arg: x: int (declared at line 23, available: [23-23])
-	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31] injectible: [31-31]
-		Arg: x: int16 (declared at line 31, available: [31-31])
-	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35] injectible: [35-35]
-		Arg: x: int32 (declared at line 35, available: [35-35])
-	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39] injectible: [39-39]
-		Arg: x: int64 (declared at line 39, available: [39-39])
-	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27] injectible: [27-27]
-		Arg: x: int8 (declared at line 27, available: [27-27])
-	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15] injectible: [15-15]
-		Arg: x: int32 (declared at line 15, available: [15-15])
-	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [12:12] injectible: [12-12]
-		Arg: x: string (declared at line 12, available: [12-12])
-	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43] injectible: [43-43]
-		Arg: x: uint (declared at line 43, available: [43-43])
-	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51] injectible: [51-51]
-		Arg: x: uint16 (declared at line 51, available: [51-51])
-	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55] injectible: [55-55]
-		Arg: x: uint32 (declared at line 55, available: [55-55])
-	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59] injectible: [59-59]
-		Arg: x: uint64 (declared at line 59, available: [59-59])
-	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47] injectible: [47-47]
-		Arg: x: uint8 (declared at line 47, available: [47-47])
-	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [69:69] injectible: [69-69]
-		Arg: xs: []struct {} (declared at line 69, available: [69-69])
-	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37] injectible: [37-37]
-		Arg: u: [][]uint (declared at line 37, available: [37-37])
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [24:24] injectible: [24-24]
+		Arg: x: [2]int32 (declared at line 24, available: [24-24])
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [25:25] injectible: [25-25]
+		Arg: x: bool (declared at line 25, available: [25-25])
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [17:17] injectible: [17-17]
+		Arg: x: uint8 (declared at line 17, available: [17-17])
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [69:69] injectible: [69-69]
+		Arg: x: float32 (declared at line 69, available: [69-69])
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
+		Arg: x: float64 (declared at line 73, available: [73-73])
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [29:29] injectible: [29-29]
+		Arg: x: int (declared at line 29, available: [29-29])
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [37:37] injectible: [37-37]
+		Arg: x: int16 (declared at line 37, available: [37-37])
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [41:41] injectible: [41-41]
+		Arg: x: int32 (declared at line 41, available: [41-41])
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [45:45] injectible: [45-45]
+		Arg: x: int64 (declared at line 45, available: [45-45])
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [33:33] injectible: [33-33]
+		Arg: x: int8 (declared at line 33, available: [33-33])
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [21:21] injectible: [21-21]
+		Arg: x: int32 (declared at line 21, available: [21-21])
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [17:17] injectible: [17-17]
+		Arg: x: string (declared at line 17, available: [17-17])
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [49:49] injectible: [49-49]
+		Arg: x: uint (declared at line 49, available: [49-49])
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [57:57] injectible: [57-57]
+		Arg: x: uint16 (declared at line 57, available: [57-57])
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [61:61] injectible: [61-61]
+		Arg: x: uint32 (declared at line 61, available: [61-61])
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [65:65] injectible: [65-65]
+		Arg: x: uint64 (declared at line 65, available: [65-65])
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [53:53] injectible: [53-53]
+		Arg: x: uint8 (declared at line 53, available: [53-53])
+	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [74:74] injectible: [74-74]
+		Arg: xs: []struct {} (declared at line 74, available: [74-74])
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [42:42] injectible: [42-42]
+		Arg: u: [][]uint (declared at line 42, available: [42-42])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
 	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
@@ -1336,120 +1368,120 @@ Package: main
 		Arg: ~r0: int (declared at line 356, available: )
 		Arg: ~r1: int (declared at line 356, available: )
 		Arg: ~r2: int (declared at line 356, available: )
-	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
-		Arg: x: [2]string (declared at line 22, available: [22-22])
-	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
-		Arg: z: *string (declared at line 91, available: [91-91])
-	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53] injectible: [53-53]
-		Arg: s: []string (declared at line 53, available: [53-53])
-	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95] injectible: [95-95]
-		Arg: a: *[]string (declared at line 95, available: [95-95])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
-		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
-		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
-		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
-		Arg: x: main.aStruct (declared at line 84, available: [84-84])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]
-		Arg: w: uint8 (declared at line 104, available: [104-104])
-		Arg: x: main.aStruct (declared at line 104, available: [104-104])
-	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67] injectible: [67-67]
-		Arg: x: *main.nStruct (declared at line 67, available: [67-67])
-	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41] injectible: [41-41]
-		Arg: xs: []main.structWithNoStrings (declared at line 41, available: [41-41])
-		Arg: a: int (declared at line 41, available: [41-41])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72] injectible: [72-72]
-		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64] injectible: [64-64]
-		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68] injectible: [68-68]
-		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [28:28] injectible: [28-28]
+		Arg: x: [2]string (declared at line 28, available: [28-28])
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [96:96] injectible: [96-96]
+		Arg: z: *string (declared at line 96, available: [96-96])
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [58:58] injectible: [58-58]
+		Arg: s: []string (declared at line 58, available: [58-58])
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [100:100] injectible: [100-100]
+		Arg: a: *[]string (declared at line 100, available: [100-100])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [122:122] injectible: [122-122]
+		Arg: t: main.threestrings (declared at line 122, available: [122-122])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [217:217] injectible: [217-217]
+		Arg: a: *main.stringType1 (declared at line 217, available: [217-217])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:223] injectible: [223-223]
+		Arg: a: **main.stringType2 (declared at line 223, available: [223-223])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [90:90] injectible: [90-90]
+		Arg: x: main.aStruct (declared at line 90, available: [90-90])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [110:110] injectible: [110-110]
+		Arg: w: uint8 (declared at line 110, available: [110-110])
+		Arg: x: main.aStruct (declared at line 110, available: [110-110])
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [72:72] injectible: [72-72]
+		Arg: x: *main.nStruct (declared at line 72, available: [72-72])
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [46:46] injectible: [46-46]
+		Arg: xs: []main.structWithNoStrings (declared at line 46, available: [46-46])
+		Arg: a: int (declared at line 46, available: [46-46])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [78:78] injectible: [78-78]
+		Arg: s: main.structWithASlice (declared at line 78, available: [78-78])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [70:70] injectible: [70-70]
+		Arg: s: main.structWithASlice (declared at line 70, available: [70-70])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [74:74] injectible: [74-74]
+		Arg: s: main.structWithASlice (declared at line 74, available: [74-74])
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73] injectible: [73-73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
-		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [66:66] injectible: [66-66]
+		Arg: a: main.structWithAnArray (declared at line 66, available: [66-66])
 	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
 		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
 		Arg: ~r0: int (declared at line 372, available: )
 		Arg: ~r1: main.structWithArray (declared at line 372, available: )
 		Var: x: int (declared at line 374, available: [372-379])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
-		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
-	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
-		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
-	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31] injectible: [31-31]
-		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [94:94] injectible: [94-94]
+		Arg: s: main.structWithTwoArrays (declared at line 94, available: [94-94])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [50:50] injectible: [50-50]
+		Arg: a: main.structWithCyclicMaps (declared at line 50, available: [50-50])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [37:37] injectible: [37-37]
+		Arg: a: main.structWithCyclicSlices (declared at line 37, available: [37-37])
 	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18] injectible: [18-18]
 		Arg: s: main.structWithMap (declared at line 18, available: [18-18])
-	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79] injectible: [79-79]
-		Arg: x: main.structWithPointer (declared at line 79, available: [79-79])
-	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87] injectible: [87-87]
-		Arg: z: main.spws (declared at line 87, available: [87-87])
-	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83] injectible: [83-83]
-		Arg: b: main.swsp (declared at line 83, available: [83-83])
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48] injectible: [48-48]
-		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
-	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [73:73] injectible: [73-73]
-		Arg: as: []uint (declared at line 73, available: [73-73])
-		Arg: bs: []uint (declared at line 73, available: [73-73])
-		Arg: cs: []uint (declared at line 73, available: [73-73])
-	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [54:54] injectible: [54-54]
-		Arg: a: string (declared at line 54, available: [54-54])
-		Arg: b: string (declared at line 54, available: [54-54])
-		Arg: c: string (declared at line 54, available: [54-54])
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [84:84] injectible: [84-84]
+		Arg: x: main.structWithPointer (declared at line 84, available: [84-84])
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [92:92] injectible: [92-92]
+		Arg: z: main.spws (declared at line 92, available: [92-92])
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [88:88] injectible: [88-88]
+		Arg: b: main.swsp (declared at line 88, available: [88-88])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [54:54] injectible: [54-54]
+		Arg: a: main.hasUnsupportedFields (declared at line 54, available: [54-54])
+	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [78:78] injectible: [78-78]
+		Arg: as: []uint (declared at line 78, available: [78-78])
+		Arg: bs: []uint (declared at line 78, available: [78-78])
+		Arg: cs: []uint (declared at line 78, available: [78-78])
+	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [59:59] injectible: [59-59]
+		Arg: a: string (declared at line 59, available: [59-59])
+		Arg: b: string (declared at line 59, available: [59-59])
+		Arg: c: string (declared at line 59, available: [59-59])
 	Function: testTakeContext (main.testTakeContext) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [24:24] injectible: [24-24]
 		Arg: ctx: context.Context (declared at line 22, available: [24-24])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112] injectible: [112-112]
-		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
-	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [16:16] injectible: [16-16]
-		Arg: x: string (declared at line 16, available: [16-16])
-		Arg: y: string (declared at line 16, available: [16-16])
-		Arg: z: string (declared at line 16, available: [16-16])
-	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [30:30] injectible: [30-30]
-		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
-	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
-		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
-		Arg: x: time.Time (declared at line 31, available: [31-31])
-	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
-		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
-	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
-		Arg: x: time.Time (declared at line 27, available: [27-27])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
-	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
-		Arg: a: []uint8 (declared at line 113, available: [113-113])
-		Arg: b: []uint8 (declared at line 113, available: [113-113])
-	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
-		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
-	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
-		Arg: x: [2]uint16 (declared at line 58, available: [58-58])
-	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62] injectible: [62-62]
-		Arg: x: [2]uint32 (declared at line 62, available: [62-62])
-	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66] injectible: [66-66]
-		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
-	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
-		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
-	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
-		Arg: x: []uint8 (declared at line 105, available: [105-105])
-	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
-		Arg: x: []uint8 (declared at line 109, available: [109-109])
-	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
-		Arg: x: [2]uint (declared at line 50, available: [50-50])
-	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]
-		Arg: x: *uint (declared at line 63, available: [63-63])
-	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29] injectible: [29-29]
-		Arg: u: []uint (declared at line 29, available: [29-29])
-	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [46:46] injectible: [46-46]
-		Arg: x: string (declared at line 46, available: [46-46])
-	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55] injectible: [55-55]
-		Arg: x: unsafe.Pointer (declared at line 55, available: [55-55])
-	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [99:99] injectible: [99-99]
-		Arg: a: [100]uint (declared at line 99, available: [99-99])
-	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
-		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [118:118] injectible: [118-118]
+		Arg: x: main.tenStrings (declared at line 118, available: [118-118])
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [21:21] injectible: [21-21]
+		Arg: x: string (declared at line 21, available: [21-21])
+		Arg: y: string (declared at line 21, available: [21-21])
+		Arg: z: string (declared at line 21, available: [21-21])
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [35:35] injectible: [35-35]
+		Arg: a: main.threeStringStruct (declared at line 35, available: [35-35])
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [39:39] injectible: [39-39]
+		Arg: a: *main.threeStringStruct (declared at line 39, available: [39-39])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [36:36] injectible: [36-36]
+		Arg: x: time.Time (declared at line 36, available: [36-36])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [40:40] injectible: [40-40]
+		Arg: c: main.timeCapture (declared at line 40, available: [40-40])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [32:32] injectible: [32-32]
+		Arg: x: time.Time (declared at line 32, available: [32-32])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [37:37] injectible: [37-37]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 37, available: [37-37])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [118:118] injectible: [118-118]
+		Arg: a: []uint8 (declared at line 118, available: [118-118])
+		Arg: b: []uint8 (declared at line 118, available: [118-118])
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [79:79] injectible: [79-79]
+		Arg: x: main.typeAlias (declared at line 79, available: [79-79])
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [64:64] injectible: [64-64]
+		Arg: x: [2]uint16 (declared at line 64, available: [64-64])
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [68:68] injectible: [68-68]
+		Arg: x: [2]uint32 (declared at line 68, available: [68-68])
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [72:72] injectible: [72-72]
+		Arg: x: [2]uint64 (declared at line 72, available: [72-72])
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [60:60] injectible: [60-60]
+		Arg: x: [2]uint8 (declared at line 60, available: [60-60])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [110:110] injectible: [110-110]
+		Arg: x: []uint8 (declared at line 110, available: [110-110])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [114:114] injectible: [114-114]
+		Arg: x: []uint8 (declared at line 114, available: [114-114])
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [56:56] injectible: [56-56]
+		Arg: x: [2]uint (declared at line 56, available: [56-56])
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [68:68] injectible: [68-68]
+		Arg: x: *uint (declared at line 68, available: [68-68])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [34:34] injectible: [34-34]
+		Arg: u: []uint (declared at line 34, available: [34-34])
+	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [51:51] injectible: [51-51]
+		Arg: x: string (declared at line 51, available: [51-51])
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [60:60] injectible: [60-60]
+		Arg: x: unsafe.Pointer (declared at line 60, available: [60-60])
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [105:105] injectible: [105-105]
+		Arg: a: [100]uint (declared at line 105, available: [105-105])
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [70:70] injectible: [70-70]
+		Arg: xs: []uint (declared at line 70, available: [70-70])
 	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
 		Arg: a: [0]int (declared at line 385, available: )
 		Arg: b: int (declared at line 385, available: [385-388])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,16 +1,22 @@
 === yield 1 [final=false] ===
 Package: main
-	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
-		Arg: x: []int (declared at line 12, available: [12-12])
-	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
-	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95] injectible: [76-80], [82-87], [89-95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [246:314] injectible: [246-246], [249-252], [257-258], [260-263], [266-266], [277-277], [280-281], [283-283], [287-287], [289-289], [294-294], [296-296], [298-299], [301-302], [304-305], [307-311], [313-314]
-		Var: s: []*string (declared at line 258, available: )
-		Var: str: string (declared at line 257, available: [246-314])
-		Var: circ: main.circularReferenceType (declared at line 279, available: [246-314])
-		Var: s1: main.stringType1 (declared at line 307, available: [302-314])
-		Var: s2: main.stringType2 (declared at line 308, available: [302-314])
-		Var: s2p: *main.stringType2 (declared at line 309, available: [302-314])
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [17:17] injectible: [17-17]
+		Arg: x: []int (declared at line 17, available: [17-17])
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [108:138] injectible: [108-110], [112-126], [128-131], [133-133], [137-138]
+		Arg: ctx: context.Context (declared at line 108, available: [108-110])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 109, available: [110-113])
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [82:104] injectible: [82-84], [86-89], [91-96], [98-104]
+		Arg: ctx: context.Context (declared at line 82, available: [82-84])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-86])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [249:320] injectible: [249-251], [255-258], [263-264], [266-269], [272-272], [283-283], [286-287], [289-289], [293-293], [295-295], [300-300], [302-302], [304-305], [307-308], [310-311], [313-317], [319-320]
+		Arg: ctx: context.Context (declared at line 249, available: [249-251])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 250, available: [251-272])
+		Var: s: []*string (declared at line 264, available: )
+		Var: str: string (declared at line 263, available: [249-320])
+		Var: circ: main.circularReferenceType (declared at line 285, available: [249-320])
+		Var: s1: main.stringType1 (declared at line 313, available: [308-320])
+		Var: s2: main.stringType2 (declared at line 314, available: [308-320])
+		Var: s2p: *main.stringType2 (declared at line 315, available: [308-320])
 	Function: executeContextFuncs (main.executeContextFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [26:33] injectible: [26-27], [29-29], [31-33]
 		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 27, available: [31-32])
 		Var: ctx: context.Context (declared at line 27, available: [31-32])
@@ -19,14 +25,18 @@ Package: main
 		Var: id: uint64 (declared at line 1360, available: [1360-1361])
 	Function: executeContextImplFuncs (main.executeContextImplFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [61:67] injectible: [61-62], [65-67]
 		Var: c: *main.contextImpl (declared at line 62, available: [61-67])
-	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [113:187] injectible: [113-113], [115-184], [186-187]
-		Var: m: main.manyPointers (declared at line 114, available: [113-187])
-	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:50] injectible: [36-36], [39-40], [42-42], [44-45], [47-47], [49-50]
-		Var: ss: []string (declared at line 39, available: [36-50])
-		Scope: 39-44
-			Var: i: int (declared at line 40, available: [42-42], [44-44])
-		Scope: 44-49
-			Var: i: int (declared at line 45, available: [47-47], [49-49])
+	Function: executeContinuationFuncs (main.executeContinuationFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [119:196] injectible: [119-121], [124-193], [195-196]
+		Arg: ctx: context.Context (declared at line 119, available: [119-121])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 120, available: [121-121])
+		Var: m: main.manyPointers (declared at line 123, available: [119-196])
+	Function: executeContinuationStringFuncs (main.executeContinuationStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [39:56] injectible: [39-41], [45-46], [48-48], [50-51], [53-53], [55-56]
+		Arg: ctx: context.Context (declared at line 39, available: [39-41])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 40, available: [41-46])
+		Var: ss: []string (declared at line 45, available: [39-56])
+		Scope: 45-50
+			Var: i: int (declared at line 46, available: [48-48], [50-50])
+		Scope: 50-55
+			Var: i: int (declared at line 51, available: [53-53], [55-55])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69] injectible: [51-52], [55-58], [60-62], [68-69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -79,10 +89,12 @@ Package: main
 		Arg: acc: string (declared at line 340, available: [340-340])
 		Arg: x: string (declared at line 340, available: [340-340])
 		Arg: ~r0: string (declared at line 340, available: )
-	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106] injectible: [97-98], [100-106]
-		Var: x: int (declared at line 99, available: )
-		Var: y: int (declared at line 100, available: [97-106])
-		Var: a: [5]int (declared at line 98, available: [97-106])
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [100:112] injectible: [100-102], [104-104], [106-112]
+		Arg: ctx: context.Context (declared at line 100, available: [100-102])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 101, available: [102-107])
+		Var: x: int (declared at line 105, available: )
+		Var: y: int (declared at line 106, available: [100-112])
+		Var: a: [5]int (declared at line 104, available: [100-112])
 	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [76:124] injectible: [76-82], [88-112], [117-120], [122-122], [124-124]
 		Var: &one: *int (declared at line 95, available: [76-124])
 		Var: &foo: *string (declared at line 98, available: [76-124])
@@ -129,103 +141,121 @@ Package: main
 			Var: i: int (declared at line 210, available: [123-219])
 			Scope: 210-212
 				Var: key: [4]int (declared at line 211, available: )
-	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
-		Var: x: chan bool (declared at line 52, available: [53-54])
-	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-140], [143-143], [145-145], [148-150], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
-		Var: self: *main.node (declared at line 172, available: [173-177])
-		Var: z: main.spws (declared at line 118, available: )
-		Var: r: string (declared at line 117, available: [112-178])
-		Var: ssaw: main.swsp (declared at line 126, available: [112-178])
-		Var: rct: main.reallyComplexType (declared at line 137, available: [112-178])
-		Var: b: main.node (declared at line 145, available: [112-178])
-		Var: stringSlice: []string (declared at line 162, available: [112-178])
-		Var: up: *int (declared at line 168, available: [112-178])
-		Var: aruint: [2]uint (declared at line 159, available: )
-		Var: n: main.nStruct (declared at line 123, available: )
-		Var: u: int (declared at line 167, available: )
-		Var: u64F: uint64 (declared at line 113, available: )
-		Var: uintToPointTo: uint (declared at line 120, available: )
-		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [92:127] injectible: [92-94], [96-96], [109-123], [127-127]
+		Arg: ctx: context.Context (declared at line 92, available: [92-94])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 93, available: [94-96])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [54:62] injectible: [54-56], [58-62]
+		Arg: ctx: context.Context (declared at line 54, available: [54-56])
+		Var: x: chan bool (declared at line 58, available: [59-60])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 55, available: [56-58])
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [117:186] injectible: [117-119], [121-121], [123-123], [125-125], [128-129], [131-134], [138-140], [142-143], [145-148], [151-151], [153-153], [156-158], [163-163], [165-165], [167-168], [170-171], [173-173], [175-176], [178-178], [180-181], [183-186]
+		Arg: ctx: context.Context (declared at line 117, available: [117-119])
+		Var: z: main.spws (declared at line 126, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 118, available: [119-123])
+		Var: self: *main.node (declared at line 180, available: [181-185])
+		Var: r: string (declared at line 125, available: [117-186])
+		Var: ssaw: main.swsp (declared at line 134, available: [117-186])
+		Var: rct: main.reallyComplexType (declared at line 145, available: [117-186])
+		Var: b: main.node (declared at line 153, available: [117-186])
+		Var: stringSlice: []string (declared at line 170, available: [117-186])
+		Var: up: *int (declared at line 176, available: [117-186])
+		Var: aruint: [2]uint (declared at line 167, available: )
+		Var: n: main.nStruct (declared at line 131, available: )
+		Var: u: int (declared at line 175, available: )
+		Var: u64F: uint64 (declared at line 121, available: )
+		Var: uintToPointTo: uint (declared at line 128, available: )
+		Var: x: main.structWithTwoValues (declared at line 142, available: )
 	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
 		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
 		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
 		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
-	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [29:33] injectible: [29-33]
-	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [132:181] injectible: [132-135], [137-144], [146-150], [152-152], [154-156], [159-160], [162-173], [175-175], [177-177], [179-181]
-		Var: originalSlice: []int (declared at line 133, available: )
-		Var: s: []uint (declared at line 142, available: )
-		Var: s2: []uint (declared at line 159, available: )
-		Scope: 143-146
-			Var: i: int (declared at line 143, available: [146-146])
-	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [30-30]
-	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [65:86] injectible: [65-65], [67-72], [75-77], [81-81], [84-86]
-		Var: abc: string (declared at line 66, available: )
-		Var: uninitializedString: string (declared at line 74, available: )
-		Var: s: string (declared at line 80, available: )
-	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [135:236] injectible: [135-137], [140-140], [142-143], [145-146], [150-150], [152-160], [172-172], [174-174], [177-182], [190-192], [194-195], [198-198], [200-201], [203-206], [208-208], [210-213], [215-216], [220-220], [222-223], [225-226], [228-229], [231-232], [235-236]
-		Var: n: main.nStruct (declared at line 139, available: )
-		Var: ns: main.structWithNoStrings (declared at line 148, available: )
-		Var: cs: main.cStruct (declared at line 149, available: )
-		Var: rcvr: main.receiver (declared at line 197, available: )
-		Var: ts: main.threestrings (declared at line 136, available: [135-236])
-		Var: s: main.aStruct (declared at line 142, available: [135-236])
-		Var: b: main.bStruct (declared at line 145, available: [135-236])
-		Var: tenStr: main.tenStrings (declared at line 162, available: [135-236])
-		Var: deep: main.deepStruct1 (declared at line 176, available: [135-236])
-		Var: fields: main.lotsOfFields (declared at line 194, available: [135-236])
-		Var: sta: main.structWithTwoArrays (declared at line 203, available: [135-236])
-		Var: .autotmp_112: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_131: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_138: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_143: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_15: [0]main.structWithCyclicSlices (declared at line 220, available: [135-236])
-		Var: .autotmp_167: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_174: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_179: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_18: [0][]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_186: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_19: [0]main.structWithCyclicSlices (declared at line 223, available: [135-236])
-		Var: .autotmp_192: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_197: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_204: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_210: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_215: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_227: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_234: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_239: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_24: [0][][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_246: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_252: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_257: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_264: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_27: [0]main.structWithCyclicSlices (declared at line 226, available: [135-236])
-		Var: .autotmp_270: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_275: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_282: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_289: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_295: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_300: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_34: [0][][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_35: [0][][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_37: [0][]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_40: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_44: [0]main.structWithCyclicSlices (declared at line 229, available: [135-236])
-		Var: .autotmp_49: [0][][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_50: [0][][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_52: [0][][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_55: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_59: [0][]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_63: [0]main.structWithCyclicSlices (declared at line 232, available: [135-236])
-		Var: .autotmp_13: [0]uint8 (declared at line 157, available: [135-236])
-		Var: .autotmp_88: main.emptyStruct (declared at line 190, available: [135-236])
-	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [39:56] injectible: [39-39], [41-42], [48-51], [56-56]
-		Var: ist: *time.Location (declared at line 48, available: [49-50])
-	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25] injectible: [22-25]
-		Arg: x: []int (declared at line 22, available: [22-23], [24-24], [25-25])
-	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30] injectible: [28-30]
-		Arg: f: func(int) (declared at line 28, available: [28-29])
+	Function: executeServerFuncs (main.executeServerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [34:41] injectible: [34-36], [38-41]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [137:189] injectible: [137-139], [141-143], [145-152], [154-158], [160-160], [162-164], [167-168], [170-181], [183-183], [185-185], [187-189]
+		Arg: ctx: context.Context (declared at line 137, available: [137-139])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 138, available: [139-141])
+		Var: originalSlice: []int (declared at line 141, available: )
+		Var: s: []uint (declared at line 150, available: )
+		Var: s2: []uint (declared at line 167, available: )
+		Scope: 151-154
+			Var: i: int (declared at line 151, available: [154-154])
+	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [34:39] injectible: [34-36], [38-39]
+		Arg: ctx: context.Context (declared at line 34, available: [34-36])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 35, available: [36-39])
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [70:94] injectible: [70-72], [75-80], [83-85], [89-89], [92-94]
+		Arg: ctx: context.Context (declared at line 70, available: [70-72])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 71, available: [72-75])
+		Var: abc: string (declared at line 74, available: )
+		Var: uninitializedString: string (declared at line 82, available: )
+		Var: s: string (declared at line 88, available: )
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [141:245] injectible: [141-143], [145-146], [149-149], [151-152], [154-155], [159-159], [161-169], [181-181], [183-183], [186-191], [199-201], [203-204], [207-207], [209-210], [212-215], [217-217], [219-222], [224-225], [229-229], [231-232], [234-235], [237-238], [240-241], [244-245]
+		Arg: ctx: context.Context (declared at line 141, available: [141-143])
+		Var: rcvr: main.receiver (declared at line 206, available: )
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 142, available: [143-149])
+		Var: n: main.nStruct (declared at line 148, available: )
+		Var: ns: main.structWithNoStrings (declared at line 157, available: )
+		Var: cs: main.cStruct (declared at line 158, available: )
+		Var: ts: main.threestrings (declared at line 145, available: [141-245])
+		Var: s: main.aStruct (declared at line 151, available: [141-245])
+		Var: b: main.bStruct (declared at line 154, available: [141-245])
+		Var: tenStr: main.tenStrings (declared at line 171, available: [141-245])
+		Var: deep: main.deepStruct1 (declared at line 185, available: [141-245])
+		Var: fields: main.lotsOfFields (declared at line 203, available: [141-245])
+		Var: sta: main.structWithTwoArrays (declared at line 212, available: [141-245])
+		Var: .autotmp_121: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_140: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_147: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_152: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_176: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_183: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_188: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_195: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_201: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_206: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_213: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_219: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_22: [0]main.structWithCyclicSlices (declared at line 229, available: [141-245])
+		Var: .autotmp_224: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_236: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_243: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_248: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_25: [0][]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_255: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_26: [0]main.structWithCyclicSlices (declared at line 232, available: [141-245])
+		Var: .autotmp_261: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_266: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_273: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_279: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_284: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_291: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_298: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_304: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_309: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_31: [0][][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_32: [0][]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_34: [0]main.structWithCyclicSlices (declared at line 235, available: [141-245])
+		Var: .autotmp_41: [0][][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_42: [0][][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_44: [0][]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_47: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_51: [0]main.structWithCyclicSlices (declared at line 238, available: [141-245])
+		Var: .autotmp_56: [0][][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_57: [0][][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_59: [0][][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_62: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_66: [0][]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_70: [0]main.structWithCyclicSlices (declared at line 241, available: [141-245])
+		Var: .autotmp_20: [0]uint8 (declared at line 166, available: [141-245])
+		Var: .autotmp_97: main.emptyStruct (declared at line 199, available: [141-245])
+	Function: executeTimeFuncs (main.executeTimeFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [44:65] injectible: [44-46], [49-50], [56-59], [64-65]
+		Arg: ctx: context.Context (declared at line 44, available: [44-46])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 45, available: [46-50])
+		Var: ist: *time.Location (declared at line 56, available: [57-58])
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [27:30] injectible: [27-30]
+		Arg: x: []int (declared at line 27, available: [27-28], [29-29], [30-30])
+	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [31:33] injectible: [31-33]
+		Arg: f: func(int) (declared at line 31, available: [31-32])
 	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [109:119] injectible: [109-115], [117-117], [119-119]
 		Arg: entriesCount: int (declared at line 109, available: [109-119])
 		Arg: ~r0: map[string][]main.structWithMap (declared at line 109, available: )
@@ -260,9 +290,9 @@ Package: main
 		Arg: b: <T> (declared at line 113, available: [113-114])
 		Arg: ~r0: <T> (declared at line 113, available: )
 		Arg: ~r1: <T> (declared at line 113, available: )
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [133:133] injectible: [133-133]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [159:159] injectible: [159-159]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [197:197] injectible: [197-197]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:17] injectible: [17-17]
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -270,11 +300,12 @@ Package: main
 	Function: iterExample.rangeOverIterator.Values[...].func1 (main.iterExample.rangeOverIterator.Values[go.shape.[]int,go.shape.int].func1) in slices/iter.go [38:40] injectible: [39-40]
 		Var: v: go.shape.int (declared at line 39, available: [40-40])
 		Arg: yield: func(go.shape.int) bool (declared at line 0, available: )
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [21:50] injectible: [21-21], [26-26], [29-30], [33-33], [35-35], [37-40], [44-48], [50-50]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [22:50] injectible: [22-22], [27-27], [30-31], [34-34], [36-36], [38-41], [44-48], [50-50]
 		Var: ticker: *time.Ticker (declared at line 44, available: [45-45])
-		Var: service: string (declared at line 29, available: [30-33])
+		Var: service: string (declared at line 30, available: [31-34])
 		Scope: 45-48
 			Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 46, available: [45-48])
+			Var: ctx: context.Context (declared at line 46, available: [47-47])
 	Type: main.Pair[...]
 		Field: Key: <T>
 		Field: Value: <T>
@@ -288,10 +319,10 @@ Package: main
 		Field: Total: float64
 	Type: main.Server
 		Field: name: string
-		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [21:26] injectible: [21-23], [25-26]
-			Arg: s: *main.Server (declared at line 21, available: [21-23])
-			Arg: req: *main.Request (declared at line 21, available: [21-26])
-			Arg: ~r0: error (declared at line 21, available: )
+		Function: handleOrder (main.(*Server).handleOrder) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go [26:31] injectible: [26-28], [30-31]
+			Arg: s: *main.Server (declared at line 26, available: [26-28])
+			Arg: req: *main.Request (declared at line 26, available: [26-31])
+			Arg: ~r0: error (declared at line 26, available: )
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [988-989])
@@ -606,12 +637,12 @@ Package: main
 		Field: aStringPtr: *string
 	Type: main.receiver
 		Field: u: uint
-		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52] injectible: [52-52]
-			Arg: r: *main.receiver (declared at line 52, available: [52-52])
-			Arg: a: int (declared at line 52, available: [52-52])
-		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56] injectible: [56-56]
-			Arg: r: main.receiver (declared at line 56, available: [56-56])
-			Arg: a: int (declared at line 56, available: [56-56])
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [58:58] injectible: [58-58]
+			Arg: r: *main.receiver (declared at line 58, available: [58-58])
+			Arg: a: int (declared at line 58, available: [58-58])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [62:62] injectible: [62-62]
+			Arg: r: main.receiver (declared at line 62, available: [62-62])
+			Arg: a: int (declared at line 62, available: [62-62])
 	Type: main.score
 	Type: main.secondBehavior
 		Field: i: int
@@ -729,14 +760,14 @@ Package: main
 		Field: i: int
 		Field: j: int
 		Field: k: int
-	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [104:107] injectible: [105-107]
-		Var: i: int (declared at line 106, available: [105-105])
-		Arg: id: int (declared at line 0, available: [105-107])
-		Var: p: *main.paddedData (declared at line 105, available: )
-	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [23:28] injectible: [23-26], [28-28]
-		Arg: n: int (declared at line 23, available: [23-28])
-		Arg: ~r0: string (declared at line 23, available: )
-		Var: prefix: string (declared at line 24, available: [23-26], [28-28])
+	Function: makePaddedData (main.makePaddedData) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [110:113] injectible: [111-113]
+		Var: i: int (declared at line 112, available: [111-111])
+		Arg: id: int (declared at line 0, available: )
+		Var: p: *main.paddedData (declared at line 111, available: )
+	Function: makeTestString (main.makeTestString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [26:31] injectible: [26-29], [31-31]
+		Arg: n: int (declared at line 26, available: [26-31])
+		Arg: ~r0: string (declared at line 26, available: )
+		Var: prefix: string (declared at line 27, available: [26-29], [31-31])
 		Var: ~r0.ptr: *uint8 (declared at line 50, available: )
 		Var: ~r0.len: int (declared at line 50, available: )
 	Function: nestedGeneric[...] (main.nestedGeneric[...]) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [203:203] injectible: [203-203]
@@ -748,20 +779,21 @@ Package: main
 		Arg: items: <T> (declared at line 183, available: [183-184])
 		Arg: pred: <T> (declared at line 183, available: [183-184])
 		Arg: ~r0: <T> (declared at line 183, available: )
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
-		Arg: ~r0: uint64 (declared at line 40, available: )
-		Var: n: uint64 (declared at line 45, available: [44-46])
-		Var: b: []uint8 (declared at line 41, available: [42-45])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [43:49] injectible: [43-49]
+		Arg: ~r0: uint64 (declared at line 43, available: )
+		Var: n: uint64 (declared at line 48, available: [47-49])
+		Var: b: []uint8 (declared at line 44, available: [45-48])
 	Function: runAll (main.runAll) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [52:88] injectible: [52-66], [68-69], [71-73], [75-77], [80-88]
+		Arg: ctx: context.Context (declared at line 52, available: [52-88])
 		Var: it: main.iterExample (declared at line 70, available: [52-88])
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 67, available: [52-88])
-	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
-		Arg: x: []int (declared at line 16, available: [16-17])
-		Arg: ~r0: string (declared at line 16, available: )
-	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14] injectible: [12-14]
-	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20] injectible: [18-20]
-	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25] injectible: [24-25]
-		Arg: ~r0: string (declared at line 24, available: )
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [21:22] injectible: [21-22]
+		Arg: x: []int (declared at line 21, available: [21-22])
+		Arg: ~r0: string (declared at line 21, available: )
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [17:19] injectible: [17-19]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [23:25] injectible: [23-25]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30] injectible: [29-30]
+		Arg: ~r0: string (declared at line 29, available: )
 	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [54:55] injectible: [54-55]
 		Arg: a: interface {} (declared at line 54, available: [54-55])
 		Arg: ~r0: string (declared at line 54, available: )
@@ -771,225 +803,225 @@ Package: main
 	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
 		Arg: arg: [3]int (declared at line 297, available: [297-302])
 		Arg: ~r0: [3]int (declared at line 297, available: )
-	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
-		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
-	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
-		Arg: a: [2][2]int (declared at line 70, available: [70-70])
-	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78] injectible: [78-78]
-		Arg: b: [2][2][2]int (declared at line 78, available: [78-78])
+	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [93:93] injectible: [93-93]
+		Arg: a: [2]struct {} (declared at line 93, available: [93-93])
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [76:76] injectible: [76-76]
+		Arg: a: [2][2]int (declared at line 76, available: [76-76])
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [84:84] injectible: [84-84]
+		Arg: b: [2][2][2]int (declared at line 84, available: [84-84])
 	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [42:42] injectible: [42-42]
 		Arg: m: [2]map[string]int (declared at line 42, available: [42-42])
-	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74] injectible: [74-74]
-		Arg: a: [2]string (declared at line 74, available: [74-74])
-	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83] injectible: [83-83]
-		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
-	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
-		Arg: x: *[2]uint (declared at line 59, available: [59-59])
-	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
-		Arg: x: uint64 (declared at line 19, available: [23-23])
-		Arg: ~r0: uint64 (declared at line 19, available: )
-	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
-		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
-	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
-		Arg: x: [2]bool (declared at line 26, available: [26-26])
-	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [117:117] injectible: [117-117]
-		Arg: a: []uint8 (declared at line 117, available: [117-117])
-		Arg: b: []uint8 (declared at line 117, available: [117-117])
-	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
-		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [129:129] injectible: [129-129]
-		Arg: a: []uint8 (declared at line 129, available: [129-129])
-		Arg: b: []int (declared at line 129, available: [129-129])
-	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [77:77] injectible: [77-77]
-		Arg: x: []uint8 (declared at line 77, available: [77-77])
-	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [81:81] injectible: [81-81]
-		Arg: x: []uint8 (declared at line 81, available: [81-81])
-	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [85:85] injectible: [85-85]
-		Arg: x: []uint8 (declared at line 85, available: [85-85])
-	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [89:89] injectible: [89-89]
-		Arg: x: []uint8 (declared at line 89, available: [89-89])
-	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [93:93] injectible: [93-93]
-		Arg: x: []uint8 (declared at line 93, available: [93-93])
-	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [121:121] injectible: [121-121]
-		Arg: x: [][]uint8 (declared at line 121, available: [121-121])
-	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [125:125] injectible: [125-125]
-		Arg: a: int (declared at line 125, available: [125-125])
-		Arg: x: []uint8 (declared at line 125, available: [125-125])
-		Arg: b: string (declared at line 125, available: [125-125])
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [80:80] injectible: [80-80]
+		Arg: a: [2]string (declared at line 80, available: [80-80])
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [89:89] injectible: [89-89]
+		Arg: a: [2]main.nestedStruct (declared at line 88, available: [89-89])
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [64:64] injectible: [64-64]
+		Arg: x: *[2]uint (declared at line 64, available: [64-64])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [26:26] injectible: [26-26]
+		Arg: x: uint64 (declared at line 22, available: [26-26])
+		Arg: ~r0: uint64 (declared at line 22, available: )
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [85:85] injectible: [85-85]
+		Arg: b: main.bigStruct (declared at line 85, available: [85-85])
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [32:32] injectible: [32-32]
+		Arg: x: [2]bool (declared at line 32, available: [32-32])
+	Function: testByteAndUint8Slices (main.testByteAndUint8Slices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [122:122] injectible: [122-122]
+		Arg: a: []uint8 (declared at line 122, available: [122-122])
+		Arg: b: []uint8 (declared at line 122, available: [122-122])
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [20:20] injectible: [20-20]
+		Arg: x: [2]uint8 (declared at line 20, available: [20-20])
+	Function: testByteSliceAndIntSlice (main.testByteSliceAndIntSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [134:134] injectible: [134-134]
+		Arg: a: []uint8 (declared at line 134, available: [134-134])
+		Arg: b: []int (declared at line 134, available: [134-134])
+	Function: testByteSliceAscii (main.testByteSliceAscii) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [82:82] injectible: [82-82]
+		Arg: x: []uint8 (declared at line 82, available: [82-82])
+	Function: testByteSliceBinary (main.testByteSliceBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [86:86] injectible: [86-86]
+		Arg: x: []uint8 (declared at line 86, available: [86-86])
+	Function: testByteSliceEmbeddedNul (main.testByteSliceEmbeddedNul) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [90:90] injectible: [90-90]
+		Arg: x: []uint8 (declared at line 90, available: [90-90])
+	Function: testByteSliceInvalidUtf8 (main.testByteSliceInvalidUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [94:94] injectible: [94-94]
+		Arg: x: []uint8 (declared at line 94, available: [94-94])
+	Function: testByteSliceMultibyteUtf8 (main.testByteSliceMultibyteUtf8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [98:98] injectible: [98-98]
+		Arg: x: []uint8 (declared at line 98, available: [98-98])
+	Function: testByteSliceOfSlices (main.testByteSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [126:126] injectible: [126-126]
+		Arg: x: [][]uint8 (declared at line 126, available: [126-126])
+	Function: testByteSliceWithOtherParams (main.testByteSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [130:130] injectible: [130-130]
+		Arg: a: int (declared at line 130, available: [130-130])
+		Arg: x: []uint8 (declared at line 130, available: [130-130])
+		Arg: b: string (declared at line 130, available: [130-130])
 	Function: testCaptureContextImpl (main.testCaptureContextImpl) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context_impl_capture.go [44:44] injectible: [44-44]
 		Arg: c: *main.contextImpl (declared at line 44, available: [44-44])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
-		Arg: c: chan bool (declared at line 30, available: [30-30])
-	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
-		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
-	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
-		Arg: w: uint8 (declared at line 34, available: [34-34])
-		Arg: x: bool (declared at line 34, available: [34-34])
-		Arg: y: float32 (declared at line 34, available: [34-34])
-	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22] injectible: [22-22]
-		Arg: w: uint8 (declared at line 22, available: [22-22])
-		Arg: x: uint8 (declared at line 22, available: [22-22])
-		Arg: y: float32 (declared at line 22, available: [22-22])
-	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38] injectible: [38-38]
-		Arg: w: uint8 (declared at line 38, available: [38-38])
-		Arg: x: int (declared at line 38, available: [38-38])
-		Arg: y: float32 (declared at line 38, available: [38-38])
-	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46] injectible: [46-46]
-		Arg: w: uint8 (declared at line 46, available: [46-46])
-		Arg: x: int16 (declared at line 46, available: [46-46])
-		Arg: y: float32 (declared at line 46, available: [46-46])
-	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50] injectible: [50-50]
-		Arg: w: uint8 (declared at line 50, available: [50-50])
-		Arg: x: int32 (declared at line 50, available: [50-50])
-		Arg: y: float32 (declared at line 50, available: [50-50])
-	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54] injectible: [54-54]
-		Arg: w: uint8 (declared at line 54, available: [54-54])
-		Arg: x: int64 (declared at line 54, available: [54-54])
-		Arg: y: float32 (declared at line 54, available: [54-54])
-	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42] injectible: [42-42]
-		Arg: w: uint8 (declared at line 42, available: [42-42])
-		Arg: x: int8 (declared at line 42, available: [42-42])
-		Arg: y: float32 (declared at line 42, available: [42-42])
-	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26] injectible: [26-26]
-		Arg: w: uint8 (declared at line 26, available: [26-26])
-		Arg: x: int32 (declared at line 26, available: [26-26])
-		Arg: y: float32 (declared at line 26, available: [26-26])
-	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30] injectible: [30-30]
-		Arg: w: uint8 (declared at line 30, available: [30-30])
-		Arg: x: string (declared at line 30, available: [30-30])
-		Arg: y: float32 (declared at line 30, available: [30-30])
-	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58] injectible: [58-58]
-		Arg: w: uint8 (declared at line 58, available: [58-58])
-		Arg: x: uint (declared at line 58, available: [58-58])
-		Arg: y: float32 (declared at line 58, available: [58-58])
-	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66] injectible: [66-66]
-		Arg: w: uint8 (declared at line 66, available: [66-66])
-		Arg: x: uint16 (declared at line 66, available: [66-66])
-		Arg: y: float32 (declared at line 66, available: [66-66])
-	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70] injectible: [70-70]
-		Arg: w: uint8 (declared at line 70, available: [70-70])
-		Arg: x: uint32 (declared at line 70, available: [70-70])
-		Arg: y: float32 (declared at line 70, available: [70-70])
-	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74] injectible: [74-74]
-		Arg: w: uint8 (declared at line 74, available: [74-74])
-		Arg: x: uint64 (declared at line 74, available: [74-74])
-		Arg: y: float32 (declared at line 74, available: [74-74])
-	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62] injectible: [62-62]
-		Arg: w: uint8 (declared at line 62, available: [62-62])
-		Arg: x: uint8 (declared at line 62, available: [62-62])
-		Arg: y: float32 (declared at line 62, available: [62-62])
-	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75] injectible: [75-75]
-		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [33:33] injectible: [33-33]
+		Arg: c: chan bool (declared at line 33, available: [33-33])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93] injectible: [93-93]
+		Arg: x: main.circularReferenceType (declared at line 93, available: [93-93])
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [40:40] injectible: [40-40]
+		Arg: w: uint8 (declared at line 40, available: [40-40])
+		Arg: x: bool (declared at line 40, available: [40-40])
+		Arg: y: float32 (declared at line 40, available: [40-40])
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [28:28] injectible: [28-28]
+		Arg: w: uint8 (declared at line 28, available: [28-28])
+		Arg: x: uint8 (declared at line 28, available: [28-28])
+		Arg: y: float32 (declared at line 28, available: [28-28])
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [44:44] injectible: [44-44]
+		Arg: w: uint8 (declared at line 44, available: [44-44])
+		Arg: x: int (declared at line 44, available: [44-44])
+		Arg: y: float32 (declared at line 44, available: [44-44])
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [52:52] injectible: [52-52]
+		Arg: w: uint8 (declared at line 52, available: [52-52])
+		Arg: x: int16 (declared at line 52, available: [52-52])
+		Arg: y: float32 (declared at line 52, available: [52-52])
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [56:56] injectible: [56-56]
+		Arg: w: uint8 (declared at line 56, available: [56-56])
+		Arg: x: int32 (declared at line 56, available: [56-56])
+		Arg: y: float32 (declared at line 56, available: [56-56])
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [60:60] injectible: [60-60]
+		Arg: w: uint8 (declared at line 60, available: [60-60])
+		Arg: x: int64 (declared at line 60, available: [60-60])
+		Arg: y: float32 (declared at line 60, available: [60-60])
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [48:48] injectible: [48-48]
+		Arg: w: uint8 (declared at line 48, available: [48-48])
+		Arg: x: int8 (declared at line 48, available: [48-48])
+		Arg: y: float32 (declared at line 48, available: [48-48])
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [32:32] injectible: [32-32]
+		Arg: w: uint8 (declared at line 32, available: [32-32])
+		Arg: x: int32 (declared at line 32, available: [32-32])
+		Arg: y: float32 (declared at line 32, available: [32-32])
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [36:36] injectible: [36-36]
+		Arg: w: uint8 (declared at line 36, available: [36-36])
+		Arg: x: string (declared at line 36, available: [36-36])
+		Arg: y: float32 (declared at line 36, available: [36-36])
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [64:64] injectible: [64-64]
+		Arg: w: uint8 (declared at line 64, available: [64-64])
+		Arg: x: uint (declared at line 64, available: [64-64])
+		Arg: y: float32 (declared at line 64, available: [64-64])
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [72:72] injectible: [72-72]
+		Arg: w: uint8 (declared at line 72, available: [72-72])
+		Arg: x: uint16 (declared at line 72, available: [72-72])
+		Arg: y: float32 (declared at line 72, available: [72-72])
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [76:76] injectible: [76-76]
+		Arg: w: uint8 (declared at line 76, available: [76-76])
+		Arg: x: uint32 (declared at line 76, available: [76-76])
+		Arg: y: float32 (declared at line 76, available: [76-76])
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [80:80] injectible: [80-80]
+		Arg: w: uint8 (declared at line 80, available: [80-80])
+		Arg: x: uint64 (declared at line 80, available: [80-80])
+		Arg: y: float32 (declared at line 80, available: [80-80])
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [68:68] injectible: [68-68]
+		Arg: w: uint8 (declared at line 68, available: [68-68])
+		Arg: x: uint8 (declared at line 68, available: [68-68])
+		Arg: y: float32 (declared at line 68, available: [68-68])
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [80:80] injectible: [80-80]
+		Arg: z: *main.reallyComplexType (declared at line 80, available: [80-80])
 	Function: testConflictingReturn (main.testConflictingReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [109:111] injectible: [109-111]
 		Arg: i: int (declared at line 109, available: [109-111])
 		Arg: ~r0: int (declared at line 109, available: )
 		Arg: r0: string (declared at line 109, available: )
-	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109] injectible: [109-109]
-		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200] injectible: [200-200]
-		Arg: a: main.deepMap1 (declared at line 200, available: [200-200])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
-		Arg: a: *main.deepMap7 (declared at line 203, available: [203-203])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [136:136] injectible: [136-136]
-		Arg: a: main.deepPtr1 (declared at line 136, available: [136-136])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
-		Arg: a: *main.deepPtr7 (declared at line 139, available: [139-139])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [162:162] injectible: [162-162]
-		Arg: a: main.deepSlice1 (declared at line 162, available: [162-162])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
-		Arg: a: *main.deepSlice7 (declared at line 165, available: [165-165])
-	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120] injectible: [120-120]
-		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
-	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [97:97] injectible: [97-97]
-		Arg: x: []uint8 (declared at line 97, available: [97-97])
-	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33] injectible: [33-33]
-		Arg: u: []uint (declared at line 33, available: [33-33])
-	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45] injectible: [45-45]
-		Arg: xs: []main.structWithNoStrings (declared at line 45, available: [45-45])
-		Arg: a: int (declared at line 45, available: [45-45])
-	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [50:50] injectible: [50-50]
-		Arg: x: string (declared at line 50, available: [50-50])
-	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [124:124] injectible: [124-124]
-		Arg: e: main.emptyStruct (declared at line 124, available: )
-	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [128:128] injectible: [128-128]
-		Arg: e: *main.emptyStruct (declared at line 128, available: [128-128])
+	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [114:114] injectible: [114-114]
+		Arg: t: *main.t (declared at line 114, available: [114-114])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:203] injectible: [203-203]
+		Arg: a: main.deepMap1 (declared at line 203, available: [203-203])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [206:206] injectible: [206-206]
+		Arg: a: *main.deepMap7 (declared at line 206, available: [206-206])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139] injectible: [139-139]
+		Arg: a: main.deepPtr1 (declared at line 139, available: [139-139])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142] injectible: [142-142]
+		Arg: a: *main.deepPtr7 (declared at line 142, available: [142-142])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [165:165] injectible: [165-165]
+		Arg: a: main.deepSlice1 (declared at line 165, available: [165-165])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [168:168] injectible: [168-168]
+		Arg: a: *main.deepSlice7 (declared at line 168, available: [168-168])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [126:126] injectible: [126-126]
+		Arg: t: main.deepStruct1 (declared at line 126, available: [126-126])
+	Function: testEmptyByteSlice (main.testEmptyByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [102:102] injectible: [102-102]
+		Arg: x: []uint8 (declared at line 102, available: [102-102])
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [38:38] injectible: [38-38]
+		Arg: u: []uint (declared at line 38, available: [38-38])
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [50:50] injectible: [50-50]
+		Arg: xs: []main.structWithNoStrings (declared at line 50, available: [50-50])
+		Arg: a: int (declared at line 50, available: [50-50])
+	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [55:55] injectible: [55-55]
+		Arg: x: string (declared at line 55, available: [55-55])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [130:130] injectible: [130-130]
+		Arg: e: main.emptyStruct (declared at line 130, available: )
+	Function: testEmptyStructPointer (main.testEmptyStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [134:134] injectible: [134-134]
+		Arg: e: *main.emptyStruct (declared at line 134, available: [134-134])
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60] injectible: [60-60]
 		Arg: e: error (declared at line 60, available: [60-60])
-	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [101:112] injectible: [101-101], [103-104], [106-106], [108-110], [112-112]
-		Arg: shouldErr: bool (declared at line 101, available: [101-106])
-		Arg: ~r0: int (declared at line 101, available: )
-		Var: x: int (declared at line 106, available: )
-		Var: err: error (declared at line 102, available: [101-112])
+	Function: testErrorAtLine (main.testErrorAtLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [104:115] injectible: [104-104], [106-107], [109-109], [111-113], [115-115]
+		Arg: shouldErr: bool (declared at line 104, available: [104-109])
+		Arg: ~r0: int (declared at line 104, available: )
+		Var: x: int (declared at line 109, available: )
+		Var: err: error (declared at line 105, available: [104-115])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49] injectible: [47-49]
 		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44] injectible: [42-44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
-	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80] injectible: [79-80]
-		Arg: x: int (declared at line 79, available: [79-80])
-		Arg: ~r0: int (declared at line 79, available: )
-	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93] injectible: [92-93]
-		Arg: a: [5]int (declared at line 92, available: [92-93])
-		Arg: ~r0: int (declared at line 92, available: )
-	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [17:19] injectible: [17-19]
-		Arg: x: int (declared at line 17, available: [17-18])
-		Arg: y: int (declared at line 17, available: [17-18])
-	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [21:25] injectible: [21-25]
-		Arg: x: int (declared at line 21, available: [21-25])
-		Arg: y: int (declared at line 21, available: [21-25])
-	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35] injectible: [32-32], [34-35]
-		Arg: x: int (declared at line 32, available: [32-34])
-	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42] injectible: [37-42]
-		Arg: x: int (declared at line 37, available: [37-38])
-		Arg: y: int (declared at line 37, available: [37-39])
-		Var: z: int (declared at line 38, available: [37-42])
-	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46] injectible: [44-46]
-		Arg: x: int (declared at line 44, available: [44-45])
-	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49] injectible: [49-49]
-	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60] injectible: [52-53], [55-56], [58-60]
-		Var: s: int (declared at line 54, available: [55-58])
-		Scope: 55-58
-			Var: i: int (declared at line 55, available: [55-58])
-	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63] injectible: [63-63]
-	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [66:67] injectible: [67-67]
-	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [13:15] injectible: [14-14]
-		Arg: x: int (declared at line 0, available: [13-14])
-	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [74:75] injectible: [75-75]
-		Arg: x: int (declared at line 0, available: [75-75])
-	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:71] injectible: [71-71]
-		Arg: a: [5]int (declared at line 0, available: [71-71])
-	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38] injectible: [38-38]
-		Arg: x: [2]int16 (declared at line 38, available: [38-38])
-	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42] injectible: [42-42]
-		Arg: x: [2]int32 (declared at line 42, available: [42-42])
-	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46] injectible: [46-46]
-		Arg: x: [2]int64 (declared at line 46, available: [46-46])
-	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34] injectible: [34-34]
-		Arg: x: [2]int8 (declared at line 34, available: [34-34])
-	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30] injectible: [30-30]
-		Arg: x: [2]int (declared at line 30, available: [30-30])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [82:83] injectible: [82-83]
+		Arg: x: int (declared at line 82, available: [82-83])
+		Arg: ~r0: int (declared at line 82, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [95:96] injectible: [95-96]
+		Arg: a: [5]int (declared at line 95, available: [95-96])
+		Arg: ~r0: int (declared at line 95, available: )
+	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [20:22] injectible: [20-22]
+		Arg: x: int (declared at line 20, available: [20-21])
+		Arg: y: int (declared at line 20, available: [20-21])
+	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [24:28] injectible: [24-28]
+		Arg: x: int (declared at line 24, available: [24-28])
+		Arg: y: int (declared at line 24, available: [24-28])
+	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [35:38] injectible: [35-35], [37-38]
+		Arg: x: int (declared at line 35, available: [35-37])
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [40:45] injectible: [40-45]
+		Arg: x: int (declared at line 40, available: [40-41])
+		Arg: y: int (declared at line 40, available: [40-42])
+		Var: z: int (declared at line 41, available: [40-45])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [47:49] injectible: [47-49]
+		Arg: x: int (declared at line 47, available: [47-48])
+	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [51:52] injectible: [52-52]
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [55:63] injectible: [55-56], [58-59], [61-63]
+		Var: s: int (declared at line 57, available: [58-61])
+		Scope: 58-61
+			Var: i: int (declared at line 58, available: [58-61])
+	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [65:66] injectible: [66-66]
+	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [69:70] injectible: [70-70]
+	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [16:18] injectible: [17-17]
+		Arg: x: int (declared at line 0, available: [16-17])
+	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [77:78] injectible: [78-78]
+		Arg: x: int (declared at line 0, available: [78-78])
+	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [73:74] injectible: [74-74]
+		Arg: a: [5]int (declared at line 0, available: [74-74])
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [44:44] injectible: [44-44]
+		Arg: x: [2]int16 (declared at line 44, available: [44-44])
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [48:48] injectible: [48-48]
+		Arg: x: [2]int32 (declared at line 48, available: [48-48])
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [52:52] injectible: [52-52]
+		Arg: x: [2]int64 (declared at line 52, available: [52-52])
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [40:40] injectible: [40-40]
+		Arg: x: [2]int8 (declared at line 40, available: [40-40])
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [36:36] injectible: [36-36]
+		Arg: x: [2]int (declared at line 36, available: [36-36])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50] injectible: [50-50]
 		Arg: b: main.behavior (declared at line 50, available: [50-50])
-	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [94:94] injectible: [94-94]
-		Arg: a: int (declared at line 94, available: [94-94])
-		Arg: b: error (declared at line 94, available: [94-94])
-		Arg: c: uint (declared at line 94, available: [94-94])
-	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
-		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [58:58] injectible: [58-58]
-		Arg: a: string (declared at line 58, available: [58-58])
-		Arg: b: string (declared at line 58, available: [58-58])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [97:97] injectible: [97-97]
+		Arg: a: int (declared at line 97, available: [97-97])
+		Arg: b: error (declared at line 97, available: [97-97])
+		Arg: c: uint (declared at line 97, available: [97-97])
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67] injectible: [67-67]
+		Arg: a: main.interfaceComplexityA (declared at line 67, available: [67-67])
+	Function: testInvalidUtf8Strings (main.testInvalidUtf8Strings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [63:63] injectible: [63-63]
+		Arg: a: string (declared at line 63, available: [63-63])
+		Arg: b: string (declared at line 63, available: [63-63])
 	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
 		Arg: arg: main.largeStruct (declared at line 281, available: [281-281])
 		Arg: ~r0: main.largeStruct (declared at line 281, available: )
 		Arg: ~r0: main.largeStruct (declared at line 281, available: )
-	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
-		Arg: a: main.node (declared at line 42, available: [42-42])
-	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
-		Var: s: int (declared at line 224, available: [237-237], [242-242])
-		Var: aPerArch: int (declared at line 228, available: [223-243])
-		Var: b: int (declared at line 229, available: [223-243])
-	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
-		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [47:47] injectible: [47-47]
+		Arg: a: main.node (declared at line 47, available: [47-47])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [226:246] injectible: [226-226], [233-233], [236-237], [239-242], [244-246]
+		Var: s: int (declared at line 227, available: [240-240], [245-245])
+		Var: aPerArch: int (declared at line 231, available: [226-246])
+		Var: b: int (declared at line 232, available: [226-246])
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [138:138] injectible: [138-138]
+		Arg: l: main.lotsOfFields (declared at line 138, available: [138-138])
 	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
 		Arg: a: int (declared at line 328, available: [328-330])
 		Arg: b: int (declared at line 328, available: [328-330])
@@ -1001,10 +1033,10 @@ Package: main
 		Arg: h: int (declared at line 328, available: [328-330])
 		Arg: i: int (declared at line 328, available: [328-330])
 		Arg: ~r0: [2]int (declared at line 328, available: )
-	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [102:102] injectible: [102-102]
-		Arg: m: main.manyPointers (declared at line 102, available: [102-102])
-	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [33:33] injectible: [33-33]
-		Arg: ss: []string (declared at line 33, available: [33-33])
+	Function: testManyPointers (main.testManyPointers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go [108:108] injectible: [108-108]
+		Arg: m: main.manyPointers (declared at line 108, available: [108-108])
+	Function: testManyStrings (main.testManyStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go [36:36] injectible: [36-36]
+		Arg: ss: []string (declared at line 36, available: [36-36])
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -1043,8 +1075,8 @@ Package: main
 		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
 	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70] injectible: [70-70]
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
-	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
-		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [47:47] injectible: [47-47]
+		Arg: x: string (declared at line 47, available: [47-47])
 	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-347], [349-349]
 		Arg: a: int (declared at line 337, available: [337-349])
 		Arg: b: int (declared at line 337, available: [337-349])
@@ -1057,17 +1089,17 @@ Package: main
 		Arg: s: string (declared at line 337, available: [337-349])
 		Arg: ~r0: main.largeStruct (declared at line 337, available: )
 		Arg: ~r0: main.largeStruct (declared at line 337, available: )
-	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [62:62] injectible: [62-62]
-		Arg: x: string (declared at line 62, available: [62-62])
+	Function: testMultibyteUtf8String (main.testMultibyteUtf8String) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [67:67] injectible: [67-67]
+		Arg: x: string (declared at line 67, available: [67-67])
 	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
 		Arg: a: [2]int (declared at line 364, available: [364-366])
 		Arg: b: [3]int (declared at line 364, available: [364-366])
 		Arg: ~r0: int (declared at line 364, available: )
 		Arg: ~r1: [2]int (declared at line 364, available: )
-	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
-		Arg: o: main.outer (declared at line 72, available: [72-72])
-	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
-		Arg: b: main.bStruct (declared at line 96, available: [96-96])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [75:75] injectible: [75-75]
+		Arg: o: main.outer (declared at line 75, available: [75-75])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [102:102] injectible: [102-102]
+		Arg: b: main.bStruct (declared at line 102, available: [102-102])
 	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
 		Arg: s1: main.largeStruct (declared at line 308, available: [308-308])
 		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
@@ -1077,99 +1109,99 @@ Package: main
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
 		Arg: result2: int (declared at line 95, available: )
-	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
-		Arg: a: bool (declared at line 78, available: [78-78])
-		Arg: b: uint8 (declared at line 78, available: [78-78])
-		Arg: c: int32 (declared at line 78, available: [78-78])
-		Arg: d: uint (declared at line 78, available: [78-78])
-		Arg: e: string (declared at line 78, available: [78-78])
-	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
-		Arg: a: main.tierA (declared at line 68, available: [68-68])
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [84:84] injectible: [84-84]
+		Arg: a: bool (declared at line 84, available: [84-84])
+		Arg: b: uint8 (declared at line 84, available: [84-84])
+		Arg: c: int32 (declared at line 84, available: [84-84])
+		Arg: d: uint (declared at line 84, available: [84-84])
+		Arg: e: string (declared at line 84, available: [84-84])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71] injectible: [71-71]
+		Arg: a: main.tierA (declared at line 71, available: [71-71])
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
 		Arg: i: int (declared at line 88, available: [88-89])
 		Arg: result: int (declared at line 88, available: )
-	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
-		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
-	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [101:101] injectible: [101-101]
-		Arg: x: []uint8 (declared at line 101, available: [101-101])
-	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
-		Arg: z: *bool (declared at line 99, available: [99-99])
-		Arg: a: uint (declared at line 99, available: [99-99])
-	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61] injectible: [61-61]
-		Arg: xs: []uint16 (declared at line 61, available: [61-61])
-	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49] injectible: [49-49]
-		Arg: xs: []main.structWithNoStrings (declared at line 49, available: [49-49])
-		Arg: a: int (declared at line 49, available: [49-49])
-	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57] injectible: [57-57]
-		Arg: a: int8 (declared at line 57, available: [57-57])
-		Arg: s: []bool (declared at line 57, available: [57-57])
-		Arg: x: uint (declared at line 57, available: [57-57])
-	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71] injectible: [71-71]
-		Arg: z: uint (declared at line 71, available: [71-71])
-		Arg: x: *main.nStruct (declared at line 71, available: [71-71])
-		Arg: a: int (declared at line 71, available: [71-71])
-	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100] injectible: [100-100]
-		Arg: c: main.cStruct (declared at line 100, available: [100-100])
-	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92] injectible: [92-92]
-		Arg: x: main.nStruct (declared at line 92, available: [92-92])
-	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [38:38] injectible: [38-38]
-		Arg: a: *main.oneStringStruct (declared at line 38, available: [38-38])
-	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95] injectible: [95-95]
-		Arg: a: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: b: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: c: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: d: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: e: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: f: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: g: [3]uint32 (declared at line 92, available: [95-95])
-		Arg: h: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: i: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: j: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: k: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: l: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: m: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: n: [3]uint32 (declared at line 93, available: [95-95])
-		Arg: o: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: p: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: q: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: r: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: s: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: t: [3]uint32 (declared at line 94, available: [95-95])
-		Arg: u: [3]uint32 (declared at line 94, available: [95-95])
-	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18] injectible: [18-18]
-		Arg: a: uint8 (declared at line 15, available: [18-18])
-		Arg: b: uint8 (declared at line 15, available: [18-18])
-		Arg: c: uint8 (declared at line 15, available: [18-18])
-		Arg: d: uint8 (declared at line 15, available: [18-18])
-		Arg: e: uint8 (declared at line 15, available: [18-18])
-		Arg: f: uint8 (declared at line 15, available: [18-18])
-		Arg: g: uint8 (declared at line 15, available: [18-18])
-		Arg: h: uint8 (declared at line 16, available: [18-18])
-		Arg: i: uint8 (declared at line 16, available: [18-18])
-		Arg: j: uint8 (declared at line 16, available: [18-18])
-		Arg: k: uint8 (declared at line 16, available: [18-18])
-		Arg: l: uint8 (declared at line 16, available: [18-18])
-		Arg: m: uint8 (declared at line 16, available: [18-18])
-		Arg: n: uint8 (declared at line 16, available: [18-18])
-		Arg: o: uint8 (declared at line 17, available: [18-18])
-		Arg: p: uint8 (declared at line 17, available: [18-18])
-		Arg: q: uint8 (declared at line 17, available: )
-		Arg: r: uint8 (declared at line 17, available: )
-		Arg: s: uint8 (declared at line 17, available: )
-		Arg: t: uint8 (declared at line 17, available: )
-		Arg: u: uint8 (declared at line 17, available: )
-	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51] injectible: [51-51]
-		Arg: a: *main.node (declared at line 51, available: [51-51])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [114:114] injectible: [114-114]
+		Arg: x: *main.anotherStruct (declared at line 114, available: [114-114])
+	Function: testNilByteSlice (main.testNilByteSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [106:106] injectible: [106-106]
+		Arg: x: []uint8 (declared at line 106, available: [106-106])
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [104:104] injectible: [104-104]
+		Arg: z: *bool (declared at line 104, available: [104-104])
+		Arg: a: uint (declared at line 104, available: [104-104])
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [66:66] injectible: [66-66]
+		Arg: xs: []uint16 (declared at line 66, available: [66-66])
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [54:54] injectible: [54-54]
+		Arg: xs: []main.structWithNoStrings (declared at line 54, available: [54-54])
+		Arg: a: int (declared at line 54, available: [54-54])
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [62:62] injectible: [62-62]
+		Arg: a: int8 (declared at line 62, available: [62-62])
+		Arg: s: []bool (declared at line 62, available: [62-62])
+		Arg: x: uint (declared at line 62, available: [62-62])
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [76:76] injectible: [76-76]
+		Arg: z: uint (declared at line 76, available: [76-76])
+		Arg: x: *main.nStruct (declared at line 76, available: [76-76])
+		Arg: a: int (declared at line 76, available: [76-76])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [106:106] injectible: [106-106]
+		Arg: c: main.cStruct (declared at line 106, available: [106-106])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [98:98] injectible: [98-98]
+		Arg: x: main.nStruct (declared at line 98, available: [98-98])
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [43:43] injectible: [43-43]
+		Arg: a: *main.oneStringStruct (declared at line 43, available: [43-43])
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [101:101] injectible: [101-101]
+		Arg: a: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: b: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: c: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: d: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: e: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: f: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: g: [3]uint32 (declared at line 98, available: [101-101])
+		Arg: h: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: i: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: j: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: k: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: l: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: m: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: n: [3]uint32 (declared at line 99, available: [101-101])
+		Arg: o: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: p: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: q: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: r: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: s: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: t: [3]uint32 (declared at line 100, available: [101-101])
+		Arg: u: [3]uint32 (declared at line 100, available: [101-101])
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [24:24] injectible: [24-24]
+		Arg: a: uint8 (declared at line 21, available: [24-24])
+		Arg: b: uint8 (declared at line 21, available: [24-24])
+		Arg: c: uint8 (declared at line 21, available: [24-24])
+		Arg: d: uint8 (declared at line 21, available: [24-24])
+		Arg: e: uint8 (declared at line 21, available: [24-24])
+		Arg: f: uint8 (declared at line 21, available: [24-24])
+		Arg: g: uint8 (declared at line 21, available: [24-24])
+		Arg: h: uint8 (declared at line 22, available: [24-24])
+		Arg: i: uint8 (declared at line 22, available: [24-24])
+		Arg: j: uint8 (declared at line 22, available: [24-24])
+		Arg: k: uint8 (declared at line 22, available: [24-24])
+		Arg: l: uint8 (declared at line 22, available: [24-24])
+		Arg: m: uint8 (declared at line 22, available: [24-24])
+		Arg: n: uint8 (declared at line 22, available: [24-24])
+		Arg: o: uint8 (declared at line 23, available: [24-24])
+		Arg: p: uint8 (declared at line 23, available: [24-24])
+		Arg: q: uint8 (declared at line 23, available: )
+		Arg: r: uint8 (declared at line 23, available: )
+		Arg: s: uint8 (declared at line 23, available: )
+		Arg: t: uint8 (declared at line 23, available: )
+		Arg: u: uint8 (declared at line 23, available: )
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [56:56] injectible: [56-56]
+		Arg: a: *main.node (declared at line 56, available: [56-56])
 	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [46:46] injectible: [46-46]
 		Arg: m: *map[string]int (declared at line 46, available: [46-46])
-	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103] injectible: [103-103]
-		Arg: u: **int (declared at line 103, available: [103-103])
-	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38] injectible: [38-38]
-		Arg: a: *main.structWithTwoValues (declared at line 38, available: [38-38])
-	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76] injectible: [76-76]
-		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
-	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
-		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [108:108] injectible: [108-108]
+		Arg: u: **int (declared at line 108, available: [108-108])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [43:43] injectible: [43-43]
+		Arg: a: *main.structWithTwoValues (declared at line 43, available: [43-43])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [82:82] injectible: [82-82]
+		Arg: s: *main.structWithASlice (declared at line 82, available: [82-82])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [86:86] injectible: [86-86]
+		Arg: s: *main.structWithAString (declared at line 86, available: [86-86])
 	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
 		Arg: v: interface {} (declared at line 60, available: [60-72])
 		Arg: ~r0: interface {} (declared at line 60, available: )
@@ -1290,44 +1322,44 @@ Package: main
 	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
 		Arg: ~r0: main.wideStruct (declared at line 225, available: )
 		Arg: ~r0: main.wideStruct (declared at line 225, available: )
-	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
-		Arg: x: [2]int32 (declared at line 18, available: [18-18])
-	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
-		Arg: x: bool (declared at line 19, available: [19-19])
-	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11] injectible: [11-11]
-		Arg: x: uint8 (declared at line 11, available: [11-11])
-	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63] injectible: [63-63]
-		Arg: x: float32 (declared at line 63, available: [63-63])
-	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67] injectible: [67-67]
-		Arg: x: float64 (declared at line 67, available: [67-67])
-	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23] injectible: [23-23]
-		Arg: x: int (declared at line 23, available: [23-23])
-	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31] injectible: [31-31]
-		Arg: x: int16 (declared at line 31, available: [31-31])
-	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35] injectible: [35-35]
-		Arg: x: int32 (declared at line 35, available: [35-35])
-	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39] injectible: [39-39]
-		Arg: x: int64 (declared at line 39, available: [39-39])
-	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27] injectible: [27-27]
-		Arg: x: int8 (declared at line 27, available: [27-27])
-	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15] injectible: [15-15]
-		Arg: x: int32 (declared at line 15, available: [15-15])
-	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [12:12] injectible: [12-12]
-		Arg: x: string (declared at line 12, available: [12-12])
-	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43] injectible: [43-43]
-		Arg: x: uint (declared at line 43, available: [43-43])
-	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51] injectible: [51-51]
-		Arg: x: uint16 (declared at line 51, available: [51-51])
-	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55] injectible: [55-55]
-		Arg: x: uint32 (declared at line 55, available: [55-55])
-	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59] injectible: [59-59]
-		Arg: x: uint64 (declared at line 59, available: [59-59])
-	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47] injectible: [47-47]
-		Arg: x: uint8 (declared at line 47, available: [47-47])
-	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [69:69] injectible: [69-69]
-		Arg: xs: []struct {} (declared at line 69, available: [69-69])
-	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37] injectible: [37-37]
-		Arg: u: [][]uint (declared at line 37, available: [37-37])
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [24:24] injectible: [24-24]
+		Arg: x: [2]int32 (declared at line 24, available: [24-24])
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [25:25] injectible: [25-25]
+		Arg: x: bool (declared at line 25, available: [25-25])
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [17:17] injectible: [17-17]
+		Arg: x: uint8 (declared at line 17, available: [17-17])
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [69:69] injectible: [69-69]
+		Arg: x: float32 (declared at line 69, available: [69-69])
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
+		Arg: x: float64 (declared at line 73, available: [73-73])
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [29:29] injectible: [29-29]
+		Arg: x: int (declared at line 29, available: [29-29])
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [37:37] injectible: [37-37]
+		Arg: x: int16 (declared at line 37, available: [37-37])
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [41:41] injectible: [41-41]
+		Arg: x: int32 (declared at line 41, available: [41-41])
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [45:45] injectible: [45-45]
+		Arg: x: int64 (declared at line 45, available: [45-45])
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [33:33] injectible: [33-33]
+		Arg: x: int8 (declared at line 33, available: [33-33])
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [21:21] injectible: [21-21]
+		Arg: x: int32 (declared at line 21, available: [21-21])
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [17:17] injectible: [17-17]
+		Arg: x: string (declared at line 17, available: [17-17])
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [49:49] injectible: [49-49]
+		Arg: x: uint (declared at line 49, available: [49-49])
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [57:57] injectible: [57-57]
+		Arg: x: uint16 (declared at line 57, available: [57-57])
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [61:61] injectible: [61-61]
+		Arg: x: uint32 (declared at line 61, available: [61-61])
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [65:65] injectible: [65-65]
+		Arg: x: uint64 (declared at line 65, available: [65-65])
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [53:53] injectible: [53-53]
+		Arg: x: uint8 (declared at line 53, available: [53-53])
+	Function: testSliceEmptyStructs (main.testSliceEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [74:74] injectible: [74-74]
+		Arg: xs: []struct {} (declared at line 74, available: [74-74])
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [42:42] injectible: [42-42]
+		Arg: u: [][]uint (declared at line 42, available: [42-42])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
 	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
@@ -1340,120 +1372,120 @@ Package: main
 		Arg: ~r0: int (declared at line 356, available: )
 		Arg: ~r1: int (declared at line 356, available: )
 		Arg: ~r2: int (declared at line 356, available: )
-	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
-		Arg: x: [2]string (declared at line 22, available: [22-22])
-	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
-		Arg: z: *string (declared at line 91, available: [91-91])
-	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53] injectible: [53-53]
-		Arg: s: []string (declared at line 53, available: [53-53])
-	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95] injectible: [95-95]
-		Arg: a: *[]string (declared at line 95, available: [95-95])
-	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116] injectible: [116-116]
-		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [214:214] injectible: [214-214]
-		Arg: a: *main.stringType1 (declared at line 214, available: [214-214])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [220:220] injectible: [220-220]
-		Arg: a: **main.stringType2 (declared at line 220, available: [220-220])
-	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84] injectible: [84-84]
-		Arg: x: main.aStruct (declared at line 84, available: [84-84])
-	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104] injectible: [104-104]
-		Arg: w: uint8 (declared at line 104, available: [104-104])
-		Arg: x: main.aStruct (declared at line 104, available: [104-104])
-	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67] injectible: [67-67]
-		Arg: x: *main.nStruct (declared at line 67, available: [67-67])
-	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41] injectible: [41-41]
-		Arg: xs: []main.structWithNoStrings (declared at line 41, available: [41-41])
-		Arg: a: int (declared at line 41, available: [41-41])
-	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72] injectible: [72-72]
-		Arg: s: main.structWithASlice (declared at line 72, available: [72-72])
-	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64] injectible: [64-64]
-		Arg: s: main.structWithASlice (declared at line 64, available: [64-64])
-	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68] injectible: [68-68]
-		Arg: s: main.structWithASlice (declared at line 68, available: [68-68])
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [28:28] injectible: [28-28]
+		Arg: x: [2]string (declared at line 28, available: [28-28])
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [96:96] injectible: [96-96]
+		Arg: z: *string (declared at line 96, available: [96-96])
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [58:58] injectible: [58-58]
+		Arg: s: []string (declared at line 58, available: [58-58])
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [100:100] injectible: [100-100]
+		Arg: a: *[]string (declared at line 100, available: [100-100])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [122:122] injectible: [122-122]
+		Arg: t: main.threestrings (declared at line 122, available: [122-122])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [217:217] injectible: [217-217]
+		Arg: a: *main.stringType1 (declared at line 217, available: [217-217])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:223] injectible: [223-223]
+		Arg: a: **main.stringType2 (declared at line 223, available: [223-223])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [90:90] injectible: [90-90]
+		Arg: x: main.aStruct (declared at line 90, available: [90-90])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [110:110] injectible: [110-110]
+		Arg: w: uint8 (declared at line 110, available: [110-110])
+		Arg: x: main.aStruct (declared at line 110, available: [110-110])
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [72:72] injectible: [72-72]
+		Arg: x: *main.nStruct (declared at line 72, available: [72-72])
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [46:46] injectible: [46-46]
+		Arg: xs: []main.structWithNoStrings (declared at line 46, available: [46-46])
+		Arg: a: int (declared at line 46, available: [46-46])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [78:78] injectible: [78-78]
+		Arg: s: main.structWithASlice (declared at line 78, available: [78-78])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [70:70] injectible: [70-70]
+		Arg: s: main.structWithASlice (declared at line 70, available: [70-70])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [74:74] injectible: [74-74]
+		Arg: s: main.structWithASlice (declared at line 74, available: [74-74])
 	Function: testStructWithAny (main.testStructWithAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [73:73] injectible: [73-73]
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
-	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
-		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [66:66] injectible: [66-66]
+		Arg: a: main.structWithAnArray (declared at line 66, available: [66-66])
 	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
 		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
 		Arg: ~r0: int (declared at line 372, available: )
 		Arg: ~r1: main.structWithArray (declared at line 372, available: )
 		Var: x: int (declared at line 374, available: [372-379])
-	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
-		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
-	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
-		Arg: a: main.structWithCyclicMaps (declared at line 44, available: [44-44])
-	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [31:31] injectible: [31-31]
-		Arg: a: main.structWithCyclicSlices (declared at line 31, available: [31-31])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [94:94] injectible: [94-94]
+		Arg: s: main.structWithTwoArrays (declared at line 94, available: [94-94])
+	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [50:50] injectible: [50-50]
+		Arg: a: main.structWithCyclicMaps (declared at line 50, available: [50-50])
+	Function: testStructWithCyclicSlices (main.testStructWithCyclicSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [37:37] injectible: [37-37]
+		Arg: a: main.structWithCyclicSlices (declared at line 37, available: [37-37])
 	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18] injectible: [18-18]
 		Arg: s: main.structWithMap (declared at line 18, available: [18-18])
-	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79] injectible: [79-79]
-		Arg: x: main.structWithPointer (declared at line 79, available: [79-79])
-	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87] injectible: [87-87]
-		Arg: z: main.spws (declared at line 87, available: [87-87])
-	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83] injectible: [83-83]
-		Arg: b: main.swsp (declared at line 83, available: [83-83])
-	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48] injectible: [48-48]
-		Arg: a: main.hasUnsupportedFields (declared at line 48, available: [48-48])
-	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [73:73] injectible: [73-73]
-		Arg: as: []uint (declared at line 73, available: [73-73])
-		Arg: bs: []uint (declared at line 73, available: [73-73])
-		Arg: cs: []uint (declared at line 73, available: [73-73])
-	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [54:54] injectible: [54-54]
-		Arg: a: string (declared at line 54, available: [54-54])
-		Arg: b: string (declared at line 54, available: [54-54])
-		Arg: c: string (declared at line 54, available: [54-54])
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [84:84] injectible: [84-84]
+		Arg: x: main.structWithPointer (declared at line 84, available: [84-84])
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [92:92] injectible: [92-92]
+		Arg: z: main.spws (declared at line 92, available: [92-92])
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [88:88] injectible: [88-88]
+		Arg: b: main.swsp (declared at line 88, available: [88-88])
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [54:54] injectible: [54-54]
+		Arg: a: main.hasUnsupportedFields (declared at line 54, available: [54-54])
+	Function: testSubslices (main.testSubslices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [78:78] injectible: [78-78]
+		Arg: as: []uint (declared at line 78, available: [78-78])
+		Arg: bs: []uint (declared at line 78, available: [78-78])
+		Arg: cs: []uint (declared at line 78, available: [78-78])
+	Function: testSubstrings (main.testSubstrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [59:59] injectible: [59-59]
+		Arg: a: string (declared at line 59, available: [59-59])
+		Arg: b: string (declared at line 59, available: [59-59])
+		Arg: c: string (declared at line 59, available: [59-59])
 	Function: testTakeContext (main.testTakeContext) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/context.go [24:24] injectible: [24-24]
 		Arg: ctx: context.Context (declared at line 22, available: [24-24])
-	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [112:112] injectible: [112-112]
-		Arg: x: main.tenStrings (declared at line 112, available: [112-112])
-	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [16:16] injectible: [16-16]
-		Arg: x: string (declared at line 16, available: [16-16])
-		Arg: y: string (declared at line 16, available: [16-16])
-		Arg: z: string (declared at line 16, available: [16-16])
-	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [30:30] injectible: [30-30]
-		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
-	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
-		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [31:31] injectible: [31-31]
-		Arg: x: time.Time (declared at line 31, available: [31-31])
-	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [35:35] injectible: [35-35]
-		Arg: c: main.timeCapture (declared at line 35, available: [35-35])
-	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [27:27] injectible: [27-27]
-		Arg: x: time.Time (declared at line 27, available: [27-27])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
-	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [113:113] injectible: [113-113]
-		Arg: a: []uint8 (declared at line 113, available: [113-113])
-		Arg: b: []uint8 (declared at line 113, available: [113-113])
-	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
-		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
-	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]
-		Arg: x: [2]uint16 (declared at line 58, available: [58-58])
-	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62] injectible: [62-62]
-		Arg: x: [2]uint32 (declared at line 62, available: [62-62])
-	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66] injectible: [66-66]
-		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
-	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54] injectible: [54-54]
-		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
-	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [105:105] injectible: [105-105]
-		Arg: x: []uint8 (declared at line 105, available: [105-105])
-	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [109:109] injectible: [109-109]
-		Arg: x: []uint8 (declared at line 109, available: [109-109])
-	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50] injectible: [50-50]
-		Arg: x: [2]uint (declared at line 50, available: [50-50])
-	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63] injectible: [63-63]
-		Arg: x: *uint (declared at line 63, available: [63-63])
-	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29] injectible: [29-29]
-		Arg: u: []uint (declared at line 29, available: [29-29])
-	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [46:46] injectible: [46-46]
-		Arg: x: string (declared at line 46, available: [46-46])
-	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55] injectible: [55-55]
-		Arg: x: unsafe.Pointer (declared at line 55, available: [55-55])
-	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [99:99] injectible: [99-99]
-		Arg: a: [100]uint (declared at line 99, available: [99-99])
-	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
-		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [118:118] injectible: [118-118]
+		Arg: x: main.tenStrings (declared at line 118, available: [118-118])
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [21:21] injectible: [21-21]
+		Arg: x: string (declared at line 21, available: [21-21])
+		Arg: y: string (declared at line 21, available: [21-21])
+		Arg: z: string (declared at line 21, available: [21-21])
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [35:35] injectible: [35-35]
+		Arg: a: main.threeStringStruct (declared at line 35, available: [35-35])
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [39:39] injectible: [39-39]
+		Arg: a: *main.threeStringStruct (declared at line 39, available: [39-39])
+	Function: testTimeFixedZone (main.testTimeFixedZone) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [36:36] injectible: [36-36]
+		Arg: x: time.Time (declared at line 36, available: [36-36])
+	Function: testTimeMonotonic (main.testTimeMonotonic) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [40:40] injectible: [40-40]
+		Arg: c: main.timeCapture (declared at line 40, available: [40-40])
+	Function: testTimeUTC (main.testTimeUTC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go [32:32] injectible: [32-32]
+		Arg: x: time.Time (declared at line 32, available: [32-32])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [37:37] injectible: [37-37]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 37, available: [37-37])
+	Function: testTwoByteSlicesAsciiAndBinary (main.testTwoByteSlicesAsciiAndBinary) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [118:118] injectible: [118-118]
+		Arg: a: []uint8 (declared at line 118, available: [118-118])
+		Arg: b: []uint8 (declared at line 118, available: [118-118])
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [79:79] injectible: [79-79]
+		Arg: x: main.typeAlias (declared at line 79, available: [79-79])
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [64:64] injectible: [64-64]
+		Arg: x: [2]uint16 (declared at line 64, available: [64-64])
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [68:68] injectible: [68-68]
+		Arg: x: [2]uint32 (declared at line 68, available: [68-68])
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [72:72] injectible: [72-72]
+		Arg: x: [2]uint64 (declared at line 72, available: [72-72])
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [60:60] injectible: [60-60]
+		Arg: x: [2]uint8 (declared at line 60, available: [60-60])
+	Function: testUint8SliceFromString (main.testUint8SliceFromString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [110:110] injectible: [110-110]
+		Arg: x: []uint8 (declared at line 110, available: [110-110])
+	Function: testUint8SliceHighBytes (main.testUint8SliceHighBytes) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [114:114] injectible: [114-114]
+		Arg: x: []uint8 (declared at line 114, available: [114-114])
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [56:56] injectible: [56-56]
+		Arg: x: [2]uint (declared at line 56, available: [56-56])
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [68:68] injectible: [68-68]
+		Arg: x: *uint (declared at line 68, available: [68-68])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [34:34] injectible: [34-34]
+		Arg: u: []uint (declared at line 34, available: [34-34])
+	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [51:51] injectible: [51-51]
+		Arg: x: string (declared at line 51, available: [51-51])
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [60:60] injectible: [60-60]
+		Arg: x: unsafe.Pointer (declared at line 60, available: [60-60])
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [105:105] injectible: [105-105]
+		Arg: a: [100]uint (declared at line 105, available: [105-105])
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [70:70] injectible: [70-70]
+		Arg: xs: []uint (declared at line 70, available: [70-70])
 	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
 		Arg: a: [0]int (declared at line 385, available: )
 		Arg: b: int (declared at line 385, available: [385-388])

--- a/pkg/dyninst/testdata/decoded/sample/stackC.json
+++ b/pkg/dyninst/testdata/decoded/sample/stackC.json
@@ -18,22 +18,22 @@
           {
             "function": "main.stackC",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go",
-            "lineNumber": 25
+            "lineNumber": 30
           },
           {
             "function": "main.stackB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go",
-            "lineNumber": 19
+            "lineNumber": 24
           },
           {
             "function": "main.stackA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go",
-            "lineNumber": 13
+            "lineNumber": 18
           },
           {
             "function": "main.executeStack",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go",
-            "lineNumber": 30
+            "lineNumber": 38
           },
           {
             "function": "main.runAll",
@@ -43,7 +43,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -117,7 +117,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -201,7 +201,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -285,7 +285,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -369,7 +369,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -453,7 +453,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -537,7 +537,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -616,7 +616,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -700,7 +700,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -785,7 +785,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -112,7 +112,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -192,7 +192,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -277,7 +277,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -362,7 +362,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -453,7 +453,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayEmptyStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayEmptyStructs.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testArrayEmptyStructs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 87
+            "lineNumber": 93
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 128
+            "lineNumber": 137
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testArrayOfArrays",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 70
+            "lineNumber": 76
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 119
+            "lineNumber": 128
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testArrayOfArraysOfArrays",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 78
+            "lineNumber": 84
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 122
+            "lineNumber": 131
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testArrayOfStrings",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 74
+            "lineNumber": 80
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 120
+            "lineNumber": 129
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStructs.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testArrayOfStructs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 83
+            "lineNumber": 89
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 121
+            "lineNumber": 130
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testAtomicAdd.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAtomicAdd.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testAtomicAdd",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go",
-            "lineNumber": 23
+            "lineNumber": 26
           },
           {
             "function": "main.executeOther",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go",
-            "lineNumber": 54
+            "lineNumber": 60
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testBigStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 82
+            "lineNumber": 85
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 260
+            "lineNumber": 266
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct_geq_go1.26rc1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testBigStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 82
+            "lineNumber": 85
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 260
+            "lineNumber": 266
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testBoolArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 26
+            "lineNumber": 32
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 107
+            "lineNumber": 116
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testByteArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testByteArray.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testByteArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 14
+            "lineNumber": 20
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 104
+            "lineNumber": 113
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testByteSliceInvalidUtf8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testByteSliceInvalidUtf8.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testByteSliceInvalidUtf8",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 89
+            "lineNumber": 94
           },
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 165
+            "lineNumber": 173
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testByteSliceMultibyteUtf8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testByteSliceMultibyteUtf8.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testByteSliceMultibyteUtf8",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 93
+            "lineNumber": 98
           },
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 166
+            "lineNumber": 174
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureContextImpl.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureContextImpl.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 84
+            "lineNumber": 90
           },
           {
             "function": "main.executeStructFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 143
+            "lineNumber": 152
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember_geq_go1.26rc1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 84
+            "lineNumber": 90
           },
           {
             "function": "main.executeStructFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 143
+            "lineNumber": 152
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprLine.json
@@ -18,17 +18,17 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 18
+            "lineNumber": 21
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 101
+            "lineNumber": 107
           },
           {
             "function": "main.runAll",
@@ -38,7 +38,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -56,12 +56,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "captureExpressions": {
                 "x_val": {
                   "type": "int",
@@ -95,22 +95,22 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedBA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 34
+            "lineNumber": 37
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 22
+            "lineNumber": 25
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -120,7 +120,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -138,12 +138,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "captureExpressions": {
                 "x_val": {
                   "type": "int",
@@ -177,22 +177,22 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedBB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 39
+            "lineNumber": 42
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 23
+            "lineNumber": 26
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -202,7 +202,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -220,12 +220,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "captureExpressions": {
                 "x_val": {
                   "type": "int",
@@ -259,27 +259,27 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedBBA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 45
+            "lineNumber": 48
           },
           {
             "function": "main.testInlinedBB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 40
+            "lineNumber": 43
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 23
+            "lineNumber": 26
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -289,7 +289,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -307,12 +307,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "captureExpressions": {
                 "x_val": {
                   "type": "int",
@@ -346,17 +346,17 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.forceOutOfLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 29
+            "lineNumber": 32
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 103
+            "lineNumber": 109
           },
           {
             "function": "main.runAll",
@@ -366,7 +366,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -384,12 +384,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "captureExpressions": {
                 "x_val": {
                   "type": "int",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprLineCond.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprLineCond.json
@@ -18,22 +18,22 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedBA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 34
+            "lineNumber": 37
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 22
+            "lineNumber": 25
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -43,7 +43,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -61,12 +61,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "captureExpressions": {
                 "x_val": {
                   "type": "int",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprLineWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprLineWithTemplate.json
@@ -18,17 +18,17 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 18
+            "lineNumber": 21
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 101
+            "lineNumber": 107
           },
           {
             "function": "main.runAll",
@@ -38,7 +38,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -56,12 +56,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "captureExpressions": {
                 "x_val": {
                   "type": "int",
@@ -96,22 +96,22 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedBA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 34
+            "lineNumber": 37
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 22
+            "lineNumber": 25
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -121,7 +121,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -139,12 +139,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "captureExpressions": {
                 "x_val": {
                   "type": "int",
@@ -179,22 +179,22 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedBB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 39
+            "lineNumber": 42
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 23
+            "lineNumber": 26
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -204,7 +204,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -222,12 +222,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "captureExpressions": {
                 "x_val": {
                   "type": "int",
@@ -262,27 +262,27 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedBBA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 45
+            "lineNumber": 48
           },
           {
             "function": "main.testInlinedBB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 40
+            "lineNumber": 43
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 23
+            "lineNumber": 26
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -292,7 +292,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -310,12 +310,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "captureExpressions": {
                 "x_val": {
                   "type": "int",
@@ -350,17 +350,17 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.forceOutOfLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 29
+            "lineNumber": 32
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 103
+            "lineNumber": 109
           },
           {
             "function": "main.runAll",
@@ -370,7 +370,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -388,12 +388,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "captureExpressions": {
                 "x_val": {
                   "type": "int",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprSimple.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprSimple.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testCombinedString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
-            "lineNumber": 30
+            "lineNumber": 36
           },
           {
             "function": "main.executeMultiParamFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
-            "lineNumber": 102
+            "lineNumber": 111
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprWithTemplate.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testCombinedString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
-            "lineNumber": 30
+            "lineNumber": 36
           },
           {
             "function": "main.executeMultiParamFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
-            "lineNumber": 102
+            "lineNumber": 111
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testChannel.json
+++ b/pkg/dyninst/testdata/decoded/sample/testChannel.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testChannel",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go",
-            "lineNumber": 30
+            "lineNumber": 33
           },
           {
             "function": "main.executeOther",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go",
-            "lineNumber": 53
+            "lineNumber": 59
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testCombinedByte",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
-            "lineNumber": 22
+            "lineNumber": 28
           },
           {
             "function": "main.executeMultiParamFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
-            "lineNumber": 100
+            "lineNumber": 109
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testConflictingReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testConflictingReturn.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testCycle.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCycle.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testCycle",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 109
+            "lineNumber": 114
           },
           {
             "function": "main.executePointerFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 177
+            "lineNumber": 185
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepMap1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 200
+            "lineNumber": 203
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 304
+            "lineNumber": 310
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepMap7",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 203
+            "lineNumber": 206
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 305
+            "lineNumber": 311
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepPtr1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 136
+            "lineNumber": 139
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 298
+            "lineNumber": 304
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepPtr7",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 139
+            "lineNumber": 142
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 299
+            "lineNumber": 305
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepSlice1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 162
+            "lineNumber": 165
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 301
+            "lineNumber": 307
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepSlice7",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 165
+            "lineNumber": 168
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 302
+            "lineNumber": 308
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testEmptySlice",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 33
+            "lineNumber": 38
           },
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 152
+            "lineNumber": 160
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testEmptySliceOfStructs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 45
+            "lineNumber": 50
           },
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 140
+            "lineNumber": 148
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testEmptyString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 50
+            "lineNumber": 55
           },
           {
             "function": "main.executeStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 76
+            "lineNumber": 84
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -87,12 +87,12 @@
           {
             "function": "main.testEmptyString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 50
+            "lineNumber": 55
           },
           {
             "function": "main.executeStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 77
+            "lineNumber": 85
           },
           {
             "function": "main.runAll",
@@ -102,7 +102,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testEmptyStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 124
+            "lineNumber": 130
           },
           {
             "function": "main.executeStructFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 190
+            "lineNumber": 199
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testEmptyStructPointer",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 128
+            "lineNumber": 134
           },
           {
             "function": "main.executeStructFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 191
+            "lineNumber": 200
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testErrorAtLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testErrorAtLine.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testErrorAtLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 108
+            "lineNumber": 111
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 296
+            "lineNumber": 302
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -51,12 +51,12 @@
           "location": {
             "method": "main.testErrorAtLine",
             "file": "complex.go",
-            "line": 108
+            "line": 111
           }
         },
         "captures": {
           "lines": {
-            "108": {
+            "111": {
               "locals": {
                 "x": {
                   "type": "int",

--- a/pkg/dyninst/testdata/decoded/sample/testErrorAtLine_config_arch=amd64,toolchain=go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testErrorAtLine_config_arch=amd64,toolchain=go1.26rc1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testErrorAtLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 108
+            "lineNumber": 111
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 296
+            "lineNumber": 302
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -51,12 +51,12 @@
           "location": {
             "method": "main.testErrorAtLine",
             "file": "complex.go",
-            "line": 108
+            "line": 111
           }
         },
         "captures": {
           "lines": {
-            "108": {
+            "111": {
               "locals": {
                 "x": {
                   "type": "int",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testFrameless.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFrameless.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testFrameless",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 80
+            "lineNumber": 83
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 104
+            "lineNumber": 110
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testFramelessArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 93
+            "lineNumber": 96
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 105
+            "lineNumber": 111
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testFramelessArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 93
+            "lineNumber": 96
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 105
+            "lineNumber": 111
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -51,12 +51,12 @@
           "location": {
             "method": "main.testFramelessArray",
             "file": "inlined.go",
-            "line": 93
+            "line": 96
           }
         },
         "captures": {
           "lines": {
-            "93": {
+            "96": {
               "locals": {
                 "a": {
                   "type": "[5]int",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericDeref.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericDeref.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -139,7 +139,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericDo.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericDo.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -117,7 +117,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericFuncContains.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericFuncContains.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -130,7 +130,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -227,7 +227,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -324,7 +324,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -421,7 +421,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericFuncContainsLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericFuncContainsLine.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -107,7 +107,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -199,7 +199,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -291,7 +291,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -383,7 +383,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLargeGet.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLargeGet.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -677,7 +677,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLibFilter.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLibFilter.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -145,7 +145,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericLibMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericLibMap.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericMethodGuess.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericMethodGuess.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -121,7 +121,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericNested.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericNested.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -117,7 +117,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericPairSetValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericPairSetValue.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -122,7 +122,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericPtrIdentity.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericPtrIdentity.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -132,7 +132,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -223,7 +223,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericSwap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericSwap.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -124,7 +124,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testGenericWrapBox.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericWrapBox.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -117,7 +117,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testHandleOrder.json
+++ b/pkg/dyninst/testdata/decoded/sample/testHandleOrder.json
@@ -18,12 +18,12 @@
           {
             "function": "main.(*Server).handleOrder",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go",
-            "lineNumber": 26
+            "lineNumber": 31
           },
           {
             "function": "main.executeServerFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go",
-            "lineNumber": 31
+            "lineNumber": 39
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -121,12 +121,12 @@
           {
             "function": "main.(*Server).handleOrder",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go",
-            "lineNumber": 23
+            "lineNumber": 28
           },
           {
             "function": "main.executeServerFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/orders.go",
-            "lineNumber": 32
+            "lineNumber": 40
           },
           {
             "function": "main.runAll",
@@ -136,7 +136,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
@@ -18,17 +18,17 @@
           {
             "function": "main.testInlinedBA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 35
+            "lineNumber": 38
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 22
+            "lineNumber": 25
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -38,7 +38,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
@@ -18,17 +18,17 @@
           {
             "function": "main.testInlinedBB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 42
+            "lineNumber": 45
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 23
+            "lineNumber": 26
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -38,7 +38,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
@@ -18,22 +18,22 @@
           {
             "function": "main.testInlinedBBA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 46
+            "lineNumber": 49
           },
           {
             "function": "main.testInlinedBB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 40
+            "lineNumber": 43
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 23
+            "lineNumber": 26
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -43,7 +43,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
@@ -18,22 +18,22 @@
           {
             "function": "main.testInlinedBBB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 49
+            "lineNumber": 52
           },
           {
             "function": "main.testInlinedBB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 41
+            "lineNumber": 44
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 23
+            "lineNumber": 26
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -43,7 +43,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
@@ -18,17 +18,17 @@
           {
             "function": "main.testInlinedBC",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 60
+            "lineNumber": 63
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 24
+            "lineNumber": 27
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -38,7 +38,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
@@ -18,22 +18,22 @@
           {
             "function": "main.testInlinedBCA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 63
+            "lineNumber": 66
           },
           {
             "function": "main.testInlinedBC",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 53
+            "lineNumber": 56
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 24
+            "lineNumber": 27
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -43,7 +43,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
@@ -18,22 +18,22 @@
           {
             "function": "main.testInlinedBCA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 63
+            "lineNumber": 66
           },
           {
             "function": "main.testInlinedBC",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 53
+            "lineNumber": 56
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 24
+            "lineNumber": 27
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -43,7 +43,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -61,12 +61,12 @@
           "location": {
             "method": "main.testInlinedBCA",
             "file": "inlined.go",
-            "line": 63
+            "line": 66
           }
         },
         "captures": {
           "lines": {
-            "63": {}
+            "66": {}
           }
         }
       },

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
@@ -18,22 +18,22 @@
           {
             "function": "main.testInlinedBCB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 67
+            "lineNumber": 70
           },
           {
             "function": "main.testInlinedBC",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 59
+            "lineNumber": 62
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 24
+            "lineNumber": 27
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -43,7 +43,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
@@ -18,22 +18,22 @@
           {
             "function": "main.testInlinedBCB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 67
+            "lineNumber": 70
           },
           {
             "function": "main.testInlinedBC",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 59
+            "lineNumber": 62
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 24
+            "lineNumber": 27
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -43,7 +43,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -61,12 +61,12 @@
           "location": {
             "method": "main.testInlinedBCB",
             "file": "inlined.go",
-            "line": 67
+            "line": 70
           }
         },
         "captures": {
           "lines": {
-            "67": {}
+            "70": {}
           }
         }
       },

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedFuncFromOtherPackage.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedFuncFromOtherPackage.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
@@ -18,17 +18,17 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 18
+            "lineNumber": 21
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 101
+            "lineNumber": 107
           },
           {
             "function": "main.runAll",
@@ -38,7 +38,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -93,22 +93,22 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedBA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 34
+            "lineNumber": 37
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 22
+            "lineNumber": 25
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -118,7 +118,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -173,22 +173,22 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedBB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 39
+            "lineNumber": 42
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 23
+            "lineNumber": 26
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -198,7 +198,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -253,27 +253,27 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedBBA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 45
+            "lineNumber": 48
           },
           {
             "function": "main.testInlinedBB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 40
+            "lineNumber": 43
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 23
+            "lineNumber": 26
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -283,7 +283,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -338,17 +338,17 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 15
+            "lineNumber": 18
           },
           {
             "function": "main.forceOutOfLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 29
+            "lineNumber": 32
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 103
+            "lineNumber": 109
           },
           {
             "function": "main.runAll",
@@ -358,7 +358,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
@@ -18,17 +18,17 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 18
+            "lineNumber": 21
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 101
+            "lineNumber": 107
           },
           {
             "function": "main.runAll",
@@ -38,7 +38,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -56,12 +56,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "locals": {
                 "x": {
                   "type": "int",
@@ -97,22 +97,22 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedBA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 34
+            "lineNumber": 37
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 22
+            "lineNumber": 25
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -122,7 +122,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -140,12 +140,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "locals": {
                 "x": {
                   "type": "int",
@@ -181,22 +181,22 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedBB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 39
+            "lineNumber": 42
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 23
+            "lineNumber": 26
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -206,7 +206,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -224,12 +224,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "locals": {
                 "x": {
                   "type": "int",
@@ -265,27 +265,27 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.testInlinedBBA",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 45
+            "lineNumber": 48
           },
           {
             "function": "main.testInlinedBB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 40
+            "lineNumber": 43
           },
           {
             "function": "main.testInlinedB",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 23
+            "lineNumber": 26
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.runAll",
@@ -295,7 +295,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -313,12 +313,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "locals": {
                 "x": {
                   "type": "int",
@@ -354,17 +354,17 @@
           {
             "function": "main.testInlinedPrint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 14
+            "lineNumber": 17
           },
           {
             "function": "main.forceOutOfLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 29
+            "lineNumber": 32
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 103
+            "lineNumber": 109
           },
           {
             "function": "main.runAll",
@@ -374,7 +374,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -392,12 +392,12 @@
           "location": {
             "method": "main.testInlinedPrint",
             "file": "inlined.go",
-            "line": 14
+            "line": 17
           }
         },
         "captures": {
           "lines": {
-            "14": {
+            "17": {
               "locals": {
                 "x": {
                   "type": "int",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
@@ -18,17 +18,17 @@
           {
             "function": "main.testInlinedSq",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 75
+            "lineNumber": 78
           },
           {
             "function": "main.testFrameless",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 80
+            "lineNumber": 83
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 104
+            "lineNumber": 110
           },
           {
             "function": "main.runAll",
@@ -38,7 +38,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
@@ -18,17 +18,17 @@
           {
             "function": "main.testInlinedSq",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 75
+            "lineNumber": 78
           },
           {
             "function": "main.testFrameless",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 80
+            "lineNumber": 83
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 104
+            "lineNumber": 110
           },
           {
             "function": "main.runAll",
@@ -38,7 +38,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -56,12 +56,12 @@
           "location": {
             "method": "main.testInlinedSq",
             "file": "inlined.go",
-            "line": 75
+            "line": 78
           }
         },
         "captures": {
           "lines": {
-            "75": {
+            "78": {
               "locals": {
                 "x": {
                   "type": "int",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testInlinedSumArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 71
+            "lineNumber": 74
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 100
+            "lineNumber": 106
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -110,17 +110,17 @@
           {
             "function": "main.testInlinedSumArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 71
+            "lineNumber": 74
           },
           {
             "function": "main.testFramelessArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 93
+            "lineNumber": 96
           },
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 105
+            "lineNumber": 111
           },
           {
             "function": "main.runAll",
@@ -130,7 +130,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testInt16Array",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 38
+            "lineNumber": 44
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 110
+            "lineNumber": 119
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testInt32Array",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 42
+            "lineNumber": 48
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 111
+            "lineNumber": 120
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testInt64Array",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 46
+            "lineNumber": 52
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 112
+            "lineNumber": 121
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testInt8Array",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 34
+            "lineNumber": 40
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 109
+            "lineNumber": 118
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testIntArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testIntArray.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testIntArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 30
+            "lineNumber": 36
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 108
+            "lineNumber": 117
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -113,7 +113,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -194,7 +194,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -274,7 +274,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -355,7 +355,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -430,7 +430,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInvalidUtf8Strings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInvalidUtf8Strings.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testInvalidUtf8Strings",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 58
+            "lineNumber": 63
           },
           {
             "function": "main.executeStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 84
+            "lineNumber": 92
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testLinkedList",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 42
+            "lineNumber": 47
           },
           {
             "function": "main.executePointerFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 155
+            "lineNumber": 163
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 230
+            "lineNumber": 233
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -51,12 +51,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 230
+            "line": 233
           }
         },
         "captures": {
           "lines": {
-            "230": {}
+            "233": {}
           }
         }
       },

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 237
+            "lineNumber": 240
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -51,12 +51,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 237
+            "line": 240
           }
         },
         "captures": {
           "lines": {
-            "237": {
+            "240": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -96,12 +96,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 237
+            "lineNumber": 240
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -111,7 +111,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -129,12 +129,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 237
+            "line": 240
           }
         },
         "captures": {
           "lines": {
-            "237": {
+            "240": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -174,12 +174,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 237
+            "lineNumber": 240
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -189,7 +189,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -207,12 +207,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 237
+            "line": 240
           }
         },
         "captures": {
           "lines": {
-            "237": {
+            "240": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -252,12 +252,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 237
+            "lineNumber": 240
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -267,7 +267,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -285,12 +285,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 237
+            "line": 240
           }
         },
         "captures": {
           "lines": {
-            "237": {
+            "240": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -330,12 +330,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 237
+            "lineNumber": 240
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -345,7 +345,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -363,12 +363,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 237
+            "line": 240
           }
         },
         "captures": {
           "lines": {
-            "237": {
+            "240": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -408,12 +408,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 237
+            "lineNumber": 240
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -423,7 +423,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -441,12 +441,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 237
+            "line": 240
           }
         },
         "captures": {
           "lines": {
-            "237": {
+            "240": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -486,12 +486,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 237
+            "lineNumber": 240
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -501,7 +501,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -519,12 +519,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 237
+            "line": 240
           }
         },
         "captures": {
           "lines": {
-            "237": {
+            "240": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -564,12 +564,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 237
+            "lineNumber": 240
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -579,7 +579,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -597,12 +597,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 237
+            "line": 240
           }
         },
         "captures": {
           "lines": {
-            "237": {
+            "240": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -642,12 +642,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 237
+            "lineNumber": 240
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -657,7 +657,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -675,12 +675,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 237
+            "line": 240
           }
         },
         "captures": {
           "lines": {
-            "237": {
+            "240": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -720,12 +720,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 237
+            "lineNumber": 240
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -735,7 +735,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -753,12 +753,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 237
+            "line": 240
           }
         },
         "captures": {
           "lines": {
-            "237": {
+            "240": {
               "locals": {
                 "aPerArch": {
                   "type": "int",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB_geq_go1.26rc1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 237
+            "lineNumber": 240
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -51,12 +51,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 237
+            "line": 240
           }
         },
         "captures": {
           "lines": {
-            "237": {
+            "240": {
               "locals": {
                 "s": {
                   "type": "int",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 242
+            "lineNumber": 245
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -51,12 +51,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 242
+            "line": 245
           }
         },
         "captures": {
           "lines": {
-            "242": {
+            "245": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -96,12 +96,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 242
+            "lineNumber": 245
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -111,7 +111,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -129,12 +129,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 242
+            "line": 245
           }
         },
         "captures": {
           "lines": {
-            "242": {
+            "245": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -174,12 +174,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 242
+            "lineNumber": 245
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -189,7 +189,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -207,12 +207,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 242
+            "line": 245
           }
         },
         "captures": {
           "lines": {
-            "242": {
+            "245": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -252,12 +252,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 242
+            "lineNumber": 245
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -267,7 +267,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -285,12 +285,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 242
+            "line": 245
           }
         },
         "captures": {
           "lines": {
-            "242": {
+            "245": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -330,12 +330,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 242
+            "lineNumber": 245
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -345,7 +345,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -363,12 +363,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 242
+            "line": 245
           }
         },
         "captures": {
           "lines": {
-            "242": {
+            "245": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -408,12 +408,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 242
+            "lineNumber": 245
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -423,7 +423,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -441,12 +441,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 242
+            "line": 245
           }
         },
         "captures": {
           "lines": {
-            "242": {
+            "245": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -486,12 +486,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 242
+            "lineNumber": 245
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -501,7 +501,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -519,12 +519,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 242
+            "line": 245
           }
         },
         "captures": {
           "lines": {
-            "242": {
+            "245": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -564,12 +564,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 242
+            "lineNumber": 245
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -579,7 +579,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -597,12 +597,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 242
+            "line": 245
           }
         },
         "captures": {
           "lines": {
-            "242": {
+            "245": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -642,12 +642,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 242
+            "lineNumber": 245
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -657,7 +657,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -675,12 +675,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 242
+            "line": 245
           }
         },
         "captures": {
           "lines": {
-            "242": {
+            "245": {
               "locals": {
                 "aPerArch": {
                   "type": "int",
@@ -720,12 +720,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 242
+            "lineNumber": 245
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -735,7 +735,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -753,12 +753,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 242
+            "line": 245
           }
         },
         "captures": {
           "lines": {
-            "242": {
+            "245": {
               "locals": {
                 "aPerArch": {
                   "type": "int",

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC_geq_go1.26rc1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 242
+            "lineNumber": 245
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 313
+            "lineNumber": 319
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -51,12 +51,12 @@
           "location": {
             "method": "main.testLongFunctionWithChangingState",
             "file": "complex.go",
-            "line": 242
+            "line": 245
           }
         },
         "captures": {
           "lines": {
-            "242": {
+            "245": {
               "locals": {
                 "s": {
                   "type": "int",

--- a/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testManyPointers.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyPointers.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testManyPointers",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go",
-            "lineNumber": 102
+            "lineNumber": 108
           },
           {
             "function": "main.executeContinuationFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation.go",
-            "lineNumber": 186
+            "lineNumber": 195
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testManyStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyStrings.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testManyStrings",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go",
-            "lineNumber": 33
+            "lineNumber": 36
           },
           {
             "function": "main.executeContinuationStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/continuation_strings.go",
-            "lineNumber": 49
+            "lineNumber": 55
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testMassiveString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 42
+            "lineNumber": 47
           },
           {
             "function": "main.executeStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 72
+            "lineNumber": 80
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveStringWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveStringWithSizeLimit.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testMassiveString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 42
+            "lineNumber": 47
           },
           {
             "function": "main.executeStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 72
+            "lineNumber": 80
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultibyteUtf8String.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultibyteUtf8String.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testMultibyteUtf8String",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 62
+            "lineNumber": 67
           },
           {
             "function": "main.executeStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 85
+            "lineNumber": 93
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultibyteUtf8StringWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultibyteUtf8StringWithSizeLimit.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testMultibyteUtf8String",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 62
+            "lineNumber": 67
           },
           {
             "function": "main.executeStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 85
+            "lineNumber": 93
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testMultipleSimpleParams",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
-            "lineNumber": 78
+            "lineNumber": 84
           },
           {
             "function": "main.executeMultiParamFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
-            "lineNumber": 87
+            "lineNumber": 96
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameCaptureExpr.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameMultiCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameMultiCaptureExpr.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameTemplate.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNestedPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNestedPointer.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testNestedPointer",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 108
+            "lineNumber": 114
           },
           {
             "function": "main.executeStructFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 152
+            "lineNumber": 161
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testNilPointer",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 99
+            "lineNumber": 104
           },
           {
             "function": "main.executePointerFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 165
+            "lineNumber": 173
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testNilSlice",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 61
+            "lineNumber": 66
           },
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 155
+            "lineNumber": 163
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testNilSliceOfStructs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 49
+            "lineNumber": 54
           },
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 141
+            "lineNumber": 149
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testNilSliceWithOtherParams",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 57
+            "lineNumber": 62
           },
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 154
+            "lineNumber": 162
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testOneStringInStructPointer",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 38
+            "lineNumber": 43
           },
           {
             "function": "main.executeStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 71
+            "lineNumber": 79
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testPointerLoop",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 51
+            "lineNumber": 56
           },
           {
             "function": "main.executePointerFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 176
+            "lineNumber": 184
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testPointerToSimpleStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 38
+            "lineNumber": 43
           },
           {
             "function": "main.executePointerFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 135
+            "lineNumber": 143
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCaptureExpr.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondMulti.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondMulti.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondMultiFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondMultiFloat.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondSingle.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondSingle.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondUnavailableFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondUnavailableFloat.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnMultiCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnMultiCaptureExpr.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnMultiTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnMultiTemplate.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnTemplate.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -112,7 +112,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -201,7 +201,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -140,7 +140,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -123,7 +123,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -117,7 +117,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -216,7 +216,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsNamedDeferLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsNamedDeferLine.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testRuneArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 18
+            "lineNumber": 24
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 105
+            "lineNumber": 114
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleBool",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 19
+            "lineNumber": 25
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 89
+            "lineNumber": 98
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleByte",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 11
+            "lineNumber": 17
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 90
+            "lineNumber": 99
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleFloat32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 63
+            "lineNumber": 69
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 86
+            "lineNumber": 95
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleFloat64",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 67
+            "lineNumber": 73
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 87
+            "lineNumber": 96
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleInt",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 23
+            "lineNumber": 29
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 92
+            "lineNumber": 101
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleInt16",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 31
+            "lineNumber": 37
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 78
+            "lineNumber": 87
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleInt32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 35
+            "lineNumber": 41
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 79
+            "lineNumber": 88
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleInt64",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 39
+            "lineNumber": 45
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 80
+            "lineNumber": 89
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleInt8",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 27
+            "lineNumber": 33
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 77
+            "lineNumber": 86
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleRune",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 15
+            "lineNumber": 21
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 91
+            "lineNumber": 100
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleString.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 12
+            "lineNumber": 17
           },
           {
             "function": "main.executeStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 67
+            "lineNumber": 75
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleUint",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 43
+            "lineNumber": 49
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 93
+            "lineNumber": 102
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleUint16",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 51
+            "lineNumber": 57
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 83
+            "lineNumber": 92
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleUint32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 55
+            "lineNumber": 61
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 84
+            "lineNumber": 93
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleUint64",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 59
+            "lineNumber": 65
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 85
+            "lineNumber": 94
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSingleUint8",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 47
+            "lineNumber": 53
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 82
+            "lineNumber": 91
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSliceEmptyStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceEmptyStructs.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSliceEmptyStructs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 69
+            "lineNumber": 74
           },
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 156
+            "lineNumber": 164
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSliceOfSlices",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 37
+            "lineNumber": 42
           },
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 147
+            "lineNumber": 155
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringArray.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStringArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 22
+            "lineNumber": 28
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 106
+            "lineNumber": 115
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStringPointer",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 91
+            "lineNumber": 96
           },
           {
             "function": "main.executePointerFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 132
+            "lineNumber": 140
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStringSlice",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 53
+            "lineNumber": 58
           },
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 137
+            "lineNumber": 145
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringType1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStringType1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 214
+            "lineNumber": 217
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 310
+            "lineNumber": 316
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStringType2.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType2.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStringType2",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 220
+            "lineNumber": 223
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 311
+            "lineNumber": 317
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStruct.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 84
+            "lineNumber": 90
           },
           {
             "function": "main.executeStructFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 143
+            "lineNumber": 152
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStructSlice",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 41
+            "lineNumber": 46
           },
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 139
+            "lineNumber": 147
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStructWithCyclicMaps",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 44
+            "lineNumber": 50
           },
           {
             "function": "main.executeStructFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 235
+            "lineNumber": 244
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps_geq_go1.26rc1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStructWithCyclicMaps",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 44
+            "lineNumber": 50
           },
           {
             "function": "main.executeStructFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 235
+            "lineNumber": 244
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStructWithCyclicSlices",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 31
+            "lineNumber": 37
           },
           {
             "function": "main.executeStructFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 215
+            "lineNumber": 224
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStruct_geq_go1.26rc1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 84
+            "lineNumber": 90
           },
           {
             "function": "main.executeStructFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
-            "lineNumber": 143
+            "lineNumber": 152
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSubslices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSubslices.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSubslices",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 73
+            "lineNumber": 78
           },
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 160
+            "lineNumber": 168
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSubstrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSubstrings.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSubstrings",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 54
+            "lineNumber": 59
           },
           {
             "function": "main.executeStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 81
+            "lineNumber": 89
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTakeContext.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTakeContext.json
@@ -35,7 +35,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testThreeStrings",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 16
+            "lineNumber": 21
           },
           {
             "function": "main.executeStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 68
+            "lineNumber": 76
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testThreeStringsInStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 30
+            "lineNumber": 35
           },
           {
             "function": "main.executeStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 69
+            "lineNumber": 77
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testThreeStringsInStructPointer",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 34
+            "lineNumber": 39
           },
           {
             "function": "main.executeStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 70
+            "lineNumber": 78
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct_geq_go1.26rc1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testThreeStringsInStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 30
+            "lineNumber": 35
           },
           {
             "function": "main.executeStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 69
+            "lineNumber": 77
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTimeFixedZone.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTimeFixedZone.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testTimeFixedZone",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go",
-            "lineNumber": 31
+            "lineNumber": 36
           },
           {
             "function": "main.executeTimeFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go",
-            "lineNumber": 51
+            "lineNumber": 59
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTimeMonotonic.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTimeMonotonic.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testTimeMonotonic",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go",
-            "lineNumber": 35
+            "lineNumber": 40
           },
           {
             "function": "main.executeTimeFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go",
-            "lineNumber": 56
+            "lineNumber": 64
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTimeUTC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTimeUTC.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testTimeUTC",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go",
-            "lineNumber": 27
+            "lineNumber": 32
           },
           {
             "function": "main.executeTimeFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/times.go",
-            "lineNumber": 42
+            "lineNumber": 50
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testTypeAlias",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 73
+            "lineNumber": 79
           },
           {
             "function": "main.executeBasicFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
-            "lineNumber": 94
+            "lineNumber": 103
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testUint16Array",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 58
+            "lineNumber": 64
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 115
+            "lineNumber": 124
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testUint32Array",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 62
+            "lineNumber": 68
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 116
+            "lineNumber": 125
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testUint64Array",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 66
+            "lineNumber": 72
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 117
+            "lineNumber": 126
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testUint8Array",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 54
+            "lineNumber": 60
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 114
+            "lineNumber": 123
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUintArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintArray.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testUintArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 50
+            "lineNumber": 56
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 113
+            "lineNumber": 122
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testUintPointer",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 63
+            "lineNumber": 68
           },
           {
             "function": "main.executePointerFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 121
+            "lineNumber": 129
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testUintSlice",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 29
+            "lineNumber": 34
           },
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 138
+            "lineNumber": 146
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testUnitializedString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 46
+            "lineNumber": 51
           },
           {
             "function": "main.executeStringFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
-            "lineNumber": 75
+            "lineNumber": 83
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testUnsafePointer",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 55
+            "lineNumber": 60
           },
           {
             "function": "main.executePointerFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
-            "lineNumber": 157
+            "lineNumber": 165
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testVeryLargeArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 99
+            "lineNumber": 105
           },
           {
             "function": "main.executeArrayFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
-            "lineNumber": 103
+            "lineNumber": 112
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testVeryLargeSlice",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 65
+            "lineNumber": 70
           },
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 146
+            "lineNumber": 154
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testVeryLargeSlice",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 65
+            "lineNumber": 70
           },
           {
             "function": "main.executeSliceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
-            "lineNumber": 146
+            "lineNumber": 154
           },
           {
             "function": "main.runAll",
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
@@ -38,7 +38,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -127,7 +127,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",
@@ -202,7 +202,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
@@ -33,7 +33,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 39
+            "lineNumber": 40
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testprogs/progs/sample/arrays.go
+++ b/pkg/dyninst/testprogs/progs/sample/arrays.go
@@ -5,6 +5,12 @@
 
 package main
 
+import (
+	"context"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
+
 /********************/
 /* ARRAY PARAMETERs */
 /********************/
@@ -99,7 +105,10 @@ func testOverLimitArrayParameters(
 func testVeryLargeArray(a [100]uint) {}
 
 //nolint:all
-func executeArrayFuncs() {
+func executeArrayFuncs(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "sample.arrays")
+	defer span.Finish()
+
 	testVeryLargeArray([100]uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100})
 	testByteArray([2]byte{1, 1})
 	testRuneArray([2]rune{1, 2})

--- a/pkg/dyninst/testprogs/progs/sample/basics.go
+++ b/pkg/dyninst/testprogs/progs/sample/basics.go
@@ -6,6 +6,12 @@
 // package main contains functions that dynamic instrumentation tests against
 package main
 
+import (
+	"context"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
+
 //nolint:all
 //go:noinline
 func testSingleByte(x byte) {}
@@ -73,7 +79,10 @@ type typeAlias uint16
 func testTypeAlias(x typeAlias) {}
 
 //nolint:all
-func executeBasicFuncs() {
+func executeBasicFuncs(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "sample.basics")
+	defer span.Finish()
+
 	testSingleInt8(-8)
 	testSingleInt16(-16)
 	testSingleInt32(-32)

--- a/pkg/dyninst/testprogs/progs/sample/complex.go
+++ b/pkg/dyninst/testprogs/progs/sample/complex.go
@@ -6,9 +6,12 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 )
 
 type tierA struct {
@@ -243,7 +246,10 @@ func testLongFunctionWithChangingState() {
 }
 
 //nolint:all
-func executeComplexFuncs() {
+func executeComplexFuncs(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "sample.complex")
+	defer span.Finish()
+
 	o := outer{
 		A: &middle{
 			B: &inner{

--- a/pkg/dyninst/testprogs/progs/sample/continuation.go
+++ b/pkg/dyninst/testprogs/progs/sample/continuation.go
@@ -5,6 +5,12 @@
 
 package main
 
+import (
+	"context"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
+
 // This file contains test functions designed to produce events that exceed
 // the 32KiB BPF scratch buffer, exercising the continuation (multi-fragment)
 // event path.
@@ -110,7 +116,10 @@ func makePaddedData(id int) *paddedData {
 }
 
 //nolint:all
-func executeContinuationFuncs() {
+func executeContinuationFuncs(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "sample.continuation")
+	defer span.Finish()
+
 	m := manyPointers{
 		p00: makePaddedData(0),
 		p01: makePaddedData(1),

--- a/pkg/dyninst/testprogs/progs/sample/continuation_strings.go
+++ b/pkg/dyninst/testprogs/progs/sample/continuation_strings.go
@@ -6,8 +6,11 @@
 package main
 
 import (
+	"context"
 	"strconv"
 	"strings"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 )
 
 // This file contains test functions that exercise continuation with string
@@ -33,7 +36,10 @@ func makeTestString(n int) string {
 func testManyStrings(ss []string) {}
 
 //nolint:all
-func executeContinuationStringFuncs() {
+func executeContinuationStringFuncs(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "sample.continuation_strings")
+	defer span.Finish()
+
 	// Build ~250 strings of 512 bytes each ≈ 128KiB total, plus one 40KiB
 	// string that exceeds the 32KiB scratch buffer on its own.
 	ss := make([]string, 0, 252)

--- a/pkg/dyninst/testprogs/progs/sample/inlined.go
+++ b/pkg/dyninst/testprogs/progs/sample/inlined.go
@@ -6,8 +6,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 )
 
 func testInlinedPrint(x int) {
@@ -94,7 +97,10 @@ func testFramelessArray(a [5]int) int {
 }
 
 //nolint:all
-func executeInlined() {
+func executeInlined(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "sample.inlined")
+	defer span.Finish()
+
 	a := [5]int{1, 2, 3, 4, 5}
 	x := 10
 	y := testInlinedSumArray(a)

--- a/pkg/dyninst/testprogs/progs/sample/main.go
+++ b/pkg/dyninst/testprogs/progs/sample/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"os"
 	"time"
 
@@ -36,32 +37,31 @@ func main() {
 		// Wait for input before executing functions to allow time for uprobe attachment
 		scanner := bufio.NewScanner(os.Stdin)
 		scanner.Scan()
-		runAll()
+		runAll(context.Background())
 		return
 	}
 
-	// Long-running mode used by the debugger demo deployment.
 	ticker := time.NewTicker(500 * time.Millisecond)
 	for range ticker.C {
-		span := tracer.StartSpan("demo-round")
-		runAll()
+		span, ctx := tracer.StartSpanFromContext(context.Background(), "demo-round")
+		runAll(ctx)
 		span.Finish()
 	}
 }
 
-func runAll() {
-	executeOther()
-	executeBasicFuncs()
-	executeMultiParamFuncs()
-	executeStringFuncs()
-	executeArrayFuncs()
-	executeSliceFuncs()
-	executeStructFuncs()
-	executeServerFuncs()
-	executeStack()
-	executeInlined()
-	executePointerFuncs()
-	executeComplexFuncs()
+func runAll(ctx context.Context) {
+	executeOther(ctx)
+	executeBasicFuncs(ctx)
+	executeMultiParamFuncs(ctx)
+	executeStringFuncs(ctx)
+	executeArrayFuncs(ctx)
+	executeSliceFuncs(ctx)
+	executeStructFuncs(ctx)
+	executeServerFuncs(ctx)
+	executeStack(ctx)
+	executeInlined(ctx)
+	executePointerFuncs(ctx)
+	executeComplexFuncs(ctx)
 	lib.Foo()
 	lib_v2.FooV2()
 	var t lib_v2.V2Type
@@ -72,9 +72,9 @@ func runAll() {
 	lib.InlinedFunc()
 	lib2.UseGenericsWithFloat64()
 
-	executeContinuationFuncs()
-	executeContinuationStringFuncs()
-	executeTimeFuncs()
+	executeContinuationFuncs(ctx)
+	executeContinuationStringFuncs(ctx)
+	executeTimeFuncs(ctx)
 
 	// unsupported for MVP, should not cause failures
 	executeEsoteric()

--- a/pkg/dyninst/testprogs/progs/sample/multi_params.go
+++ b/pkg/dyninst/testprogs/progs/sample/multi_params.go
@@ -5,6 +5,12 @@
 
 package main
 
+import (
+	"context"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
+
 /***********************/
 /* Multiple Parameters */
 /***********************/
@@ -83,7 +89,10 @@ func testMultipleCompositeParams(a [3]string, b aStruct, c []int, d map[string]s
 }
 
 //nolint:all
-func executeMultiParamFuncs() {
+func executeMultiParamFuncs(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "sample.multi_params")
+	defer span.Finish()
+
 	testMultipleSimpleParams(false, 42, 'z', 1337, "xyz")
 
 	// fails because slices and maps are not supported

--- a/pkg/dyninst/testprogs/progs/sample/orders.go
+++ b/pkg/dyninst/testprogs/progs/sample/orders.go
@@ -5,7 +5,12 @@
 
 package main
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
 
 type Request struct {
 	ID       int
@@ -26,7 +31,10 @@ func (s *Server) handleOrder(req *Request) error {
 	return nil
 }
 
-func executeServerFuncs() {
+func executeServerFuncs(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "sample.orders")
+	defer span.Finish()
+
 	s := &Server{name: "orders"}
 	s.handleOrder(&Request{ID: 1, Customer: "Alice", Total: 42.50})
 	s.handleOrder(&Request{ID: 2, Customer: "Bob", Total: -1})

--- a/pkg/dyninst/testprogs/progs/sample/other.go
+++ b/pkg/dyninst/testprogs/progs/sample/other.go
@@ -7,9 +7,12 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"runtime"
 	"strconv"
 	"sync/atomic"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 )
 
 var atomicCounter uint64
@@ -48,7 +51,10 @@ func returnGoroutineId() uint64 {
 
 //nolint:all
 //go:noinline
-func executeOther() {
+func executeOther(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "sample.other")
+	defer span.Finish()
+
 	x := make(chan bool)
 	testChannel(x)
 	testAtomicAdd(1)

--- a/pkg/dyninst/testprogs/progs/sample/pointers.go
+++ b/pkg/dyninst/testprogs/progs/sample/pointers.go
@@ -5,7 +5,12 @@
 
 package main
 
-import "unsafe"
+import (
+	"context"
+	"unsafe"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
 
 type structWithTwoValues struct {
 	a uint
@@ -109,7 +114,10 @@ type t []*t
 func testCycle(t *t) {}
 
 //nolint:all
-func executePointerFuncs() {
+func executePointerFuncs(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "sample.pointers")
+	defer span.Finish()
+
 	var u64F uint64 = 5
 	swp := structWithPointer{a: &u64F}
 	testStructWithPointer(swp)

--- a/pkg/dyninst/testprogs/progs/sample/slices.go
+++ b/pkg/dyninst/testprogs/progs/sample/slices.go
@@ -5,7 +5,12 @@
 
 package main
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
 
 //nolint:all
 //go:noinline
@@ -129,7 +134,10 @@ func testByteSliceWithOtherParams(a int, x []byte, b string) {}
 func testByteSliceAndIntSlice(a []byte, b []int) {}
 
 //nolint:all
-func executeSliceFuncs() {
+func executeSliceFuncs(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "sample.slices")
+	defer span.Finish()
+
 	originalSlice := []int{1, 2, 3}
 	expandSlice(originalSlice)
 	sprintSlice(originalSlice)

--- a/pkg/dyninst/testprogs/progs/sample/stacktraces.go
+++ b/pkg/dyninst/testprogs/progs/sample/stacktraces.go
@@ -5,7 +5,12 @@
 
 package main
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
 
 //nolint:all
 //go:noinline
@@ -26,6 +31,9 @@ func stackC() string {
 }
 
 //nolint:all
-func executeStack() {
+func executeStack(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "sample.stack")
+	defer span.Finish()
+
 	stackA()
 }

--- a/pkg/dyninst/testprogs/progs/sample/strings.go
+++ b/pkg/dyninst/testprogs/progs/sample/strings.go
@@ -5,7 +5,12 @@
 
 package main
 
-import "strings"
+import (
+	"context"
+	"strings"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
 
 //nolint:all
 //go:noinline
@@ -62,7 +67,10 @@ func testInvalidUtf8Strings(a string, b string) {}
 func testMultibyteUtf8String(x string) {}
 
 //nolint:all
-func executeStringFuncs() {
+func executeStringFuncs(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "sample.strings")
+	defer span.Finish()
+
 	abc := "abc"
 	testSingleString(abc)
 	testThreeStrings(abc, "def", "ghi")

--- a/pkg/dyninst/testprogs/progs/sample/structs.go
+++ b/pkg/dyninst/testprogs/progs/sample/structs.go
@@ -5,6 +5,12 @@
 
 package main
 
+import (
+	"context"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
+
 type receiver struct {
 	u uint
 }
@@ -132,7 +138,10 @@ func testEmptyStructPointer(e *emptyStruct) {}
 func testLotsOfFields(l lotsOfFields) {}
 
 //nolint:all
-func executeStructFuncs() {
+func executeStructFuncs(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "sample.structs")
+	defer span.Finish()
+
 	ts := threestrings{"a", "bb", "ccc"}
 	testStringStruct(ts)
 

--- a/pkg/dyninst/testprogs/progs/sample/times.go
+++ b/pkg/dyninst/testprogs/progs/sample/times.go
@@ -5,7 +5,12 @@
 
 package main
 
-import "time"
+import (
+	"context"
+	"time"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
 
 // testTimeUTC and testTimeFixedZone use literal Unix timestamps so the
 // captured instant is deterministic across runs; their snapshot values
@@ -36,7 +41,10 @@ func testTimeMonotonic(c timeCapture) {}
 
 //nolint:all
 //go:noinline
-func executeTimeFuncs() {
+func executeTimeFuncs(ctx context.Context) {
+	span, _ := tracer.StartSpanFromContext(ctx, "sample.times")
+	defer span.Finish()
+
 	// 2023-11-14T22:13:20Z (Unix 1_700_000_000) — past, no monotonic.
 	t := time.Unix(1_700_000_000, 123_456_789).UTC()
 	testTimeUTC(t)

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -2144,7 +2144,7 @@ probes:
       methodName: main.testInlinedPrint
       sourceFile: inlined.go
       lines:
-        - "14"
+        - "17"
     template: "{x}"
     segments:
       - json:
@@ -2159,7 +2159,7 @@ probes:
       methodName: main.testInlinedBCA
       sourceFile: inlined.go
       lines:
-        - "63"
+        - "66"
     template: "testInlinedBCA"
     segments:
       - str: "testInlinedBCA"
@@ -2172,7 +2172,7 @@ probes:
       methodName: main.testInlinedBCB
       sourceFile: inlined.go
       lines:
-        - "67"
+        - "70"
     template: "testInlinedBCB"
     segments:
       - str: "testInlinedBCB"
@@ -2185,7 +2185,7 @@ probes:
       methodName: main.testInlinedSq
       sourceFile: inlined.go
       lines:
-        - "75"
+        - "78"
     template: "{x}"
     segments:
       - json:
@@ -2200,7 +2200,7 @@ probes:
       methodName: main.testFramelessArray
       sourceFile: inlined.go
       lines:
-        - "93"
+        - "96"
     template: "{a}"
     segments:
       - json:
@@ -2215,7 +2215,7 @@ probes:
       methodName: main.testLongFunctionWithChangingState
       sourceFile: complex.go
       lines:
-        - "230"
+        - "233"
     template: "testLongFunctionWithChangingState"
     segments:
       - str: "testLongFunctionWithChangingState"
@@ -2230,7 +2230,7 @@ probes:
       methodName: main.testLongFunctionWithChangingState
       sourceFile: complex.go
       lines:
-        - "237"
+        - "240"
     template: "testLongFunctionWithChangingState"
     segments:
       - str: "testLongFunctionWithChangingState"
@@ -2245,7 +2245,7 @@ probes:
       methodName: main.testLongFunctionWithChangingState
       sourceFile: complex.go
       lines:
-        - "242"
+        - "245"
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
@@ -2680,7 +2680,7 @@ probes:
       methodName: main.testInlinedPrint
       sourceFile: inlined.go
       lines:
-        - "14"
+        - "17"
     captureSnapshot: false
     captureExpressions:
       - name: "x_val"
@@ -2696,7 +2696,7 @@ probes:
       methodName: main.testInlinedPrint
       sourceFile: inlined.go
       lines:
-        - "14"
+        - "17"
     template: "x={x}"
     segments:
       - str: "x="
@@ -2718,7 +2718,7 @@ probes:
       methodName: main.testInlinedPrint
       sourceFile: inlined.go
       lines:
-        - "14"
+        - "17"
     captureSnapshot: false
     captureExpressions:
       - name: "x_val"
@@ -2757,7 +2757,7 @@ probes:
       methodName: main.testErrorAtLine
       sourceFile: complex.go
       lines:
-        - "108"
+        - "111"
     template: "x={x}, err={err}"
     segments:
       - str: "x="


### PR DESCRIPTION
### What does this PR do?

Makes the sample debugger demo produce more useful trace data. Each time the demo loop runs, it now starts a fresh trace, and each of the demo's internal steps shows up as its own span within that trace instead of everything being lumped together.

### Motivation

Before this change, one run of the demo loop showed up as a single flat block in the trace, so you couldn't tell which part of the demo was doing what. Breaking it into separate steps makes the demo's output more realistic and easier to look at.

### Describe how you validated your changes

Ran the demo program directly to confirm it still works end to end. Also ran the full existing test suite for this code and updated the saved test data to match the small internal changes, confirming everything still passes.