### PR TITLE
[ABLD-476] Stop installing rtloader for lint jobs

### DIFF
--- a/.gitlab/build/lint/linux.yml
+++ b/.gitlab/build/lint/linux.yml
@@ -1,7 +1,5 @@
 ---
 .lint_script:
-  - dda inv -- -e rtloader.make --install-prefix=$CI_PROJECT_DIR/dev
-  - dda inv -- -e rtloader.install
   - dda inv -- -e linter.go --cpus $KUBERNETES_CPU_REQUEST --debug $FLAVORS $EXTRA_OPTS
 
 .linux_lint:


### PR DESCRIPTION
### What does this PR do?

Stop installing rtloader for lint jobs.
- It is not needed.
- It uses the cmake build instead of the bazel one, so (if it was testing anything) it would have been testing a different build than we ship.

### Motivation
Overall plan to remove all cmake from the build.

### Describe how you validated your changes
- All the CI lint still passes