### PR TITLE
fix(ci): remove stale Windows containers before mounting Bazel cache

### DIFF
--- a/tools/ci/docker-run-with-bazel-cache.ps1
+++ b/tools/ci/docker-run-with-bazel-cache.ps1
@@ -9,6 +9,23 @@ Set-StrictMode -Version 3.0
 $outputBase = Join-Path $env:CI_PROJECT_DIR ".cache\bob" # $CI_PROJECT_DIR is unique per slot and swept at startup
 $null = New-Item $outputBase -ItemType Directory -Force
 
+# Despite `FF_USE_WINDOWS_JOB_OBJECT: true` in .gitlab-ci.yml, canceled jobs may leave containers running, causing
+# the next job on the same runner to fail with: `CreateJvmOutputFile(c:\bob\server\jvm.out) failed: (error: 32):
+# The process cannot access the file because it is being used by another process.` (CIEXE-1152). Since the runner
+# executes only one job per CI_PROJECT_DIR, remove any such container having the same Bazel's `outputBase` mounted.
+docker ps -aq | ForEach-Object {
+    $containerId = $_
+    try {
+        $container = docker inspect $containerId | ConvertFrom-Json
+        Write-Output "Found container $containerId with mounts on: $($container.Mounts.Source -join ', ')"
+        if ($container.Mounts.Source -contains $outputBase) {
+            docker rm -fv $containerId
+        }
+    } catch {
+        Write-Warning "Failed to process container $containerId, it may have already been removed: $_"
+    }
+}
+
 # Allow any container user to refresh disk-cache files written by a prior job's container.
 $diskCache = Join-Path $env:XDG_CACHE_HOME "bazel\disk-cache"
 $null = New-Item $diskCache -ItemType Directory -Force
@@ -19,7 +36,7 @@ if (-not (($acl = Get-Acl $diskCache).Access | Where-Object { -not $_.IsInherite
     Set-Acl $diskCache $acl
     Get-ChildItem $diskCache -Recurse | ForEach-Object { Set-Acl $_.FullName $acl }
 }
-& docker run --rm `
+docker run --rm `
     --env=BAZELISK_HOME `
     --env=BUILDBARN_ID_TOKEN `
     --env=CI `


### PR DESCRIPTION
### What does this PR do?
`docker-run-with-bazel-cache.ps1` now removes any Docker container whose Bazel `outputBase` mount matches this job's own, before that mount is created, by inspecting each container's mounts rather than force-removing everything on the shared daemon.

### Motivation
Bazel has been [failing at times on Windows](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20CreateJvmOutputFile&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2Cci.node.name&fromUser=true&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1785273864526&to_ts=1786569864526&live=true) with:
```
FATAL: ExecuteDaemon(...java.exe): CreateJvmOutputFile(c:\bob\server\jvm.out)
failed: (error: 32): The process cannot access the file because it is
being used by another process.
```
A canceled or timed-out job's container can survive with `jvm.out` still open despite `FF_USE_WINDOWS_JOB_OBJECT: true`, and Windows won't let the clone-time `CI_PROJECT_DIR` wipe delete that one locked file, so it collides with the next job's Bazel server in the same runner slot (the same class of leftover-state bug as CIEXE-1152).

A first pass removed every container on the daemon at startup, but up to 3 runner slots share one Docker daemon per Windows VM (see `.gitlab/windows/build/lint/windows.yml`).

`CI_PROJECT_DIR` (and so `outputBase`) is unique per slot per GitLab Runner's own `<short-token>/<concurrent-id>/...` build-dir layout, so matching on its mount, rather than a label or a blanket removal, is what keeps this scoped to the current slot without touching a sibling job.

### Describe how you validated your changes
Confirmed via `docker/cli` and `moby/moby` source that a bind mount's `Source` reported by `docker inspect` is byte-identical to what was passed to `--mount`, so exact-match comparison is safe.

**Concrete working case** first triggered in [job #1980908745](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1980908745#L340):
```
Found container e4346459d3e7 with mounts on: c:\gitlab-ci\builds\cxnwibkbi\0\datadog\datadog-agent, C:\gitlab-ci\builds\CXNwiBkBi\0\DataDog\datadog-agent\.cache\bob, c:\bzl
e4346459d3e7
```