### PR TITLE
comp/api: restrict IPC unix socket to dd-agent

### DIFF
--- a/comp/api/api/apiimpl/listener/BUILD.bazel
+++ b/comp/api/api/apiimpl/listener/BUILD.bazel
@@ -15,7 +15,17 @@ go_library(
         "//pkg/config/setup",
         "//pkg/util/system/socket",
         "@com_github_mdlayher_vsock//:vsock",
-    ],
+    ] + select({
+        "@rules_go//go/platform:android": [
+            "//pkg/util/filesystem",
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/util/filesystem",
+            "//pkg/util/log",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 dd_agent_go_test(

--- a/comp/api/api/apiimpl/listener/listener_nix.go
+++ b/comp/api/api/apiimpl/listener/listener_nix.go
@@ -8,12 +8,52 @@
 package listener
 
 import (
+	"fmt"
 	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // platformSpecificListener returns a unix net.Listener for linux platforms
 func platformSpecificListener(address string) (net.Listener, error) {
-	return net.Listen("unix", address)
+	ln, err := net.Listen("unix", address)
+	if err != nil {
+		return nil, err
+	}
+
+	// 0770 so non-root processes in the dd-agent group can connect
+	// (connecting to a unix socket needs write). os.Root.Chmod/Chown act
+	// on the path entry and refuse to follow symlinks, closing a TOCTOU
+	// where the socket is swapped for a symlink between Listen and here.
+	root, err := os.OpenRoot(filepath.Dir(address))
+	if err != nil {
+		ln.Close()
+		return nil, fmt.Errorf("unable to open run directory for socket %s: %w", address, err)
+	}
+	defer root.Close()
+
+	name := filepath.Base(address)
+	if err := root.Chmod(name, 0770); err != nil {
+		ln.Close()
+		return nil, fmt.Errorf("unable to set permissions on socket %s: %w", address, err)
+	}
+
+	// When root, hand ownership to dd-agent so non-root agent processes
+	// can connect. Root is unaffected by owner.
+	if os.Geteuid() == 0 {
+		if uid, gid, ok := filesystem.GetAgentUserGroupIDs(); ok {
+			if err := root.Chown(name, uid, gid); err != nil {
+				log.Warnf("unable to set dd-agent ownership for socket %s: %v", address, err)
+			} else {
+				log.Debugf("set socket ownership to dd-agent (uid=%d, gid=%d): %s", uid, gid, address)
+			}
+		}
+	}
+
+	return ln, nil
 }
 
 func hasPlatformSupport() bool {

--- a/comp/api/api/apiimpl/listener/listener_nix_test.go
+++ b/comp/api/api/apiimpl/listener/listener_nix_test.go
@@ -8,6 +8,7 @@
 package listener
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -15,6 +16,21 @@ import (
 
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 )
+
+func TestLinuxGetListenerSocketPermissions(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "agent_ipc.socket")
+
+	res, err := GetListener(socketPath)
+	require.NoError(t, err)
+	defer res.Close()
+
+	info, err := os.Stat(socketPath)
+	require.NoError(t, err)
+	// Socket must be restricted to owner+group only so unrelated non-root
+	// users cannot connect (connecting requires write permission).
+	require.Equal(t, os.FileMode(0770|os.ModeSocket), info.Mode())
+}
 
 func TestLinuxGetIPCServerPath(t *testing.T) {
 	t.Run("default unix socket", func(t *testing.T) {

--- a/pkg/util/filesystem/permission_nix.go
+++ b/pkg/util/filesystem/permission_nix.go
@@ -107,6 +107,27 @@ func getDatadogUserUID() (uint32, error) {
 	return uint32(os.Getuid()), nil
 }
 
+// GetAgentUserGroupIDs returns the UID and primary GID of the agent service
+// account ("dd-agent" on Linux, "_dd-agent" on macOS). The GID is the
+// user's primary group (e.g. "root" in the standard container, where no
+// same-named group exists), not a separately-named group. ok is false if the
+// user does not exist on the system.
+func GetAgentUserGroupIDs() (uid, gid int, ok bool) {
+	u, err := user.Lookup(agentUsername())
+	if err != nil {
+		return 0, 0, false
+	}
+	uid, err = strconv.Atoi(u.Uid)
+	if err != nil {
+		return 0, 0, false
+	}
+	gid, err = strconv.Atoi(u.Gid)
+	if err != nil {
+		return 0, 0, false
+	}
+	return uid, gid, true
+}
+
 // isRootOrAgentUID reports whether uid is root (0) or the dd-agent service account.
 func (p *Permission) isRootOrAgentUID(uid uint32) bool {
 	return uid == 0 || uid == p.ddUserUID


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Restricts the IPC Unix socket (`agent_ipc.socket`) on Linux:
- `chmod 0770` (was default `0755`)
- when the Core Agent runs as root, `chown` the socket to the `dd-agent` user/group when they exist

This matches the precedent already set by the runtime security agent gRPC server (`pkg/security/utils/grpc/grpc.go`).

### Motivation

Deploying the host profiler under a non-root UID fails with:

```
Error: failed to sync config at startup, is the core agent listening on '<https+unix://localhost>/config/v1/' ?
```

When the core agent runs as root in docker, it creates `agent_ipc.socket` as `root:root` with mode `0755`. Connecting to a Unix socket on Linux requires **write** permission, so a subagent running as `dd-agent` (e.g. the host profiler) cannot connect. Other agent sockets (statsd, apm, the runtime security agent) already lock down their permissions; the IPC/CMD socket did not.

### Describe how you validated your changes
CI

### Additional notes
