### PR TITLE
fix(lint_windows-x64): move `cwdLogLimiter` out of shared file

### DIFF
--- a/pkg/network/sender/event_consumer.go
+++ b/pkg/network/sender/event_consumer.go
@@ -9,7 +9,6 @@ package sender
 
 import (
 	"sync/atomic"
-	"time"
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	sysprobeconfig "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/def"
@@ -17,7 +16,6 @@ import (
 	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	logutil "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const eventConsumerSubsystem = "sender__event_consumer"
@@ -92,8 +90,6 @@ func (d *directSenderConsumer) Start() error {
 
 // Stop implements eventmonitor.EventConsumer
 func (d *directSenderConsumer) Stop() {}
-
-var cwdLogLimiter = logutil.NewLogLimit(20, 10*time.Minute)
 
 // HandleEvent implements eventmonitor.EventConsumerHandler
 func (d *directSenderConsumer) HandleEvent(ev any) {

--- a/pkg/network/sender/event_consumer_linux.go
+++ b/pkg/network/sender/event_consumer_linux.go
@@ -11,13 +11,17 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"time"
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	sysprobeconfig "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/def"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	logutil "github.com/DataDog/datadog-agent/pkg/util/log"
 	ddos "github.com/DataDog/datadog-agent/pkg/util/os"
 )
+
+var cwdLogLimiter = logutil.NewLogLimit(20, 10*time.Minute)
 
 type directSenderConsumer struct {
 	log       log.Component


### PR DESCRIPTION
### Motivation
Despite #55076 and #55162, `lint_windows-x64` still fails, this time on the system-probe go linter step ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1971344465)):
```
Linter failures:
pkg\network\sender\event_consumer.go:96:5: var cwdLogLimiter is unused (unused)
var cwdLogLimiter = logutil.NewLogLimit(20, 10*time.Minute)
    ^
1 issues:
* unused: 1
system-probe Go linter result is 1
system-probe go linter failed 1
```
`event_consumer.go` builds under `linux || (windows && npm)`, but `cwdLogLimiter` is only read from `event_consumer_linux.go`, whose `_linux.go` suffix restricts it to `GOOS=linux`: the `windows && npm` build declares the limiter and never uses it.

### What does this PR do?
Move the `cwdLogLimiter` declaration, and its now-unused `time` and `logutil` imports, from `event_consumer.go` into `event_consumer_linux.go`, next to its only caller.

### Describe how you validated your changes
`dda inv linter.go --targets=./pkg/network/sender/...`