### PR TITLE
fix(data-race): scope sessionIDInterceptor err per request

### DIFF
--- a/comp/core/remoteagent/helper/serverhelper.go
+++ b/comp/core/remoteagent/helper/serverhelper.go
@@ -127,8 +127,9 @@ func NewUnimplementedRemoteAgentServer(ipcComp ipc.Component, log log.Component,
 		if sessionID == "" {
 			return nil, errors.New("remote agent is not registered yet")
 		}
-		err = grpc.SetHeader(ctx, metadata.New(map[string]string{"session_id": sessionID}))
-		if err != nil {
+		// Use a local err so concurrent RPCs (this interceptor runs per request) don't
+		// race on the outer err captured from NewUnimplementedRemoteAgentServer.
+		if err := grpc.SetHeader(ctx, metadata.New(map[string]string{"session_id": sessionID})); err != nil {
 			return nil, err
 		}
 		return handler(ctx, req)


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Shadows `err` inside the `sessionIDInterceptor` closure in `NewUnimplementedRemoteAgentServer` so each gRPC request writes its own local `err` instead of the outer function's `err`.

### Motivation

The closure captured the outer `err` (from `buildRemoteAgentListener`) by reference and did `err = grpc.SetHeader(...)`. Two concurrent RPCs invoking the interceptor both write the same outer `err`:

```
WARNING: DATA RACE
Write at ... by goroutine 775:
  NewUnimplementedRemoteAgentServer.func1()  serverhelper.go:130
  ... _TelemetryProvider_GetTelemetry_Handler
Previous write at ... by goroutine 774:
  NewUnimplementedRemoteAgentServer.func1()  serverhelper.go:130
```

### Describe how you validated your changes

CI

### Additional Notes