### PR TITLE
Add severity tag to health_platform.issues_detected metric

### DIFF
--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -23,6 +23,7 @@ profiles:
       - name: health_platform.issues_detected
         preserve_tags:
           - issue_type
+          - severity
   schedule:
     start_after: 30
     iterations: 0

--- a/comp/healthplatform/store/impl/store.go
+++ b/comp/healthplatform/store/impl/store.go
@@ -292,7 +292,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 		issuesCounter: reqs.Telemetry.NewCounter(
 			"health_platform",
 			"issues_detected",
-			[]string{"issue_type"},
+			[]string{"issue_type", "severity"},
 			"Number of health issues detected",
 		),
 	}
@@ -565,7 +565,7 @@ func (h *healthPlatformImpl) storeIssue(issueType string, issue *healthplatform.
 	issueID := issue.Id
 	now := time.Now().Format(time.RFC3339)
 	issue.DetectedAt = now
-	h.metrics.issuesCounter.Add(1, issueType)
+	h.metrics.issuesCounter.Add(1, issueType, issue.Severity.String())
 
 	h.issuesByName[issueType] = appendUnique(h.issuesByName[issueType], issueID)
 

--- a/comp/healthplatform/store/impl/store_test.go
+++ b/comp/healthplatform/store/impl/store_test.go
@@ -120,7 +120,7 @@ func newTestStore(t *testing.T) *healthPlatformImpl {
 		persistence:      &memPersistence{},
 		metrics: telemetryMetrics{
 			issuesCounter: tel.NewCounter(
-				"health_platform", "issues_detected", []string{"issue_type"}, ""),
+				"health_platform", "issues_detected", []string{"issue_type", "severity"}, ""),
 		},
 	}
 }
@@ -502,7 +502,7 @@ func TestFillFlareWritesWhenNonEmpty(t *testing.T) {
 
 func TestTelemetryCounterIncrements(t *testing.T) {
 	tel := telemetrymock.New(t)
-	counter := tel.NewCounter("health_platform", "issues_detected", []string{"issue_type"}, "")
+	counter := tel.NewCounter("health_platform", "issues_detected", []string{"issue_type", "severity"}, "")
 	h := &healthPlatformImpl{
 		log:              logmock.New(t),
 		telemetry:        tel,
@@ -517,7 +517,7 @@ func TestTelemetryCounterIncrements(t *testing.T) {
 
 	require.NoError(t, h.ReportIssue(&healthplatformpayload.Issue{Id: "t:id", IssueName: "t"}))
 
-	assert.Equal(t, 1.0, counter.WithValues("t").Get())
+	assert.Equal(t, 1.0, counter.WithValues("t", "ISSUE_SEVERITY_UNSPECIFIED").Get())
 }
 
 func TestGetActiveIssueIDsByIssueName(t *testing.T) {

--- a/releasenotes/notes/health-platform-severity-tag-d4478d0a182c0df0.yaml
+++ b/releasenotes/notes/health-platform-severity-tag-d4478d0a182c0df0.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Health Platform: the ``health_platform.issues_detected`` telemetry counter
+    is now also tagged with ``severity``, in addition to the existing
+    ``issue_type`` tag. This allows filtering or grouping detected health
+    issues by their severity level.


### PR DESCRIPTION
## Summary
- Tag the `health_platform.issues_detected` telemetry counter with the issue's `severity`, in addition to the existing `issue_type` tag.
- Preserve the new `severity` tag in the agent telemetry default profile (`defaultProfiles.yaml`) so it isn't aggregated away.

## Test plan
- [x] `dda inv test --targets=./comp/healthplatform/store/impl/...` passes (27 tests)
- [x] `dda inv test --targets=./comp/core/agenttelemetry/impl/...` passes (105 tests)