### PR TITLE
config: reduce int64<->int Set() conversion warning noise

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -138,6 +138,11 @@ type ntmConfig struct {
 	// message. This map is used to keep track of already emitted errors
 	setWarnings map[string]bool
 
+	// Tracks whether the int64<->int Set() conversion has already warned once; later keys hitting it
+	// log at DEBUG instead. Scoped to int64<->int since that's the conversion dominating fleet-wide
+	// noise; other conversions still warn every time.
+	setTypeWarnings map[string]bool
+
 	// extraConfigFilePaths represents additional configuration file paths that will be merged into the main configuration when ReadInConfig() is called.
 	extraConfigFilePaths []string
 
@@ -240,11 +245,18 @@ func (c *ntmConfig) Set(key string, newValue interface{}, source model.Source) {
 	// convert the value to the type of the default
 	if declaredNode.IsLeafNode() {
 		if converted, err := basic.ConvertToDefaultType(newValue, declaredNode.Get(), false); err == nil {
-			if ok := c.setWarnings[key]; !ok {
-				if reflect.TypeOf(converted) != reflect.TypeOf(newValue) {
+			if ok := c.setWarnings[key]; !ok && reflect.TypeOf(converted) != reflect.TypeOf(newValue) {
+				typePair := fmt.Sprintf("%T->%T", newValue, converted)
+				isIntWidthConversion := typePair == "int64->int" || typePair == "int->int64"
+				if isIntWidthConversion && c.setTypeWarnings[typePair] {
+					log.Debugf("Set('%s'): converting value from %T to %T to match default type", key, newValue, converted)
+				} else {
 					log.Warnf("Set('%s'): converting value from %T to %T to match default type", key, newValue, converted)
-					c.setWarnings[key] = true
+					if isIntWidthConversion {
+						c.setTypeWarnings[typePair] = true
+					}
 				}
+				c.setWarnings[key] = true
 			}
 			newValue = converted
 		}
@@ -1219,6 +1231,7 @@ func NewNodeTreeConfig(name string, envPrefix string, envKeyReplacer *strings.Re
 		configEnvVars:      map[string][]string{},
 		knownKeys:          map[string]bool{},
 		setWarnings:        map[string]bool{},
+		setTypeWarnings:    map[string]bool{},
 		defaults:           newInnerNode(nil),
 		file:               newInnerNode(nil),
 		unknown:            newInnerNode(nil),


### PR DESCRIPTION
## What

`nodetreemodel`'s `Set()` logs a WARN each time it silently coerces a value to match a setting's declared type (e.g. `int64 -> int`). Fleet-wide this is dominated by `int64<->int`, which JSON/protobuf round-tripping (configstream, remote config) triggers for many distinct keys per process. This PR keeps the first `int64<->int` occurrence at WARN and demotes later occurrences to DEBUG. Other conversions (e.g. `float64 -> int64`) still warn every time, since they're rarer and more likely to indicate a real bug.

## How validated

- `dda inv linter.go` and `dda inv test` on `pkg/config/nodetreemodel` — all pass.
- Live test in a Linux container (colima): ran a real core agent streaming its full resolved config (2136+ settings) to a real trace-agent and system-probe via configstream.
  - system-probe saw 912 total type-conversion events across 3 distinct type pairs.
  - Only 3 WARN lines were emitted (one per pair, first occurrence).
  - Of the 575 `int64<->int` conversions, only the first logged at WARN; the remaining 574 logged at DEBUG.
  - The 135 `int64 -> float64` and 69 `int64 -> time.Duration` conversions each logged at WARN every time, confirming the dedup is scoped to `int64<->int` only.