### PR TITLE
feat(serializer): add per-endpoint metric filter lists

### DIFF
--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -8522,21 +8522,15 @@ properties:
         type: string
       type: array
     comment: |-
-      Per-endpoint metric filter lists, keyed by the endpoint URL exactly as it is
-      configured under `dd_url` or `additional_endpoints`. Metrics named in an entry are
-      not sent to that endpoint, and every other endpoint keeps receiving them.
+      Keyed by the endpoint URL exactly as configured under `dd_url` or
+      `additional_endpoints`. Unlike metric_filterlist, which drops during sampling and
+      so affects every destination, this is applied per destination as its payload is
+      built.
 
-      This differs from `metric_filterlist`, which is applied while metrics are sampled
-      and therefore removes them from every destination. This setting is applied when the
-      payload for each destination is built, so it can single out one endpoint.
-
-      Names are matched exactly. metric_filterlist_match_prefix does not apply, because
-      Remote Config resets that setting whenever it pushes a metric filter list.
-
-      Requires use_v2_api.series, which is the default. On the v1 series API a single
-      payload is built and copied to every destination, so there is no point at which a
-      per-endpoint filter can be applied; the Agent logs a warning if both are set.
-      Sketches are unaffected and always honour these lists.
+      Names are matched exactly; metric_filterlist_match_prefix does not apply, because
+      Remote Config resets that setting whenever it pushes a filter list. Requires
+      use_v2_api.series (the default): the v1 path builds one payload for all
+      destinations, so nothing can be filtered per endpoint there.
     tags:
     - full-agent-only:true
   metric_filterlist_match_prefix:

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -8532,6 +8532,11 @@ properties:
 
       Names are matched exactly. metric_filterlist_match_prefix does not apply, because
       Remote Config resets that setting whenever it pushes a metric filter list.
+
+      Requires use_v2_api.series, which is the default. On the v1 series API a single
+      payload is built and copied to every destination, so there is no point at which a
+      per-endpoint filter can be applied; the Agent logs a warning if both are set.
+      Sketches are unaffected and always honour these lists.
     tags:
     - full-agent-only:true
   metric_filterlist_match_prefix:

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -8513,6 +8513,27 @@ properties:
       type: string
     tags:
     - full-agent-only:true
+  metric_filterlist_endpoints:
+    node_type: setting
+    type: object
+    default: {}
+    additionalProperties:
+      items:
+        type: string
+      type: array
+    comment: |-
+      Per-endpoint metric filter lists, keyed by the endpoint URL exactly as it is
+      configured under `dd_url` or `additional_endpoints`. Metrics named in an entry are
+      not sent to that endpoint, and every other endpoint keeps receiving them.
+
+      This differs from `metric_filterlist`, which is applied while metrics are sampled
+      and therefore removes them from every destination. This setting is applied when the
+      payload for each destination is built, so it can single out one endpoint.
+
+      Names are matched exactly. metric_filterlist_match_prefix does not apply, because
+      Remote Config resets that setting whenever it pushes a metric filter list.
+    tags:
+    - full-agent-only:true
   metric_filterlist_match_prefix:
     node_type: setting
     type: boolean

--- a/pkg/serializer/internal/metrics/pipeline.go
+++ b/pkg/serializer/internal/metrics/pipeline.go
@@ -11,8 +11,10 @@ import (
 	"slices"
 	"strconv"
 
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/resolver"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
+	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 )
 
 // Filterable defines the minimal interface needed for pipeline
@@ -56,6 +58,38 @@ func (mf MapFilter) Filter(f Filterable) bool {
 // ToList returns a sorted list of allowed metric names.
 func (mf MapFilter) ToList() []string {
 	return slices.Sorted(maps.Keys(*mf.m))
+}
+
+var tlmEndpointFilteredMetrics = telemetryimpl.GetCompatComponent().NewCounter(
+	"serializer", "endpoint_filtered_metrics",
+	[]string{"endpoint"},
+	"Number of metrics left out of a payload by a per-endpoint filter list",
+)
+
+// ExcludeFilter admits every metric except those matching the supplied
+// matcher.
+type ExcludeFilter struct {
+	m *utilstrings.Matcher
+	// endpoint labels the telemetry counter so that each destination's
+	// exclusions can be read separately.
+	endpoint string
+}
+
+// NewExcludeFilter creates a new filter using the supplied matcher.
+//
+// The matcher is not copied and is shared with the filter. A pointer is held so
+// that the filter stays comparable, which PipelineConfig requires.
+func NewExcludeFilter(m *utilstrings.Matcher, endpoint string) ExcludeFilter {
+	return ExcludeFilter{m: m, endpoint: endpoint}
+}
+
+// Filter implements Filter interface.
+func (ef ExcludeFilter) Filter(f Filterable) bool {
+	if ef.m.Test(f.GetName()) {
+		tlmEndpointFilteredMetrics.Inc(ef.endpoint)
+		return false
+	}
+	return true
 }
 
 // PipelineConfig contains properties that determine how a payload is

--- a/pkg/serializer/internal/metrics/pipeline.go
+++ b/pkg/serializer/internal/metrics/pipeline.go
@@ -14,7 +14,6 @@ import (
 	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/resolver"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
-	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 )
 
 // Filterable defines the minimal interface needed for pipeline
@@ -66,26 +65,29 @@ var tlmEndpointFilteredMetrics = telemetryimpl.GetCompatComponent().NewCounter(
 	"Number of metrics left out of a payload by a per-endpoint filter list",
 )
 
-// ExcludeFilter admits every metric except those matching the supplied
-// matcher.
+// ExcludeFilter admits every metric except those whose name is present in the
+// map.
+//
+// A map is used rather than pkg/util/strings.Matcher because that package
+// belongs to the root module, and pkg/serializer depends only on submodules.
 type ExcludeFilter struct {
-	m *utilstrings.Matcher
+	m *map[string]struct{}
 	// endpoint labels the telemetry counter so that each destination's
 	// exclusions can be read separately.
 	endpoint string
 }
 
-// NewExcludeFilter creates a new filter using the supplied matcher.
+// NewExcludeFilter creates a new filter using the supplied map.
 //
-// The matcher is not copied and is shared with the filter. A pointer is held so
+// The map is not copied and is shared with the filter. A pointer is held so
 // that the filter stays comparable, which PipelineConfig requires.
-func NewExcludeFilter(m *utilstrings.Matcher, endpoint string) ExcludeFilter {
-	return ExcludeFilter{m: m, endpoint: endpoint}
+func NewExcludeFilter(m map[string]struct{}, endpoint string) ExcludeFilter {
+	return ExcludeFilter{m: &m, endpoint: endpoint}
 }
 
 // Filter implements Filter interface.
 func (ef ExcludeFilter) Filter(f Filterable) bool {
-	if ef.m.Test(f.GetName()) {
+	if _, excluded := (*ef.m)[f.GetName()]; excluded {
 		tlmEndpointFilteredMetrics.Inc(ef.endpoint)
 		return false
 	}

--- a/pkg/serializer/internal/metrics/pipeline_test.go
+++ b/pkg/serializer/internal/metrics/pipeline_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/resolver"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
-	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil"
 )
 
@@ -103,8 +102,7 @@ type filterableMetric string
 func (m filterableMetric) GetName() string { return string(m) }
 
 func TestExcludeFilter(t *testing.T) {
-	matcher := utilstrings.NewMatcher([]string{"foo.bar", "foo.baz"}, false)
-	filter := NewExcludeFilter(&matcher, "http://example.test")
+	filter := NewExcludeFilter(map[string]struct{}{"foo.bar": {}, "foo.baz": {}}, "http://example.test")
 
 	require.False(t, filter.Filter(filterableMetric("foo.bar")))
 	require.False(t, filter.Filter(filterableMetric("foo.baz")))
@@ -115,8 +113,7 @@ func TestExcludeFilter(t *testing.T) {
 }
 
 func TestExcludeFilterEmptyMatcher(t *testing.T) {
-	matcher := utilstrings.NewMatcher(nil, false)
-	filter := NewExcludeFilter(&matcher, "http://example.test")
+	filter := NewExcludeFilter(map[string]struct{}{}, "http://example.test")
 
 	require.True(t, filter.Filter(filterableMetric("foo.bar")))
 }

--- a/pkg/serializer/internal/metrics/pipeline_test.go
+++ b/pkg/serializer/internal/metrics/pipeline_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/resolver"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil"
 )
 
@@ -94,4 +95,28 @@ func TestPipelineSendValidate(t *testing.T) {
 			require.Empty(t, txn.Headers.Get("x-metrics-request-payload-len"))
 		},
 	)
+}
+
+// filterableMetric is a minimal Filterable used to exercise the filters.
+type filterableMetric string
+
+func (m filterableMetric) GetName() string { return string(m) }
+
+func TestExcludeFilter(t *testing.T) {
+	matcher := utilstrings.NewMatcher([]string{"foo.bar", "foo.baz"}, false)
+	filter := NewExcludeFilter(&matcher, "http://example.test")
+
+	require.False(t, filter.Filter(filterableMetric("foo.bar")))
+	require.False(t, filter.Filter(filterableMetric("foo.baz")))
+	require.True(t, filter.Filter(filterableMetric("foo.qux")))
+	require.True(t, filter.Filter(filterableMetric("foo")))
+	// Without prefix matching an entry only excludes the exact name.
+	require.True(t, filter.Filter(filterableMetric("foo.bar.count")))
+}
+
+func TestExcludeFilterEmptyMatcher(t *testing.T) {
+	matcher := utilstrings.NewMatcher(nil, false)
+	filter := NewExcludeFilter(&matcher, "http://example.test")
+
+	require.True(t, filter.Filter(filterableMetric("foo.bar")))
 }

--- a/pkg/serializer/metrics.go
+++ b/pkg/serializer/metrics.go
@@ -190,6 +190,7 @@ func (s *Serializer) buildPipelinesRng(kind metricsKind, rng prng) metrics.Pipel
 
 	mrfFilter := s.getFailoverAllowlist()
 	autoscalingFilter := s.getAutoscalingFailoverMetrics()
+	endpointFilters := s.getEndpointFilterLists()
 	shadowRate := metricsShadowSampleRate(s.config, kind)
 	shadowSites := metricsShadowSites(s.config, kind)
 
@@ -237,17 +238,26 @@ func (s *Serializer) buildPipelinesRng(kind metricsKind, rng prng) metrics.Pipel
 				dest.ValidationBatchID = s.genUUID()
 			}
 
+			// An endpoint with its own filter list only receives the metrics
+			// that list does not name. Every other endpoint is unaffected.
+			var filter metrics.Filter = metrics.AllowAllFilter{}
+			if endpointFilter, ok := endpointFilters[resolver.GetConfigName()]; ok {
+				filter = endpointFilter
+			}
+
 			conf := metrics.PipelineConfig{
-				Filter: metrics.AllowAllFilter{},
+				Filter: filter,
 				V3:     useV3,
 			}
 			pipelines.Add(conf, dest)
 
 			// On a regular v2 route, send a sampled shadow copy to v3beta for
 			// intake-side validation. The same batchID correlates v2 and v3beta.
+			// The shadow uses the same filter so that the two payloads stay
+			// comparable.
 			if shadowV3 {
 				sconf := metrics.PipelineConfig{
-					Filter: metrics.AllowAllFilter{},
+					Filter: filter,
 					V3:     true,
 				}
 				sdest := metrics.PipelineDestination{

--- a/pkg/serializer/metrics.go
+++ b/pkg/serializer/metrics.go
@@ -238,8 +238,7 @@ func (s *Serializer) buildPipelinesRng(kind metricsKind, rng prng) metrics.Pipel
 				dest.ValidationBatchID = s.genUUID()
 			}
 
-			// An endpoint with its own filter list only receives the metrics
-			// that list does not name. Every other endpoint is unaffected.
+			// Endpoints without a filter list receive every metric.
 			var filter metrics.Filter = metrics.AllowAllFilter{}
 			if endpointFilter, ok := endpointFilters[resolver.GetConfigName()]; ok {
 				filter = endpointFilter

--- a/pkg/serializer/metrics_test.go
+++ b/pkg/serializer/metrics_test.go
@@ -316,6 +316,37 @@ func TestBuildPipelinesWithEndpointFilterList(t *testing.T) {
 	}
 }
 
+func TestEndpointFilterListsIgnoredOnV1Series(t *testing.T) {
+	logger := logmock.New(t)
+	config := configmock.New(t)
+
+	config.SetInTest("dd_url", "http://example.test")
+	config.SetInTest("api_key", "test_key")
+	// The v1 series API builds one payload for every destination, so the
+	// per-endpoint lists cannot be applied and must not silently appear to work.
+	config.SetInTest("use_v2_api.series", false)
+	config.SetInTest("metric_filterlist_endpoints", map[string][]string{
+		"http://example.test": {"datadog.agent.running"},
+	})
+
+	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
+	require.NoError(t, err)
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
+	s := NewSerializer(f, nil, compressor, config, logger, "")
+
+	// The warning is emitted once and must not panic or alter the pipelines that
+	// other payload kinds still build.
+	s.warnEndpointFilterListsIgnored()
+	s.warnEndpointFilterListsIgnored()
+
+	pipelines := s.buildPipelines(metricsKindSketches)
+	require.Len(t, pipelines, 1)
+	for conf := range pipelines {
+		assert.False(t, conf.Filter.Filter(filterableMetric("datadog.agent.running")),
+			"sketches still honour the endpoint filter list")
+	}
+}
+
 func TestBuildPipelinesWithEndpointFilterListUnknownEndpoint(t *testing.T) {
 	logger := logmock.New(t)
 	config := configmock.New(t)

--- a/pkg/serializer/metrics_test.go
+++ b/pkg/serializer/metrics_test.go
@@ -269,6 +269,78 @@ func TestBuildPipelinesWithMRFActiveFilter(t *testing.T) {
 	}
 }
 
+// filterableMetric is a minimal metrics.Filterable used to exercise a pipeline
+// filter without building a full series.
+type filterableMetric string
+
+func (m filterableMetric) GetName() string { return string(m) }
+
+func TestBuildPipelinesWithEndpointFilterList(t *testing.T) {
+	logger := logmock.New(t)
+	config := configmock.New(t)
+
+	config.SetInTest("dd_url", "http://example.test")
+	config.SetInTest("api_key", "test_key")
+	config.SetInTest("use_v3_api.series.enabled", "true")
+	config.SetInTest("additional_endpoints", map[string][]string{
+		"http://another.test": {"another_key"},
+	})
+	config.SetInTest("metric_filterlist_endpoints", map[string][]string{
+		"http://example.test": {"datadog.agent.running"},
+	})
+
+	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
+	require.NoError(t, err)
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
+	s := NewSerializer(f, nil, compressor, config, logger, "")
+
+	pipelines := s.buildPipelines(metricsKindSeries)
+	// The filtered endpoint no longer shares a payload with the unfiltered one.
+	require.Len(t, pipelines, 2)
+
+	for conf, ctx := range pipelines {
+		require.Len(t, ctx.Destinations, 1)
+		dest := ctx.Destinations[0]
+		assert.True(t, conf.V3)
+		assert.Equal(t, endpoints.V3SeriesEndpoint, dest.Endpoint)
+
+		switch dest.Resolver.GetBaseDomain() {
+		case "http://example.test":
+			assert.False(t, conf.Filter.Filter(filterableMetric("datadog.agent.running")))
+			assert.True(t, conf.Filter.Filter(filterableMetric("datadog.agent.started")))
+		case "http://another.test":
+			assert.Equal(t, metrics.AllowAllFilter{}, conf.Filter)
+		default:
+			t.Fatal("unexpected destination address")
+		}
+	}
+}
+
+func TestBuildPipelinesWithEndpointFilterListUnknownEndpoint(t *testing.T) {
+	logger := logmock.New(t)
+	config := configmock.New(t)
+
+	config.SetInTest("dd_url", "http://example.test")
+	config.SetInTest("api_key", "test_key")
+	config.SetInTest("use_v3_api.series.enabled", "true")
+	// An entry for an endpoint that is not configured must not affect anything.
+	config.SetInTest("metric_filterlist_endpoints", map[string][]string{
+		"http://absent.test": {"datadog.agent.running"},
+	})
+
+	f, err := defaultforwarderimpl.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
+	require.NoError(t, err)
+	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
+	s := NewSerializer(f, nil, compressor, config, logger, "")
+
+	pipelines := s.buildPipelines(metricsKindSeries)
+	require.Len(t, pipelines, 1)
+
+	for conf := range pipelines {
+		assert.Equal(t, metrics.AllowAllFilter{}, conf.Filter)
+	}
+}
+
 func TestBuildPipelinesSketches(t *testing.T) {
 	logger := logmock.New(t)
 	config := configmock.New(t)

--- a/pkg/serializer/metrics_test.go
+++ b/pkg/serializer/metrics_test.go
@@ -334,8 +334,7 @@ func TestEndpointFilterListsIgnoredOnV1Series(t *testing.T) {
 	compressor := metricscompressionimpl.NewComponent(metricscompressionimpl.Requires{Cfg: config}).Comp
 	s := NewSerializer(f, nil, compressor, config, logger, "")
 
-	// The warning is emitted once and must not panic or alter the pipelines that
-	// other payload kinds still build.
+	// Emitted once; sketches must still honor the list.
 	s.warnEndpointFilterListsIgnored()
 	s.warnEndpointFilterListsIgnored()
 
@@ -343,7 +342,7 @@ func TestEndpointFilterListsIgnoredOnV1Series(t *testing.T) {
 	require.Len(t, pipelines, 1)
 	for conf := range pipelines {
 		assert.False(t, conf.Filter.Filter(filterableMetric("datadog.agent.running")),
-			"sketches still honour the endpoint filter list")
+			"sketches still honor the endpoint filter list")
 	}
 }
 

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer/split"
 	"github.com/DataDog/datadog-agent/pkg/serializer/types"
 	"github.com/DataDog/datadog-agent/pkg/util/compression"
+	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -313,6 +314,33 @@ func (s *Serializer) getAutoscalingFailoverMetrics() metricsserializer.Filter {
 	}
 
 	return metricsserializer.NewMapFilter(allowlist)
+}
+
+// getEndpointFilterLists returns the per-endpoint exclusion filters, keyed by
+// the endpoint URL as it appears in the configuration. Endpoints without an
+// entry are absent from the map and receive every metric.
+//
+// Names are matched exactly. metric_filterlist_match_prefix is deliberately not
+// reused: Remote Config resets it whenever it pushes a metric filter list, so
+// honoring it here would make these lists change matching behavior as a side
+// effect of an unrelated remote update.
+func (s *Serializer) getEndpointFilterLists() map[string]metricsserializer.Filter {
+	rawLists := s.config.GetStringMapStringSlice("metric_filterlist_endpoints")
+	if len(rawLists) == 0 {
+		return nil
+	}
+
+	filters := make(map[string]metricsserializer.Filter, len(rawLists))
+	for endpoint, metricNames := range rawLists {
+		if len(metricNames) == 0 {
+			continue
+		}
+
+		matcher := utilstrings.NewMatcher(metricNames, false)
+		filters[endpoint] = metricsserializer.NewExcludeFilter(&matcher, endpoint)
+	}
+
+	return filters
 }
 
 // AreSketchesEnabled returns whether sketches are enabled for serialization

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -32,7 +32,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer/split"
 	"github.com/DataDog/datadog-agent/pkg/serializer/types"
 	"github.com/DataDog/datadog-agent/pkg/util/compression"
-	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -127,7 +126,8 @@ type Serializer struct {
 	hostname             string
 	logger               log.Component
 
-	zlibV3WarnOnce sync.Once
+	zlibV3WarnOnce   sync.Once
+	v1FilterWarnOnce sync.Once
 }
 
 // NewSerializer returns a new Serializer initialized
@@ -258,6 +258,7 @@ func (s *Serializer) SendIterableSeries(serieSource metrics.SerieSource) error {
 	var err error
 
 	if useV1API {
+		s.warnEndpointFilterListsIgnored()
 		seriesBytesPayloads, extraHeaders, err = s.serializeIterableStreamablePayload(seriesSerializer, stream.DropItemOnErrItemTooBig)
 		if err != nil {
 			return fmt.Errorf("dropping series payload: %s", err)
@@ -336,11 +337,33 @@ func (s *Serializer) getEndpointFilterLists() map[string]metricsserializer.Filte
 			continue
 		}
 
-		matcher := utilstrings.NewMatcher(metricNames, false)
-		filters[endpoint] = metricsserializer.NewExcludeFilter(&matcher, endpoint)
+		excluded := make(map[string]struct{}, len(metricNames))
+		for _, name := range metricNames {
+			excluded[name] = struct{}{}
+		}
+		filters[endpoint] = metricsserializer.NewExcludeFilter(excluded, endpoint)
 	}
 
 	return filters
+}
+
+// warnEndpointFilterListsIgnored reports, once per serializer, that
+// metric_filterlist_endpoints has no effect on the v1 series path.
+//
+// The v1 path builds a single payload and the forwarder copies it to every
+// destination, so there is no point at which a per-endpoint filter could be
+// applied. Sketches are unaffected: they always go through buildPipelines.
+func (s *Serializer) warnEndpointFilterListsIgnored() {
+	if len(s.config.GetStringMapStringSlice("metric_filterlist_endpoints")) == 0 {
+		return
+	}
+
+	s.v1FilterWarnOnce.Do(func() {
+		s.logger.Warn(
+			"metric_filterlist_endpoints is set but use_v2_api.series is false; " +
+				"per-endpoint filter lists are not applied to series on the v1 API. " +
+				"Set use_v2_api.series to true to enable them.")
+	})
 }
 
 // AreSketchesEnabled returns whether sketches are enabled for serialization

--- a/releasenotes/notes/metric-filterlist-endpoints-803e6361cb421d3a.yaml
+++ b/releasenotes/notes/metric-filterlist-endpoints-803e6361cb421d3a.yaml
@@ -1,0 +1,19 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added the ``metric_filterlist_endpoints`` configuration option, which holds a
+    per-endpoint list of metric names to leave out of the payload built for that
+    endpoint. It is keyed by the endpoint URL as configured under ``dd_url`` or
+    ``additional_endpoints``, and endpoints without an entry keep receiving every
+    metric. Unlike ``metric_filterlist``, which drops metrics while they are
+    sampled and therefore removes them from every destination, this option makes
+    it possible to withhold metrics from one endpoint while still sending them to
+    the others. Names are matched exactly, and an Agent telemetry counter tagged
+    by endpoint reports how many metrics each list left out.


### PR DESCRIPTION
### What does this PR do?

Adds `metric_filterlist_endpoints`, a per-endpoint list of metric names to leave out of the payload built for that endpoint. It is keyed by the endpoint URL as configured under `dd_url` or `additional_endpoints`, and endpoints without an entry keep receiving every metric. Names are matched exactly.

```yaml
metric_filterlist_endpoints:
  "https://app.datadoghq.com":
    - myapp.request.duration
    - myapp.cache.miss
```

A telemetry counter tagged by endpoint reports how many metrics each list left out.

### Motivation

`metric_filterlist` is applied while metrics are sampled, so a filtered metric is removed from every destination. An Agent configured with `additional_endpoints` has no way to stop sending a metric to one endpoint while still sending it to the others, so the choice today is all destinations or none.

That distinction matters when one Agent feeds two destinations with different needs, for example a primary intake alongside a secondary that only needs a subset of the metrics, or a cost sensitive destination next to one that keeps everything.

The serializer is where this belongs, because it is the only stage that knows which destination a payload is being built for. `comp/filterlist` runs during ingestion, before any destination exists, so it cannot express a per-endpoint rule. Two per-destination filters already live in `buildPipelines` and are built the same way: `getFailoverAllowlist` for multi-region failover and `getAutoscalingFailoverMetrics` for autoscaling. This adds a third, `getEndpointFilterLists`, and attaches it to that destination's `PipelineConfig`.

### Describe how you validated your changes

- `dda inv test --targets=./pkg/serializer`: 104 tests pass. New coverage for `ExcludeFilter` and its empty case, pipeline level tests for a filtered endpoint alongside an unfiltered one and for an entry naming an endpoint that is not configured, plus a test that sketches still honor the lists when series fall back to the v1 API.
- `dda inv linter.go --targets=./pkg/serializer`: 0 issues.
- `dda inv schema.lint`: both schemas pass.
- `dda inv tidy` and `bazel run //:gazelle`: no module or BUILD changes.

### Additional Notes

- Prefix matching is deliberately not applied. `metric_filterlist_match_prefix` is reset by Remote Config whenever it pushes a metric filter list, so honoring it would let an unrelated remote update silently change how these lists match. Remote Config matches exactly, so exact matching also keeps the two consistent.
- The lists require `use_v2_api.series`, which is the default. The v1 series path builds a single payload and the forwarder copies it to every destination, so there is no point at which a per-endpoint filter could be applied; the Agent logs a warning if both are set. Sketches always honor the lists.
- `ExcludeFilter` uses a map rather than `pkg/util/strings.Matcher`. That package is in the root module and `pkg/serializer` depends only on submodules, so importing it would add a root module dependency to a leaf.
- Giving one endpoint its own filter means its payload is no longer shared with endpoints that have none, so that payload is built separately. It is the smaller of the two.
- Follow-ups that are out of scope here: delivery through the Metric Control Remote Config product, and parity in the ADP metric pipeline.
