### PR TITLE
Harden ddot ubuntu e2e job against apt mirror 503

### DIFF
--- a/test/new-e2e/tests/agent-platform/tests/ddot_install_test.go
+++ b/test/new-e2e/tests/agent-platform/tests/ddot_install_test.go
@@ -97,6 +97,13 @@ func (is *ddotInstallSuite) SetupSuite() {
 	defer is.CleanupOnSetupFailure()
 
 	is.host = host.New(is.T, is.Env().RemoteHost, is.osDesc, is.osDesc.Architecture)
+	// Harden apt against Ubuntu/Debian package-mirror outages before the ddot install runs
+	// "apt-get install apt-transport-https ...". This bounds apt's timeout/retries and adds the
+	// global archive.ubuntu.com / ports.ubuntu.com fallbacks so a 503/slow regional EC2 mirror
+	// fails fast instead of hanging until the 2h CI timeout. Without it the
+	// new-e2e-agent-platform-ddot-ubuntu-a7-arm64 job flakes on mirror outages (incident 59571).
+	// No-op on non-apt flavors. Same helper already used by the installer suites.
+	is.host.ConfigureAptMirrors()
 	// CentOS 7 is EOL and its stock vault path 403s; repoint yum at the working vault
 	// archive/mirrors before the ddot RPM install refreshes CentOS base metadata. No-op on
 	// non-CentOS-7 flavors (e.g. the RedHat descriptor this job also runs).

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -177,8 +177,9 @@ func (h *Host) setSystemdVersion() {
 // It bounds apt's per-request timeout and retries so an unreachable mirror fails within
 // minutes instead of hanging until the CI job's 2h timeout, and on Ubuntu rewrites the apt
 // sources to a "mirror+file" list so apt fails over to the global archive.ubuntu.com /
-// ports.ubuntu.com mirrors when the regional EC2 mirror is down. This mirrors the pattern
-// used in Dockerfiles/agent/Dockerfile. See incident 58780.
+// ports.ubuntu.com mirrors when the regional EC2 mirror is down. The source rewrite is skipped
+// on releases whose apt lacks the "mirror+file" method driver (apt < 1.6, e.g. Ubuntu 16.04).
+// This mirrors the pattern used in Dockerfiles/agent/Dockerfile. See incidents 58780 and 59571.
 func (h *Host) ConfigureAptMirrors() {
 	if h.pkgManager != "apt" {
 		return
@@ -187,6 +188,14 @@ func (h *Host) ConfigureAptMirrors() {
 	h.remote.MustExecute(`printf 'Acquire::Retries "2";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' | sudo tee /etc/apt/apt.conf.d/99datadog-e2e-fail-fast`)
 	// Ubuntu EC2 AMIs point at a single regional mirror with no fallback; add global mirrors.
 	if h.os.Flavor != e2eos.Ubuntu {
+		return
+	}
+	// The "mirror+file" transport used below only exists in apt >= 1.6 (Ubuntu >= 18.04). On
+	// older releases (e.g. Ubuntu 16.04, which ships apt 1.2) the method driver is absent, so
+	// rewriting the sources to "mirror+file:" makes every subsequent apt operation fail with
+	// "The method driver /usr/lib/apt/methods/mirror+file could not be found". Skip the source
+	// rewrite there; the Acquire retry/timeout hardening above still applies. See incident 59571.
+	if _, err := h.remote.Execute("test -e /usr/lib/apt/methods/mirror+file"); err != nil {
 		return
 	}
 	h.remote.MustExecute(`printf 'http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu\n' | sudo tee /etc/apt/mirrorlist.main`)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"00000000-0000-0000-0000-000000000000","source":"chat","resourceId":"1dd901d3-691c-4fc8-ac44-10e6da9179e0","workflowId":"92770bc9-1d63-478d-bfcc-a935837edd32","codeChangeId":"92770bc9-1d63-478d-bfcc-a935837edd32","sourceType":"slack"} -->
### What does this PR do?

Two related changes to make the `new-e2e-agent-platform-ddot-{ubuntu,debian}-*` E2E jobs resilient to Ubuntu package-mirror outages:

1. **Wire `(*Host).ConfigureAptMirrors()` into the DDOT install suite** (`test/new-e2e/tests/agent-platform/tests/ddot_install_test.go`), called from `SetupSuite` next to the existing `ConfigureYumMirrors()`. On Ubuntu it bounds apt's per-request timeout/retries and rewrites the apt sources to a `mirror+file` list so apt fails over to the global `archive.ubuntu.com` / `ports.ubuntu.com` mirrors when the regional EC2 mirror is unavailable. Both helpers no-op on the other's package manager.

2. **Guard the `mirror+file` source rewrite behind a method-driver check** in the shared helper (`test/new-e2e/tests/installer/host/host.go`). The `mirror+file` transport only exists in apt >= 1.6 (Ubuntu >= 18.04). On older releases (Ubuntu 16.04 ships apt 1.2) the method driver is absent, so rewriting the sources to `mirror+file:` makes every subsequent apt operation fail with `The method driver /usr/lib/apt/methods/mirror+file could not be found`. The helper now probes `test -e /usr/lib/apt/methods/mirror+file` and skips the source rewrite when it is missing; the Acquire retry/timeout hardening still applies on those hosts.

### Motivation

The `new-e2e-agent-platform-ddot-ubuntu-a7-arm64` job flakes red on `main` (incident 59571). Its Ubuntu/Debian install path runs `apt-get update && apt-get install -y apt-transport-https curl gnupg` against a single regional EC2 Ubuntu mirror with no fallback and no bounded timeout; a `503`/slow mirror either fails fast or hangs to the 2h CI timeout. The apt-mirror resilience helper already existed and was used by the installer suites; a prior fix (#54987) added only the yum counterpart to the DDOT suite. Change 1 closes that gap.

Change 2 fixes a regression that change 1 introduced: because the installer suites only run Ubuntu 24.04, the helper's `mirror+file` rewrite had never been exercised on old apt. The DDOT job runs Ubuntu 16.04, where the rewrite made `apt-get update` fail deterministically (job `1972006537`: only the `16-04` subtest failed with the `mirror+file` method-driver error; 18.04/20.04/22.04/24.04 passed).

### Changes

- `test/new-e2e/tests/agent-platform/tests/ddot_install_test.go`: call `is.host.ConfigureAptMirrors()` in `SetupSuite`.
- `test/new-e2e/tests/installer/host/host.go`: skip the Ubuntu `mirror+file` source rewrite when the `mirror+file` apt method driver is not present (apt < 1.6, e.g. Ubuntu 16.04); keep the Acquire timeout/retry hardening for all apt hosts. Doc comment updated.

### Describe how you validated your changes

- Root-caused the failure on the PR pipeline (`new-e2e-agent-platform-ddot-ubuntu-a7-x86_64`, job `1972006537`) from CI logs: the `16-04` subtest failed at `apt-get update` with `E: The method driver /usr/lib/apt/methods/mirror+file could not be found`, while the newer Ubuntu subtests in the same job passed — confirming the discriminator is the presence of the `mirror+file` method driver.
- Confirmed the installer suites (`tests/installer/unix`, `tests/installer/script`) that already call `ConfigureAptMirrors()` only run Ubuntu 24.04, which is why the incompatibility was latent until now.
- `gofmt` reports both files clean.
- Type-safe: `h.remote.Execute` already returns `(string, error)` and is used identically in `host.New`; no new imports.
- End-to-end validation is the DDOT jobs themselves once this runs in CI: the `16-04` subtest should now skip the rewrite and install normally, while 18.04+ keeps the mirror fallback.

### Additional Notes

Test-only change (E2E test setup); no Agent runtime behavior is affected, so no release note is added. The change is scoped to the DDOT suite plus the shared apt-mirror helper; extending the same hardening to the other `new-e2e-agent-platform-*` suites (install-script, step-by-step, upgrade) is intentionally left as a follow-up.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/1dd901d3-691c-4fc8-ac44-10e6da9179e0)

Comment @datadog to request changes