### PR TITLE
filesystem: make RestrictAccessToUser symlink-safe via os.Root

### DIFF
--- a/pkg/util/filesystem/permission_nix.go
+++ b/pkg/util/filesystem/permission_nix.go
@@ -13,6 +13,7 @@ import (
 	"io/fs"
 	"os"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"syscall"
@@ -67,7 +68,17 @@ func (p *Permission) RestrictAccessToUser(path string) error {
 		return fmt.Errorf("couldn't parse GID (%s): %w", usr.Gid, err)
 	}
 
-	if err = os.Chown(path, usrID, grpID); err != nil {
+	dir, name, err := splitDirBase(path)
+	if err != nil {
+		return fmt.Errorf("couldn't restrict access to %s: %w", path, err)
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return fmt.Errorf("couldn't open parent directory of %s: %w", path, err)
+	}
+	defer root.Close()
+
+	if err = root.Lchown(name, usrID, grpID); err != nil {
 		if errors.Is(err, fs.ErrPermission) {
 			log.Infof("Cannot change owner of '%s', permission denied", path)
 			return nil
@@ -85,13 +96,35 @@ func (p *Permission) RemoveAccessToOtherUsers(path string) error {
 	// We first try to set other and group to "dd-agent" when possible
 	_ = p.RestrictAccessToUser(path)
 
-	fperm, err := os.Stat(path)
+	dir, name, err := splitDirBase(path)
+	if err != nil {
+		return fmt.Errorf("couldn't restrict access to %s: %w", path, err)
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return fmt.Errorf("couldn't open parent directory of %s: %w", path, err)
+	}
+	defer root.Close()
+
+	fperm, err := root.Lstat(name)
 	if err != nil {
 		return err
 	}
 	// We keep the original 'user' rights but set 'group' and 'other' to zero.
 	newPerm := fperm.Mode().Perm() & 0700
-	return os.Chmod(path, fs.FileMode(newPerm))
+	return root.Chmod(name, fs.FileMode(newPerm))
+}
+
+// splitDirBase returns the parent directory and base name of path, with any
+// trailing separators removed so that e.g. "/tmp/work/" splits into
+// "/tmp" and "work" instead of "/tmp/work" and "work". An empty path
+// is rejected, matching the error behavior of the previous os.Chown/Chmod.
+func splitDirBase(path string) (dir, base string, err error) {
+	if path == "" {
+		return "", "", errors.New("path is empty")
+	}
+	cleaned := filepath.Clean(path)
+	return filepath.Dir(cleaned), filepath.Base(cleaned), nil
 }
 
 func getDatadogUserUID() (uint32, error) {

--- a/pkg/util/filesystem/permission_nix_test.go
+++ b/pkg/util/filesystem/permission_nix_test.go
@@ -43,6 +43,20 @@ func TestRemoveAccessToOtherUsers(t *testing.T) {
 	stat, err = os.Stat(testDir)
 	require.NoError(t, err)
 	assert.Equal(t, int(stat.Mode().Perm()), 0700)
+
+	// Trailing separators must not change which entry is restricted.
+	testFileTrailing := testFile + string(filepath.Separator)
+	err = os.WriteFile(testFile, []byte("test"), 0777)
+	require.NoError(t, err)
+	err = p.RemoveAccessToOtherUsers(testFileTrailing)
+	require.NoError(t, err)
+	stat, err = os.Stat(testFile)
+	require.NoError(t, err)
+	assert.Equal(t, int(stat.Mode().Perm()), 0700)
+
+	// An empty path must error and not touch the current working directory.
+	err = p.RemoveAccessToOtherUsers("")
+	require.Error(t, err)
 }
 
 func TestGetDatadogUserUID(t *testing.T) {


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Hardens `RestrictAccessToUser` and `RemoveAccessToOtherUsers` in `pkg/util/filesystem` to set file ownership and permissions relative to the file's parent directory via `os.Root`, which refuses to follow symlinks that escape the parent.

### Motivation

`RestrictAccessToUser` and `RemoveAccessToOtherUsers` used path-based `os.Chown` / `os.Chmod`, which follow symlinks. When the file's parent directory is writable by a less-privileged user (e.g. `dd-agent` owns the run directory in the standard container), that user can swap the file for a symlink to a root-owned file between the path lookup and the chown/chmod. The chown would then transfer ownership of the target file to `dd-agent`.

### Describe how you validated your changes
CI

### Additional notes
