### PR TITLE
Upload coverage data from bazel coverage jobs

### DIFF
--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -71,32 +71,45 @@ bazel:test:linux-amd64:
 bazel:test:linux-arm64:
   extends: [.bazel:runner:linux-arm64, .bazel:test:linux]
 
-bazel:test:macos-amd64:
-  extends: [.bazel:test:reporting, .bazel:runner:macos-amd64, .bazel:test]
+.bazel:coverage:macos:
+  extends: [.bazel:test:reporting, .bazel:test]
   script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --config=gorace --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
+    - bazel coverage --config=go --config=gorace --config=dd-agent-go-tests-only --build_tests_only --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
   after_script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting, after_script]
-
-bazel:test:macos-arm64:
-  extends: [.bazel:test:reporting, .bazel:runner:macos-arm64, .bazel:test]
-  script:
-    - !reference [.install_python_dependencies]
-    - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --config=gorace --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE --execution_log_compact_file=$CI_PROJECT_DIR/bazel-exec.log //... -- -//test/new-e2e/...
-  after_script:
-    - !reference [.install_python_dependencies]
-    - !reference [.bazel:test:reporting, after_script]
+    - cp "$(bazel info output_path)/_coverage/_coverage_report.dat" "$CI_PROJECT_DIR/coverage-bazel-$CI_JOB_NAME_SLUG.out"
   artifacts:
     paths:
       - $RESULT_JSON
       - test_output_unified.json
       - junit-*.tgz
       - bazel-bep.json
-      - bazel-exec.log
+      - coverage-bazel-*.out
+
+bazel:coverage:macos-amd64:
+  extends: [.bazel:runner:macos-amd64, .bazel:coverage:macos]
+
+bazel:coverage:macos-arm64:
+  extends: [.bazel:runner:macos-arm64, .bazel:coverage:macos]
+
+.bazel:test:macos:
+  extends: [.bazel:test:reporting, .bazel:test]
+  script:
+    - !reference [.install_python_dependencies]
+    - !reference [.bazel:test:reporting:ci_links]
+    - bazel test --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
+  after_script:
+    - !reference [.install_python_dependencies]
+    - !reference [.bazel:test:reporting, after_script]
+
+bazel:test:macos-amd64:
+  extends: [.bazel:runner:macos-amd64, .bazel:test:macos]
+
+bazel:test:macos-arm64:
+  extends: [.bazel:runner:macos-arm64, .bazel:test:macos]
 
 # Windows splits the build from the Go tests, unlike the other platforms: the
 # runner has 16 CPUs, and compiling the rest of the repo alongside ~1k

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -43,6 +43,9 @@
   after_script:
     - !reference [.bazel:test:reporting, after_script]
     - cp "$(bazel info output_path)/_coverage/_coverage_report.dat" "$CI_PROJECT_DIR/coverage-bazel-$CI_JOB_NAME_SLUG.out"
+    - cp "$(bazel info output_path)/_coverage/_coverage_report.dat" "$CI_PROJECT_DIR/coverage.out"
+    - !reference [.upload_coverage]
+    - !reference [.upload_coverage_datadog]
   artifacts:
     paths:
       - $RESULT_JSON
@@ -81,6 +84,9 @@ bazel:test:linux-arm64:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting, after_script]
     - cp "$(bazel info output_path)/_coverage/_coverage_report.dat" "$CI_PROJECT_DIR/coverage-bazel-$CI_JOB_NAME_SLUG.out"
+    - cp "$(bazel info output_path)/_coverage/_coverage_report.dat" "$CI_PROJECT_DIR/coverage.out"
+    - !reference [.upload_coverage]
+    - !reference [.upload_coverage_datadog]
   artifacts:
     paths:
       - $RESULT_JSON


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

It adds coverage uploading to `bazel:coverage` jobs, bringing them closer to parity with existing `source_test` jobs.

### Motivation

Switching to bazel as the only way for testing.

### Describe how you validated your changes

CI, and confirm data was uploaded as expected.

https://app.datadoghq.com/ci/code-coverage/github.com%2Fdatadog%2Fdatadog-agent/pull-requests/55236?currentTab=changed-files&filterBy=codeowner&viewBy=file-explorer reported 4 reports being submitted, matching the 4 new jobs (the existing jobs didn't upload reports because the tests didn't run due to no code changes).

### Additional Notes
