### PR TITLE
Remove explicit execution of otel integration test (task and CI)

### DIFF
--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -18,7 +18,8 @@ integration_tests_otel:
     - !reference [.retrieve_linux_go_deps]
     - dda inv -- check-otel-build
     - dda inv -- check-otel-module-versions
-    - dda inv -- otel-agent.integration-test
+    # TODO: remove once Bazel is used to build the Agent
+    - dda inv -- -e schema.codegen
   rules:
     - !reference [.except_mergequeue]
     - when: on_success

--- a/tasks/otel_agent.py
+++ b/tasks/otel_agent.py
@@ -10,7 +10,6 @@ from tasks.build_tags import get_default_build_tags
 from tasks.flavor import AgentFlavor
 from tasks.libs.common.go import go_build
 from tasks.libs.common.utils import REPO_PATH, bin_name, get_version_ldflags
-from tasks.schema.generate import schema_codegen
 from tasks.windows_resources import build_messagetable, build_rc, versioninfo_vars
 
 BIN_NAME = "otel-agent"
@@ -127,21 +126,3 @@ def image_build(ctx, arch='amd64', base_version='latest', tag=DDOT_AGENT_TAG, pu
 
     os.remove(os.path.join(build_context, BIN_NAME))
     os.remove(os.path.join(build_context, CFG_NAME))
-
-
-@task
-def integration_test(ctx):
-    """
-    Run the otel integration test
-    """
-    # Include zlib,zstd so the config-driven metrics compressor (selector.FromConfig,
-    # //go:build zlib && zstd) resolves to a real compressor — matching the shipped
-    # otel-agent tags (OTEL_AGENT_TAGS). Without them the selector links its noop
-    # variant and metrics ship uncompressed ("identity") instead of zstd.
-    cmd = """go test -timeout 0s -tags otlp,test,zlib,zstd -run ^TestIntegration$ \
-        github.com/DataDog/datadog-agent/comp/otelcol/otlp/integrationtest -v"""
-
-    # TODO: remove once Bazel is used to build the Agent
-    schema_codegen(ctx)
-
-    ctx.run(cmd)


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

It removes the otel-agent.integration invoke task and removes the run of the integration test that runs on the `integration_tests_otel` job.

### Motivation

https://github.com/DataDog/datadog-agent/pull/55117 (which https://github.com/DataDog/datadog-agent/pull/55163 made possible) runs all go tests without race detection, which includes this test. This test is skipped in "legacy" test jobs because they run exclusively with race detection enabled and the test is tagged with `!race`. Given that we're now running this test under Bazel already, running it again from this job and having an ad-hoc task for the test looks redundant.

### Describe how you validated your changes

Green CI.

### Additional Notes

I'm open to keeping the task (which could invoke bazel instead) for now if the owning team feels strongly about it, but I'd strongly suggest we don't and that we use bazel to run the test when needed.