### PR TITLE
Mute flaky TestEC2VMWKitDirectSuite (NPM Windows)

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -54,3 +54,11 @@ test/new-e2e/tests/agent-subcommands:
 comp/core/flare/helpers:
   - test: TestSave
   - test: TestNewFlareBuilder
+
+# TODO: https://app.datadoghq.com/incidents/59580
+# Windows EC2 VM hostname changes mid-run (rename + reboot), splitting NPM
+# CollectorConnections payloads across two hostnames. test1HostFakeIntakeNPM
+# locks onto the first-seen hostname and never reaches the required payload
+# count, failing with "not enough payloads".
+test/new-e2e/tests/npm:
+  - test: TestEC2VMWKitDirectSuite

--- a/flakes.yaml
+++ b/flakes.yaml
@@ -61,4 +61,4 @@ comp/core/flare/helpers:
 # locks onto the first-seen hostname and never reaches the required payload
 # count, failing with "not enough payloads".
 test/new-e2e/tests/npm:
-  - test: TestEC2VMWKitDirectSuite
+  - test: TestEC2VMWKitDirectSuite/Test00FakeIntakeNPM_HostRequests


### PR DESCRIPTION
<!-- dd-meta {"pullId":"1b0dd00a-544a-4014-91c8-b161fd29d782","source":"chat","resourceId":"4e51c89b-d268-469a-a871-53e7be5d177b","workflowId":"39b8eba4-963e-430b-a676-26f2455715a6","codeChangeId":"39b8eba4-963e-430b-a676-26f2455715a6","sourceType":"slack"} -->
### What does this PR do?

Marks the new-e2e suite `TestEC2VMWKitDirectSuite` (`test/new-e2e/tests/npm`) as flaky in `flakes.yaml`, referencing incident 59580.

### Motivation

The `new-e2e-npm-packages-windows` job has been failing intermittently on `main` (~8 errors / 11 successes since it was introduced), blocking the pipeline and driving incident #59580.

Root cause: the suite was added on 2026-08-21 in PR #52410 ("add support for CNM direct send to windows"). Its `Test00FakeIntakeNPM_HostRequests` assertion (`common_1host.go:91`) locks onto the first-seen hostname and requires at least 5 CollectorConnections payloads (30s cadence, ~150s) within a 150s window. On Windows EC2, the VM hostname changes mid-run (rename + reboot → system-probe restart → new cached hostname), so payloads split across two hostname/networkID keys. The first-seen hostname then freezes (e.g. at 2 payloads) and the test fails with "not enough payloads".

Test is [flaky](https://app.datadoghq.com/ci/ci-cd/explorer?query=test_level%3Atest%20%40test.name%3ATestEC2VMWKitDirectSuite%2A%20-%40test.status%3Apass&agg_m=count&agg_m_source=base&agg_t=count&ci_cd_explorer_tab=tests&citest_explorer_sort=%40duration%2Cdesc&cols=timestamp%2C%40test.status%2C%40test.name%3A209%2C%40test.suite%3A274%2C%40test.is_known_flaky%2C%40duration%2C%40test.service%2Cerror.type&currentTab=overview&eventStack=&fromUser=false&index=citest&refresh_mode=paused&start=1787229769000&end=1787403431000&paused=true) since they were created


### Describe how you validated your changes

### Additional Notes

Tracking: https://app.datadoghq.com/incidents/59580. This is a temporary mitigation and should be reverted once the hostname-stability fix lands.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/4e51c89b-d268-469a-a871-53e7be5d177b)

Comment @datadog to request changes