### PR TITLE
feat(orchestrator): collect DRA ResourceClaim and ResourceSlice 

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -158,6 +158,7 @@ func (cb *CollectorBundle) prepareCollectors() {
 	}
 
 	defer cb.importBuiltinCollectors()
+	defer cb.importDRACollectors()
 
 	if ok := cb.importCollectorsFromCheckConfig(); ok {
 		return
@@ -465,6 +466,31 @@ func (cb *CollectorBundle) EnableTerminatedResourceBundle() {
 }
 
 // importBuiltinCollectors imports the builtin collectors into the bundle.
+// importDRACollectors appends the DRA collectors when the check asks for them.
+//
+// Appended rather than selected: the resources are registered as non-stable so
+// discovery never activates them on its own, and naming them in the check's
+// collectors list would replace the default selection instead of adding to it.
+// Deferred alongside importBuiltinCollectors so it runs whichever way the rest
+// of the bundle was filled.
+func (cb *CollectorBundle) importDRACollectors() {
+	// Accepted from datadog.yaml as well as the check instance, so it can be
+	// set through DD_ORCHESTRATOR_EXPLORER_COLLECT_DRA_RESOURCES. The
+	// orchestrator instance config ships inside the image as an
+	// autodiscovery template, so an instance-only flag would not be reachable
+	// from a Helm value or an operator env var.
+	enabled := cb.check.instance.CollectDRAResources
+	if !enabled && cb.check.cfg != nil {
+		enabled = cb.check.cfg.GetBool("orchestrator_explorer.collect_dra_resources")
+	}
+	if !enabled {
+		return
+	}
+	for _, name := range []string{"resourceclaims", "resourceslices"} {
+		cb.addCollectorFromConfig(name, false)
+	}
+}
+
 func (cb *CollectorBundle) importBuiltinCollectors() {
 	// add builtin CR collectors
 	builtinCollectors := cb.getBuiltinCustomResourceCollectors()

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
@@ -672,3 +672,57 @@ func TestFilterCRCollectorsByPermission(t *testing.T) {
 		require.Len(t, result, 0)
 	})
 }
+
+// TestImportDRACollectors pins the opt-in path for DRA. The generic resources
+// are registered non-stable so discovery never activates them without RBAC, and
+// naming them in the check's `collectors` list would replace the default
+// selection rather than add to it -- so the flag has to append, the way builtin
+// collectors do.
+func TestImportDRACollectors(t *testing.T) {
+	cfg := mockconfig.New(t)
+
+	collectorDiscovery := &discovery.DiscoveryCollector{}
+	collectorDiscovery.SetCache(discovery.DiscoveryCache{
+		CollectorForVersion: map[discovery.CollectorVersion]struct{}{
+			{GroupVersion: "v1", Kind: "pods"}:                           {},
+			{GroupVersion: "resource.k8s.io/v1", Kind: "resourceclaims"}: {},
+			{GroupVersion: "resource.k8s.io/v1", Kind: "resourceslices"}: {},
+		},
+	})
+
+	newBundle := func(collectDRA bool) *CollectorBundle {
+		return &CollectorBundle{
+			check: &OrchestratorCheck{
+				instance: &OrchestratorInstance{CollectDRAResources: collectDRA},
+			},
+			collectorDiscovery:  collectorDiscovery,
+			activatedCollectors: make(map[string]struct{}),
+			collectors:          []collectors.K8sCollector{k8s.NewUnassignedPodCollector(nil, nil, nil)},
+			inventory:           inventory.NewCollectorInventory(cfg, nil, nil),
+			runCfg: &collectors.CollectorRunConfig{
+				K8sCollectorRunConfig: collectors.K8sCollectorRunConfig{
+					APIClient: createMockAPIClient(),
+				},
+			},
+		}
+	}
+
+	t.Run("flag off leaves the bundle untouched", func(t *testing.T) {
+		cb := newBundle(false)
+		cb.importDRACollectors()
+		require.Len(t, cb.collectors, 1, "DRA must not be collected unless asked for")
+	})
+
+	t.Run("flag on appends both, keeping what was already selected", func(t *testing.T) {
+		cb := newBundle(true)
+		cb.importDRACollectors()
+
+		names := make([]string, 0, len(cb.collectors))
+		for _, collector := range cb.collectors {
+			names = append(names, collector.Metadata().FullName())
+		}
+		require.Contains(t, names, "v1/pods", "the default selection must survive opting into DRA")
+		require.Contains(t, names, "resource.k8s.io/v1/resourceclaims")
+		require.Contains(t, names, "resource.k8s.io/v1/resourceslices")
+	})
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/BUILD.bazel
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "inventory",
@@ -12,5 +13,25 @@ go_library(
         "//pkg/collector/corechecks/cluster/orchestrator/collectors",
         "//pkg/collector/corechecks/cluster/orchestrator/collectors/k8s",
         "//pkg/orchestrator",
+    ],
+)
+
+dd_agent_go_test(
+    name = "inventory_test",
+    srcs = ["inventory_test.go"],
+    embed = [":inventory"],
+    gotags_sets = [[
+        "cel",
+        "clusterchecks",
+        "kubeapiserver",
+        "kubelet",
+        "orchestrator",
+    ]],
+    include_default = False,
+    deps = [
+        "//pkg/collector/corechecks/cluster/orchestrator/collectors",
+        "//pkg/orchestrator/model",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory.go
@@ -43,6 +43,17 @@ var draAPIVersions = []string{"v1", "v1beta2", "v1beta1"}
 // server-preferred group versions first, so exactly one version of each is
 // enabled: whichever the API server prefers. Only the newest is the default
 // version — see GenericResource.IsDefaultVersion for why that matters.
+//
+// Registered as non-stable, so they are collected only when the check names
+// them explicitly. Stable would activate them on every cluster serving
+// resource.k8s.io, including the ones whose Cluster Agent has no RBAC for the
+// group yet: the LIST 403s, HasSynced never fires, and Initialize blocks for
+// kube_cache_sync_timeout_seconds plus the extra sync timeout (70s by default)
+// before skipCollector gives up on them. The permissions ship from
+// helm-charts and datadog-operator, on their own release trains, so that
+// window is real rather than hypothetical. Flip to stable once those carry the
+// grant; until then this also matches kubernetes_state_core, where DRA sits
+// behind collect_dra_resources.
 func draGenericResources() []k8sCollectors.GenericResource {
 	resources := make([]k8sCollectors.GenericResource, 0, 2*len(draAPIVersions))
 	for _, name := range []string{"resourceclaims", "resourceslices"} {
@@ -52,7 +63,7 @@ func draGenericResources() []k8sCollectors.GenericResource {
 				Group:            "resource.k8s.io",
 				Version:          version,
 				NodeType:         orchestrator.K8sCR,
-				Stable:           true,
+				Stable:           false,
 				IsDefaultVersion: i == 0,
 			})
 		}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory.go
@@ -20,14 +20,44 @@ import (
 )
 
 // defaultGenericResource is a list of generic resources that are collected by default.
-var defaultGenericResource = []k8sCollectors.GenericResource{
+var defaultGenericResource = append([]k8sCollectors.GenericResource{
 	{
-		Name:     "endpointslices",
-		Group:    "discovery.k8s.io",
-		Version:  "v1",
-		NodeType: orchestrator.K8sEndpointSlice,
-		Stable:   true,
+		Name:             "endpointslices",
+		Group:            "discovery.k8s.io",
+		Version:          "v1",
+		NodeType:         orchestrator.K8sEndpointSlice,
+		Stable:           true,
+		IsDefaultVersion: true,
 	},
+}, draGenericResources()...)
+
+// draAPIVersions are the resource.k8s.io versions this collector understands,
+// newest first. The group reached v1 only in Kubernetes 1.34, so a cluster in
+// the field commonly serves a beta version instead — and discovery matches on
+// the exact GroupVersion and skips a miss without logging, so registering v1
+// alone means collecting nothing at all, silently, on every earlier cluster.
+var draAPIVersions = []string{"v1", "v1beta2", "v1beta1"}
+
+// draGenericResources registers DRA's ResourceClaim and ResourceSlice once per
+// understood API version. Discovery dedupes by resource name and walks
+// server-preferred group versions first, so exactly one version of each is
+// enabled: whichever the API server prefers. Only the newest is the default
+// version — see GenericResource.IsDefaultVersion for why that matters.
+func draGenericResources() []k8sCollectors.GenericResource {
+	resources := make([]k8sCollectors.GenericResource, 0, 2*len(draAPIVersions))
+	for _, name := range []string{"resourceclaims", "resourceslices"} {
+		for i, version := range draAPIVersions {
+			resources = append(resources, k8sCollectors.GenericResource{
+				Name:             name,
+				Group:            "resource.k8s.io",
+				Version:          version,
+				NodeType:         orchestrator.K8sCR,
+				Stable:           true,
+				IsDefaultVersion: i == 0,
+			})
+		}
+	}
+	return resources
 }
 
 // getGenericCollectorVersions returns a list of collector versions for the default generic resources.

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory_test.go
@@ -61,7 +61,6 @@ func TestDRAGenericResourcesCoverBetaVersions(t *testing.T) {
 		for _, version := range []string{"v1", "v1beta2", "v1beta1"} {
 			m, ok := byNameVersion[[2]string{name, version}]
 			require.True(t, ok, "%s must be registered for %s", name, version)
-			assert.True(t, m.IsStable, "%s/%s must be stable or discovery skips it", name, version)
 			assert.Equal(t, "resource.k8s.io/"+version, m.GroupVersion())
 		}
 	}
@@ -86,5 +85,24 @@ func TestGenericResourcesHaveExactlyOneDefaultVersion(t *testing.T) {
 
 	for name := range names {
 		assert.Equal(t, 1, defaults[name], "generic resource %q must have exactly one default version", name)
+	}
+}
+
+// TestDRAGenericResourcesAreOptIn pins the activation model. Marking these
+// stable makes APIServerDiscoveryProvider.walkAPIResources activate them on
+// every cluster serving resource.k8s.io -- including those whose Cluster Agent
+// has no RBAC for the group, where the LIST 403s and Initialize stalls for the
+// full cache-sync plus extra-sync timeout before skipping them. Unstable keeps
+// discovery off them while addCollectorFromConfig still honours an explicit
+// collectors list, so the feature stays reachable without that cost.
+func TestDRAGenericResourcesAreOptIn(t *testing.T) {
+	byNameVersion := genericMetadataByNameVersion(t)
+
+	for _, name := range []string{"resourceclaims", "resourceslices"} {
+		for _, version := range []string{"v1", "v1beta2", "v1beta1"} {
+			m, ok := byNameVersion[[2]string{name, version}]
+			require.True(t, ok, "%s must be registered for %s", name, version)
+			assert.False(t, m.IsStable, "%s/%s must stay opt-in until the charts ship resource.k8s.io RBAC", name, version)
+		}
 	}
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory_test.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+
+package inventory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
+	pkgorchestratormodel "github.com/DataDog/datadog-agent/pkg/orchestrator/model"
+)
+
+// genericMetadataByNameVersion flattens the default generic collectors into a
+// (name, version) -> metadata map.
+func genericMetadataByNameVersion(t *testing.T) map[[2]string]*collectors.CollectorMetadata {
+	t.Helper()
+	out := map[[2]string]*collectors.CollectorMetadata{}
+	for _, cv := range getGenericCollectorVersions() {
+		for _, collector := range cv.Collectors {
+			m := collector.Metadata()
+			out[[2]string{m.Name, m.Version}] = m
+		}
+	}
+	return out
+}
+
+// TestDRAGenericResourcesRegistered guards the WS3 change: DRA's built-in
+// resource.k8s.io types ride the generic manifest channel (NodeType: K8sCR,
+// IsManifestProducer: true) rather than first-class backend types. If either
+// entry is dropped, ResourceClaim/ResourceSlice stop appearing in Kubernetes
+// Explorer with no error.
+func TestDRAGenericResourcesRegistered(t *testing.T) {
+	byNameVersion := genericMetadataByNameVersion(t)
+
+	for _, name := range []string{"resourceclaims", "resourceslices"} {
+		m, ok := byNameVersion[[2]string{name, "v1"}]
+		require.True(t, ok, "generic collector %q is not registered in defaultGenericResource", name)
+
+		assert.Equal(t, "resource.k8s.io", m.Group, "%s must use the resource.k8s.io group", name)
+		assert.Equal(t, pkgorchestratormodel.NodeType(pkgorchestratormodel.K8sCR), m.NodeType, "%s must ride the generic manifest channel (K8sCR)", name)
+		assert.True(t, m.IsManifestProducer, "%s must be a manifest producer", name)
+		assert.True(t, m.IsGenericCollector, "%s must be a generic collector", name)
+	}
+}
+
+// TestDRAGenericResourcesCoverBetaVersions pins version coverage. Discovery
+// matches a collector on its exact GroupVersion and skips a miss without
+// logging, so registering only v1 -- which exists from Kubernetes 1.34 -- means
+// collecting nothing at all, silently, on every cluster serving a beta version.
+func TestDRAGenericResourcesCoverBetaVersions(t *testing.T) {
+	byNameVersion := genericMetadataByNameVersion(t)
+
+	for _, name := range []string{"resourceclaims", "resourceslices"} {
+		for _, version := range []string{"v1", "v1beta2", "v1beta1"} {
+			m, ok := byNameVersion[[2]string{name, version}]
+			require.True(t, ok, "%s must be registered for %s", name, version)
+			assert.True(t, m.IsStable, "%s/%s must be stable or discovery skips it", name, version)
+			assert.Equal(t, "resource.k8s.io/"+version, m.GroupVersion())
+		}
+	}
+}
+
+// TestGenericResourcesHaveExactlyOneDefaultVersion pins the invariant that
+// makes multi-version registration safe. Discovery dedupes by name, but the
+// fallback used when discovery fails selects on IsStable && IsDefaultVersion --
+// so a second default version there would start an informer that can only 404.
+func TestGenericResourcesHaveExactlyOneDefaultVersion(t *testing.T) {
+	defaults := map[string]int{}
+	names := map[string]struct{}{}
+	for _, cv := range getGenericCollectorVersions() {
+		for _, collector := range cv.Collectors {
+			m := collector.Metadata()
+			names[m.Name] = struct{}{}
+			if m.IsDefaultVersion {
+				defaults[m.Name]++
+			}
+		}
+	}
+
+	for name := range names {
+		assert.Equal(t, 1, defaults[name], "generic resource %q must have exactly one default version", name)
+	}
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/generic.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/generic.go
@@ -24,6 +24,14 @@ type GenericResource struct {
 	Version  string
 	Stable   bool
 	NodeType pkgorchestratormodel.NodeType
+
+	// IsDefaultVersion marks the one version of a resource that the inventory
+	// should treat as canonical. Exactly one entry per Name must set it: the
+	// discovery path dedupes by Name and picks whichever version the API server
+	// actually serves, but the no-discovery fallback (StableCollectors, used
+	// when discovery fails) selects on IsDefaultVersion and would otherwise
+	// start an informer per registered version, all but one of them 404ing.
+	IsDefaultVersion bool
 }
 
 // NewCollectorVersions creates a new collector versions for the generic resource.
@@ -40,7 +48,7 @@ func (r GenericResource) NewGenericCollector() *CRCollector {
 	}
 	return &CRCollector{
 		metadata: &collectors.CollectorMetadata{
-			IsDefaultVersion:                     true,
+			IsDefaultVersion:                     r.IsDefaultVersion,
 			IsStable:                             r.Stable,
 			IsManifestProducer:                   true,
 			IsMetadataProducer:                   false,

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -70,6 +70,17 @@ type OrchestratorInstance struct {
 	//   - stable.example.com/v1/crontabs
 	CRDCollectors           []string `yaml:"crd_collectors"`
 	ExtraSyncTimeoutSeconds int      `yaml:"extra_sync_timeout_seconds"`
+	// CollectDRAResources adds Dynamic Resource Allocation's ResourceClaim and
+	// ResourceSlice to whatever collectors are otherwise selected.
+	//
+	// A separate flag rather than an entry in Collectors, because naming
+	// anything there replaces the default selection entirely -- so opting into
+	// DRA that way would mean enumerating every other resource as well. Off by
+	// default: the collectors need resource.k8s.io RBAC that ships from
+	// helm-charts and datadog-operator, and activating them without it stalls
+	// informer sync until the cache-sync timeout expires.
+	// collect_dra_resources: true
+	CollectDRAResources bool `yaml:"collect_dra_resources"`
 }
 
 func (c *OrchestratorInstance) parse(data []byte) error {

--- a/pkg/config/schema/yaml/orchestrator_explorer.yaml
+++ b/pkg/config/schema/yaml/orchestrator_explorer.yaml
@@ -11,6 +11,16 @@ properties:
         node_type: setting
         type: boolean
         default: true
+  collect_dra_resources:
+    node_type: setting
+    type: boolean
+    default: false
+    description: |
+      Collect Dynamic Resource Allocation ResourceClaim and ResourceSlice
+      objects with the orchestrator check. Off by default: the collectors need
+      get/list/watch on the resource.k8s.io group, and activating them without
+      that permission stalls informer synchronisation until the cache-sync
+      timeout expires.
   container_scrubbing:
     node_type: section
     type: object

--- a/releasenotes-dca/notes/dra-orchestrator-inventory-3f2a91c7e04b8d65.yaml
+++ b/releasenotes-dca/notes/dra-orchestrator-inventory-3f2a91c7e04b8d65.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    The orchestrator check can now collect Dynamic Resource Allocation
+    ``ResourceClaim`` and ``ResourceSlice`` objects from the ``resource.k8s.io``
+    API group, on whichever of ``v1``, ``v1beta2`` or ``v1beta1`` the cluster
+    serves. They ride the existing manifest channel, so no new resource type is
+    required on the backend.
+
+    Collection is opt-in: set ``collect_dra_resources: true`` on the
+    orchestrator check instance. The Cluster Agent service account also needs
+    ``get``, ``list`` and ``watch`` on ``resourceclaims`` and
+    ``resourceslices`` in the ``resource.k8s.io`` group.


### PR DESCRIPTION
## What does this PR do?

collect DRA `ResourceClaim` and `ResourceSlice` and register them as default generic resourcescheck.

## Changes

- `collectors/inventory/inventory.go`: add `resourceclaims` and `resourceslices`
  to `defaultGenericResource` with `NodeType: K8sCR` (`IsManifestProducer: true`).
  DRA's built-in types ride the generic manifest channel — the `CRCollector`'s
  dynamic informer handles the `resource.k8s.io` group with no new backend type
  or serializer (JIRA-8).
- `collectors/inventory/inventory_test.go`: `TestDRAGenericResourcesRegistered`
  guards the registration (group/version/NodeType/manifest-producer).

