### PR TITLE
[AGENTRUN-1460][AGENTRUN-1461][AGENTRUN-1462] Fix mid-suite teardown flake

### DIFF
--- a/test/new-e2e/tests/fips-compliance/fips_nix_test.go
+++ b/test/new-e2e/tests/fips-compliance/fips_nix_test.go
@@ -59,6 +59,8 @@ instances: [{}]
 `,
 					false,
 				),
+				agentparams.WithSecurityAgentConfig(securityAgentConfig),
+				agentparams.WithSystemProbeConfig(systemProbeConfig),
 			),
 		),
 	)),
@@ -117,17 +119,6 @@ func (v *LinuxFIPSComplianceSuite) TestReportsFIPSStatusMetrics() {
 
 // this test check that the FIPS Agent processes are loaded with the FIPS OpenSSL libraries
 func (v *LinuxFIPSComplianceSuite) TestFIPSEnabledLoadedOPENSSLLibs() {
-	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(
-		awshost.WithRunOptions(
-			ec2.WithEC2InstanceOptions(ec2.WithOS(os.UbuntuDefault)),
-			ec2.WithAgentOptions(
-				agentparams.WithFlavor("datadog-fips-agent"),
-				agentparams.WithSecurityAgentConfig(securityAgentConfig),
-				agentparams.WithSystemProbeConfig(systemProbeConfig),
-			),
-		),
-	))
-
 	paths := []string{
 		"/opt/datadog-agent/bin/agent/agent",
 		"/opt/datadog-agent/embedded/bin/trace-agent",


### PR DESCRIPTION
## What does this PR do?

Removes the `UpdateEnv(ProvisionerNoFakeIntake)` in `TestFIPSEnabledLoadedOPENSSLLibs`. `security-agent` and `system-probe` now start on the base VM from the beginning of the suite instead of being enabled mid-run by swapping environments.

## Motivation

Fixes [AGENTRUN-1460](https://datadoghq.atlassian.net/browse/AGENTRUN-1460) / [1461](https://datadoghq.atlassian.net/browse/AGENTRUN-1461) / [1462](https://datadoghq.atlassian.net/browse/AGENTRUN-1462), same root cause in job `1974558530`.

The `UpdateEnv` destroys the FakeIntake ECS service mid-suite. The next subtest's `BeforeTest` re-added it. That re-add hit a `tfSTABLE` timeout, which the framework classifies as `ReCreate` — destroying the healthy EC2. The rebuild then hit `InsufficientFreeAddressesInSubnet` and cascaded to the remaining subtests.

With this change, FakeIntake is created once at the start of the suite and never destroyed or re-added.

## Describe how you validated your changes

`new-e2e-fips-compliance-test`, the job that caused the tickets, passes on this PR.

## Additional Notes

[AGENTRUN-1460]: https://datadoghq.atlassian.net/browse/AGENTRUN-1460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ