### PR TITLE
fix(e2e): Bump memory for stress-ng container in ecs fargate

### DIFF
--- a/test/e2e-framework/components/datadog/apps/cpustress/ecsFargate.go
+++ b/test/e2e-framework/components/datadog/apps/cpustress/ecsFargate.go
@@ -39,7 +39,7 @@ func FargateAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, apiK
 			pulumi.String("--cpu-load=15"),
 		},
 		Cpu:    pulumi.IntPtr(200),
-		Memory: pulumi.IntPtr(64),
+		Memory: pulumi.IntPtr(128),
 	}
 
 	stressTaskDef, err := ecsClient.FargateTaskDefinitionWithAgent(e, "stress-ng-fg", pulumi.String("stress-ng-fg"), 1024, 2048,


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Mitigation for #incident-59576 where we have missing metrics due to the container being oom killed

### Motivation

### Describe how you validated your changes

### Additional Notes
