### PR TITLE
SVLS-9645: [spike] serverless logic in inventory agent

### DIFF
--- a/cmd/serverless-init/INVENTORY_METADATA_PLAN.md
+++ b/cmd/serverless-init/INVENTORY_METADATA_PLAN.md
@@ -1,0 +1,380 @@
+# Plan: serverless-init inventory metadata collection
+
+Status: planning — no implementation started.
+
+## Goal
+
+Emit `inventoryagent`-style metadata from serverless-init to the existing
+inventory intake (`serializer.SendMetadata` → `Forwarder.SubmitMetadata` →
+`datadog_agent` endpoint), tagged with a `serverless-init` flavor so the
+downstream metadata extractor can route serverless-specific fields into
+separate serverless tables.
+
+Design principles:
+- Keep coupling to the shared inventory code minimal and *deliberate*.
+- Keep serverless-specific logic in `cmd/serverless-init`.
+- Even if we build our own component, do **not** drift from the normal agent
+  metadata pipeline for the fields the pipeline requires (see
+  `PopulateCoreFields` below).
+
+## Key findings that constrain the design
+
+1. **Submission plumbing already exists.** serverless-init wires a forwarder +
+   demultiplexer, so `demux.Serializer().SendMetadata(payload)` is available
+   today. No new transport work.
+2. **The metadata runner and `inventoryagent` are not wired into
+   serverless-init.** Whatever we build must supply its own periodic trigger
+   (or reuse `comp/metadata/runner`).
+3. **Config-schema split.** `inventories_enabled`,
+   `inventories_first_run_delay`, `inventories_min_interval`,
+   `inventories_max_interval` are tagged `full-agent-only:true` and are
+   generated only into `initCoreAgentFull`. serverless-init's config init
+   (`pkg/config/setup/config_init_serverless.go`) calls **only
+   `initCommonBase`**, so those keys **do not exist in the serverless config
+   schema**. `enable_metadata_collection` **is** in the common base and present;
+   `inventories_configuration_enabled` is also tagged `full-agent-only:true`
+   and is therefore **absent** from the serverless schema too.
+   Reading a key absent from the serverless schema logs `config key <x> is
+   unknown` and returns the zero value, so any key we rely on must be declared
+   in the serverless schema. `fixupInitServerlessOnlyComponents` documents an
+   explicit philosophy: *"the same config must be compatible with any Agent no
+   matter its version."* Serverless-only config additions are reviewed against
+   this rule.
+4. **Flavor is process-global, set once at startup** via
+   `flavor.SetFlavor(...)`. serverless-init never calls it (defaults to
+   `"agent"`), and `serverless-init` is not a registered flavor constant (only
+   `serverless_agent` exists). Crucially, `NewBufferedAggregator` captures
+   `flavor.GetFlavor()` **once at construction** and uses it for the
+   `datadog.<flavor>.running` / `datadog.<flavor>.up` heartbeat metric and
+   service check (`pkg/aggregator/aggregator.go`). Calling
+   `SetFlavor("serverless-init")` process-wide would rename those to
+   `datadog.serverless-init.running` / `.up` (a dash in a metric name, and a
+   break in agent-host identification / existing monitors). So we must NOT set
+   the flavor process-wide; the payload's `flavor` value is injected locally
+   instead (see Flavor section).
+5. **First-run delay rationale.** The 60s `inventories_first_run_delay` default
+   orders inventory after host-tags/host metadata. serverless-init pulls in
+   none of that, so an effective delay of 0 with an early first send is sound.
+
+## Central shared seam: `PopulateCoreFields`
+
+To resist drift from the normal agent pipeline regardless of the reuse-vs-new
+decision, we extract a shared method in the `inventoryagent` component
+(`comp/metadata/inventoryagent/impl`) that populates **only** the fields
+required for a payload to be recognized and processed as an agent-metadata
+payload. Both the core-agent component and the serverless builder call it, and
+the core agent's `initData` is refactored to call it so there is a single
+source of truth. It must not pull in cross-process fetchers
+(security/process/trace/system-probe) or config dumps. We may relocate it to a
+shared helper package later; starting in the component keeps the refactor
+local.
+
+Because `initData` sets `flavor` from `flavor.GetFlavor()` but serverless must
+emit `serverless-init` **without** changing the process-global flavor (see Key
+finding #4), `PopulateCoreFields` must take the flavor value as a parameter (or
+the caller overrides `data["flavor"]` afterward) rather than hardwiring
+`flavor.GetFlavor()`. The core agent passes `flavor.GetFlavor()`; serverless
+passes `"serverless-init"`.
+
+Candidate source of truth is today's `inventoryagent.initData()`, which already
+contains exactly the no-cross-process-dependency core fields: `agent_version`,
+`package_version`, `agent_startup_time_ms`, `flavor`, `hostname_source`,
+`infrastructure_mode`, `install_method_tool`, `install_method_tool_version`,
+`install_method_installer_version`. (`hostname_source` is set conditionally —
+only when a hostname provider resolves and it is not Fargate — so it may be
+absent; in serverless with no host it will typically be omitted.)
+
+Open: the exact required set is a downstream contract to confirm with the
+pipeline owners (`PopulateCoreFields` should contain the minimal set the
+pipeline requires, not necessarily all of `initData`), and whether it is an
+exported method on the component or a package-level function operating on the
+`agent_metadata` map.
+
+## Reuse vs. new component (Phase 1 decision)
+
+Both options reuse `PopulateCoreFields` so neither drifts on core fields. We
+build both to a "compiles + emits a payload to a local fakeintake" level, then
+compare and pick one. Current lean is Option B.
+
+### Option A — Reuse the existing `inventoryagent` component
+- Needs (fx graph): three of the six `Requires` are NOT in the serverless-init
+  graph today and would fail construction:
+  - `serializer.MetricSerializer` is only reachable via `demux.Serializer()`,
+    not as an fx type — needs an adapter
+    `fx.Provide(func(d aggregator.Demultiplexer) serializer.MetricSerializer { return d.Serializer() })`.
+  - `ipc.HTTPClient` is not provided — pulls in IPC auth-token/cert
+    bootstrapping serverless-init does not set up.
+  - `option.Option[sysprobeconfig.Component]` needs an explicit
+    `option.None[...]()` provider (the wrapper does not make it optional).
+- Needs (behavior): wire `comp/metadata/runner` (nothing calls `collect()`
+  otherwise), and add the `inventories_*` keys to the serverless schema.
+- Risks:
+  - **Cached enablement ignores the ramp gate.** `CreateInventoryPayload`
+    caches `Enabled = InventoryEnabled(conf)` at construction and `collect()`
+    never re-checks. The stock component never consults
+    `serverless.inventory_enabled`, so Option A would emit **by default**
+    (both underlying keys default true), violating disabled-by-default.
+    Bespoke gating would be needed, eroding the reuse benefit.
+  - **`refreshMetadata()` hits localhost.** Its trace fetcher targets the APM
+    debug port (5012), which serverless-init actually runs, adding real
+    round-trip latency to every payload build; the others fail fast and fall
+    back to local config (safe but meaningless). Gating requires shared-code
+    edits inside `refreshMetadata`/the fetchers.
+  - **Per-process uuid / empty hostname** require editing the shared
+    `getPayload`/`Payload` struct (it hardcodes `uuid.GetUUID()`), a shared-code
+    hook.
+  - Serverless fields still injected via `Set(...)`; more shared-code coupling.
+- Benefit: automatic parity with future core-agent inventory fields.
+
+### Option B — New serverless-init-local payload reusing `PopulateCoreFields` + `util.InventoryPayload`
+- Needs: a small builder in `cmd/serverless-init` that calls
+  `PopulateCoreFields`, layers serverless fields, embeds
+  `util.InventoryPayload` (or calls `SendMetadata` directly with our own
+  scheduling), and registers a periodic trigger.
+- Risks: we own any schema drift beyond the shared core fields.
+- Benefit: no changes to shared `inventoryagent` behavior; only serverless-
+  relevant fields; simplest deps; logic stays in serverless-init. Best fit for
+  "minimal hooks."
+
+Each sketch must answer: (a) enablement/intervals given the missing config
+keys, (b) how the `serverless-init` flavor is set, (c) how serverless fields +
+resource id are injected, (d) how first-send/scheduling works, (e) exactly
+which lines of shared code change.
+
+## Serverless field derivation: delegate to the CloudService structs
+
+The per-platform serverless fields (workload_type, resource_id, resource_name,
+region, gcp/azure specifics, workload_runtime, deployment types) are derived
+inside the `cmd/serverless-init/cloudservice` implementations rather than in the
+payload builder. Each platform already has its own struct (CloudRun,
+CloudRunJobs, ContainerApp, AppService, ...) that knows how to read its
+environment; keeping the inventory derivation there co-locates it with the
+existing tag logic and keeps the payload builder thin.
+
+- The `CloudService` interface gains the inventory-relevant accessors, most
+  likely a single method returning an inventory struct so new fields don't
+  churn the interface. The payload builder calls it and maps the result into
+  `agent_metadata`.
+- `workload_type`, `resource_id` (CCRID), and the workload-specific fields
+  (gcp/azure deployment type, hosting plan, runtime) all live on the struct
+  that owns that platform's environment.
+
+## Field set
+
+The downstream table's tentative columns and their agent-side sources are
+below. The per-platform ones come from the CloudService structs (above).
+
+All serverless fields sit as flat keys in the `agent_metadata` map, each with a
+`serverless_` prefix applied uniformly (e.g. `serverless_resource_id`,
+`serverless_workload_type`, `serverless_region`, `serverless_dd_env`). A nested
+`serverless` object is out of scope for now. `serverless_agent_version_base`
+duplicates the core `agent_version` value into the prefixed key; the init
+version is intentionally double-prefixed as `serverless_serverless_init_version`.
+
+`last_seen_at` is not an agent field: it is derived downstream from the existing
+payload `timestamp`.
+
+**Payload envelope** (the `Payload` fields outside `agent_metadata`):
+- `hostname`: empty, and this happens **for free** in serverless builds —
+  `pkg/util/hostname/providers_serverless.go` (`//go:build serverless`) makes
+  `Hostname.Get()` return `""` regardless of `DD_HOSTNAME=none`, so the payload
+  serializes `"hostname": ""` with no extra work. Emitting JSON `null` instead
+  would require a pointer/omit field in the payload struct (only ours to change
+  cleanly under Option B); the extractor's preference is still open.
+- `uuid`: a per-process UUID generated at startup (`uuid.New().String()`), not
+  the shared `uuid.GetUUID()` (that returns the cached host machine GUID, which
+  is not per-process and is meaningless across serverless containers).
+- `timestamp`: as today; the downstream `last_seen_at` derives from it.
+
+**Core lineage:**
+- `agent_version_base` <- `version.AgentVersion` (the core `agent_version`,
+  duplicated into `serverless_agent_version_base`).
+- `agent_commit` <- `version.Commit`. Not in the core payload today; added to
+  the serverless fields.
+- `serverless_init_version` (REQUIRED, gating) <- `tags.GetExtensionVersion()`
+  (`currentExtensionVersion`). The serverless-init build system always injects
+  a real value, so no defensive handling is needed here.
+
+**Identity / composite key:**
+- `resource_id` (REQUIRED CCRID, first key component) <- CloudService. CCRID
+  composition/format to be specified. Multiple agents may share a resource id
+  where the rest of the data is identical.
+- `resource_name` (REQUIRED) <- CloudService display name (app/job/revision).
+  Never substitute `dd_service`.
+- `workload_type` (REQUIRED) <- CloudService method. Existing `CloudRunType`
+  enum is service/function/job; each struct maps to the canonical values
+  (`cloud_run_service`, `cloud_run_job`, `cloud_function_gen2`,
+  `azure_container_app`, `azure_app_service`), incl. gen2 and Azure types.
+
+**Location:**
+- `region` <- CloudService (GCP or Azure region).
+- `gcp_project_id` (nullable) <- GCP env; NULL for Azure.
+- `azure_subscription_id` (nullable) <- Azure env/tags (subscription id already
+  surfaces in `serverlessProfileTags`); NULL for GCP.
+
+**Deployment shape:**
+- `deployment_model` <- `mode.Conf.SidecarMode` -> `sidecar` / `in-container`.
+- `gcp_deployment_type` (nullable) <- CloudService (Function|Source|Container|Repo).
+- `azure_hosting_plan` (nullable) <- CloudService (Consumption|Flex).
+- `azure_deployment_type` (nullable) <- CloudService (Code|Container).
+- `workload_runtime` (nullable) <- CloudService; likely NULL for sidecar.
+- `wrapped_command` (nullable, internal only) <- wrapped workload command
+  (`os.Args[1:]` in init mode); NULL in sidecar mode.
+
+**DD_* passthrough (all nullable):**
+- `dd_env` <- config `env` / `DD_ENV`.
+- `dd_site` <- config `site` / `DD_SITE`.
+- `dd_version` <- `DD_VERSION`.
+- `dd_service` <- `DD_SERVICE` (distinct from `resource_name`).
+
+Note: `env` and `site` are real config keys, but there are **no** `version` /
+`service` config keys (`DD_VERSION` / `DD_SERVICE` are in the `knownVars`
+"used by the agent but not via the Config struct" list). Read those two from
+the env vars directly (as `tag.GetBaseTagsMap` already does) or from the
+already-computed `tagConfig.Tags` map (keys `service` / `version`) — not via
+`conf.GetString("service"/"version")`, which would return empty and log an
+unknown-key warning.
+
+## Flavor
+
+The payload's `flavor` field carries `serverless-init` (with the dash), injected
+locally via `PopulateCoreFields`' flavor parameter. We do **not** call
+`flavor.SetFlavor` process-wide: the aggregator would otherwise rename the
+`datadog.<flavor>.running` / `.up` heartbeat metric and service check (Key
+finding #4), and `flavor=="agent"` gates elsewhere would change. Registering a
+`serverless-init` constant in `pkg/util/flavor` is optional/cosmetic (only
+affects `GetHumanReadableFlavor`, which would otherwise show "Unknown Agent")
+and is not required for the payload.
+
+## Scheduling / early send / shutdown
+
+The payload content does not change between sends, so a single successful send
+per process lifetime is sufficient.
+
+- Effective first-run delay = 0; send the first payload as early as the process
+  has enough data.
+- Sending is non-blocking during the run: we do not want to hold up the
+  customer's workload or the rest of serverless-init on metadata delivery.
+- At shutdown, check that at least one send has occurred. If one already has,
+  do nothing (no blocking final flush). If none has, attempt a best-effort
+  final send within the shutdown budget.
+- No "force send" retry loop for short-lived workloads in v1 — revisit only if
+  e2e shows the at-least-one-send guarantee is unreliable for Cloud Run Jobs /
+  very short containers.
+
+Trigger mechanism: serverless-init does not wire `comp/metadata/runner`, and
+`InventoryPayload.collect()` is unexported. So we either wire the runner, or
+drive sends ourselves by calling `demux.Serializer().SendMetadata(getPayload())`
+directly. Driving it ourselves bypasses the util's `firstRunDelay` / interval /
+`forceRefresh` ordering, which only exists to avoid a backend host-creation
+race that does not apply to serverless (no host-metadata pipeline) — so the
+bypass is acceptable and gives us direct control over the early send and the
+non-blocking / at-least-one-send behavior. Note the util's serializer-nil skip
+is dead code here: `demux.Serializer()` is always non-nil, so send suppression
+must come from the enablement gate, not from a missing serializer.
+
+## Config / enablement
+
+Requirements: (1) disabled by default initially, flipped to enabled-by-default
+later once volume is validated, on a serverless ramp independent of the full
+agent; (2) respect user intent to turn inventory off; (3) minimize drift from
+`util.InventoryEnabled`; (4) honor the "same key = same meaning/default across
+all agents" philosophy in `fixupInitServerlessOnlyComponents`.
+
+Enablement gate (parity key + serverless ramp gate):
+- `inventories_enabled` is added to the serverless schema keeping default
+  `true` everywhere, and we reuse `util.InventoryEnabled` for parity
+  (= `enable_metadata_collection && inventories_enabled`, both present).
+- A new serverless-scoped ramp gate `serverless.inventory_enabled` is nested
+  under the existing `serverless:` schema section, with env var
+  `DD_SERVERLESS_INIT_INVENTORY_ENABLED` (matching the existing
+  `DD_SERVERLESS_INIT_*` convention), **default `false`** initially, flipped to
+  `true` at GA (the key can remain as a permanent feature toggle). This gate is
+  legitimately serverless-only because it gates a serverless-only feature's
+  availability, not the behavior of a shared setting.
+- Emission = `util.InventoryEnabled(conf) && conf.GetBool("serverless.inventory_enabled")`.
+  The stock component's `Enabled` is cached once in `CreateInventoryPayload`
+  and never re-checked, and it never consults `serverless.inventory_enabled` at
+  all — so reusing that cached path (Option A) would emit **by default**,
+  violating disabled-by-default. Our builder must evaluate the gate itself.
+  (Remote Config is not supported in serverless-init today, so live RC toggling
+  is not a requirement; a config/env value read at startup is sufficient.)
+
+Schema-codegen consequences of adding the `inventories_*` keys to serverless:
+the only lever is removing `full-agent-only:true` from each key in
+`core_schema.yaml` (codegen has no serverless-init-only bucket; it is binary
+full-agent vs common-base). This does not change full-agent behavior (the full
+agent still runs `initCommonBase`). `cmd/serverless-init` is the only binary in
+this repo built with the `serverless` tag (the AWS Lambda extension moved off
+this codebase over a year ago), so nothing else is affected. It does break the
+split assertions in `TestServerlessConfigInit` / `TestAgentConfigInit`
+(`pkg/config/setup/config_test.go`), which must be updated, and requires
+regenerating `all_settings.go` via `dda inv schema.codegen` (the generated file
+is not hand-edited).
+
+Rejected alternatives: single shared `inventories_enabled` with a serverless
+default of `false` (per-flavor default divergence on a shared key — the exact
+thing the philosophy warns against); a pure serverless-only key ignoring
+`inventories_enabled` (drifts from `util.InventoryEnabled`, so
+`inventories_enabled: false` would not silence serverless inventory);
+`enable_metadata_collection` alone (master switch for all metadata, cannot
+express an inventory-specific disabled-by-default ramp).
+
+Intervals / first-run delay: `inventories_min_interval`,
+`inventories_max_interval`, and `inventories_first_run_delay` are declared in
+the serverless schema at the shared defaults (0 / 0 / 60), and the serverless
+value is forced via the existing `preloadEarly` / `setOverride` pattern (e.g.
+`setOverride("inventories_first_run_delay", 0)`). `setOverride` writes at
+`SourceAgentRuntime`, which outranks env vars and yaml (`SourceEnvVar` /
+`SourceFile`) while the schema default stays identical across flavors. This
+gets delay=0 even when reusing `CreateInventoryPayload`, so scheduling control
+is not a reason to prefer Option B.
+
+`setOverride` outranks env/yaml, so it is appropriate for values we always
+force (delay=0), not for the enablement ramp gate — that stays a real config
+key a user can set. In all cases keys must be declared in the serverless schema
+first; `setOverride` sets a value, not schema membership.
+
+## Platform coverage
+
+All supported serverless-init platforms/modes: Cloud Run, Cloud Run Jobs,
+Container Apps, App Service; init and sidecar modes.
+
+## Testing
+
+- Unit tests for the payload builder (field presence, flavor value, resource
+  id, enablement gating, `PopulateCoreFields` output).
+- fakeintake e2e asserting the serverless payload lands with
+  `flavor: serverless-init` and expected fields — across chosen platforms (at
+  minimum Cloud Run; extend per `write-e2e` / `e2e-audit`).
+
+## Open items
+
+- Finalize the field list with the extractor team.
+- `workload_type` mapping, `resource_id` / CCRID composition, and the
+  gcp/azure deployment-type / hosting-plan / runtime derivations (CloudService
+  methods, this team).
+- `PopulateCoreFields` contract (which fields the pipeline requires) and its
+  shape (method vs. package function).
+- `full_configuration` include/exclude decision, i.e. whether the scrubbed
+  config dump is useful/safe in serverless. Its gate
+  `inventories_configuration_enabled` is full-agent-only and absent from the
+  serverless schema, so including the dump would require declaring that key in
+  serverless too.
+- Whether the downstream extractor prefers `hostname: null` over empty string
+  (would push toward a serverless-owned payload struct with a pointer field).
+
+## Phasing
+
+0. Spikes: define the `PopulateCoreFields` contract with pipeline owners;
+   `full_configuration` content/size spike; finalize field list.
+1. Build both sketches (A and B) on top of `PopulateCoreFields` to
+   local-fakeintake level; compare; pick one.
+2. Implement chosen approach (flavor injected via `PopulateCoreFields`, payload
+   builder, resource id, enablement gate disabled-by-default, early send).
+   Includes: remove `full-agent-only:true` from the `inventories_*` keys, add
+   `serverless.inventory_enabled`, regenerate `all_settings.go`
+   (`dda inv schema.codegen`), and update `TestServerlessConfigInit` /
+   `TestAgentConfigInit`.
+3. Tests (unit + e2e across platforms).
+4. Rollout (validate volume, then flip default to enabled).

--- a/cmd/serverless-init/INVENTORY_METADATA_PLAN.md
+++ b/cmd/serverless-init/INVENTORY_METADATA_PLAN.md
@@ -255,23 +255,26 @@ per process lifetime is sufficient.
   has enough data.
 - Sending is non-blocking during the run: we do not want to hold up the
   customer's workload or the rest of serverless-init on metadata delivery.
-- At shutdown, check that at least one send has occurred. If one already has,
-  do nothing (no blocking final flush). If none has, attempt a best-effort
-  final send within the shutdown budget.
+- The at-least-one-send guarantee rests on the runner firing early (delay=0)
+  plus the forwarder's shutdown drain (`forwarder_stop_timeout`), not on a
+  manual final flush at shutdown.
 - No "force send" retry loop for short-lived workloads in v1 — revisit only if
   e2e shows the at-least-one-send guarantee is unreliable for Cloud Run Jobs /
   very short containers.
 
-Trigger mechanism: serverless-init does not wire `comp/metadata/runner`, and
-`InventoryPayload.collect()` is unexported. So we either wire the runner, or
-drive sends ourselves by calling `demux.Serializer().SendMetadata(getPayload())`
-directly. Driving it ourselves bypasses the util's `firstRunDelay` / interval /
-`forceRefresh` ordering, which only exists to avoid a backend host-creation
-race that does not apply to serverless (no host-metadata pipeline) — so the
-bypass is acceptable and gives us direct control over the early send and the
-non-blocking / at-least-one-send behavior. Note the util's serializer-nil skip
-is dead code here: `demux.Serializer()` is always non-nil, so send suppression
-must come from the enablement gate, not from a missing serializer.
+Trigger mechanism (decided): wire `comp/metadata/runner` and let it drive
+`collect()` on the normal schedule, with `inventories_first_run_delay` forced to
+`0` (via `setOverride`, see Config / enablement) so the first send happens
+promptly. We deliberately do **not** add a `ForceCollect` / synchronous-send
+hook to the shared `inventoryagent` / `util.InventoryPayload` code: the shared
+metadata pipeline stays untouched, and the early send comes purely from the
+runner + delay=0. This is simpler than a bespoke `SendMetadata` loop and avoids
+any shared-code change to the metadata agent. (The prototype added an
+`InventoryPayload.ForceCollect()` shared hook to force an immediate synchronous
+send at startup; we are not adopting that.) The util's `firstRunDelay` /
+interval / `forceRefresh` ordering exists to avoid a backend host-creation race
+that does not apply to serverless (no host-metadata pipeline), so running the
+runner as-is with delay=0 is safe.
 
 ## Config / enablement
 
@@ -339,6 +342,10 @@ first; `setOverride` sets a value, not schema membership.
 
 All supported serverless-init platforms/modes: Cloud Run, Cloud Run Jobs,
 Container Apps, App Service; init and sidecar modes.
+
+serverless-init is Linux-only. Windows-based Azure environments are not
+supported by serverless-init (a different instrumentation mechanism covers
+them), so no Windows build path is required here.
 
 ## Testing
 

--- a/cmd/serverless-init/INVENTORY_METADATA_PLAN.md
+++ b/cmd/serverless-init/INVENTORY_METADATA_PLAN.md
@@ -385,3 +385,73 @@ them), so no Windows build path is required here.
    `TestAgentConfigInit`.
 3. Tests (unit + e2e across platforms).
 4. Rollout (validate volume, then flip default to enabled).
+
+## Spike results: Option A (reuse `inventoryagent`) vs Option B (new component)
+
+Both spikes were built to the same "compiles + wired, emission gated off by
+default" bar, sharing `PopulateCoreFields` and the `cloudservice.GetInventoryData`
+per-platform seam. Option B lives on
+`aleksandr.pasechnik/svls-9645-serverless-init-inventory-component-spike`;
+Option A is on this branch.
+
+### What each option touched
+
+| Concern | Option A (reuse) | Option B (new component) |
+|---|---|---|
+| New component | none | `comp/metadata/serverlessinventory` (def/fx/impl, ~250 lines) |
+| Shared `inventoryagent` code changed | **yes** — `Requires` gains `compdef.In` + optional `Params`; struct gains 4 fields; `NewComponent`/`getPayload`/`initData` learn about params | none beyond the shared `PopulateCoreFields` extraction |
+| serverless-init fx graph additions | `serializer` adapter, `ipcfx-none` + `ipc.HTTPClient` adapter, `option.None[sysprobeconfig]`, `runnerfx`, `inventoryagentfx`, `Params` provider | `serializer` adapter, `runnerfx`, `serverlessinventoryfx`, `FieldProvider` provider |
+| Flavor injection | `Params.Flavor` → `initData` (shared code) | payload-local constant (component-local) |
+| Per-process uuid | `Params.UUID` → `getPayload` (shared code) | own `Payload` struct (component-local) |
+| Empty hostname | inherited from shared `getPayload` (`hostname` from `Hostname.Get`, empty in serverless build) | own `Payload` struct, explicit `""` |
+| Skip cross-process fetch (IPC/localhost incl. trace :5012) | `Params.SkipRemoteMetadata` guard in shared `getPayload` | never had it — component only builds core + serverless fields |
+| Serverless field injection | `Params.ExtraFields`, merged in shared `getPayload` | typed `Fields` flattened in component |
+| Enablement gate | `Params.Enabled` pointer overrides the cached `util.InventoryEnabled` | `Enabled` reassigned after `CreateInventoryPayload` |
+
+### Cost of reuse (Option A), concretely
+
+The shared `inventoryagent` needed a new optional **`Params` seam** (following
+the metadata/resources `Params`/`Disabled()` and rcclient `Params` convention:
+a construction-time struct supplied by the binary and received with
+`optional:"true"`, built via `inventoryagent.NewServerlessParams`) because every
+serverless divergence lands inside shared code that the full agent also runs:
+
+- `initData` hardwired `flavor.GetFlavor()`; `getPayload` hardwired
+  `uuid.GetUUID()`, `ia.hostname`, and an unconditional `refreshMetadata()` that
+  fetches from security/process/trace/system-probe. None of that is right for
+  serverless, and none of it is reachable via the existing `Set(...)` API (which
+  only adds keys, and only after `Enabled`). So the reuse path requires editing
+  the shared component's hot path (`getPayload`) and its init, guarded by an
+  optional dependency so the full agent is unaffected.
+- The IPC dependency is dead weight: serverless has no agent processes to query,
+  so we wire `ipcfx-none` (whose `GetClient()` returns `nil`) purely to satisfy
+  the graph, then set `SkipRemoteMetadata` so the nil client is never
+  dereferenced. Option B never takes on the dependency at all.
+- `Params` is 5 knobs (`Enabled`, `Flavor`, `UUID`, `ExtraFields`,
+  `SkipRemoteMetadata`). Each exists solely to bend full-agent behavior for
+  serverless. That surface is the ongoing maintenance tax of reuse: future
+  changes to `getPayload`/`initData` must keep the param branches correct,
+  and the full-agent payload now carries an `optional` dependency it never uses.
+  (The convention keeps `resources`/`rcclient` `Params` mostly plain data;
+  ours carries more behavioral surface, which is the honest cost signal.)
+
+### Read
+
+- Option A adds **no new component** (the stated long-term preference) but pays
+  for it by threading serverless-specific behavior through the shared component
+  via a `Params` struct and taking on an unused IPC dependency. The blast
+  radius is the full agent's own metadata hot path.
+- Option B keeps all serverless logic in serverless-owned code and touches
+  shared code only for the `PopulateCoreFields` extraction (which both options
+  want anyway), at the cost of one small new component.
+- Both still need the same follow-up work regardless of choice: the config
+  schema changes for real enablement gating (`inventories_*` +
+  `serverless.inventory_enabled`), the real `GetInventoryData` derivations, and
+  the `PopulateCoreFields` contract sign-off. Neither spike did the schema work;
+  both hardcode enablement to `false`.
+
+Decision heuristic: if the `Params` seam stays at ~5 stable knobs, Option A's
+"no new component" wins. If serverless divergence keeps growing (more envelope
+differences, `hostname: null`, force-send at shutdown, RC toggling), each new
+divergence is another branch in shared full-agent code — and Option B's
+component isolation becomes the cheaper long-term maintenance story.

--- a/cmd/serverless-init/cloudservice/inventory.go
+++ b/cmd/serverless-init/cloudservice/inventory.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cloudservice
+
+// InventoryData holds the per-platform serverless fields that feed the
+// serverless-init inventory metadata payload. Each CloudService implementation
+// derives these from its own environment so the payload builder stays thin and
+// the derivation lives next to the existing tag logic.
+//
+// The zero value of every field is a valid "not applicable / unknown" value.
+// Nullable downstream columns map from empty strings here.
+type InventoryData struct {
+	// WorkloadType is the canonical workload type, e.g. cloud_run_service,
+	// cloud_run_job, cloud_function_gen2, azure_container_app,
+	// azure_app_service.
+	WorkloadType string
+
+	// ResourceID is the Canonical Cloud Resource ID (CCRID); the first
+	// component of the downstream composite key.
+	ResourceID string
+
+	// ResourceName is the platform display name (app / job / revision). It is
+	// never substituted with dd_service.
+	ResourceName string
+
+	// Region is the GCP or Azure region.
+	Region string
+
+	// GCPProjectID is set for GCP platforms; empty for Azure.
+	GCPProjectID string
+
+	// AzureSubscriptionID is set for Azure platforms; empty for GCP.
+	AzureSubscriptionID string
+
+	// GCPDeploymentType is one of Function|Source|Container|Repo; empty for
+	// non-GCP.
+	GCPDeploymentType string
+
+	// AzureHostingPlan is one of Consumption|Flex; empty for non-Azure.
+	AzureHostingPlan string
+
+	// AzureDeploymentType is one of Code|Container; empty for non-Azure.
+	AzureDeploymentType string
+
+	// WorkloadRuntime is the detected workload runtime; likely empty in
+	// sidecar mode.
+	WorkloadRuntime string
+}
+
+// GetInventoryData returns the inventory metadata fields for this cloud
+// service. The default implementation returns an empty struct; each platform
+// overrides it with real derivation.
+//
+// TODO(SVLS): derive real per-platform inventory fields.
+func (l *LocalService) GetInventoryData() InventoryData { return InventoryData{} }
+
+// GetInventoryData returns the inventory metadata fields for Cloud Run
+// (service, function).
+//
+// TODO(SVLS): derive workload_type (service vs cloud_function_gen2), CCRID,
+// region, project id, and GCP deployment type from the Cloud Run environment.
+func (c *CloudRun) GetInventoryData() InventoryData { return InventoryData{} }
+
+// GetInventoryData returns the inventory metadata fields for Cloud Run Jobs.
+//
+// TODO(SVLS): derive cloud_run_job workload_type, CCRID, region, and project id.
+func (c *CloudRunJobs) GetInventoryData() InventoryData { return InventoryData{} }
+
+// GetInventoryData returns the inventory metadata fields for Azure Container
+// Apps.
+//
+// TODO(SVLS): derive azure_container_app workload_type, CCRID, region,
+// subscription id, hosting plan, and deployment type.
+func (c *ContainerApp) GetInventoryData() InventoryData { return InventoryData{} }
+
+// GetInventoryData returns the inventory metadata fields for Azure App Service.
+//
+// TODO(SVLS): derive azure_app_service workload_type, CCRID, region,
+// subscription id, hosting plan, and deployment type.
+func (a *AppService) GetInventoryData() InventoryData { return InventoryData{} }

--- a/cmd/serverless-init/cloudservice/service.go
+++ b/cmd/serverless-init/cloudservice/service.go
@@ -83,6 +83,10 @@ type CloudService interface {
 
 	// AddStartMetric adds the start (and legacy start, if any) metric to the metric agent
 	AddStartMetric(metricAgent *serverlessMetrics.ServerlessMetricAgent)
+
+	// GetInventoryData returns the per-platform serverless fields for the
+	// inventory metadata payload.
+	GetInventoryData() InventoryData
 }
 
 //nolint:revive // TODO(SERV) Fix revive linter

--- a/cmd/serverless-init/inventory/params.go
+++ b/cmd/serverless-init/inventory/params.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+// Package inventory adapts serverless-init's cloud-platform knowledge into the
+// inventoryagent component's Params. All serverless- and platform-specific
+// derivation lives here (and in the CloudService structs it delegates to); the
+// shared inventoryagent component stays generic and only learns about
+// serverless through the typed Params contract.
+package inventory
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
+	inventoryagent "github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
+	serverlessTags "github.com/DataDog/datadog-agent/pkg/serverless/tags"
+)
+
+// serverlessFieldPrefix is applied uniformly to every serverless-specific key
+// in agent_metadata.
+const serverlessFieldPrefix = "serverless_"
+
+// BuildParams assembles the inventoryagent.Params for the detected cloud
+// service and run mode. It is supplied to the inventoryagent component via fx
+// so serverless-init can reuse the shared component. The serverless payload
+// flavor, per-process uuid, and no-cross-process-fetch defaults are encoded by
+// inventoryagent.NewServerlessParams.
+func BuildParams(cloudService cloudservice.CloudService, modeConf mode.Conf) *inventoryagent.Params {
+	return inventoryagent.NewServerlessParams(
+		inventoryEnabled(),
+		// A per-process uuid: serverless containers do not share the host
+		// machine GUID that uuid.GetUUID() returns.
+		uuid.New().String(),
+		buildExtraFields(cloudService, modeConf),
+	)
+}
+
+// inventoryEnabled reports whether serverless-init inventory emission is on. It
+// is disabled by default while the feature ramps.
+//
+// TODO(SVLS): gate on util.InventoryEnabled + a serverless-scoped config key
+// (DD_SERVERLESS_INIT_INVENTORY_ENABLED) once those keys are added to the
+// serverless config schema. Kept as a hardcoded false here so the spike stays
+// at the same "wired but off by default" bar as the serverlessinventory spike.
+func inventoryEnabled() bool {
+	return false
+}
+
+// buildExtraFields flattens the per-platform inventory data and process-level
+// serverless context into the prefixed agent_metadata keys.
+func buildExtraFields(cloudService cloudservice.CloudService, modeConf mode.Conf) map[string]interface{} {
+	inv := cloudService.GetInventoryData()
+
+	fields := map[string]interface{}{
+		"serverless_init_version": serverlessTags.GetExtensionVersion(),
+
+		"resource_id":   inv.ResourceID,
+		"resource_name": inv.ResourceName,
+		"workload_type": inv.WorkloadType,
+
+		"region":                inv.Region,
+		"gcp_project_id":        inv.GCPProjectID,
+		"azure_subscription_id": inv.AzureSubscriptionID,
+
+		"deployment_model":      deploymentModel(modeConf),
+		"gcp_deployment_type":   inv.GCPDeploymentType,
+		"azure_hosting_plan":    inv.AzureHostingPlan,
+		"azure_deployment_type": inv.AzureDeploymentType,
+		"workload_runtime":      inv.WorkloadRuntime,
+	}
+
+	prefixed := make(map[string]interface{}, len(fields))
+	for key, value := range fields {
+		prefixed[serverlessFieldPrefix+key] = value
+	}
+	return prefixed
+}
+
+// deploymentModel maps the run mode to the downstream deployment_model value.
+func deploymentModel(modeConf mode.Conf) string {
+	if modeConf.SidecarMode {
+		return "sidecar"
+	}
+	return "in-container"
+}

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -52,13 +52,22 @@ import (
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
+	inventoryagent "github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
+	inventoryagentfx "github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/fx"
+	runner "github.com/DataDog/datadog-agent/comp/metadata/runner/def"
+	runnerfx "github.com/DataDog/datadog-agent/comp/metadata/runner/fx"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
 
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
 	enhancedmetrics "github.com/DataDog/datadog-agent/cmd/serverless-init/enhanced-metrics"
+	serverlessInitInventory "github.com/DataDog/datadog-agent/cmd/serverless-init/inventory"
 	serverlessInitTag "github.com/DataDog/datadog-agent/cmd/serverless-init/tag"
+	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx-none"
+	sysprobeconfig "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/def"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -70,6 +79,7 @@ import (
 	tracelog "github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
 const datadogConfigPath = "datadog.yaml"
@@ -308,6 +318,25 @@ func main() {
 		fx.Provide(func() cloudservice.CloudService { return cloudService }),
 		fx.Supply(tagConfig),
 		fx.Supply(metricTags),
+		// Inventory metadata via the shared inventoryagent component + runner.
+		// Three of the component's six deps are not in serverless-init's fx
+		// graph, so they are adapted here:
+		//   - MetricSerializer is reached through the demultiplexer rather than
+		//     as a distinct fx type.
+		//   - ipc.HTTPClient comes from the noop IPC component; it is unused
+		//     because the Params skip remote-process metadata fetching.
+		//   - the sysprobeconfig option has no provider, so supply None.
+		// The Params adapt enablement, flavor, uuid, extra fields, and remote
+		// fetching for the serverless environment.
+		fx.Provide(func(d aggregator.Demultiplexer) serializer.MetricSerializer { return d.Serializer() }),
+		ipcfx.Module(),
+		fx.Provide(func(c ipc.Component) ipc.HTTPClient { return c.GetClient() }),
+		fx.Provide(func() option.Option[sysprobeconfig.Component] { return option.None[sysprobeconfig.Component]() }),
+		fx.Provide(func(cs cloudservice.CloudService) *inventoryagent.Params {
+			return serverlessInitInventory.BuildParams(cs, modeConf)
+		}),
+		runnerfx.Module(),
+		inventoryagentfx.Module(),
 		delegatedauthfx.Module(),
 		healthplatform.Bundle(),
 		fx.Provide(func(config coreconfig.Component) healthprobeDef.Options {
@@ -368,6 +397,10 @@ func run(
 	cloudService cloudservice.CloudService,
 	tagConfig tagConfiguration,
 	metricTags metrics.Tags,
+	// Requested so Fx constructs the metadata runner (which starts its
+	// lifecycle collection loop) and the inventoryagent component that feeds it.
+	_ runner.Component,
+	_ inventoryagent.Component,
 ) error {
 	cloudService, logConfig, tracingCtx, metricAgent, logsAgent, enhancedMetricsCollector, enhancedMetricsEnabled := setup(
 		secretComp, delegatedAuthComp, modeConf, tagger, logsCompression, hostname,

--- a/comp/metadata/internal/util/core_fields.go
+++ b/comp/metadata/internal/util/core_fields.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package util
+
+import (
+	"slices"
+
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// installinfoGet is a package var so tests can stub it.
+var installinfoGet = installinfo.Get
+
+// PopulateCoreFields sets the subset of agent-metadata fields required for a
+// payload to be recognized and processed as an agent-metadata payload by the
+// inventory pipeline. It populates only fields with no cross-process
+// dependency; callers layer their own component-specific and config-fetched
+// fields on top.
+//
+// It lives here, in the shared inventory util package, so both the core-agent
+// inventoryagent component and the serverlessinventory component have one
+// source of truth without the serverless component importing the core-agent
+// component's cross-process machinery.
+//
+// flavor is a parameter rather than flavor.GetFlavor() so a caller can emit a
+// payload flavor (e.g. "serverless-init") without changing the process-global
+// flavor, which the aggregator captures once for its heartbeat metric.
+//
+// hostnameSource is only recorded when non-empty: callers with no resolvable
+// host (serverless) pass "" and the key is omitted, matching the core agent's
+// conditional behavior.
+func PopulateCoreFields(data map[string]interface{}, conf model.Reader, flavor string, hostnameSource string) {
+	tool := "undefined"
+	toolVersion := ""
+	installerVersion := ""
+
+	install, err := installinfoGet(conf)
+	if err == nil {
+		tool = install.Tool
+		toolVersion = install.ToolVersion
+		installerVersion = install.InstallerVersion
+	}
+	data["install_method_tool"] = tool
+	data["install_method_tool_version"] = toolVersion
+	data["install_method_installer_version"] = installerVersion
+
+	if hostnameSource != "" {
+		data["hostname_source"] = hostnameSource
+	}
+
+	data["agent_version"] = version.AgentVersion
+	data["package_version"] = version.AgentPackageVersion
+	data["agent_startup_time_ms"] = conf.StartTime().UnixMilli()
+	data["flavor"] = flavor
+
+	infraMode, _ := scrubber.ScrubString(conf.GetString("infrastructure_mode"))
+	// fleet-automation: This validation should be done by the Config once we have such mechanism
+	if !slices.Contains([]string{"full", "end_user_device", "basic", "cloud_cost_only", "none"}, infraMode) {
+		log.Warnf("invalid value for 'infrastructure_mode': '%s' (defaulting to 'full')", infraMode)
+		infraMode = "full"
+	}
+	data["infrastructure_mode"] = infraMode
+}

--- a/comp/metadata/internal/util/core_fields_test.go
+++ b/comp/metadata/internal/util/core_fields_test.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package util
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
+)
+
+func TestPopulateCoreFieldsInstallInfo(t *testing.T) {
+	defer func() { installinfoGet = installinfo.Get }()
+
+	conf := configmock.New(t)
+
+	installinfoGet = func(model.Reader) (*installinfo.InstallInfo, error) {
+		return nil, errors.New("some error")
+	}
+	data := map[string]interface{}{}
+	PopulateCoreFields(data, conf, "agent", "")
+	assert.Equal(t, "undefined", data["install_method_tool"])
+	assert.Equal(t, "", data["install_method_tool_version"])
+	assert.Equal(t, "", data["install_method_installer_version"])
+
+	installinfoGet = func(model.Reader) (*installinfo.InstallInfo, error) {
+		return &installinfo.InstallInfo{
+			Tool:             "test_tool",
+			ToolVersion:      "1.2.3",
+			InstallerVersion: "4.5.6",
+		}, nil
+	}
+	data = map[string]interface{}{}
+	PopulateCoreFields(data, conf, "agent", "")
+	assert.Equal(t, "test_tool", data["install_method_tool"])
+	assert.Equal(t, "1.2.3", data["install_method_tool_version"])
+	assert.Equal(t, "4.5.6", data["install_method_installer_version"])
+}
+
+func TestPopulateCoreFieldsFlavorAndHostnameSource(t *testing.T) {
+	conf := configmock.New(t)
+
+	// hostnameSource is omitted when empty and recorded when set; flavor is
+	// injected verbatim.
+	data := map[string]interface{}{}
+	PopulateCoreFields(data, conf, "serverless-init", "")
+	assert.Equal(t, "serverless-init", data["flavor"])
+	_, ok := data["hostname_source"]
+	assert.False(t, ok)
+
+	data = map[string]interface{}{}
+	PopulateCoreFields(data, conf, "agent", "gce")
+	assert.Equal(t, "agent", data["flavor"])
+	assert.Equal(t, "gce", data["hostname_source"])
+}

--- a/comp/metadata/inventoryagent/def/component.go
+++ b/comp/metadata/inventoryagent/def/component.go
@@ -16,3 +16,73 @@ type Component interface {
 	// Get returns a copy of the agent metadata. Useful to be incorporated in the status page.
 	Get() map[string]interface{}
 }
+
+// serverlessInitFlavor is the payload flavor emitted by serverless-init. It
+// carries the dash intentionally and is injected only into the payload (via
+// Params.Flavor). serverless-init does not change the process-global flavor
+// (flavor.SetFlavor), which stays "agent": the aggregator captures the flavor
+// once at construction for the datadog.<flavor>.running / .up heartbeat metric
+// and service check, so renaming it process-wide would break agent-host
+// identification and existing monitors.
+const serverlessInitFlavor = "serverless-init"
+
+// Params lets an embedding binary adapt the inventoryagent component for an
+// environment that diverges from the standard full-agent one (currently:
+// serverless-init). It is supplied as an optional fx dependency; binaries that
+// do not provide it get the standard full-agent behavior.
+//
+// This mirrors the metadata/resources component's optional Params (see
+// resourcesimpl.Params / Disabled()) and rcclient's Params: a construction-time
+// struct, supplied by the binary and received with `optional:"true"`, whose
+// fields select which code paths the constructor takes.
+//
+// Each field exists because reusing the full-agent component in serverless
+// surfaced a concrete divergence:
+//   - Enabled: the component's enablement is normally derived from
+//     util.InventoryEnabled (inventories_enabled + enable_metadata_collection),
+//     keys that are absent from the serverless config schema. A caller with its
+//     own enablement gate sets this pointer to force the value.
+//   - Flavor: initData normally hardwires flavor.GetFlavor() ("agent").
+//     serverless must emit "serverless-init" in the payload without changing the
+//     process-global flavor (which the aggregator captures for its heartbeat
+//     metric), so it overrides just the payload value.
+//   - UUID: getPayload normally uses uuid.GetUUID() (the cached host machine
+//     GUID), which is meaningless across serverless containers. A caller can
+//     supply a per-process UUID instead.
+//   - ExtraFields: additional agent_metadata keys layered into every payload
+//     (serverless injects its cloud-platform fields here rather than through
+//     Set, so they are present on the very first payload).
+//   - SkipRemoteMetadata: the full-agent payload fetches config from the
+//     security/process/trace/system-probe processes over IPC/localhost. None of
+//     those run alongside serverless-init, so a caller can skip that phase.
+type Params struct {
+	// Enabled, when non-nil, forces the component's Enabled flag instead of
+	// deriving it from util.InventoryEnabled.
+	Enabled *bool
+	// Flavor, when non-empty, is the payload flavor value (e.g.
+	// "serverless-init") used in place of flavor.GetFlavor().
+	Flavor string
+	// UUID, when non-empty, is the payload uuid used in place of
+	// uuid.GetUUID().
+	UUID string
+	// ExtraFields are additional agent_metadata keys merged into every payload.
+	ExtraFields map[string]interface{}
+	// SkipRemoteMetadata skips fetching metadata from other agent processes
+	// (security/process/trace/system-probe) when true.
+	SkipRemoteMetadata bool
+}
+
+// NewServerlessParams builds the Params that configure the inventoryagent
+// component for serverless-init: the serverless-init payload flavor, a
+// per-process uuid, no cross-process metadata fetching, and the supplied
+// enablement and extra fields. It encodes the serverless defaults the same way
+// resourcesimpl.Disabled() encodes a specific resources configuration.
+func NewServerlessParams(enabled bool, processUUID string, extraFields map[string]interface{}) *Params {
+	return &Params{
+		Enabled:            &enabled,
+		Flavor:             serverlessInitFlavor,
+		UUID:               processUUID,
+		ExtraFields:        extraFields,
+		SkipRemoteMetadata: true,
+	}
+}

--- a/comp/metadata/inventoryagent/impl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/impl/inventoryagent.go
@@ -12,7 +12,6 @@ import (
 	"maps"
 	"net/http"
 	"reflect"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -27,6 +26,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	sysprobeconfig "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
 	"github.com/DataDog/datadog-agent/comp/metadata/internal/util"
 	iainterface "github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
 	runnerdef "github.com/DataDog/datadog-agent/comp/metadata/runner/def"
@@ -42,16 +42,13 @@ import (
 	ecsmeta "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
-	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 	"github.com/DataDog/datadog-agent/pkg/util/uuid"
-	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 var (
 	// for testing
-	installinfoGet      = installinfo.Get
 	fetchSecurityConfig = configFetcher.SecurityAgentConfig
 	fetchProcessConfig  = func(cfg model.Reader, client ipc.HTTPClient) (string, error) {
 		return configFetcher.ProcessAgentConfig(cfg, client, true)
@@ -79,24 +76,34 @@ func (p *Payload) MarshalJSON() ([]byte, error) {
 type inventoryagent struct {
 	util.InventoryPayload
 
-	log          log.Component
-	conf         config.Component
-	hostnameComp hostnameinterface.Component
-	sysprobeConf option.Option[sysprobeconfig.Component]
-	m            sync.Mutex
-	data         agentMetadata
-	hostname     string
-	client       ipc.HTTPClient
+	log                log.Component
+	conf               config.Component
+	hostnameComp       hostnameinterface.Component
+	sysprobeConf       option.Option[sysprobeconfig.Component]
+	m                  sync.Mutex
+	data               agentMetadata
+	hostname           string
+	client             ipc.HTTPClient
+	flavorName         string
+	uuidValue          string
+	extraFields        map[string]interface{}
+	skipRemoteMetadata bool
 }
 
 // Requires defines the dependencies for the inventoryagent component
 type Requires struct {
+	compdef.In
+
 	Log            log.Component
 	Config         config.Component
 	SysProbeConfig option.Option[sysprobeconfig.Component]
 	Serializer     serializer.MetricSerializer
 	IPCClient      ipc.HTTPClient
 	Hostname       hostnameinterface.Component
+	// Params is optional. When absent the component uses standard full-agent
+	// behavior; serverless-init supplies it (via NewServerlessParams) to adapt
+	// enablement, flavor, uuid, extra fields, and remote-metadata fetching.
+	Params *iainterface.Params `optional:"true"`
 }
 
 // Provides defines the output of the inventoryagent component
@@ -119,8 +126,11 @@ func NewComponent(deps Requires) Provides {
 		hostname:     hname,
 		data:         make(agentMetadata),
 		client:       deps.IPCClient,
+		flavorName:   flavor.GetFlavor(),
 	}
 	ia.InventoryPayload = util.CreateInventoryPayload(deps.Config, deps.Log, deps.Serializer, ia.getPayload, "agent.json")
+
+	applyParams(ia, deps.Params)
 
 	if ia.Enabled {
 		ia.initData()
@@ -145,41 +155,17 @@ func scrub(s string) string {
 }
 
 func (ia *inventoryagent) initData() {
-	tool := "undefined"
-	toolVersion := ""
-	installerVersion := ""
-
-	install, err := installinfoGet(ia.conf)
-	if err == nil {
-		tool = install.Tool
-		toolVersion = install.ToolVersion
-		installerVersion = install.InstallerVersion
-	}
-	ia.data["install_method_tool"] = tool
-	ia.data["install_method_tool_version"] = toolVersion
-	ia.data["install_method_installer_version"] = installerVersion
-
+	hostnameSource := ""
 	data, err := ia.hostnameComp.GetWithProvider(context.Background())
 	if err == nil {
 		if data.Provider != "" && !data.FromFargate() {
-			ia.data["hostname_source"] = data.Provider
+			hostnameSource = data.Provider
 		}
 	} else {
 		ia.log.Warnf("could not fetch 'hostname_source': %v", err)
 	}
 
-	ia.data["agent_version"] = version.AgentVersion
-	ia.data["package_version"] = version.AgentPackageVersion
-	ia.data["agent_startup_time_ms"] = ia.conf.StartTime().UnixMilli()
-	ia.data["flavor"] = flavor.GetFlavor()
-
-	infraMode := scrub(ia.conf.GetString("infrastructure_mode"))
-	// fleet-automation: This validation should be done by the Config once we have such mechanism
-	if !slices.Contains([]string{"full", "end_user_device", "basic", "cloud_cost_only", "none"}, infraMode) {
-		ia.log.Warnf("invalid value for 'infrastructure_mode': '%s' (defaulting to 'full')", infraMode)
-		infraMode = "full"
-	}
-	ia.data["infrastructure_mode"] = infraMode
+	util.PopulateCoreFields(ia.data, ia.conf, ia.flavorName, hostnameSource)
 }
 
 type configGetter interface {
@@ -529,11 +515,14 @@ func (ia *inventoryagent) getPayload() marshaler.JSONMarshaler {
 	ia.m.Lock()
 	defer ia.m.Unlock()
 
-	ia.refreshMetadata()
+	if !ia.skipRemoteMetadata {
+		ia.refreshMetadata()
+	}
 
 	// Create a static copy of agentMetadata for the payload
 	data := make(agentMetadata)
 	maps.Copy(data, ia.data)
+	maps.Copy(data, ia.extraFields)
 
 	ia.getConfigs(data)
 
@@ -541,8 +530,34 @@ func (ia *inventoryagent) getPayload() marshaler.JSONMarshaler {
 		Hostname:  ia.hostname,
 		Timestamp: time.Now().UnixNano(),
 		Metadata:  data,
-		UUID:      uuid.GetUUID(),
+		UUID:      ia.payloadUUID(),
 	}
+}
+
+// applyParams adapts the component for a non-standard embedding binary (see
+// iainterface.Params). It is a no-op when params is nil.
+func applyParams(ia *inventoryagent, params *iainterface.Params) {
+	if params == nil {
+		return
+	}
+	if params.Enabled != nil {
+		ia.Enabled = *params.Enabled
+	}
+	if params.Flavor != "" {
+		ia.flavorName = params.Flavor
+	}
+	ia.uuidValue = params.UUID
+	ia.extraFields = params.ExtraFields
+	ia.skipRemoteMetadata = params.SkipRemoteMetadata
+}
+
+// payloadUUID returns the per-process uuid override when set, otherwise the
+// cached host machine GUID used by the full agent.
+func (ia *inventoryagent) payloadUUID() string {
+	if ia.uuidValue != "" {
+		return ia.uuidValue
+	}
+	return uuid.GetUUID()
 }
 
 // Get returns a copy of the agent metadata. Useful to be incorporated in the status page.

--- a/comp/metadata/inventoryagent/impl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/impl/inventoryagent_test.go
@@ -38,7 +38,6 @@ import (
 	sysprobecfg "github.com/DataDog/datadog-agent/pkg/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -110,33 +109,6 @@ func TestGetPayload(t *testing.T) {
 	assert.True(t, payload.Timestamp > startTime)
 	assert.Equal(t, "hostname-for-test", payload.Hostname)
 	assert.Equal(t, 1234, payload.Metadata["test"])
-}
-
-func TestInitDataErrorInstallInfo(t *testing.T) {
-	defer func() { installinfoGet = installinfo.Get }()
-	installinfoGet = func(config.Reader) (*installinfo.InstallInfo, error) {
-		return nil, errors.New("some error")
-	}
-
-	ia := getTestInventoryPayload(t, nil, nil)
-
-	ia.initData()
-	assert.Equal(t, "undefined", ia.data["install_method_tool"])
-	assert.Equal(t, "", ia.data["install_method_tool_version"])
-	assert.Equal(t, "", ia.data["install_method_installer_version"])
-
-	installinfoGet = func(config.Reader) (*installinfo.InstallInfo, error) {
-		return &installinfo.InstallInfo{
-			Tool:             "test_tool",
-			ToolVersion:      "1.2.3",
-			InstallerVersion: "4.5.6",
-		}, nil
-	}
-
-	ia.initData()
-	assert.Equal(t, "test_tool", ia.data["install_method_tool"])
-	assert.Equal(t, "1.2.3", ia.data["install_method_tool_version"])
-	assert.Equal(t, "4.5.6", ia.data["install_method_installer_version"])
 }
 
 func TestInitData(t *testing.T) {


### PR DESCRIPTION
### What does this PR 
Wires the things we need for submitting serverless-init data into the existing upstream inventory agent.

### Motivation
We'd like to see if working with the existing inventory agent would be okay for serverless-init (this PR) or if we can create our own, more focused component (other PR https://github.com/DataDog/datadog-agent/pull/55325).

### Describe how you validated your changes
No live validation yet. This PR is intended as a draft for us to compare to the other one before we decide on an approach.

### Additional Notes
@nina9753 's original prototype PRs: https://github.com/DataDog/datadog-agent/pull/54537 , https://github.com/DataDog/datadog-agent/pull/54538 , https://github.com/DataDog/datadog-agent/pull/54543