### PR TITLE
feat(renovate): Track lading release versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -252,6 +252,15 @@
       },
       {
         "customType": "regex",
+        "managerFilePatterns": ["test/regression/config.yaml"],
+        "matchStrings": [
+          "  version: (?<currentValue>[0-9]+.[0-9]+.[0-9]+)"
+        ],
+        "depNameTemplate": "DataDog/lading",
+        "datasourceTemplate": "github-releases"
+      },
+      {
+        "customType": "regex",
         "managerFilePatterns": [
           "Dockerfiles/agent-ddot/Dockerfile.agent-otel"
         ],


### PR DESCRIPTION
Create a new regex entry in renovate config to track https://github.com/DataDog/lading github releases automatically

<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
