### PR TITLE
cloud_hostinfo: back off failed preemption IMDS lookups

### DIFF
--- a/pkg/collector/corechecks/cloud/hostinfo/hostinfo.go
+++ b/pkg/collector/corechecks/cloud/hostinfo/hostinfo.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net/http"
 	"sync"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/shirou/gopsutil/v4/host"
@@ -35,14 +37,30 @@ const PreemptionEventType = "HostPreemption"
 const PreemptionRiskEventType = "HostPreemptionRisk"
 
 // After this many consecutive failed IMDS lookups, the check only retries
-// once per preemptionFailureBackoff instead of on every run: on hosts where
+// once per metadataFailureBackoff instead of on every run: on hosts where
 // IMDS can never answer (e.g. hop-limited containers), every-run lookups
 // each block a collector slot for the metadata timeout doing work that
 // cannot succeed (#55269).
 const (
-	preemptionFailureThreshold = 4
-	preemptionFailureBackoff   = 60 * time.Second
+	metadataFailureThreshold = 4
+	metadataFailureBackoff   = 60 * time.Second
 )
+
+// metadataLookupFailure reports whether an error from a metadata lookup is a
+// connectivity-style failure that can never succeed on this host, as opposed
+// to the healthy no-active-notice response: IMDS answers 404 for the spot
+// termination and rebalance endpoints when no notice exists, and those must
+// not count toward the backoff.
+func metadataLookupFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	var statusCodeError *httputils.StatusCodeError
+	if errors.As(err, &statusCodeError) {
+		return statusCodeError.StatusCode != http.StatusNotFound
+	}
+	return true
+}
 
 // Check collects host information from cloud provider metadata services
 type Check struct {
@@ -54,8 +72,8 @@ type Check struct {
 	rebalanceNoticeTime   time.Time
 	preemptionUnsupported bool // Set to true when preemption detection is not supported or instance is not preemptible
 
-	preemptionFailures    int       // consecutive transient preemption-lookup failures
-	preemptionLastAttempt time.Time // time of the last preemption lookup
+	metadataFailures    int       // consecutive transient preemption-lookup failures
+	metadataLastAttempt time.Time // time of the last preemption lookup
 }
 
 // For testing purposes
@@ -118,12 +136,11 @@ func (c *Check) checkPreemptionEvents(sender sender.Sender) {
 	// After repeated transient failures (e.g. IMDS unreachable from a
 	// hop-limited container), retry at most once per backoff window instead
 	// of on every check run.
-	if c.preemptionFailures >= preemptionFailureThreshold && time.Since(c.preemptionLastAttempt) < preemptionFailureBackoff {
-		log.Tracef("Skipping preemption detection, %d consecutive failures, backing off until %s", c.preemptionFailures, c.preemptionLastAttempt.Add(preemptionFailureBackoff))
+	if c.metadataFailures >= metadataFailureThreshold && time.Since(c.metadataLastAttempt) < metadataFailureBackoff {
+		log.Tracef("Skipping preemption detection, %d consecutive failures, backing off until %s", c.metadataFailures, c.metadataLastAttempt.Add(metadataFailureBackoff))
 		return
 	}
 
-	c.preemptionLastAttempt = time.Now()
 	terminationTime, err := getPreemptionTerminationFn(ctx, c.cloudProvider)
 	if err != nil {
 		// Check if we should stop polling for preemption events
@@ -132,11 +149,15 @@ func (c *Check) checkPreemptionEvents(sender sender.Sender) {
 			log.Debugf("Preemption detection disabled, cloud provider: %s, error: %s", c.cloudProvider, err)
 			return
 		}
-		c.preemptionFailures++
+		// The healthy no-active-notice 404 must not count toward backoff.
+		if metadataLookupFailure(err) {
+			c.metadataFailures++
+			c.metadataLastAttempt = time.Now()
+		}
 		log.Tracef("Preemption detection returned an error (usually expected), cloud provider: %s, error: %s", c.cloudProvider, err)
 		return
 	}
-	c.preemptionFailures = 0
+	c.metadataFailures = 0
 
 	// Store termination time to avoid emitting duplicate events
 	c.terminationTime = terminationTime
@@ -184,11 +205,23 @@ func (c *Check) checkRebalanceRecommendation(sender sender.Sender) {
 		return
 	}
 
+	// The rebalance lookup hits the same unreachable IMDS endpoint; back it
+	// off on the same counter as the preemption lookup.
+	if c.metadataFailures >= metadataFailureThreshold && time.Since(c.metadataLastAttempt) < metadataFailureBackoff {
+		log.Tracef("Skipping rebalance recommendation check, %d consecutive failures, backing off until %s", c.metadataFailures, c.metadataLastAttempt.Add(metadataFailureBackoff))
+		return
+	}
+
 	noticeTime, err := getRebalanceRecommendationFn(context.Background(), c.cloudProvider)
 	if err != nil {
+		if metadataLookupFailure(err) {
+			c.metadataFailures++
+			c.metadataLastAttempt = time.Now()
+		}
 		log.Tracef("Rebalance recommendation check returned an error (usually expected), cloud provider: %s, error: %s", c.cloudProvider, err)
 		return
 	}
+	c.metadataFailures = 0
 
 	c.rebalanceNoticeTime = noticeTime
 

--- a/pkg/collector/corechecks/cloud/hostinfo/hostinfo.go
+++ b/pkg/collector/corechecks/cloud/hostinfo/hostinfo.go
@@ -34,6 +34,16 @@ const PreemptionEventType = "HostPreemption"
 // PreemptionRiskEventType is the event type for rebalance recommendation events
 const PreemptionRiskEventType = "HostPreemptionRisk"
 
+// After this many consecutive failed IMDS lookups, the check only retries
+// once per preemptionFailureBackoff instead of on every run: on hosts where
+// IMDS can never answer (e.g. hop-limited containers), every-run lookups
+// each block a collector slot for the metadata timeout doing work that
+// cannot succeed (#55269).
+const (
+	preemptionFailureThreshold = 4
+	preemptionFailureBackoff   = 60 * time.Second
+)
+
 // Check collects host information from cloud provider metadata services
 type Check struct {
 	core.CheckBase
@@ -43,6 +53,9 @@ type Check struct {
 	terminationTime       time.Time
 	rebalanceNoticeTime   time.Time
 	preemptionUnsupported bool // Set to true when preemption detection is not supported or instance is not preemptible
+
+	preemptionFailures    int       // consecutive transient preemption-lookup failures
+	preemptionLastAttempt time.Time // time of the last preemption lookup
 }
 
 // For testing purposes
@@ -102,16 +115,28 @@ func (c *Check) checkPreemptionEvents(sender sender.Sender) {
 		return
 	}
 
+	// After repeated transient failures (e.g. IMDS unreachable from a
+	// hop-limited container), retry at most once per backoff window instead
+	// of on every check run.
+	if c.preemptionFailures >= preemptionFailureThreshold && time.Since(c.preemptionLastAttempt) < preemptionFailureBackoff {
+		log.Tracef("Skipping preemption detection, %d consecutive failures, backing off until %s", c.preemptionFailures, c.preemptionLastAttempt.Add(preemptionFailureBackoff))
+		return
+	}
+
+	c.preemptionLastAttempt = time.Now()
 	terminationTime, err := getPreemptionTerminationFn(ctx, c.cloudProvider)
 	if err != nil {
 		// Check if we should stop polling for preemption events
 		if errors.Is(err, cloudproviders.ErrNotPreemptible) || errors.Is(err, cloudproviders.ErrPreemptionUnsupported) {
 			c.preemptionUnsupported = true
 			log.Debugf("Preemption detection disabled, cloud provider: %s, error: %s", c.cloudProvider, err)
+			return
 		}
+		c.preemptionFailures++
 		log.Tracef("Preemption detection returned an error (usually expected), cloud provider: %s, error: %s", c.cloudProvider, err)
 		return
 	}
+	c.preemptionFailures = 0
 
 	// Store termination time to avoid emitting duplicate events
 	c.terminationTime = terminationTime

--- a/pkg/collector/corechecks/cloud/hostinfo/hostinfo_test.go
+++ b/pkg/collector/corechecks/cloud/hostinfo/hostinfo_test.go
@@ -8,6 +8,7 @@ package hostinfo
 import (
 	"context"
 	"errors"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
@@ -410,4 +411,63 @@ func TestHostInfoCheckNoRebalanceRecommendation(t *testing.T) {
 	mockSender.AssertExpectations(t)
 	mockSender.AssertNumberOfCalls(t, "Event", 0)
 	mockSender.AssertNumberOfCalls(t, "Commit", 1)
+}
+
+func TestHostInfoCheckPreemptionFailureBackoff(t *testing.T) {
+	defer resetTestVars()
+
+	detectCloudProviderFn = func(_ context.Context, _ bool) (string, string) {
+		return "AWS", ""
+	}
+
+	attempts := 0
+	// A transient failure mode (IMDS unreachable — not one of the sentinel
+	// errors that stops polling), so the check must keep retrying, but only
+	// once per backoff window after repeated failures (#55269).
+	getPreemptionTerminationFn = func(_ context.Context, _ string) (time.Time, error) {
+		attempts++
+		return time.Time{}, errors.New("connection timed out")
+	}
+	getRebalanceRecommendationFn = func(_ context.Context, _ string) (time.Time, error) {
+		return time.Time{}, errors.New("no rebalance recommendation")
+	}
+	uptime = uptimeSampler
+
+	mockSender := mocksender.NewMockSender(t, CheckName)
+	mockSender.On("FinalizeCheckServiceTag").Return()
+	mockSender.On("Commit").Return()
+
+	check := newCheck().(*Check)
+	check.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test", "provider")
+	mocksender.SetSender(mockSender, check.ID())
+
+	// Simulate the default 15s check interval: four consecutive runs hit the
+	// lookup, then the backoff window must skip it.
+	for i := 0; i < 4; i++ {
+		check.Run()
+	}
+	assert.Equal(t, 4, attempts)
+	assert.Equal(t, 4, check.preemptionFailures)
+
+	// The backoff window is 60s; without advancing the clock, further runs
+	// must not reach the lookup.
+	check.Run()
+	check.Run()
+	assert.Equal(t, 4, attempts)
+
+	// After the window elapses, the lookup is attempted again.
+	check.preemptionLastAttempt = check.preemptionLastAttempt.Add(-preemptionFailureBackoff)
+	check.Run()
+	assert.Equal(t, 5, attempts)
+
+	// A later success resets the failure count so every run polls again.
+	// (A past termination time is a success path that stores no event.)
+	getPreemptionTerminationFn = func(_ context.Context, _ string) (time.Time, error) {
+		attempts++
+		return time.Now().Add(-time.Minute), nil
+	}
+	check.preemptionFailures = preemptionFailureThreshold - 1
+	check.preemptionLastAttempt = time.Now().Add(-preemptionFailureBackoff)
+	check.Run()
+	assert.Equal(t, 0, check.preemptionFailures)
 }

--- a/pkg/collector/corechecks/cloud/hostinfo/hostinfo_test.go
+++ b/pkg/collector/corechecks/cloud/hostinfo/hostinfo_test.go
@@ -8,6 +8,7 @@ package hostinfo
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 )
 
 func uptimeSampler() (uint64, error) {
@@ -428,8 +430,11 @@ func TestHostInfoCheckPreemptionFailureBackoff(t *testing.T) {
 		attempts++
 		return time.Time{}, errors.New("connection timed out")
 	}
+	// Healthy no-notice 404 for rebalance so only the preemption failures
+	// advance the shared counter in this test.
+	rebalanceNotFound := &httputils.StatusCodeError{StatusCode: 404, Method: "GET", URL: "http://169.254.169.254/latest/meta-data/events/recommendations/rebalance"}
 	getRebalanceRecommendationFn = func(_ context.Context, _ string) (time.Time, error) {
-		return time.Time{}, errors.New("no rebalance recommendation")
+		return time.Time{}, rebalanceNotFound
 	}
 	uptime = uptimeSampler
 
@@ -447,7 +452,7 @@ func TestHostInfoCheckPreemptionFailureBackoff(t *testing.T) {
 		check.Run()
 	}
 	assert.Equal(t, 4, attempts)
-	assert.Equal(t, 4, check.preemptionFailures)
+	assert.Equal(t, 4, check.metadataFailures)
 
 	// The backoff window is 60s; without advancing the clock, further runs
 	// must not reach the lookup.
@@ -456,7 +461,7 @@ func TestHostInfoCheckPreemptionFailureBackoff(t *testing.T) {
 	assert.Equal(t, 4, attempts)
 
 	// After the window elapses, the lookup is attempted again.
-	check.preemptionLastAttempt = check.preemptionLastAttempt.Add(-preemptionFailureBackoff)
+	check.metadataLastAttempt = check.metadataLastAttempt.Add(-metadataFailureBackoff)
 	check.Run()
 	assert.Equal(t, 5, attempts)
 
@@ -466,8 +471,56 @@ func TestHostInfoCheckPreemptionFailureBackoff(t *testing.T) {
 		attempts++
 		return time.Now().Add(-time.Minute), nil
 	}
-	check.preemptionFailures = preemptionFailureThreshold - 1
-	check.preemptionLastAttempt = time.Now().Add(-preemptionFailureBackoff)
+	check.metadataFailures = metadataFailureThreshold - 1
+	check.metadataLastAttempt = time.Now().Add(-metadataFailureBackoff)
 	check.Run()
-	assert.Equal(t, 0, check.preemptionFailures)
+	assert.Equal(t, 0, check.metadataFailures)
+}
+
+func TestMetadataLookupFailureClassification(t *testing.T) {
+	// The healthy no-active-notice response is a 404 from IMDS and must not
+	// count toward the backoff; every other failure (timeout, connection
+	// refused, 5xx) must.
+	assert.True(t, metadataLookupFailure(nil) == false)
+	assert.False(t, metadataLookupFailure(&httputils.StatusCodeError{StatusCode: 404, Method: "GET", URL: "http://169.254.169.254/latest/meta-data/spot/instance-action"}))
+	assert.True(t, metadataLookupFailure(&httputils.StatusCodeError{StatusCode: 503, Method: "GET", URL: "http://169.254.169.254/latest/meta-data/spot/instance-action"}))
+	assert.True(t, metadataLookupFailure(errors.New("connection timed out")))
+	// Wrapped StatusCodeError still classifies by status code.
+	assert.False(t, metadataLookupFailure(fmt.Errorf("unable to retrieve spot instance-action from IMDS: %w", &httputils.StatusCodeError{StatusCode: 404, Method: "GET", URL: "u"})))
+}
+
+func TestHostInfoCheckHealthy404DoesNotBackOff(t *testing.T) {
+	defer resetTestVars()
+
+	detectCloudProviderFn = func(_ context.Context, _ bool) (string, string) {
+		return "AWS", ""
+	}
+
+	attempts := 0
+	// The healthy steady state on a spot instance without an active notice:
+	// the termination endpoint answers 404 every time.
+	notFound := &httputils.StatusCodeError{StatusCode: 404, Method: "GET", URL: "http://169.254.169.254/latest/meta-data/spot/instance-action"}
+	getPreemptionTerminationFn = func(_ context.Context, _ string) (time.Time, error) {
+		attempts++
+		return time.Time{}, notFound
+	}
+	getRebalanceRecommendationFn = func(_ context.Context, _ string) (time.Time, error) {
+		return time.Time{}, notFound
+	}
+	uptime = uptimeSampler
+
+	mockSender := mocksender.NewMockSender(t, CheckName)
+	mockSender.On("FinalizeCheckServiceTag").Return()
+	mockSender.On("Commit").Return()
+
+	check := newCheck().(*Check)
+	check.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test", "provider")
+	mocksender.SetSender(mockSender, check.ID())
+
+	// Far more runs than the backoff threshold: 404s must never arm it.
+	for i := 0; i < 10; i++ {
+		check.Run()
+	}
+	assert.Equal(t, 10, attempts)
+	assert.Equal(t, 0, check.metadataFailures)
 }


### PR DESCRIPTION
Fixes #55269.

### What does this PR do?

Backs off failed preemption IMDS lookups in the `cloud_hostinfo` check.

On EC2 instances with `HttpPutResponseHopLimit: 1` and `HttpTokens: required`, IMDS is unreachable from the agent when it runs in a container: the hop limit drops the IMDSv2 token response and IMDSv1 is refused, so **no code path can succeed**. The check retried anyway on every run (default 15s interval) — each attempt blocking a collector slot for the metadata timeout (~600ms, ~4% of a slot doing work that cannot succeed, per the report).

After **4 consecutive transient failures** (errors other than `ErrNotPreemptible` / `ErrPreemptionUnsupported`, which already stop polling entirely), the check now skips the lookup for **60 seconds** between attempts. A successful lookup resets the failure count. Rebalance-recommendation polling is untouched (it piggybacks the same run but has its own once-only semantics).

### Describe how to test/QA your PR

New `TestHostInfoCheckPreemptionFailureBackoff` (mocked lookup, the package's existing pattern):

- 4 consecutive transient failures → 4 attempts, counter at 4;
- further runs inside the 60s window make **no** further attempts;
- after the window elapses, one more attempt is made;
- a subsequent success resets the failure counter.

Differential: with the check reverted, the test fails (attempts continue every run). Package tests pass with `go test -tags test ./pkg/collector/corechecks/cloud/hostinfo/`; gofmt clean.

*(Note: `pkg/config/setup` codegen artifacts were generated locally to build the package but are not part of this PR.)*
