### PR TITLE
Test that the macOS floor agrees across the files that declare it

### DIFF
--- a/tasks/unit_tests/macos_support_tests.py
+++ b/tasks/unit_tests/macos_support_tests.py
@@ -1,0 +1,56 @@
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[2]
+OMNIBUS_TASK = REPO_ROOT / 'tasks' / 'omnibus.py'
+FINALIZE_RECIPE = REPO_ROOT / 'omnibus' / 'config' / 'software' / 'datadog-agent-finalize.rb'
+INSTALL_SCRIPT = REPO_ROOT / 'cmd' / 'agent' / 'macos' / 'install_mac_os.sh'
+
+
+def _search(path: Path, pattern: str) -> str:
+    match = re.search(pattern, path.read_text())
+    assert match is not None, f'{pattern!r} no longer matches anything in {path.relative_to(REPO_ROOT)}'
+    return match.group(1)
+
+
+class TestMacOSFloorIsConsistent(unittest.TestCase):
+    """
+    The minimum macOS we support is written down in several places that have to agree.
+    https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
+
+    Deliberately narrow. Most divergence here is already caught by the ABI gate in
+    datadog-agent-finalize.rb, which fails the DMG build if any binary declares a minimum
+    newer than the floor -- so the Swift systray target, for instance, needs no test. What
+    the gate cannot catch is covered below.
+    """
+
+    def _build_target(self) -> str:
+        return _search(OMNIBUS_TASK, r"MACOSX_DEPLOYMENT_TARGET'\] = '(\d+)\.")
+
+    def test_installer_minimum_matches_build_target(self):
+        # The gate structurally cannot catch this one. It asks "is every binary loadable on
+        # the floor?", while the installer encodes what the floor *is* -- and the installer is
+        # a shell script running on the user's Mac, not a binary the gate ever scans. Raise the
+        # build target without raising this and the gate stays green while macOS users below
+        # the new floor install an Agent that cannot start.
+        installer_minimum = _search(INSTALL_SCRIPT, r'macos_major_version\}" -lt (\d+)')
+        self.assertEqual(
+            installer_minimum,
+            self._build_target(),
+            f'install_mac_os.sh admits macOS {installer_minimum}+ but binaries are built for '
+            f'{self._build_target()}.0+. Nothing in the build catches this: the installer would '
+            'let users below the build target install an Agent that cannot launch.',
+        )
+
+    def test_abi_gate_floor_matches_build_target(self):
+        # Divergence here does fail the DMG build, but only once that job runs -- and a change
+        # to tasks/omnibus.py alone does not trigger it, so the breakage would land on main and
+        # surface in a later pipeline. Cheap to catch on the PR instead.
+        gate_floor = _search(FINALIZE_RECIPE, r'MIN_ACCEPTABLE_VERSION: "(\d+)\.')
+        self.assertEqual(
+            gate_floor,
+            self._build_target(),
+            f'the macOS ABI gate accepts a {gate_floor}.0 floor but binaries are built for '
+            f'{self._build_target()}.0+. Keep both in step, or every binary trips the gate.',
+        )


### PR DESCRIPTION
### What does this PR do?

Adds two unit tests asserting the minimum macOS version agrees across the files
that declare it: `MACOSX_DEPLOYMENT_TARGET` in `tasks/omnibus.py`, the `-lt 12`
check in `cmd/agent/macos/install_mac_os.sh`, and `MIN_ACCEPTABLE_VERSION` in
`omnibus/config/software/datadog-agent-finalize.rb`.

No new binary inspection — `omnibus/scripts/check_macos_version.sh` already does
that, and this deliberately does not duplicate it.

### Motivation

The ABI gate in `datadog-agent-finalize.rb` fails the DMG build when a binary
declares a minimum newer than the floor, which covers most divergence. Two cases
it cannot:

- `install_mac_os.sh` is a shell script running on the user's Mac, not a Mach-O
  binary the gate scans. Raise `MACOSX_DEPLOYMENT_TARGET` without raising the
  installer's check and the gate stays green while macOS users below the new
  floor install an Agent that cannot launch.
- A change to `tasks/omnibus.py` alone matches no path in `.on_macos_change` or
  `.on_build_changes`, so the DMG job does not run on the PR and a floor
  mismatch lands on `main`.

### Describe how you validated your changes

`dda inv -- -e invoke-unit-tests.run --tests=macos_support` — 2 passed.

Confirmed the tests are not vacuous by pointing them at fixtures with divergent
values:

| build target | installer | gate floor | result |
|---|---|---|---|
| 12 | 12 | 12 | pass |
| 13 | 12 | 13 | fail (installer) |
| 13 | 13 | 12 | fail (gate floor) |
| 13 | 12 | 12 | fail (both) |

### Additional Notes

Test-only, no runtime code touched. Rebased on `0dcae6d882d`; all three values
still read 12 there.

Context: this came out of reviewing DataDog/integrations-core#24864, which bumps
ddtrace to 4.12.2 for CVE-2026-50271. Verifying the Agent still supports macOS 12
surfaced that the floor is declared in four places with nothing checking they
agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
