### PR TITLE
[OTAGENT-1305] Bump go version to 1.26.0 for otel-used modules

### DIFF
--- a/comp/api/api/def/go.mod
+++ b/comp/api/api/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/api/api/def
 
-go 1.25.0
+go 1.26.0
 
 require go.uber.org/fx v1.24.0
 

--- a/comp/core/agenttelemetry/def/go.mod
+++ b/comp/core/agenttelemetry/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/fleet/installer v0.70.0

--- a/comp/core/agenttelemetry/fx/go.mod
+++ b/comp/core/agenttelemetry/fx/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/agenttelemetry/fx
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def v0.83.0-devel.0.20260729075015-99ed037f1c29

--- a/comp/core/agenttelemetry/impl/go.mod
+++ b/comp/core/agenttelemetry/impl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/agenttelemetry/impl
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.72.0-rc.1

--- a/comp/core/config/go.mod
+++ b/comp/core/config/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/config
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/configstreamconsumer/def v0.0.0-00010101000000-000000000000

--- a/comp/core/configstreamconsumer/def/go.mod
+++ b/comp/core/configstreamconsumer/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/configstreamconsumer/def
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/comp/core/delegatedauth/api/cloudauth/aws/go.mod
+++ b/comp/core/delegatedauth/api/cloudauth/aws/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/delegatedauth/api/cloudauth/aws
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000

--- a/comp/core/delegatedauth/go.mod
+++ b/comp/core/delegatedauth/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/delegatedauth
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth/api/cloudauth/aws v0.0.0-00010101000000-000000000000

--- a/comp/core/flare/builder/go.mod
+++ b/comp/core/flare/builder/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/flare/builder
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/comp/core/flare/types/go.mod
+++ b/comp/core/flare/types/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/flare/types
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.61.0

--- a/comp/core/hostname/hostnameinterface/def/go.mod
+++ b/comp/core/hostname/hostnameinterface/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/comp/core/hostname/hostnameinterface/go.mod
+++ b/comp/core/hostname/hostnameinterface/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/comp/core/hostname/hostnameinterface/mock/go.mod
+++ b/comp/core/hostname/hostnameinterface/mock/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/mock
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def v0.61.0

--- a/comp/core/ipc/def/go.mod
+++ b/comp/core/ipc/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/ipc/def
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/comp/core/ipc/httphelpers/go.mod
+++ b/comp/core/ipc/httphelpers/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/ipc/httphelpers
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.72.0-rc.5

--- a/comp/core/ipc/impl/go.mod
+++ b/comp/core/ipc/impl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/ipc/impl
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.72.0-rc.5

--- a/comp/core/ipc/mock/go.mod
+++ b/comp/core/ipc/mock/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/ipc/mock
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.72.0-rc.5

--- a/comp/core/log/def/go.mod
+++ b/comp/core/log/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/log/def
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/comp/core/log/fx/go.mod
+++ b/comp/core/log/fx/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/log/fx
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/log/impl v0.61.0

--- a/comp/core/log/impl/go.mod
+++ b/comp/core/log/impl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/log/impl
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel

--- a/comp/core/log/mock/go.mod
+++ b/comp/core/log/mock/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/log/mock
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.64.0-devel

--- a/comp/core/secrets/def/go.mod
+++ b/comp/core/secrets/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/secrets/def
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/comp/core/secrets/fx/go.mod
+++ b/comp/core/secrets/fx/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/secrets/fx
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/secrets/impl v0.70.0

--- a/comp/core/secrets/impl/go.mod
+++ b/comp/core/secrets/impl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/secrets/impl
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.68.3

--- a/comp/core/secrets/mock/go.mod
+++ b/comp/core/secrets/mock/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/secrets/mock
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.71.0-rc.1

--- a/comp/core/secrets/noop-impl/go.mod
+++ b/comp/core/secrets/noop-impl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.72.0-rc.1

--- a/comp/core/secrets/utils/go.mod
+++ b/comp/core/secrets/utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/secrets/utils
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/comp/core/status/go.mod
+++ b/comp/core/status/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/status
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/template v0.65.1

--- a/comp/core/tagger/def/go.mod
+++ b/comp/core/tagger/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/def
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel

--- a/comp/core/tagger/fx-remote/go.mod
+++ b/comp/core/tagger/fx-remote/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/def v0.72.0-rc.5

--- a/comp/core/tagger/generic_store/go.mod
+++ b/comp/core/tagger/generic_store/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/generic_store
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.60.0

--- a/comp/core/tagger/impl-remote/go.mod
+++ b/comp/core/tagger/impl-remote/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/impl-remote
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.72.0-rc.1

--- a/comp/core/tagger/origindetection/go.mod
+++ b/comp/core/tagger/origindetection/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/origindetection
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/comp/core/tagger/subscriber/go.mod
+++ b/comp/core/tagger/subscriber/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/subscriber
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/telemetry v0.0.0-20250129172314-517df3f51a84

--- a/comp/core/tagger/tags/go.mod
+++ b/comp/core/tagger/tags/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/tags
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/comp/core/tagger/telemetry/go.mod
+++ b/comp/core/tagger/telemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/telemetry
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.60.0

--- a/comp/core/tagger/types/go.mod
+++ b/comp/core/tagger/types/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/types
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.60.0

--- a/comp/core/tagger/utils/go.mod
+++ b/comp/core/tagger/utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/utils
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/comp/core/telemetry/go.mod
+++ b/comp/core/telemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/telemetry
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.0.0-00010101000000-000000000000

--- a/comp/def/go.mod
+++ b/comp/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/def
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/comp/forwarder/defaultforwarder/go.mod
+++ b/comp/forwarder/defaultforwarder/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel

--- a/comp/forwarder/orchestrator/orchestratorinterface/go.mod
+++ b/comp/forwarder/orchestrator/orchestratorinterface/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface
 
-go 1.25.0
+go 1.26.0
 
 require github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.56.0-rc.3
 

--- a/comp/logs-library/go.mod
+++ b/comp/logs-library/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/logs-library
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.209

--- a/comp/logs/agent/config/go.mod
+++ b/comp/logs/agent/config/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/logs/agent/config
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel

--- a/comp/otelcol/ddprofilingextension/def/go.mod
+++ b/comp/otelcol/ddprofilingextension/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/ddprofilingextension/def
 
-go 1.25.0
+go 1.26.0
 
 require go.opentelemetry.io/collector/extension v1.64.0
 

--- a/comp/otelcol/ddprofilingextension/impl/go.mod
+++ b/comp/otelcol/ddprofilingextension/impl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/ddprofilingextension/impl
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.77.0-devel.0.20260213154712-e02b9359151a

--- a/comp/otelcol/logsagentpipeline/go.mod
+++ b/comp/otelcol/logsagentpipeline/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.1

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.64.0-rc.12

--- a/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
+++ b/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/connector/datadogconnector
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.80.2

--- a/comp/otelcol/otlp/components/datadogconfig/go.mod
+++ b/comp/otelcol/otlp/components/datadogconfig/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/datadogconfig
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics v0.0.0-00010101000000-000000000000

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/datadogexporter
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.82.0-devel.0.20260624113434-509b872045c2

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.209

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.82.0-devel.0.20260624113434-509b872045c2

--- a/comp/otelcol/otlp/components/metricsclient/go.mod
+++ b/comp/otelcol/otlp/components/metricsclient/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/trace v0.64.0-devel.0.20250129182827-bab631c10d61

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/go.mod
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/processor/infraattributesprocessor
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.72.0-rc.5

--- a/comp/otelcol/otlp/testutil/go.mod
+++ b/comp/otelcol/otlp/testutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.62.0-rc.7

--- a/comp/serializer/logscompression/go.mod
+++ b/comp/serializer/logscompression/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/serializer/logscompression
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/compression v0.56.0-rc.3

--- a/comp/serializer/metricscompression/go.mod
+++ b/comp/serializer/metricscompression/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/serializer/metricscompression
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel

--- a/comp/trace/agent/def/go.mod
+++ b/comp/trace/agent/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/trace/agent/def
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.71.0-rc.1

--- a/comp/trace/compression/def/go.mod
+++ b/comp/trace/compression/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/trace/compression/def
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/comp/trace/compression/impl-gzip/go.mod
+++ b/comp/trace/compression/impl-gzip/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip
 
-go 1.25.0
+go 1.26.0
 
 require github.com/DataDog/datadog-agent/comp/trace/compression/def v0.61.0
 

--- a/comp/trace/compression/impl-zstd/go.mod
+++ b/comp/trace/compression/impl-zstd/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/trace/compression/impl-zstd
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.61.0

--- a/pkg/aggregator/ckey/go.mod
+++ b/pkg/aggregator/ckey/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/aggregator/ckey
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/tagset v0.60.0

--- a/pkg/api/go.mod
+++ b/pkg/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/api
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.70.0

--- a/pkg/collector/check/defaults/go.mod
+++ b/pkg/collector/check/defaults/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/collector/check/defaults
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/pkg/config/basic/go.mod
+++ b/pkg/config/basic/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/basic
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/spf13/cast v1.10.0

--- a/pkg/config/create/go.mod
+++ b/pkg/config/create/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/create
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.77.2

--- a/pkg/config/env/go.mod
+++ b/pkg/config/env/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/env
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.0-devel

--- a/pkg/config/helper/go.mod
+++ b/pkg/config/helper/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/helper
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.77.2

--- a/pkg/config/mock/go.mod
+++ b/pkg/config/mock/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/mock
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/create v0.70.0

--- a/pkg/config/model/go.mod
+++ b/pkg/config/model/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/model
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/pkg/config/nodetreemodel/go.mod
+++ b/pkg/config/nodetreemodel/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/nodetreemodel
 
-go 1.25.0
+go 1.26.0
 
 // Internal deps fix version
 replace github.com/spf13/cast => github.com/DataDog/cast v1.8.0

--- a/pkg/config/setup/constants/go.mod
+++ b/pkg/config/setup/constants/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/setup/constants
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/pkg/config/setup/go.mod
+++ b/pkg/config/setup/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/setup
 
-go 1.25.0
+go 1.26.0
 
 // Internal deps fix version
 replace github.com/spf13/cast => github.com/DataDog/cast v1.8.0

--- a/pkg/config/structure/go.mod
+++ b/pkg/config/structure/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/structure
 
-go 1.25.0
+go 1.26.0
 
 // Internal deps fix version
 replace github.com/spf13/cast => github.com/DataDog/cast v1.8.0

--- a/pkg/config/utils/go.mod
+++ b/pkg/config/utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/utils
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.70.0

--- a/pkg/fips/go.mod
+++ b/pkg/fips/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/fips
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/pkg/fleet/installer/go.mod
+++ b/pkg/fleet/installer/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/fleet/installer
 
-go 1.25.0
+go 1.26.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/pkg/gohai/go.mod
+++ b/pkg/gohai/go.mod
@@ -2,7 +2,7 @@ module github.com/DataDog/datadog-agent/pkg/gohai
 
 // we don't want to just use the agent's go version because gohai might be used outside of it
 // eg. opentelemetry
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.0-devel

--- a/pkg/logs/message/go.mod
+++ b/pkg/logs/message/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/message
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.75.4

--- a/pkg/logs/sources/go.mod
+++ b/pkg/logs/sources/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/sources
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.75.4

--- a/pkg/logs/status/statusinterface/go.mod
+++ b/pkg/logs/status/statusinterface/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/pkg/logs/status/utils/go.mod
+++ b/pkg/logs/status/utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/status/utils
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/logs/types/go.mod
+++ b/pkg/logs/types/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/types
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/pkg/logs/util/testutils/go.mod
+++ b/pkg/logs/util/testutils/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/util/testutils
 
-go 1.25.0
+go 1.26.0
 
 require github.com/DataDog/datadog-agent/pkg/logs/sources v0.75.4
 

--- a/pkg/metrics/go.mod
+++ b/pkg/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/metrics
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/def v0.70.0

--- a/pkg/obfuscate/go.mod
+++ b/pkg/obfuscate/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/obfuscate
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.9.1

--- a/pkg/opentelemetry-mapping-go/inframetadata/go.mod
+++ b/pkg/opentelemetry-mapping-go/inframetadata/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.71.0-rc.1

--- a/pkg/opentelemetry-mapping-go/inframetadata/gohai/internal/gohaitest/go.mod
+++ b/pkg/opentelemetry-mapping-go/inframetadata/gohai/internal/gohaitest/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata/gohai/internal/gohaitest
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata v0.67.0

--- a/pkg/opentelemetry-mapping-go/otlp/attributes/go.mod
+++ b/pkg/opentelemetry-mapping-go/otlp/attributes/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/trace/log v0.77.0-devel.0.20260211235139-a5361978c2b6

--- a/pkg/opentelemetry-mapping-go/otlp/logs/go.mod
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/logs
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.209

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/go.mod
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.71.0-rc.1

--- a/pkg/opentelemetry-mapping-go/otlp/rum/go.mod
+++ b/pkg/opentelemetry-mapping-go/otlp/rum/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/rum
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/orchestrator/model/go.mod
+++ b/pkg/orchestrator/model/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/orchestrator/model
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.0-devel

--- a/pkg/orchestrator/util/go.mod
+++ b/pkg/orchestrator/util/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/orchestrator/util
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/pkg/process/util/api/go.mod
+++ b/pkg/process/util/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/process/util/api
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.209

--- a/pkg/proto/go.mod
+++ b/pkg/proto/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/proto
 
-go 1.25.0
+go 1.26.0
 
 retract v0.46.0-devel
 

--- a/pkg/remoteconfig/state/go.mod
+++ b/pkg/remoteconfig/state/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/remoteconfig/state
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/go-tuf v1.1.1-0.5.2

--- a/pkg/serializer/go.mod
+++ b/pkg/serializer/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/serializer
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.209

--- a/pkg/status/health/go.mod
+++ b/pkg/status/health/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/status/health
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/pkg/tagger/types/go.mod
+++ b/pkg/tagger/types/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/tagger/types
 
-go 1.25.0
+go 1.26.0
 
 require github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.62.0-rc.7
 

--- a/pkg/tagset/go.mod
+++ b/pkg/tagset/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/tagset
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/sort v0.60.0

--- a/pkg/template/go.mod
+++ b/pkg/template/go.mod
@@ -1,3 +1,3 @@
 module github.com/DataDog/datadog-agent/pkg/template
 
-go 1.25.0
+go 1.26.0

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/trace
 
-go 1.25.0
+go 1.26.0
 
 // NOTE: Prefer using simple `require` directives instead of using `replace` if possible.
 // See https://github.com/DataDog/datadog-agent/blob/main/docs/dev/gomodreplace.md

--- a/pkg/trace/log/go.mod
+++ b/pkg/trace/log/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/trace/log
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/trace/otel/go.mod
+++ b/pkg/trace/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/trace/otel
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.72.0-rc.5

--- a/pkg/trace/stats/client_stats_aggregator.go
+++ b/pkg/trace/stats/client_stats_aggregator.go
@@ -220,7 +220,7 @@ func (a *ClientStatsAggregator) setVersionDataFromContainerTags(p *pb.ClientStat
 	if p.ContainerID != "" {
 		cTags, err := a.conf.ContainerTags(p.ContainerID)
 		if err != nil {
-			log.Error("Client stats aggregator is unable to resolve container ID (%s) to container tags: %v", p.ContainerID, err)
+			log.Errorf("Client stats aggregator is unable to resolve container ID (%s) to container tags: %v", p.ContainerID, err)
 		} else {
 			gitCommitSha, imageTag, appVersion := version.GetVersionDataFromContainerTags(cTags)
 			// Only override if the payload's original values were empty strings.

--- a/pkg/trace/stats/go.mod
+++ b/pkg/trace/stats/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/trace/stats
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.71.0

--- a/pkg/trace/traceutil/go.mod
+++ b/pkg/trace/traceutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/trace/traceutil
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/proto v0.71.0

--- a/pkg/util/aws/creds/go.mod
+++ b/pkg/util/aws/creds/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/aws/creds
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.70.0

--- a/pkg/util/backoff/go.mod
+++ b/pkg/util/backoff/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/backoff
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/pkg/util/buf/go.mod
+++ b/pkg/util/buf/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/buf
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/pkg/util/cache/go.mod
+++ b/pkg/util/cache/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/cache
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/pkg/util/cgroups/go.mod
+++ b/pkg/util/cgroups/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/cgroups
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.0-devel

--- a/pkg/util/common/go.mod
+++ b/pkg/util/common/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/common
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/pkg/util/compression/go.mod
+++ b/pkg/util/compression/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/compression
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel

--- a/pkg/util/confmaputils/go.mod
+++ b/pkg/util/confmaputils/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/confmaputils
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/util/containers/image/go.mod
+++ b/pkg/util/containers/image/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/containers/image
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/pkg/util/defaultpaths/go.mod
+++ b/pkg/util/defaultpaths/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/defaultpaths
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.61.0

--- a/pkg/util/executable/go.mod
+++ b/pkg/util/executable/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/executable
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/pkg/util/filesystem/go.mod
+++ b/pkg/util/filesystem/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/filesystem
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.0-devel

--- a/pkg/util/flavor/go.mod
+++ b/pkg/util/flavor/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/flavor
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.70.0

--- a/pkg/util/fxutil/go.mod
+++ b/pkg/util/fxutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/fxutil
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/def v0.61.0

--- a/pkg/util/grpc/go.mod
+++ b/pkg/util/grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/grpc
 
-go 1.25.0
+go 1.26.0
 
 require (
 	cloud.google.com/go/compute v1.66.0

--- a/pkg/util/hostinfo/go.mod
+++ b/pkg/util/hostinfo/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/hostinfo
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/gohai v0.69.4

--- a/pkg/util/hostname/validate/go.mod
+++ b/pkg/util/hostname/validate/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/hostname/validate
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.0-devel

--- a/pkg/util/hostport/go.mod
+++ b/pkg/util/hostport/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/hostport
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/pkg/util/http/go.mod
+++ b/pkg/util/http/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/http
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.70.0

--- a/pkg/util/json/go.mod
+++ b/pkg/util/json/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/json
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/json-iterator/go v1.1.12

--- a/pkg/util/jsonquery/go.mod
+++ b/pkg/util/jsonquery/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/jsonquery
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/cache v0.69.4

--- a/pkg/util/kubernetes/apiserver/common/namespace/go.mod
+++ b/pkg/util/kubernetes/apiserver/common/namespace/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.77.0-devel.0.20260211235139-a5361978c2b6

--- a/pkg/util/log/go.mod
+++ b/pkg/util/log/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/log
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/template v0.64.1

--- a/pkg/util/log/setup/go.mod
+++ b/pkg/util/log/setup/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/log/setup
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.70.0

--- a/pkg/util/option/go.mod
+++ b/pkg/util/option/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/option
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/pkg/util/otel/go.mod
+++ b/pkg/util/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/otel
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.71.0-rc.1

--- a/pkg/util/pointer/go.mod
+++ b/pkg/util/pointer/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/pointer
 
-go 1.25.0
+go 1.26.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/pkg/util/quantile/go.mod
+++ b/pkg/util/quantile/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/quantile
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/quantile/sketchtest v0.70.0

--- a/pkg/util/quantile/sketchtest/go.mod
+++ b/pkg/util/quantile/sketchtest/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/quantile/sketchtest
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/pkg/util/scrubber/go.mod
+++ b/pkg/util/scrubber/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/scrubber
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/version v0.62.3

--- a/pkg/util/sort/go.mod
+++ b/pkg/util/sort/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/sort
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/pkg/util/startstop/go.mod
+++ b/pkg/util/startstop/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/startstop
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/pkg/util/statstracker/go.mod
+++ b/pkg/util/statstracker/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/statstracker
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/pkg/util/system/go.mod
+++ b/pkg/util/system/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/system
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.61.0

--- a/pkg/util/testutil/go.mod
+++ b/pkg/util/testutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/testutil
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/util/utilizationtracker/go.mod
+++ b/pkg/util/utilizationtracker/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/utilizationtracker
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/benbjohnson/clock v1.3.5

--- a/pkg/util/uuid/go.mod
+++ b/pkg/util/uuid/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/uuid
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/cache v0.61.0

--- a/pkg/util/winutil/go.mod
+++ b/pkg/util/winutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/winutil
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.0-devel

--- a/pkg/version/go.mod
+++ b/pkg/version/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/version
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -26,7 +26,6 @@ from invoke.context import Context
 from invoke.exceptions import Exit
 
 from tasks.build_tags import compute_build_tags_for_flavor
-from tasks.collector import OTEL_CONTRIB_VERSION
 from tasks.coverage import PROFILE_COV, CodecovWorkaround
 from tasks.devcontainer import run_on_devcontainer
 from tasks.flavor import AgentFlavor
@@ -78,8 +77,10 @@ TRIGGER_ALL_TESTS_PATHS = ["tasks/gotest.py", "tasks/build_tags.py", ".gitlab/bu
 MODULE_PREFIX = "github.com/DataDog/datadog-agent"
 BAZEL_TEST_JOBS_ENV = "DD_BAZEL_TEST_JOBS"
 DEFAULT_WINDOWS_CI_BAZEL_TEST_JOBS = 4
+# TODO(OTAGENT-1305): point back to a tagged release (see OTEL_CONTRIB_VERSION in tasks/collector.py)
+# once one ships with the go.mod bump upstream currently only has on main.
 OTEL_UPSTREAM_GO_MOD_PATH = (
-    f"https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-contrib/v{OTEL_CONTRIB_VERSION}/go.mod"
+    "https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-contrib/main/go.mod"
 )
 
 

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -26,6 +26,7 @@ from invoke.context import Context
 from invoke.exceptions import Exit
 
 from tasks.build_tags import compute_build_tags_for_flavor
+from tasks.collector import OTEL_CONTRIB_VERSION
 from tasks.coverage import PROFILE_COV, CodecovWorkaround
 from tasks.devcontainer import run_on_devcontainer
 from tasks.flavor import AgentFlavor
@@ -77,8 +78,8 @@ TRIGGER_ALL_TESTS_PATHS = ["tasks/gotest.py", "tasks/build_tags.py", ".gitlab/bu
 MODULE_PREFIX = "github.com/DataDog/datadog-agent"
 BAZEL_TEST_JOBS_ENV = "DD_BAZEL_TEST_JOBS"
 DEFAULT_WINDOWS_CI_BAZEL_TEST_JOBS = 4
-# TODO(OTAGENT-1305): point back to a tagged release (see OTEL_CONTRIB_VERSION in tasks/collector.py)
-# once one ships with the go.mod bump upstream currently only has on main.
+# TODO(OTAGENT-1305): point back to a tagged release once one ships with the go.mod
+# bump upstream currently only has on main.
 OTEL_UPSTREAM_GO_MOD_PATH = (
     "https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-contrib/main/go.mod"
 )
@@ -1494,6 +1495,11 @@ def check_otel_build(ctx):
 
 @task
 def check_otel_module_versions(ctx, fix=False):
+    print(
+        f"Checking against opentelemetry-collector-contrib main instead of the latest "
+        f"tagged release (v{OTEL_CONTRIB_VERSION}) — see OTAGENT-1305"
+    )
+
     # Get Go version from upstream (e.g., "1.24" or "1.24.0")
     upstream_pattern = r"^go (1(?:\.\d+){1,2})[\r]?$"
     r = requests.get(OTEL_UPSTREAM_GO_MOD_PATH)

--- a/test/otel/go.mod
+++ b/test/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/test/otel
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.82.0-devel.0.20260624113434-509b872045c2


### PR DESCRIPTION
## Summary
- Upstream `opentelemetry-collector-contrib` bumped its `go.mod` directive to `go 1.26.0` on `main` (OTAGENT-1305), ahead of a tagged release.
- Bumps the `go` directive to `1.26.0` in all 148 modules flagged `used_by_otel: true` in `modules.yml`, to stay in sync with what upstream now requires.
- Points `check_otel_module_versions` (`tasks/gotest.py`) at upstream's `main` branch `go.mod` instead of the last tagged release, since no tagged release with this bump exists yet. Left a TODO to revert once one ships.
- Ran `dda inv tidy` (which internally invokes `bazel run //:gazelle`) after the bump; no go.sum or BUILD file changes were needed.

## Test plan
- [x] `dda inv check-otel-module-versions` passes
- [x] `dda inv modules.validate-used-by-otel` passes
- [x] `dda inv tidy` ran clean, no dependency/go.sum changes
- [x] `bazel run //:gazelle` ran clean, no changes beyond pre-existing warnings unrelated to this change
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)