### PR TITLE
[DBM][Oracle] Corrected default query timeout

### DIFF
--- a/pkg/collector/corechecks/oracle/config/config.go
+++ b/pkg/collector/corechecks/oracle/config/config.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	defaultLoader       = "core"
-	defaultQueryTimeout = 20000
+	defaultQueryTimeout = 20
 )
 
 // InitConfig is used to deserialize integration init config.

--- a/pkg/collector/corechecks/oracle/oracle_integration_test.go
+++ b/pkg/collector/corechecks/oracle/oracle_integration_test.go
@@ -81,7 +81,7 @@ END;`
 			c.config.ConnectionConfig.QueryTimeout = tt.queryTimeout
 			defer c.Teardown()
 			if tt.queryTimeout <= 0 {
-				require.Equal(t, 20000*time.Second, c.config.QueryTimeoutDuration())
+				require.Equal(t, 20*time.Second, c.config.QueryTimeoutDuration())
 				return
 			}
 			require.Equal(t, time.Duration(tt.queryTimeout)*time.Second, c.config.QueryTimeoutDuration())

--- a/releasenotes/notes/fix-default-query_timeout-9a648d3c4bd9962c.yaml
+++ b/releasenotes/notes/fix-default-query_timeout-9a648d3c4bd9962c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix the default ``query_timeout`` for the Oracle check from 20,000 seconds to 20 seconds.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Changes the Oracle check default `query_timeout` from `20000` to `20` seconds. Updates the integration test to match.

### Motivation

The Go Oracle integration treats `query_timeout` as seconds. The default of `20000` produced a ~5.5 hour timeout, not ~20 seconds. That can leave checks hung after DB maintenance or outages when customers rely on the default. This came up from SDBM-2909.

### Describe how you validated your changes

Updated `TestTimeout` default expectation from `20000*time.Second` to `20*time.Second`. Oracle integration tests require `-tags oracle` and a live Oracle instance; not run locally in this environment.

### Additional Notes

- `query_timeout` stays a hidden option (not in `conf.yaml.example`).
- Only applies on the go-ora path, not godror / `oracle_client` / `tns_alias`. This is potentially an area of improvement for the future so that other drivers also use the timeout.