### PR TITLE
[ACIX-1920] e2e: consume prebaked Windows Server e2e AMIs

### DIFF
--- a/test/e2e-framework/components/os/scripts/setup-ssh.ps1
+++ b/test/e2e-framework/components/os/scripts/setup-ssh.ps1
@@ -14,29 +14,6 @@ function Is-WindowsServer2025 {
   return $isWindowsServer2025
 }
 
-# function to test if the sshd service is running and if it needs to be replaced
-function Test-SshInstallationNeeded {
-  if (Test-Path $sshInstallMarkerPath) {
-    # Already installed/replaced on a previous boot -- nothing to do.
-    return $false
-  }
-
-  $service = Get-Service -Name sshd -ErrorAction SilentlyContinue
-
-  if ($service -ne $null) {
-    Write-Host "Stop sshd service"
-    Stop-Service sshd
-    if (Is-WindowsServer2025) {
-      # Windows Server 2025 ships a preinstalled OpenSSH that's a different, inconsistent version;
-      # replace it with our pinned MSI version below (only happens once, per $sshInstallMarkerPath).
-      return $true
-    }
-  } else {
-    return $true
-  }
-  return $false
-}
-
 # function to restore the auto inherited flag without affecting the DACL
 # This function applies to Windows Server 2025 only
 # WINA-1694: The root drive on Windows Server 2025 is missing the SE_DACL_AUTO_INHERITED flag
@@ -79,7 +56,7 @@ function Set-SshFirewallConfiguration {
               -Profile Any `
               -RemoteAddress Any `
               -EdgeTraversalPolicy Allow
-                
+
       Write-Host "Universal SSH firewall rule created"
     } else {
         Write-Host "Universal SSH firewall rule already exists"
@@ -90,11 +67,18 @@ function Set-SshFirewallConfiguration {
 }
 
 # Main script execution
-if (Test-SshInstallationNeeded) {
-  Write-Host "sshd service not found or needs replacement, installing OpenSSH Server"
+# The marker indicates that either a previous boot installed OpenSSH, or the AMI shipped with it already
+if (-not (Test-Path $sshInstallMarkerPath)) {
+  Write-Host "OpenSSH not set up on this host yet, installing OpenSSH Server"
+  # Windows Server 2025 ships a preinstalled OpenSSH under System32 that's a different,
+  # inconsistent version; stop it so the pinned MSI below can replace it.
+  if (Get-Service -Name sshd -ErrorAction SilentlyContinue) {
+    Write-Host "Stop sshd service"
+    Stop-Service sshd
+  }
   # Add-WindowsCapability does NOT install a consistent version across Windows versions, this lead to
   # compatibility issues (different command line quoting rules).
-  # Prefer installing sshd via MSI  
+  # Prefer installing sshd via MSI
   $res = start-process -passthru -wait msiexec.exe -args '/i https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.5.0.0p1-Beta/OpenSSH-Win64-v9.5.0.0.msi /qn'
   if ($res.ExitCode -ne 0) {
     throw "SSH install failed: $($res.ExitCode)"
@@ -112,7 +96,7 @@ if (Test-SshInstallationNeeded) {
     Write-Output "Firewall Rule 'OpenSSH-Server-In-TCP' does not exist, creating it..."
     New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
     $retries++
-  } 
+  }
   Write-Output "Firewall rule 'OpenSSH-Server-In-TCP' created."
   $powershellPath = "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
   $retries = 0
@@ -125,7 +109,7 @@ if (Test-SshInstallationNeeded) {
       Start-Sleep -Seconds 5
     }
     Write-Host "Set powershell as default shell for sshd"
-    New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value $powershellPath -PropertyType String -Force 
+    New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value $powershellPath -PropertyType String -Force
     $retries++
   }
   $retries = 0
@@ -162,7 +146,6 @@ if (Test-SshInstallationNeeded) {
     "       AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys"
   )
   Set-Content -Path "$env:ProgramData\ssh\sshd_config" -Value $sshdConfigLines
-  Restart-Service sshd -ErrorAction SilentlyContinue
 
   New-Item -Path $sshInstallMarkerPath -ItemType File -Force | Out-Null
 }
@@ -181,7 +164,7 @@ try {
 
 Write-Host "Resetting ssh authorized keys"
 $retries = 0
-while (Test-Path $env:ProgramData\ssh\administrators_authorized_keys) { 
+while (Test-Path $env:ProgramData\ssh\administrators_authorized_keys) {
   if ($retries -ge 10) {
     throw "Failed to remove existing administrators_authorized_keys file after 10 retries"
   }
@@ -194,7 +177,7 @@ while (Test-Path $env:ProgramData\ssh\administrators_authorized_keys) {
 }
 
 $retries = 0
-while (-not (Test-Path $env:ProgramData\ssh\administrators_authorized_keys)) { 
+while (-not (Test-Path $env:ProgramData\ssh\administrators_authorized_keys)) {
   if ($retries -ge 10) {
     throw "Failed to create administrators_authorized_keys file after 10 retries"
   }
@@ -221,4 +204,3 @@ while ((Get-Service -Name sshd -ErrorAction SilentlyContinue).Status -ne "Runnin
   Start-Service sshd
   $retries++
 }
-

--- a/test/e2e-framework/components/os/windows_descriptors.go
+++ b/test/e2e-framework/components/os/windows_descriptors.go
@@ -8,7 +8,7 @@ package os
 // Implements commonly used descriptors for easier usage
 // See platforms.go for the AMIs used for each OS
 var (
-	WindowsServerDefault = WindowsServer2025
+	WindowsServerDefault = WindowsServer2025E2E
 	WindowsServer2025    = NewDescriptor(WindowsServer, "2025")
 	WindowsServer2022    = NewDescriptor(WindowsServer, "2022")
 	WindowsServer2019    = NewDescriptor(WindowsServer, "2019")
@@ -36,8 +36,8 @@ var WindowsDescriptorsDefault = map[Flavor]Descriptor{
 
 // WindowsServerVersionsForE2E is the set of Windows Server versions used for e2e random selection (CI coverage across 2016–2025).
 var WindowsServerVersionsForE2E = []Descriptor{
-	WindowsServer2016,
-	WindowsServer2019,
-	WindowsServer2022,
-	WindowsServer2025,
+	WindowsServer2016E2E,
+	WindowsServer2019E2E,
+	WindowsServer2022E2E,
+	WindowsServer2025E2E,
 }

--- a/test/e2e-framework/components/os/windows_descriptors.go
+++ b/test/e2e-framework/components/os/windows_descriptors.go
@@ -14,6 +14,11 @@ var (
 	WindowsServer2019    = NewDescriptor(WindowsServer, "2019")
 	WindowsServer2016    = NewDescriptor(WindowsServer, "2016")
 
+	WindowsServer2025E2E = NewDescriptor(WindowsServer, "2025-e2e")
+	WindowsServer2022E2E = NewDescriptor(WindowsServer, "2022-e2e")
+	WindowsServer2019E2E = NewDescriptor(WindowsServer, "2019-e2e")
+	WindowsServer2016E2E = NewDescriptor(WindowsServer, "2016-e2e")
+
 	WindowsClientDefault = WindowsClient1124H2
 	WindowsClient11      = WindowsClient1124H2
 	WindowsClient1124H2  = NewDescriptor(WindowsClient, "windows-11:win11-24h2-pro")

--- a/test/e2e-framework/resources/aws/platforms.json
+++ b/test/e2e-framework/resources/aws/platforms.json
@@ -128,9 +128,13 @@
     "windows-server": {
         "x86_64": {
             "2016": "ami-02d12824a464a28ae",
+            "2016-e2e": "ami-0721eead097aa205f",
             "2019": "ami-0cd77a1bbde0488e2",
+            "2019-e2e": "ami-072125f8ef0bdebac",
             "2022": "ami-0fcc930391c87ec7b",
-            "2025": "ami-0d03f0a2f81ced53e"
+            "2022-e2e": "ami-013d4572f24b543a9",
+            "2025": "ami-0d03f0a2f81ced53e",
+            "2025-e2e": "ami-02e3f5a43a8e5c5da"
         }
     }
 }

--- a/test/e2e-framework/resources/aws/platforms.json
+++ b/test/e2e-framework/resources/aws/platforms.json
@@ -128,13 +128,13 @@
     "windows-server": {
         "x86_64": {
             "2016": "ami-02d12824a464a28ae",
-            "2016-e2e": "ami-0721eead097aa205f",
+            "2016-e2e": "ami-04768ca6b914ca911",
             "2019": "ami-0cd77a1bbde0488e2",
-            "2019-e2e": "ami-072125f8ef0bdebac",
+            "2019-e2e": "ami-0850d92fe7ed199a7",
             "2022": "ami-0fcc930391c87ec7b",
-            "2022-e2e": "ami-013d4572f24b543a9",
+            "2022-e2e": "ami-0979cd4acf7874ba9",
             "2025": "ami-0d03f0a2f81ced53e",
-            "2025-e2e": "ami-02e3f5a43a8e5c5da"
+            "2025-e2e": "ami-004c3c6126a26e23d"
         }
     }
 }

--- a/test/e2e-framework/scenarios/azure/compute/BUILD.bazel
+++ b/test/e2e-framework/scenarios/azure/compute/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "compute",
@@ -19,5 +20,17 @@ go_library(
         "//test/e2e-framework/resources/azure",
         "//test/e2e-framework/resources/azure/compute",
         "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
+    ],
+)
+
+dd_agent_go_test(
+    name = "compute_test",
+    srcs = ["os_resolver_test.go"],
+    embed = [":compute"],
+    deps = [
+        "//test/e2e-framework/components/os",
+        "//test/e2e-framework/resources/azure",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/test/e2e-framework/scenarios/azure/compute/os_resolver.go
+++ b/test/e2e-framework/scenarios/azure/compute/os_resolver.go
@@ -8,6 +8,7 @@ package compute
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/azure"
@@ -54,12 +55,16 @@ func resolveWindowsURN(_ azure.Environment, osInfo os.Descriptor) (string, error
 		osInfo.Version = os.WindowsServerDefault.Version
 	}
 
-	if osInfo.Version == "2016" || osInfo.Version == "2019" {
+	// The "-e2e" suffix selects a prebaked AMI on AWS; Azure has no equivalent
+	// image, so fall back to the same Marketplace image as the plain version.
+	version := strings.TrimSuffix(osInfo.Version, "-e2e")
+
+	if version == "2016" || version == "2019" {
 		// 2016 and 2019 uses a different URN format
-		return fmt.Sprintf("MicrosoftWindowsServer:WindowsServer:%s-datacenter-gensecond:latest", osInfo.Version), nil
+		return fmt.Sprintf("MicrosoftWindowsServer:WindowsServer:%s-datacenter-gensecond:latest", version), nil
 	}
 
-	return fmt.Sprintf("MicrosoftWindowsServer:WindowsServer:%s-datacenter-azure-edition-core:latest", osInfo.Version), nil
+	return fmt.Sprintf("MicrosoftWindowsServer:WindowsServer:%s-datacenter-azure-edition-core:latest", version), nil
 }
 
 func resolveWindowsClientURN(_ azure.Environment, osInfo os.Descriptor) (string, error) {

--- a/test/e2e-framework/scenarios/azure/compute/os_resolver_test.go
+++ b/test/e2e-framework/scenarios/azure/compute/os_resolver_test.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package compute
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/azure"
+)
+
+func TestResolveWindowsURN(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{
+			name:    "2025 plain version",
+			version: "2025",
+			want:    "MicrosoftWindowsServer:WindowsServer:2025-datacenter-azure-edition-core:latest",
+		},
+		{
+			name:    "2025 e2e variant normalizes to the same Marketplace image",
+			version: "2025-e2e",
+			want:    "MicrosoftWindowsServer:WindowsServer:2025-datacenter-azure-edition-core:latest",
+		},
+		{
+			name:    "2019 e2e variant uses the gensecond URN format",
+			version: "2019-e2e",
+			want:    "MicrosoftWindowsServer:WindowsServer:2019-datacenter-gensecond:latest",
+		},
+		{
+			name:    "empty version falls back to WindowsServerDefault, e2e suffix normalized",
+			version: "",
+			want:    "MicrosoftWindowsServer:WindowsServer:" + strings.TrimSuffix(os.WindowsServerDefault.Version, "-e2e") + "-datacenter-azure-edition-core:latest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			urn, err := resolveWindowsURN(azure.Environment{}, os.NewDescriptor(os.WindowsServer, tt.version))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, urn)
+		})
+	}
+}

--- a/test/e2e-framework/testing/utils/e2e/client/host_cache.go
+++ b/test/e2e-framework/testing/utils/e2e/client/host_cache.go
@@ -9,12 +9,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v7"
-	"github.com/pkg/sftp"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components"
 	oscomp "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
@@ -23,16 +20,9 @@ import (
 const (
 	cacheBucketURL = "s3://agent-e2e-s3-bucket"
 
-	// awsCliInstallRetries/awsS3CopyRetries account for a flaky AWS network on the test host.
-	awsCliInstallRetries = 3
-	awsS3CopyRetries     = 3
-	awsRetryInterval     = 5 * time.Second
-
-	awsCliRemoteInstallLogPath = `C:\Windows\Temp\awscli-install.log`
-
-	// msiExitSuccessRebootRequired is the successful msiexec exit code returned when /norestart
-	// defers a pending reboot. See https://learn.microsoft.com/en-us/windows/win32/msi/error-codes
-	msiExitSuccessRebootRequired = 3010
+	// awsS3CopyRetries accounts for a flaky AWS network on the test host.
+	awsS3CopyRetries = 3
+	awsRetryInterval = 5 * time.Second
 )
 
 type unimplementedHostCache struct{}
@@ -73,49 +63,7 @@ type windowsAWSCLI struct {
 	sshExecutor *sshExecutor
 }
 
-// ensureInstalled installs AWS CLI v2 if it isn't already present on the host.
-//
-// TEMPORARY: Linux e2e AMIs have AWS CLI v2 pre-baked, but the Windows Server
-// AMIs we use have not yet been re-baked with it. Once ami-builder ships
-// Windows e2e AMI variants with AWS CLI pre-installed, delete this method and
-// the call from download() below. Tracked in ACIX-1305.
-func (c *windowsAWSCLI) ensureInstalled() error {
-	if _, err := c.sshExecutor.Execute("& \"c:\\Program Files\\Amazon\\AWSCLIV2\\aws.exe\" --version"); err == nil {
-		return nil
-	}
-	_, err := backoff.Retry(context.Background(), func() (any, error) {
-		// Start-Process's own exit code only reflects whether it launched msiexec, not whether the
-		// install succeeded, so capture the process with -PassThru and check its ExitCode explicitly.
-		_, err := c.sshExecutor.Execute(fmt.Sprintf(
-			`$p = Start-Process msiexec.exe -Wait -PassThru -ArgumentList "/i https://awscli.amazonaws.com/AWSCLIV2.msi /qn /norestart /L*V %s"; if ($p.ExitCode -ne 0 -and $p.ExitCode -ne %d) { throw "msiexec exited with code $($p.ExitCode)" }`,
-			awsCliRemoteInstallLogPath, msiExitSuccessRebootRequired))
-		return nil, err
-	}, backoff.WithBackOff(backoff.NewConstantBackOff(awsRetryInterval)), backoff.WithMaxTries(awsCliInstallRetries))
-	c.collectInstallLog()
-	return err
-}
-
-// collectInstallLog best-effort copies the AWS CLI msiexec log to the test's artifacts folder,
-// mirroring the log collection test/new-e2e/tests/windows/common/msi.go does for Agent MSI installs.
-func (c *windowsAWSCLI) collectInstallLog() {
-	sftpClient, err := sftp.NewClient(c.sshExecutor.client, sftp.UseConcurrentWrites(true))
-	if err != nil {
-		c.sshExecutor.context.Logf("failed to collect AWS CLI install log: %v", err)
-		return
-	}
-	defer sftpClient.Close()
-
-	remotePath := strings.ReplaceAll(awsCliRemoteInstallLogPath, "\\", "/")
-	localPath := filepath.Join(c.sshExecutor.context.SessionOutputDir(), "awscli-install.log")
-	if err := downloadFile(sftpClient, remotePath, localPath); err != nil {
-		c.sshExecutor.context.Logf("failed to collect AWS CLI install log: %v", err)
-	}
-}
-
 func (c *windowsAWSCLI) download(path string, destPath string) error {
-	if err := c.ensureInstalled(); err != nil {
-		return err
-	}
 	_, err := backoff.Retry(context.Background(), func() (any, error) {
 		_, err := c.sshExecutor.Execute(fmt.Sprintf("& \"c:\\Program Files\\Amazon\\AWSCLIV2\\aws.exe\" s3 cp \"%s\" \"%s\"", path, destPath))
 		return nil, err

--- a/test/new-e2e/tests/fleet/suite/suite.go
+++ b/test/new-e2e/tests/fleet/suite/suite.go
@@ -40,10 +40,10 @@ var (
 	}
 	// WindowsPlatforms is the list of supported Windows platforms.
 	WindowsPlatforms = []e2eos.Descriptor{
-		e2eos.WindowsServer2016,
-		e2eos.WindowsServer2019,
-		e2eos.WindowsServer2022,
-		e2eos.WindowsServer2025,
+		e2eos.WindowsServer2016E2E,
+		e2eos.WindowsServer2019E2E,
+		e2eos.WindowsServer2022E2E,
+		e2eos.WindowsServer2025E2E,
 	}
 	// AllPlatforms is the list of all supported platforms.
 	AllPlatforms = append(LinuxPlatforms, WindowsPlatforms...)


### PR DESCRIPTION
## Summary
- Adds the `-e2e` Windows Server AMI IDs (2016/2019/2022/2025) built by ami-builder (DataDog/ami-builder#335) to `platforms.json`.
- Defaults Windows e2e tests (fleet suite, `WindowsServerDefault`, `WindowsServerVersionsForE2E`) to the new prebaked AMIs.
- Drops the runtime AWS CLI install on Windows e2e hosts (`host_cache.go`), now that the AMIs ship it prebaked.
- Skips the runtime OpenSSH install when the AMI already ships the pinned MSI build under `Program Files`.

Depends on DataDog/ami-builder#335 merging (or at least the built AMI IDs being retained) for the referenced AMIs to remain valid.

## Test plan
- [x] `go build ./test/e2e-framework/... ./test/new-e2e/tests/fleet/...`
- [x] `gofmt -l` clean
- [x] `new-e2e-windows-agent-msi-windows-server-a7-x86_64 [TestInstall]` green, no `awscli.amazonaws.com`/`Win32-OpenSSH` fetch in the log
- [x] `new-e2e-installer-windows [--run "TestInstaller$"]` green
- [x] domain-tests, fips, ddot-package, eudm-package, fleet Windows (config/extensions/upgrade) jobs all green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)