### PR TITLE
AGTMETRICS-579 enable v3beta sketch shadowing

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -342,6 +342,11 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 	pkgconfig.Set("serializer_compressor_kind", constants.DefaultCompressorKind, pkgconfigmodel.SourceDefault)
 	pkgconfig.Set("serializer_zstd_compressor_level", ddotZstdCompressionLevel, pkgconfigmodel.SourceDefault)
 
+	// The v3beta sketches shadow validates the upcoming v3 sketch payload against
+	// core Agent traffic; DDOT is out of scope for that validation, so opt out of
+	// the non-zero default sample rate.
+	pkgconfig.Set("serializer_experimental_use_v3_api.sketches.shadow_sample_rate", float64(0), pkgconfigmodel.SourceAgentRuntime)
+
 	// Log configs
 	pkgconfig.Set("logs_enabled", true, pkgconfigmodel.SourceDefault)
 	pkgconfig.Set("logs_config.force_use_http", true, pkgconfigmodel.SourceDefault)

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -154,6 +154,18 @@ func TestDDOTSeriesV3RespectsExplicitOptOut(t *testing.T) {
 	assert.False(t, present, "explicit enabled=false must not be overridden by the per-endpoint opt-in")
 }
 
+// TestDDOTSketchesV3BetaShadowDisabled verifies DDOT opts out of the v3beta sketches
+// shadow, which defaults to a non-zero sample rate in the core Agent. SourceAgentRuntime
+// outranks SourceEnvVar, so a colocated core Agent's DD_ env vars cannot re-enable it.
+func TestDDOTSketchesV3BetaShadowDisabled(t *testing.T) {
+	configmock.New(t)
+	t.Setenv("DD_SERIALIZER_EXPERIMENTAL_USE_V3_API_SKETCHES_SHADOW_SAMPLE_RATE", "1")
+	c, err := NewConfigComponent(context.Background(), "", []string{"testdata/config_default.yaml"})
+	require.NoError(t, err)
+
+	assert.Zero(t, c.GetFloat64("serializer_experimental_use_v3_api.sketches.shadow_sample_rate"))
+}
+
 func (suite *ConfigTestSuite) TestAgentConfig() {
 	t := suite.T()
 	fileName := "testdata/config.yaml"

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
@@ -102,6 +102,7 @@ func setupSerializer(config pkgconfigmodel.Config, cfg *ExporterConfig) {
 	// = zstd set above has no effect here: series are sent zlib-compressed
 	// (Content-Encoding: deflate). Only the v2 intake accepts zlib, so v3 is disabled below.
 	config.Set("use_v3_api.series.enabled", "false", pkgconfigmodel.SourceAgentRuntime)
+	config.Set("serializer_experimental_use_v3_api.sketches.shadow_sample_rate", float64(0), pkgconfigmodel.SourceAgentRuntime)
 
 	// Serializer: allow user to blacklist any kind of payload to be sent
 	config.Set("enable_payloads.events", true, pkgconfigmodel.SourceDefault)

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -9049,7 +9049,7 @@ properties:
           shadow_sample_rate:
             node_type: setting
             type: number
-            default: 0
+            default: 0.001
             tags:
             - golang_type:float64
           shadow_sites:

--- a/releasenotes/notes/v3beta-sketches-shadow-sampling-c81430c6ce9ce5ff.yaml
+++ b/releasenotes/notes/v3beta-sketches-shadow-sampling-c81430c6ce9ce5ff.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    A small sample of sketch metric flushes (0.1% by default) is now
+    additionally sent to a v3beta metrics intake endpoint to validate the
+    upcoming v3 metrics protocol. Shadow traffic is only sent for agents
+    configured against the ``datadoghq.com`` (US1) site. To opt out, set
+    ``serializer_experimental_use_v3_api.sketches.shadow_sample_rate`` to
+    ``0``.


### PR DESCRIPTION
### What does this PR do?

Enable v3beta sketch shadowing.

### Motivation

Additional verification before switching all sketches to use the v3 format by default.

### Describe how you validated your changes

Run the agent with `DD_SERIALIZER_EXPERIMENTAL_USE_V3_API_SKETCHES_SHADOW_SAMPLE_RATE=0.5` pointed at the test intake and verify via telemetry number of transactions for `sketches_v3beta` is roughly 50% of transactions for `sketches` endpoint.

When doing final QA:

Run the agent with `DD_SERIALIZER_EXPERIMENTAL_USE_V3_API_SKETCHES_SHADOW_SAMPLE_RATE=0.5` with the real intake and verify that it accepts sketches_v3beta payloads without errors.

### Additional Notes
