### PR TITLE
fix(omnibus): restore datadog-uwsgi-stats from PyPI instead of the integration repo

### DIFF
--- a/omnibus/python-scripts/packages.py
+++ b/omnibus/python-scripts/packages.py
@@ -66,6 +66,7 @@ DEPS_STARTING_WITH_DATADOG = [
     "datadog-serverless-utils",
     "datadog-sma",
     "datadog-threadstats",
+    "datadog-uwsgi-stats",
 ]
 
 def run_command(args):

--- a/omnibus/python-scripts/packages_tests.py
+++ b/omnibus/python-scripts/packages_tests.py
@@ -180,3 +180,45 @@ class TestPackages(unittest.TestCase):
         os.remove(req_file)
         os.rmdir(install_dir)
         os.rmdir(storage_dir)
+
+    @unittest.skipIf(os.name == 'nt', "Skip on Windows")
+    def test_install_diff_packages_file_routes_allowlisted_datadog_package_to_pip(self):
+        """A name on DEPS_STARTING_WITH_DATADOG restores from PyPI, not the integration repo.
+
+        The integration repo only carries integrations Datadog publishes, so a
+        package that merely happens to carry the `datadog-` prefix must be routed
+        to pip; sending it to the repo raises NoSuchDatadogPackage and fails the
+        whole upgrade.
+        """
+        install_dir = tempfile.mkdtemp()
+        storage_dir = tempfile.mkdtemp()
+        diff_file = os.path.join(storage_dir, '.diff_python_installed_packages.txt')
+        req_file = os.path.join(install_dir, 'requirements-agent-release.txt')
+
+        # Any member of the allowlist exercises the same branch; take the first
+        # so the test does not pin a specific entry.
+        allowlisted = packages.DEPS_STARTING_WITH_DATADOG[0]
+
+        with open(diff_file, 'w') as f:
+            f.write("# DO NOT REMOVE/MODIFY\n")
+            f.write(f"{allowlisted}==1.0.0\n")
+            f.write("datadog-snmp==1.0.0\n")
+
+        with open(req_file, 'w') as f:
+            f.write('')
+
+        with patch('packages.install_datadog_package') as mock_integration:
+            with patch('packages.install_dependency_package') as mock_pip:
+                install_diff_packages_file(install_dir, diff_file, req_file)
+
+        # The non-allowlisted name still goes to the integration repo...
+        mock_integration.assert_called_once_with('datadog-snmp==1.0.0', install_dir)
+        # ...and the allowlisted one goes to pip instead.
+        self.assertEqual(mock_pip.call_count, 1)
+        self.assertEqual(mock_pip.call_args[0][1], f'{allowlisted}==1.0.0')
+
+        # Cleanup
+        os.remove(diff_file)
+        os.remove(req_file)
+        os.rmdir(install_dir)
+        os.rmdir(storage_dir)

--- a/releasenotes/notes/restore-uwsgi-stats-from-pypi-8e98a47a1acd5d79.yaml
+++ b/releasenotes/notes/restore-uwsgi-stats-from-pypi-8e98a47a1acd5d79.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed the post-upgrade restore of the third-party ``datadog-uwsgi-stats``
+    integration. Because its distribution name carries the ``datadog-`` prefix,
+    the restore looked for it in the Datadog integration repository, which does
+    not host it; the resulting ``NoSuchDatadogPackage`` error failed the whole
+    Agent package upgrade (for example ``apt upgrade``) in its post-install
+    step. The package is now restored from PyPI using the embedded ``pip``,
+    like the other third-party distributions sharing that prefix.


### PR DESCRIPTION
### What does this PR do?

Adds `datadog-uwsgi-stats` to `DEPS_STARTING_WITH_DATADOG` in
`omnibus/python-scripts/packages.py`, so the post-upgrade restore installs it
from PyPI with the embedded pip rather than from the Datadog integration
repository.

### Motivation

`datadog-uwsgi-stats` is a third-party uWSGI stats check published on PyPI. Its
distribution name carries the `datadog-` prefix, so `install_diff_packages_file`
routes it here:

```python
if install_package_line.startswith('datadog-') and dep_name not in DEPS_STARTING_WITH_DATADOG:
    install_datadog_package(...)          # -> datadog-agent integration install -t
else:
    install_dependency_package(pip, ...)  # -> embedded pip -> PyPI
```

Because it is not on the allowlist, the restore is sent to the integration
repository, which has never hosted it. Upgrading the Agent on a host with the
check installed fails the whole package transaction in `post.py`:

```
datadog_checks.downloader.exceptions.TargetNotFoundError: No TUF target for 'datadog-uwsgi-stats' version '1.0.0'
...
datadog_checks.downloader.exceptions.NoSuchDatadogPackage: datadog-uwsgi-stats
Error: error when downloading the wheel for datadog-uwsgi-stats 1.0.0: error running command: exit status 1
Restore summary: 0/1 package(s) restored successfully (0 skipped)
ERROR: post failed to restore custom integrations: failed to restore 1 package(s): datadog-uwsgi-stats==1.0.0
```

Observed on `apt upgrade` to `datadog-agent 1:7.82.2-1`, which left `dpkg`
half-configured and the check uninstalled. The failure is deterministic and
recurs on every Agent upgrade.

This is the same situation the allowlist already exists for: a PyPI
distribution whose name happens to start with `datadog-` but which is not
served from the integration repository.

Upstream, the project has also renamed its distribution to `uwsgi-stats` (no
prefix) so new installs avoid this path entirely. This PR is for the installed
base still on `datadog-uwsgi-stats` 1.0.0, which is still published on PyPI and
resolves correctly through pip.

### Describe how you validated your changes

- Added `test_install_diff_packages_file_routes_allowlisted_datadog_package_to_pip`
  to `omnibus/python-scripts/packages_tests.py`, asserting from both sides in one
  call: a non-allowlisted `datadog-` name still goes to `install_datadog_package`,
  and an allowlisted one goes to `install_dependency_package` instead. That branch
  had no direct coverage.
- Ran `python -m unittest packages_tests` against the patched
  `omnibus/python-scripts/`. The new test passes. Two pre-existing tests
  (`test_create_python_installed_packages_file`,
  `test_create_diff_installed_packages_file`) error identically before and after
  this change on a machine with no `dd-agent` user, from the unconditional
  `os.chown(..., pwd.getpwnam('dd-agent'))`; unrelated to this change.

### Additional Notes

The change to `packages.py` is a single data entry; the behaviour it selects is
existing, unmodified code.
