### PR TITLE
Add mandatory windows tags to dd_agent_go_binary

### DIFF
--- a/bazel/rules/go/go_binary.bzl
+++ b/bazel/rules/go/go_binary.bzl
@@ -157,8 +157,8 @@ def dd_agent_go_binary(name, gc_linkopts = None, gotags = None, exact_gotags = N
         kwargs["gotags"] = select({
             "@platforms//os:macos": sorted((COMMON_TAGS | gotags) - LINUX_ONLY_TAGS - DARWIN_EXCLUDED_TAGS),
             "//packages/agent:linux_fips": sorted(COMMON_TAGS | gotags | FIPS_TAGS),
-            "//packages/agent:windows_x86_64_fips": sorted((COMMON_TAGS | gotags | FIPS_TAGS) - LINUX_ONLY_TAGS - WINDOWS_EXCLUDED_TAGS | WINDOWS_INCLUDED_TAGS),
-            "//:windows_x86_64": sorted((COMMON_TAGS | gotags) - LINUX_ONLY_TAGS - WINDOWS_EXCLUDED_TAGS | WINDOWS_INCLUDED_TAGS),
+            "//packages/agent:windows_x86_64_fips": sorted((COMMON_TAGS | gotags | FIPS_TAGS | WINDOWS_INCLUDED_TAGS) - LINUX_ONLY_TAGS - WINDOWS_EXCLUDED_TAGS),
+            "//:windows_x86_64": sorted((COMMON_TAGS | gotags | WINDOWS_INCLUDED_TAGS) - LINUX_ONLY_TAGS - WINDOWS_EXCLUDED_TAGS),
             "//conditions:default": sorted(COMMON_TAGS | gotags),
         })
 

--- a/bazel/rules/go/go_binary.bzl
+++ b/bazel/rules/go/go_binary.bzl
@@ -30,7 +30,15 @@ load("@agent_volatile//:env_vars.bzl", "env_vars")
 load("@dd_release_json//:release_json.bzl", "release_json")
 load("@rules_go//go:def.bzl", "go_binary")
 load("//tasks:agent_payload_version.bzl", "AGENT_PAYLOAD_VERSION")
-load("//tasks:build_tags.bzl", "COMMON_TAGS", "DARWIN_EXCLUDED_TAGS", "FIPS_TAGS", "LINUX_ONLY_TAGS", "WINDOWS_EXCLUDED_TAGS")
+load(
+    "//tasks:build_tags.bzl",
+    "COMMON_TAGS",
+    "DARWIN_EXCLUDED_TAGS",
+    "FIPS_TAGS",
+    "LINUX_ONLY_TAGS",
+    "WINDOWS_EXCLUDED_TAGS",
+    "WINDOWS_INCLUDED_TAGS",
+)
 
 _REPO = "github.com/DataDog/datadog-agent"
 _VERSION_PKG = _REPO + "/pkg/version"
@@ -149,8 +157,8 @@ def dd_agent_go_binary(name, gc_linkopts = None, gotags = None, exact_gotags = N
         kwargs["gotags"] = select({
             "@platforms//os:macos": sorted((COMMON_TAGS | gotags) - LINUX_ONLY_TAGS - DARWIN_EXCLUDED_TAGS),
             "//packages/agent:linux_fips": sorted(COMMON_TAGS | gotags | FIPS_TAGS),
-            "//packages/agent:windows_x86_64_fips": sorted((COMMON_TAGS | gotags | FIPS_TAGS) - LINUX_ONLY_TAGS - WINDOWS_EXCLUDED_TAGS),
-            "//:windows_x86_64": sorted((COMMON_TAGS | gotags) - LINUX_ONLY_TAGS - WINDOWS_EXCLUDED_TAGS),
+            "//packages/agent:windows_x86_64_fips": sorted((COMMON_TAGS | gotags | FIPS_TAGS) - LINUX_ONLY_TAGS - WINDOWS_EXCLUDED_TAGS | WINDOWS_INCLUDED_TAGS),
+            "//:windows_x86_64": sorted((COMMON_TAGS | gotags) - LINUX_ONLY_TAGS - WINDOWS_EXCLUDED_TAGS | WINDOWS_INCLUDED_TAGS),
             "//conditions:default": sorted(COMMON_TAGS | gotags),
         })
 


### PR DESCRIPTION
c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Add mandatory windows tags to dd_agent_go_binary.

dd_agent_go_binary was not correctly adding mandatory gotags on windows. This was discovered in https://github.com/DataDog/datadog-agent/pull/54238, and will surface as we drop target_compatible_with=linux on ebpf. That will cause more builds to happen on windows and expose the issue.

This change pulls the windows fix out of that #54238 for easier PR review.

### Describe how you validated your changes
- CI passing here and in https://github.com/DataDog/datadog-agent/pull/54238
