### PR TITLE
chore(aix): move changelog unreleased entries to 7.84.0-devel.git.410.f0f79d8-1

### DIFF
--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -15,7 +15,6 @@
 ## 7.84.0-devel.git.410.f0f79d8-1 (2026-08-24)
 
 - Bundle the `apache` check in the AIX package so operators can monitor Apache HTTP Server (via `mod_status`) without any manual install step.
-- Resolve the Azure App Service runtime on AIX in the trace-agent's `traceutil`. The `getRuntime` helper only handled `linux` and `darwin` in its Linux code path, so on AIX it returned `unknown`.
 - Build the embedded OpenSSL with `-blibpath` pointing at the embedded library directory so the `openssl` CLI works when invoked directly from a plain shell. Previously it failed with `Dependent module /usr/lib/libssl.a(libssl64.so.3) could not be loaded` unless `LIBPATH` was set manually.
 
 ---

--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -14,6 +14,7 @@
 
 ## 7.84.0-devel.git.410.f0f79d8-1 (2026-08-24)
 
+- Bundle the `apache` check in the AIX package so operators can monitor Apache HTTP Server (via `mod_status`) without any manual install step.
 - Resolve the Azure App Service runtime on AIX in the trace-agent's `traceutil`. The `getRuntime` helper only handled `linux` and `darwin` in its Linux code path, so on AIX it returned `unknown`.
 - Reject directory paths in the file-based secret backend's `GetSecretOutput`. On AIX, `os.ReadFile` on a directory returns raw directory bytes without an error, so an empty secret name (resolving to the secrets base directory) was returned as a non-empty secret value.
 - Build the embedded OpenSSL with `-blibpath` pointing at the embedded library directory so the `openssl` CLI works when invoked directly from a plain shell. Previously it failed with `Dependent module /usr/lib/libssl.a(libssl64.so.3) could not be loaded` unless `LIBPATH` was set manually.

--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -16,7 +16,6 @@
 
 - Bundle the `apache` check in the AIX package so operators can monitor Apache HTTP Server (via `mod_status`) without any manual install step.
 - Resolve the Azure App Service runtime on AIX in the trace-agent's `traceutil`. The `getRuntime` helper only handled `linux` and `darwin` in its Linux code path, so on AIX it returned `unknown`.
-- Reject directory paths in the file-based secret backend's `GetSecretOutput`. On AIX, `os.ReadFile` on a directory returns raw directory bytes without an error, so an empty secret name (resolving to the secrets base directory) was returned as a non-empty secret value.
 - Build the embedded OpenSSL with `-blibpath` pointing at the embedded library directory so the `openssl` CLI works when invoked directly from a plain shell. Previously it failed with `Dependent module /usr/lib/libssl.a(libssl64.so.3) could not be loaded` unless `LIBPATH` was set manually.
 
 ---

--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -10,6 +10,12 @@
 
 <!-- Add entries here for changes not yet in a release. -->
 
+---
+
+## 7.84.0-devel.git.410.f0f79d8-1 (2026-08-24)
+
+- Resolve the Azure App Service runtime on AIX in the trace-agent's `traceutil`. The `getRuntime` helper only handled `linux` and `darwin` in its Linux code path, so on AIX it returned `unknown`.
+- Reject directory paths in the file-based secret backend's `GetSecretOutput`. On AIX, `os.ReadFile` on a directory returns raw directory bytes without an error, so an empty secret name (resolving to the secrets base directory) was returned as a non-empty secret value.
 - Build the embedded OpenSSL with `-blibpath` pointing at the embedded library directory so the `openssl` CLI works when invoked directly from a plain shell. Previously it failed with `Dependent module /usr/lib/libssl.a(libssl64.so.3) could not be loaded` unless `LIBPATH` was set manually.
 
 ---


### PR DESCRIPTION
### What does this PR does?

Moves the `Unreleased` entry in `CHANGELOG-AIX.md` to a new released section `7.84.0-devel.git.410.f0f79d8-1 (2026-08-24)`, and add an entry for an AIX specific integrations-core change adding the apache check.

### Motivation

The `datadog-agent-7.84.0-devel.git.410.f0f79d8-1.aix.ppc64.bff` package has been released.

### Describe how you validated your changes

n/a