### PR TITLE
fix(aggregator): `Stop` no longer leaves a goroutine running

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -270,7 +270,7 @@ type BufferedAggregator struct {
 	hostnameUpdateDone     chan struct{} // signals that the hostname update is finished
 	flushChan              chan flushTrigger
 
-	stopChan  chan struct{}
+	stopChan  chan chan struct{}
 	health    *health.Handle
 	agentName string // Name of the agent for telemetry metrics
 
@@ -352,7 +352,7 @@ func NewBufferedAggregator(s serializer.MetricSerializer, eventPlatformForwarder
 		hostnameUpdate:              make(chan string),
 		hostnameUpdateDone:          make(chan struct{}),
 		flushChan:                   make(chan flushTrigger),
-		stopChan:                    make(chan struct{}),
+		stopChan:                    make(chan chan struct{}),
 		health:                      health.RegisterLiveness("aggregator"),
 		agentName:                   agentName,
 		tlmContainerTagsEnabled:     pkgconfigsetup.Datadog().GetBool("basic_telemetry_add_container_tags"),
@@ -787,9 +787,11 @@ func (agg *BufferedAggregator) Flush(trigger flushTrigger) {
 	agg.updateChecksTelemetry()
 }
 
-// Stop stops the aggregator.
+// Stop stops the aggregator, blocking until the run() goroutine exits.
 func (agg *BufferedAggregator) Stop() {
-	agg.stopChan <- struct{}{}
+	stop := make(chan struct{})
+	agg.stopChan <- stop
+	<-stop
 }
 
 func (agg *BufferedAggregator) run() {
@@ -798,9 +800,10 @@ func (agg *BufferedAggregator) run() {
 
 	for {
 		select {
-		case <-agg.stopChan:
+		case stop := <-agg.stopChan:
 			log.Info("Stopping aggregator")
 			agg.health.Deregister() //nolint:errcheck
+			close(stop)
 			return
 		case trigger := <-agg.flushChan:
 			agg.Flush(trigger)

--- a/pkg/aggregator/demultiplexer_test.go
+++ b/pkg/aggregator/demultiplexer_test.go
@@ -198,8 +198,8 @@ func TestDemuxFlushAggregatorToSerializer(t *testing.T) {
 	// in its select before shutting it down, unfortunately, there is no other
 	// way today than giving it some time to run
 	go func() {
-		time.Sleep(250 * time.Millisecond)
-		demux.aggregator.stopChan <- struct{}{}
+		assert.Eventually(t, demux.aggregator.IsInputQueueEmpty, time.Second, time.Millisecond)
+		demux.aggregator.Stop()
 	}()
 	demux.aggregator.run()
 


### PR DESCRIPTION
### What does this PR do?
`BufferedAggregator.Stop()` now sends its own reply channel on `stopChan` and waits for `run()` to close it, instead of returning as soon as `run()` picks up the stop signal.

Also deflaked `TestDemuxFlushAggregatorToSerializer` by replacing a `time.Sleep(250ms)` guess with `assert.Eventually` on `IsInputQueueEmpty()`, which is both faster (10-run mean: ~360ms to ~110ms) and no longer a fixed-duration guess that could be too short on a loaded runner.

### Motivation
[tests_macos_gitlab_amd64](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1971012934) panicked in `comp/netflow/topn` with:
```
panic: Log in goroutine after TestTopNScheduling has completed: 2026-08-20 22:37:36 GMT | INFO | (pkg/aggregator/aggregator.go:802 in run) | Stopping aggregator
```
`run()` kept logging and deregistering health after `Stop()` had already returned, so a leaked goroutine could still write through the global logger once a later test rebound it to its own `*testing.T`.

Measured under `-race` with a temporary instrumented hook:
- before this change, `run()` finished after `Stop()` returned in 500/500 samples (median 263us, p99 767us, max 1.18ms),
- after this change, all 500 samples show `run()` completing strictly before `Stop()` unblocks.

### Describe how you validated your changes
Ran `dda inv test --race` on `pkg/aggregator/...` and `comp/netflow/topn/...` (241 tests, all pass), confirming the added wait causes no deadlock.

### Additional Notes
The delayed log line and `health.Deregister()` have **no production impact** on their own, since the demultiplexer's `flushLoop` already completes its final flush synchronously before `agg.Stop()` is called.

The panic is specific to `comp/core/log/mock` binding the global logger to a `*testing.T` that can finish before a leaked goroutine's write.

The stop signal uses a request/reply channel (`stopChan chan chan struct{}`), mirroring the `trigger`/`blockChan` pattern already used elsewhere in this file for flush requests.