### PR TITLE
test(regression): enable ADP for timestamped contexts DogStatsD regression cases

### DIFF
--- a/test/regression/cases/dsd_uds_10mb_3k_timestamped_contexts_cpu/datadog-agent/datadog.yaml
+++ b/test/regression/cases/dsd_uds_10mb_3k_timestamped_contexts_cpu/datadog-agent/datadog.yaml
@@ -11,3 +11,7 @@ telemetry.enabled: true
 telemetry.checks: '*'
 
 dogstatsd_socket: '/tmp/dsd.socket'
+
+# Route DogStatsD traffic through the Agent Data Plane to check for regressions
+# with ADP enabled.
+data_plane.enabled: true

--- a/test/regression/cases/dsd_uds_10mb_3k_timestamped_contexts_memory/datadog-agent/datadog.yaml
+++ b/test/regression/cases/dsd_uds_10mb_3k_timestamped_contexts_memory/datadog-agent/datadog.yaml
@@ -11,3 +11,7 @@ telemetry.enabled: true
 telemetry.checks: '*'
 
 dogstatsd_socket: '/tmp/dsd.socket'
+
+# Route DogStatsD traffic through the Agent Data Plane to check for regressions
+# with ADP enabled.
+data_plane.enabled: true


### PR DESCRIPTION
### What does this PR do?

Enables the Agent Data Plane (`data_plane.enabled: true`) for the `dsd_uds_10mb_3k_timestamped_contexts_cpu` and `dsd_uds_10mb_3k_timestamped_contexts_memory` regression cases added in #54998.

### Motivation

#54998 added regression coverage for DogStatsD timestamped contexts, but exercised the default (non-ADP) DogStatsD path. This draft PR routes that same traffic through ADP so we can compare the regression results and check for any CPU/memory regressions specific to the ADP path.

### Describe how you validated your changes

Opened as a draft to let CI run the two regression cases with ADP enabled and compare against the baseline (non-ADP) results from #54998.

### Additional Notes

Scoped to only the two timestamped-contexts cases. `quality_gate_metrics_logs` also generates DogStatsD traffic but is a merge-gating quality gate with an existing ADP preflight-only setup used to measure overhead without affecting its threshold — left untouched here to avoid changing what that gate measures.