### PR TITLE
Bump base feature version and disable optional developer tools

### DIFF
--- a/.devcontainer/datadog/default/devcontainer.json
+++ b/.devcontainer/datadog/default/devcontainer.json
@@ -1,7 +1,7 @@
 // This devcontainer directs workspaces to use a pre-built image. To make
 // configuration changes, edit prebuild-devcontainer.json in this folder instead
 {
-  "image": "registry.ddbuild.io/workspaces/prebuilt/datadog/datadog-agent@sha256:5d8bf28b3e932c6e5e25cccc32f283a6cff9ddb475346f132c36b0a5ae81975d",
+  "image": "registry.ddbuild.io/workspaces/prebuilt/datadog/datadog-agent@sha256:64f2cb846c8cc8fabf213083b6f4f1f7a594741b1bbe47eae8eb2c3fbe4625f9",
   "runArgs": [
     "--pid=host",
     "--cgroupns=host",

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -6,7 +6,9 @@
         "registry.ddbuild.io/workspaces/features/claude-code:0.1.122114922": {},
         "registry.ddbuild.io/workspaces/features/trajectory:0.1.121704661": {},
         "registry.ddbuild.io/workspaces/features/codex:0.1.116595837": {},
-        "registry.ddbuild.io/workspaces/features/base:0.4.116964598": {},
+        "registry.ddbuild.io/workspaces/features/base:0.4.132266657": {
+            "installDeveloperTools": false
+        },
         "./features/datadog-agent": {}
     },
     "forwardPorts": [22],


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a59f1965-14de-4301-ae14-3ee693d10a72","source":"chat","resourceId":"4749fbe9-b73e-4fc8-ba44-e60666dbc423","workflowId":"c03e564e-80fa-4db4-bdcc-e9092e4ec295","codeChangeId":"c03e564e-80fa-4db4-bdcc-e9092e4ec295","sourceType":"chat"} -->
### What does this PR do?

Updates `.devcontainer/datadog/default/prebuild-devcontainer.json` to use base feature version `0.4.132266657` and sets `installDeveloperTools` to `false`.

### Motivation
[This PR](https://github.com/ddoghq/dd-source/pull/51416) was merged, which released a new version of the base feature that contains a slim mode. The scaled down version of the base feature removes the blockers from that caused the original base image to be incompatible with the agent base image. Updating to `0.4.132266657` and disabling the developer tools install adopts the slimmer prebuild devcontainer.

### Changes

- Bumped `registry.ddbuild.io/workspaces/features/base` from `0.4.116964598` to `0.4.132266657`.
- Set `installDeveloperTools: false` on the base feature.

### Describe how you validated your changes

Verified the JSON edit preserves valid structure and matches the requested configuration.

### Additional Notes

None.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/4749fbe9-b73e-4fc8-ba44-e60666dbc423)

Comment @datadog to request changes