### PR TITLE
Add Bazel coverage macos jobs and remove race detection from test jobs to match the Linux setup

### DIFF
--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -71,32 +71,45 @@ bazel:test:linux-amd64:
 bazel:test:linux-arm64:
   extends: [.bazel:runner:linux-arm64, .bazel:test:linux]
 
-bazel:test:macos-amd64:
-  extends: [.bazel:test:reporting, .bazel:runner:macos-amd64, .bazel:test]
+.bazel:coverage:macos:
+  extends: [.bazel:test:reporting, .bazel:test]
   script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --config=gorace --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
+    - bazel coverage --config=go --config=gorace --config=dd-agent-go-tests-only --build_tests_only --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
   after_script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting, after_script]
-
-bazel:test:macos-arm64:
-  extends: [.bazel:test:reporting, .bazel:runner:macos-arm64, .bazel:test]
-  script:
-    - !reference [.install_python_dependencies]
-    - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --config=gorace --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE --execution_log_compact_file=$CI_PROJECT_DIR/bazel-exec.log //... -- -//test/new-e2e/...
-  after_script:
-    - !reference [.install_python_dependencies]
-    - !reference [.bazel:test:reporting, after_script]
+    - cp "$(bazel info output_path)/_coverage/_coverage_report.dat" "$CI_PROJECT_DIR/coverage-bazel-$CI_JOB_NAME_SLUG.out"
   artifacts:
     paths:
       - $RESULT_JSON
       - test_output_unified.json
       - junit-*.tgz
       - bazel-bep.json
-      - bazel-exec.log
+      - coverage-bazel-*.out
+
+bazel:coverage:macos-amd64:
+  extends: [.bazel:runner:macos-amd64, .bazel:coverage:macos]
+
+bazel:coverage:macos-arm64:
+  extends: [.bazel:runner:macos-arm64, .bazel:coverage:macos]
+
+.bazel:test:macos:
+  extends: [.bazel:test:reporting, .bazel:test]
+  script:
+    - !reference [.install_python_dependencies]
+    - !reference [.bazel:test:reporting:ci_links]
+    - bazel test --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
+  after_script:
+    - !reference [.install_python_dependencies]
+    - !reference [.bazel:test:reporting, after_script]
+
+bazel:test:macos-amd64:
+  extends: [.bazel:runner:macos-amd64, .bazel:test:macos]
+
+bazel:test:macos-arm64:
+  extends: [.bazel:runner:macos-arm64, .bazel:test:macos]
 
 # Windows splits the build from the Go tests, unlike the other platforms: the
 # runner has 16 CPUs, and compiling the rest of the repo alongside ~1k


### PR DESCRIPTION
### What does this PR do?

Matches the linux setup for bazel tests (applying the equivalent of #55084 and #55117):

- Adds `coverage` jobs.
- Drops race detection from the "default" `test` jobs.
- Refactors jobs to benefit from Gitlab templating.
- Drops uploading of execution log (which was intended as a temporary measure for debugging cache issues).

### Motivation

These are the jobs that will replace the existing gotestsum-driven one. This covers macos.

### Describe how you validated your changes

CI.

### Additional Notes
