### PR TITLE
SVLS-9645: [spike] serverless logic in our own inventory component

### DIFF
--- a/cmd/serverless-init/INVENTORY_METADATA_PLAN.md
+++ b/cmd/serverless-init/INVENTORY_METADATA_PLAN.md
@@ -1,0 +1,380 @@
+# Plan: serverless-init inventory metadata collection
+
+Status: planning — no implementation started.
+
+## Goal
+
+Emit `inventoryagent`-style metadata from serverless-init to the existing
+inventory intake (`serializer.SendMetadata` → `Forwarder.SubmitMetadata` →
+`datadog_agent` endpoint), tagged with a `serverless-init` flavor so the
+downstream metadata extractor can route serverless-specific fields into
+separate serverless tables.
+
+Design principles:
+- Keep coupling to the shared inventory code minimal and *deliberate*.
+- Keep serverless-specific logic in `cmd/serverless-init`.
+- Even if we build our own component, do **not** drift from the normal agent
+  metadata pipeline for the fields the pipeline requires (see
+  `PopulateCoreFields` below).
+
+## Key findings that constrain the design
+
+1. **Submission plumbing already exists.** serverless-init wires a forwarder +
+   demultiplexer, so `demux.Serializer().SendMetadata(payload)` is available
+   today. No new transport work.
+2. **The metadata runner and `inventoryagent` are not wired into
+   serverless-init.** Whatever we build must supply its own periodic trigger
+   (or reuse `comp/metadata/runner`).
+3. **Config-schema split.** `inventories_enabled`,
+   `inventories_first_run_delay`, `inventories_min_interval`,
+   `inventories_max_interval` are tagged `full-agent-only:true` and are
+   generated only into `initCoreAgentFull`. serverless-init's config init
+   (`pkg/config/setup/config_init_serverless.go`) calls **only
+   `initCommonBase`**, so those keys **do not exist in the serverless config
+   schema**. `enable_metadata_collection` **is** in the common base and present;
+   `inventories_configuration_enabled` is also tagged `full-agent-only:true`
+   and is therefore **absent** from the serverless schema too.
+   Reading a key absent from the serverless schema logs `config key <x> is
+   unknown` and returns the zero value, so any key we rely on must be declared
+   in the serverless schema. `fixupInitServerlessOnlyComponents` documents an
+   explicit philosophy: *"the same config must be compatible with any Agent no
+   matter its version."* Serverless-only config additions are reviewed against
+   this rule.
+4. **Flavor is process-global, set once at startup** via
+   `flavor.SetFlavor(...)`. serverless-init never calls it (defaults to
+   `"agent"`), and `serverless-init` is not a registered flavor constant (only
+   `serverless_agent` exists). Crucially, `NewBufferedAggregator` captures
+   `flavor.GetFlavor()` **once at construction** and uses it for the
+   `datadog.<flavor>.running` / `datadog.<flavor>.up` heartbeat metric and
+   service check (`pkg/aggregator/aggregator.go`). Calling
+   `SetFlavor("serverless-init")` process-wide would rename those to
+   `datadog.serverless-init.running` / `.up` (a dash in a metric name, and a
+   break in agent-host identification / existing monitors). So we must NOT set
+   the flavor process-wide; the payload's `flavor` value is injected locally
+   instead (see Flavor section).
+5. **First-run delay rationale.** The 60s `inventories_first_run_delay` default
+   orders inventory after host-tags/host metadata. serverless-init pulls in
+   none of that, so an effective delay of 0 with an early first send is sound.
+
+## Central shared seam: `PopulateCoreFields`
+
+To resist drift from the normal agent pipeline regardless of the reuse-vs-new
+decision, we extract a shared method in the `inventoryagent` component
+(`comp/metadata/inventoryagent/impl`) that populates **only** the fields
+required for a payload to be recognized and processed as an agent-metadata
+payload. Both the core-agent component and the serverless builder call it, and
+the core agent's `initData` is refactored to call it so there is a single
+source of truth. It must not pull in cross-process fetchers
+(security/process/trace/system-probe) or config dumps. We may relocate it to a
+shared helper package later; starting in the component keeps the refactor
+local.
+
+Because `initData` sets `flavor` from `flavor.GetFlavor()` but serverless must
+emit `serverless-init` **without** changing the process-global flavor (see Key
+finding #4), `PopulateCoreFields` must take the flavor value as a parameter (or
+the caller overrides `data["flavor"]` afterward) rather than hardwiring
+`flavor.GetFlavor()`. The core agent passes `flavor.GetFlavor()`; serverless
+passes `"serverless-init"`.
+
+Candidate source of truth is today's `inventoryagent.initData()`, which already
+contains exactly the no-cross-process-dependency core fields: `agent_version`,
+`package_version`, `agent_startup_time_ms`, `flavor`, `hostname_source`,
+`infrastructure_mode`, `install_method_tool`, `install_method_tool_version`,
+`install_method_installer_version`. (`hostname_source` is set conditionally —
+only when a hostname provider resolves and it is not Fargate — so it may be
+absent; in serverless with no host it will typically be omitted.)
+
+Open: the exact required set is a downstream contract to confirm with the
+pipeline owners (`PopulateCoreFields` should contain the minimal set the
+pipeline requires, not necessarily all of `initData`), and whether it is an
+exported method on the component or a package-level function operating on the
+`agent_metadata` map.
+
+## Reuse vs. new component (Phase 1 decision)
+
+Both options reuse `PopulateCoreFields` so neither drifts on core fields. We
+build both to a "compiles + emits a payload to a local fakeintake" level, then
+compare and pick one. Current lean is Option B.
+
+### Option A — Reuse the existing `inventoryagent` component
+- Needs (fx graph): three of the six `Requires` are NOT in the serverless-init
+  graph today and would fail construction:
+  - `serializer.MetricSerializer` is only reachable via `demux.Serializer()`,
+    not as an fx type — needs an adapter
+    `fx.Provide(func(d aggregator.Demultiplexer) serializer.MetricSerializer { return d.Serializer() })`.
+  - `ipc.HTTPClient` is not provided — pulls in IPC auth-token/cert
+    bootstrapping serverless-init does not set up.
+  - `option.Option[sysprobeconfig.Component]` needs an explicit
+    `option.None[...]()` provider (the wrapper does not make it optional).
+- Needs (behavior): wire `comp/metadata/runner` (nothing calls `collect()`
+  otherwise), and add the `inventories_*` keys to the serverless schema.
+- Risks:
+  - **Cached enablement ignores the ramp gate.** `CreateInventoryPayload`
+    caches `Enabled = InventoryEnabled(conf)` at construction and `collect()`
+    never re-checks. The stock component never consults
+    `serverless.inventory_enabled`, so Option A would emit **by default**
+    (both underlying keys default true), violating disabled-by-default.
+    Bespoke gating would be needed, eroding the reuse benefit.
+  - **`refreshMetadata()` hits localhost.** Its trace fetcher targets the APM
+    debug port (5012), which serverless-init actually runs, adding real
+    round-trip latency to every payload build; the others fail fast and fall
+    back to local config (safe but meaningless). Gating requires shared-code
+    edits inside `refreshMetadata`/the fetchers.
+  - **Per-process uuid / empty hostname** require editing the shared
+    `getPayload`/`Payload` struct (it hardcodes `uuid.GetUUID()`), a shared-code
+    hook.
+  - Serverless fields still injected via `Set(...)`; more shared-code coupling.
+- Benefit: automatic parity with future core-agent inventory fields.
+
+### Option B — New serverless-init-local payload reusing `PopulateCoreFields` + `util.InventoryPayload`
+- Needs: a small builder in `cmd/serverless-init` that calls
+  `PopulateCoreFields`, layers serverless fields, embeds
+  `util.InventoryPayload` (or calls `SendMetadata` directly with our own
+  scheduling), and registers a periodic trigger.
+- Risks: we own any schema drift beyond the shared core fields.
+- Benefit: no changes to shared `inventoryagent` behavior; only serverless-
+  relevant fields; simplest deps; logic stays in serverless-init. Best fit for
+  "minimal hooks."
+
+Each sketch must answer: (a) enablement/intervals given the missing config
+keys, (b) how the `serverless-init` flavor is set, (c) how serverless fields +
+resource id are injected, (d) how first-send/scheduling works, (e) exactly
+which lines of shared code change.
+
+## Serverless field derivation: delegate to the CloudService structs
+
+The per-platform serverless fields (workload_type, resource_id, resource_name,
+region, gcp/azure specifics, workload_runtime, deployment types) are derived
+inside the `cmd/serverless-init/cloudservice` implementations rather than in the
+payload builder. Each platform already has its own struct (CloudRun,
+CloudRunJobs, ContainerApp, AppService, ...) that knows how to read its
+environment; keeping the inventory derivation there co-locates it with the
+existing tag logic and keeps the payload builder thin.
+
+- The `CloudService` interface gains the inventory-relevant accessors, most
+  likely a single method returning an inventory struct so new fields don't
+  churn the interface. The payload builder calls it and maps the result into
+  `agent_metadata`.
+- `workload_type`, `resource_id` (CCRID), and the workload-specific fields
+  (gcp/azure deployment type, hosting plan, runtime) all live on the struct
+  that owns that platform's environment.
+
+## Field set
+
+The downstream table's tentative columns and their agent-side sources are
+below. The per-platform ones come from the CloudService structs (above).
+
+All serverless fields sit as flat keys in the `agent_metadata` map, each with a
+`serverless_` prefix applied uniformly (e.g. `serverless_resource_id`,
+`serverless_workload_type`, `serverless_region`, `serverless_dd_env`). A nested
+`serverless` object is out of scope for now. `serverless_agent_version_base`
+duplicates the core `agent_version` value into the prefixed key; the init
+version is intentionally double-prefixed as `serverless_serverless_init_version`.
+
+`last_seen_at` is not an agent field: it is derived downstream from the existing
+payload `timestamp`.
+
+**Payload envelope** (the `Payload` fields outside `agent_metadata`):
+- `hostname`: empty, and this happens **for free** in serverless builds —
+  `pkg/util/hostname/providers_serverless.go` (`//go:build serverless`) makes
+  `Hostname.Get()` return `""` regardless of `DD_HOSTNAME=none`, so the payload
+  serializes `"hostname": ""` with no extra work. Emitting JSON `null` instead
+  would require a pointer/omit field in the payload struct (only ours to change
+  cleanly under Option B); the extractor's preference is still open.
+- `uuid`: a per-process UUID generated at startup (`uuid.New().String()`), not
+  the shared `uuid.GetUUID()` (that returns the cached host machine GUID, which
+  is not per-process and is meaningless across serverless containers).
+- `timestamp`: as today; the downstream `last_seen_at` derives from it.
+
+**Core lineage:**
+- `agent_version_base` <- `version.AgentVersion` (the core `agent_version`,
+  duplicated into `serverless_agent_version_base`).
+- `agent_commit` <- `version.Commit`. Not in the core payload today; added to
+  the serverless fields.
+- `serverless_init_version` (REQUIRED, gating) <- `tags.GetExtensionVersion()`
+  (`currentExtensionVersion`). The serverless-init build system always injects
+  a real value, so no defensive handling is needed here.
+
+**Identity / composite key:**
+- `resource_id` (REQUIRED CCRID, first key component) <- CloudService. CCRID
+  composition/format to be specified. Multiple agents may share a resource id
+  where the rest of the data is identical.
+- `resource_name` (REQUIRED) <- CloudService display name (app/job/revision).
+  Never substitute `dd_service`.
+- `workload_type` (REQUIRED) <- CloudService method. Existing `CloudRunType`
+  enum is service/function/job; each struct maps to the canonical values
+  (`cloud_run_service`, `cloud_run_job`, `cloud_function_gen2`,
+  `azure_container_app`, `azure_app_service`), incl. gen2 and Azure types.
+
+**Location:**
+- `region` <- CloudService (GCP or Azure region).
+- `gcp_project_id` (nullable) <- GCP env; NULL for Azure.
+- `azure_subscription_id` (nullable) <- Azure env/tags (subscription id already
+  surfaces in `serverlessProfileTags`); NULL for GCP.
+
+**Deployment shape:**
+- `deployment_model` <- `mode.Conf.SidecarMode` -> `sidecar` / `in-container`.
+- `gcp_deployment_type` (nullable) <- CloudService (Function|Source|Container|Repo).
+- `azure_hosting_plan` (nullable) <- CloudService (Consumption|Flex).
+- `azure_deployment_type` (nullable) <- CloudService (Code|Container).
+- `workload_runtime` (nullable) <- CloudService; likely NULL for sidecar.
+- `wrapped_command` (nullable, internal only) <- wrapped workload command
+  (`os.Args[1:]` in init mode); NULL in sidecar mode.
+
+**DD_* passthrough (all nullable):**
+- `dd_env` <- config `env` / `DD_ENV`.
+- `dd_site` <- config `site` / `DD_SITE`.
+- `dd_version` <- `DD_VERSION`.
+- `dd_service` <- `DD_SERVICE` (distinct from `resource_name`).
+
+Note: `env` and `site` are real config keys, but there are **no** `version` /
+`service` config keys (`DD_VERSION` / `DD_SERVICE` are in the `knownVars`
+"used by the agent but not via the Config struct" list). Read those two from
+the env vars directly (as `tag.GetBaseTagsMap` already does) or from the
+already-computed `tagConfig.Tags` map (keys `service` / `version`) — not via
+`conf.GetString("service"/"version")`, which would return empty and log an
+unknown-key warning.
+
+## Flavor
+
+The payload's `flavor` field carries `serverless-init` (with the dash), injected
+locally via `PopulateCoreFields`' flavor parameter. We do **not** call
+`flavor.SetFlavor` process-wide: the aggregator would otherwise rename the
+`datadog.<flavor>.running` / `.up` heartbeat metric and service check (Key
+finding #4), and `flavor=="agent"` gates elsewhere would change. Registering a
+`serverless-init` constant in `pkg/util/flavor` is optional/cosmetic (only
+affects `GetHumanReadableFlavor`, which would otherwise show "Unknown Agent")
+and is not required for the payload.
+
+## Scheduling / early send / shutdown
+
+The payload content does not change between sends, so a single successful send
+per process lifetime is sufficient.
+
+- Effective first-run delay = 0; send the first payload as early as the process
+  has enough data.
+- Sending is non-blocking during the run: we do not want to hold up the
+  customer's workload or the rest of serverless-init on metadata delivery.
+- At shutdown, check that at least one send has occurred. If one already has,
+  do nothing (no blocking final flush). If none has, attempt a best-effort
+  final send within the shutdown budget.
+- No "force send" retry loop for short-lived workloads in v1 — revisit only if
+  e2e shows the at-least-one-send guarantee is unreliable for Cloud Run Jobs /
+  very short containers.
+
+Trigger mechanism: serverless-init does not wire `comp/metadata/runner`, and
+`InventoryPayload.collect()` is unexported. So we either wire the runner, or
+drive sends ourselves by calling `demux.Serializer().SendMetadata(getPayload())`
+directly. Driving it ourselves bypasses the util's `firstRunDelay` / interval /
+`forceRefresh` ordering, which only exists to avoid a backend host-creation
+race that does not apply to serverless (no host-metadata pipeline) — so the
+bypass is acceptable and gives us direct control over the early send and the
+non-blocking / at-least-one-send behavior. Note the util's serializer-nil skip
+is dead code here: `demux.Serializer()` is always non-nil, so send suppression
+must come from the enablement gate, not from a missing serializer.
+
+## Config / enablement
+
+Requirements: (1) disabled by default initially, flipped to enabled-by-default
+later once volume is validated, on a serverless ramp independent of the full
+agent; (2) respect user intent to turn inventory off; (3) minimize drift from
+`util.InventoryEnabled`; (4) honor the "same key = same meaning/default across
+all agents" philosophy in `fixupInitServerlessOnlyComponents`.
+
+Enablement gate (parity key + serverless ramp gate):
+- `inventories_enabled` is added to the serverless schema keeping default
+  `true` everywhere, and we reuse `util.InventoryEnabled` for parity
+  (= `enable_metadata_collection && inventories_enabled`, both present).
+- A new serverless-scoped ramp gate `serverless.inventory_enabled` is nested
+  under the existing `serverless:` schema section, with env var
+  `DD_SERVERLESS_INIT_INVENTORY_ENABLED` (matching the existing
+  `DD_SERVERLESS_INIT_*` convention), **default `false`** initially, flipped to
+  `true` at GA (the key can remain as a permanent feature toggle). This gate is
+  legitimately serverless-only because it gates a serverless-only feature's
+  availability, not the behavior of a shared setting.
+- Emission = `util.InventoryEnabled(conf) && conf.GetBool("serverless.inventory_enabled")`.
+  The stock component's `Enabled` is cached once in `CreateInventoryPayload`
+  and never re-checked, and it never consults `serverless.inventory_enabled` at
+  all — so reusing that cached path (Option A) would emit **by default**,
+  violating disabled-by-default. Our builder must evaluate the gate itself.
+  (Remote Config is not supported in serverless-init today, so live RC toggling
+  is not a requirement; a config/env value read at startup is sufficient.)
+
+Schema-codegen consequences of adding the `inventories_*` keys to serverless:
+the only lever is removing `full-agent-only:true` from each key in
+`core_schema.yaml` (codegen has no serverless-init-only bucket; it is binary
+full-agent vs common-base). This does not change full-agent behavior (the full
+agent still runs `initCommonBase`). `cmd/serverless-init` is the only binary in
+this repo built with the `serverless` tag (the AWS Lambda extension moved off
+this codebase over a year ago), so nothing else is affected. It does break the
+split assertions in `TestServerlessConfigInit` / `TestAgentConfigInit`
+(`pkg/config/setup/config_test.go`), which must be updated, and requires
+regenerating `all_settings.go` via `dda inv schema.codegen` (the generated file
+is not hand-edited).
+
+Rejected alternatives: single shared `inventories_enabled` with a serverless
+default of `false` (per-flavor default divergence on a shared key — the exact
+thing the philosophy warns against); a pure serverless-only key ignoring
+`inventories_enabled` (drifts from `util.InventoryEnabled`, so
+`inventories_enabled: false` would not silence serverless inventory);
+`enable_metadata_collection` alone (master switch for all metadata, cannot
+express an inventory-specific disabled-by-default ramp).
+
+Intervals / first-run delay: `inventories_min_interval`,
+`inventories_max_interval`, and `inventories_first_run_delay` are declared in
+the serverless schema at the shared defaults (0 / 0 / 60), and the serverless
+value is forced via the existing `preloadEarly` / `setOverride` pattern (e.g.
+`setOverride("inventories_first_run_delay", 0)`). `setOverride` writes at
+`SourceAgentRuntime`, which outranks env vars and yaml (`SourceEnvVar` /
+`SourceFile`) while the schema default stays identical across flavors. This
+gets delay=0 even when reusing `CreateInventoryPayload`, so scheduling control
+is not a reason to prefer Option B.
+
+`setOverride` outranks env/yaml, so it is appropriate for values we always
+force (delay=0), not for the enablement ramp gate — that stays a real config
+key a user can set. In all cases keys must be declared in the serverless schema
+first; `setOverride` sets a value, not schema membership.
+
+## Platform coverage
+
+All supported serverless-init platforms/modes: Cloud Run, Cloud Run Jobs,
+Container Apps, App Service; init and sidecar modes.
+
+## Testing
+
+- Unit tests for the payload builder (field presence, flavor value, resource
+  id, enablement gating, `PopulateCoreFields` output).
+- fakeintake e2e asserting the serverless payload lands with
+  `flavor: serverless-init` and expected fields — across chosen platforms (at
+  minimum Cloud Run; extend per `write-e2e` / `e2e-audit`).
+
+## Open items
+
+- Finalize the field list with the extractor team.
+- `workload_type` mapping, `resource_id` / CCRID composition, and the
+  gcp/azure deployment-type / hosting-plan / runtime derivations (CloudService
+  methods, this team).
+- `PopulateCoreFields` contract (which fields the pipeline requires) and its
+  shape (method vs. package function).
+- `full_configuration` include/exclude decision, i.e. whether the scrubbed
+  config dump is useful/safe in serverless. Its gate
+  `inventories_configuration_enabled` is full-agent-only and absent from the
+  serverless schema, so including the dump would require declaring that key in
+  serverless too.
+- Whether the downstream extractor prefers `hostname: null` over empty string
+  (would push toward a serverless-owned payload struct with a pointer field).
+
+## Phasing
+
+0. Spikes: define the `PopulateCoreFields` contract with pipeline owners;
+   `full_configuration` content/size spike; finalize field list.
+1. Build both sketches (A and B) on top of `PopulateCoreFields` to
+   local-fakeintake level; compare; pick one.
+2. Implement chosen approach (flavor injected via `PopulateCoreFields`, payload
+   builder, resource id, enablement gate disabled-by-default, early send).
+   Includes: remove `full-agent-only:true` from the `inventories_*` keys, add
+   `serverless.inventory_enabled`, regenerate `all_settings.go`
+   (`dda inv schema.codegen`), and update `TestServerlessConfigInit` /
+   `TestAgentConfigInit`.
+3. Tests (unit + e2e across platforms).
+4. Rollout (validate volume, then flip default to enabled).

--- a/cmd/serverless-init/INVENTORY_METADATA_PLAN.md
+++ b/cmd/serverless-init/INVENTORY_METADATA_PLAN.md
@@ -5,6 +5,9 @@ component) is built and wired here with specialized field/enablement logic
 stubbed; Option A (reuse the `inventoryagent` component) is being spiked on a
 separate branch. See "Architecture" and "Alternative under evaluation" below.
 
+The shared `PopulateCoreFields` seam is now built (in `comp/metadata/internal/util`),
+replacing the earlier local placeholder; see "Central shared seam" below.
+
 ## Goal
 
 Emit `inventoryagent`-style metadata from serverless-init to the existing
@@ -46,7 +49,7 @@ machinery without importing serverless code.
     flare (the same pattern as `inventoryhost`).
   - Owns its `Payload` envelope: empty `hostname`, a per-process `uuid.New()`
     (not the shared host GUID), and the `agent_metadata` map.
-  - `getPayload` = `populateCoreFields` + `addPrefixedFields`; the latter
+  - `getPayload` = `util.PopulateCoreFields` + `addPrefixedFields`; the latter
     flattens the typed `Fields` through a JSON round-trip and prefixes each
     key, so adding a field to `Fields` needs no change here.
   - `Enabled` is set from a local `enabled()` gate, overriding the cached
@@ -69,9 +72,8 @@ machinery without importing serverless code.
 
 ### Stubbed, pending the sections below
 
-- `populateCoreFields` is a local placeholder for the shared
-  `PopulateCoreFields` seam (see below); `install_method_*` are placeholder
-  values.
+- `install_method_*` are placeholder values inside `PopulateCoreFields`
+  (the shared seam itself is built; only these values are still stubbed).
 - Every `CloudService.GetInventoryData()` returns the zero struct; per-platform
   derivation (workload_type, CCRID, region, deployment types, runtime) is not
   implemented.
@@ -120,39 +122,57 @@ machinery without importing serverless code.
    orders inventory after host-tags/host metadata. serverless-init pulls in
    none of that, so an effective delay of 0 with an early first send is sound.
 
-## Central shared seam: `PopulateCoreFields`
+## Central shared seam: `PopulateCoreFields` (built)
 
 To resist drift from the normal agent pipeline regardless of the reuse-vs-new
-decision, we extract a shared method in the `inventoryagent` component
-(`comp/metadata/inventoryagent/impl`) that populates **only** the fields
-required for a payload to be recognized and processed as an agent-metadata
-payload. Both the core-agent component and the serverless builder call it, and
-the core agent's `initData` is refactored to call it so there is a single
-source of truth. It must not pull in cross-process fetchers
-(security/process/trace/system-probe) or config dumps. We may relocate it to a
-shared helper package later; starting in the component keeps the refactor
-local.
+decision, a shared function populates **only** the fields required for a payload
+to be recognized and processed as an agent-metadata payload. Both the core-agent
+component and the serverless builder call it, so there is a single source of
+truth. It must not pull in cross-process fetchers
+(security/process/trace/system-probe) or config dumps.
 
-Because `initData` sets `flavor` from `flavor.GetFlavor()` but serverless must
-emit `serverless-init` **without** changing the process-global flavor (see Key
-finding #4), `PopulateCoreFields` must take the flavor value as a parameter (or
-the caller overrides `data["flavor"]` afterward) rather than hardwiring
-`flavor.GetFlavor()`. The core agent passes `flavor.GetFlavor()`; serverless
-passes `"serverless-init"`.
+Location (built): `comp/metadata/internal/util.PopulateCoreFields`, **not**
+`comp/metadata/inventoryagent/impl`. `internal/util` is already imported by both
+components (via `InventoryPayload` / `InventoryEnabled`), whereas putting the
+seam in `inventoryagent/impl` and importing it from `serverlessinventory` would
+drag the core-agent component's cross-process machinery (IPC, sysprobe, ECS
+metadata, trace fetchers, FIPS) into the serverless fx graph — defeating Option
+B's isolation goal. `go list -deps` confirms `serverlessinventory` does **not**
+import `inventoryagent/impl`.
 
-Candidate source of truth is today's `inventoryagent.initData()`, which already
-contains exactly the no-cross-process-dependency core fields: `agent_version`,
-`package_version`, `agent_startup_time_ms`, `flavor`, `hostname_source`,
-`infrastructure_mode`, `install_method_tool`, `install_method_tool_version`,
-`install_method_installer_version`. (`hostname_source` is set conditionally —
-only when a hostname provider resolves and it is not Fargate — so it may be
-absent; in serverless with no host it will typically be omitted.)
+Shape (built): a package-level function operating on the `agent_metadata` map,
+not a method on a component:
+
+```go
+func PopulateCoreFields(data map[string]interface{}, conf model.Reader, flavor string, hostnameSource string)
+```
+
+- `flavor` is a **parameter**, not `flavor.GetFlavor()`: serverless must emit
+  `serverless-init` **without** changing the process-global flavor (see Key
+  finding #4). The core agent passes `flavor.GetFlavor()`; serverless passes
+  `"serverless-init"`.
+- `hostnameSource` is a **parameter**, recorded only when non-empty. Its
+  resolution (the hostname provider + `!FromFargate()` guard) stays in
+  `inventoryagent.initData()` because it needs the hostname component; only the
+  resolved string is handed to the seam. Serverless has no host and passes `""`,
+  so the key is omitted — matching the core agent's conditional behavior.
+
+Fields it sets (the no-cross-process-dependency subset of the former
+`inventoryagent.initData()`): `agent_version`, `package_version`,
+`agent_startup_time_ms`, `flavor`, `hostname_source` (conditional),
+`infrastructure_mode` (with its existing validation), `install_method_tool`,
+`install_method_tool_version`, `install_method_installer_version`.
+
+Callers (built): `inventoryagent.initData()` was refactored to delegate to the
+seam (preserving existing keys/values and the conditional `hostname_source`
+omission); `serverlessinventory`'s former local `populateCoreFields` placeholder
+was deleted in favor of the shared call. Tests for the install-info branch moved
+to `comp/metadata/internal/util` alongside the code.
 
 Open: the exact required set is a downstream contract to confirm with the
 pipeline owners (`PopulateCoreFields` should contain the minimal set the
-pipeline requires, not necessarily all of `initData`), and whether it is an
-exported method on the component or a package-level function operating on the
-`agent_metadata` map.
+pipeline requires, not necessarily all of `initData`); the field set can be
+trimmed once that contract lands.
 
 ## Alternative under evaluation: reuse the existing `inventoryagent` component
 
@@ -419,8 +439,9 @@ them), so no Windows build path is required here.
 - `workload_type` mapping, `resource_id` / CCRID composition, and the
   gcp/azure deployment-type / hosting-plan / runtime derivations (CloudService
   methods, this team).
-- `PopulateCoreFields` contract (which fields the pipeline requires) and its
-  shape (method vs. package function).
+- `PopulateCoreFields` contract: which fields the pipeline requires (the seam's
+  location and shape are decided and built — a package function in
+  `comp/metadata/internal/util`; only the required-field membership is open).
 - `full_configuration` include/exclude decision, i.e. whether the scrubbed
   config dump is useful/safe in serverless. Its gate
   `inventories_configuration_enabled` is full-agent-only and absent from the
@@ -433,20 +454,21 @@ them), so no Windows build path is required here.
 
 Compare Option A and Option B once both reach a compiles-and-emits level and
 settle on one. The items below carry the Option B build forward; several
-(`PopulateCoreFields` extraction, per-platform `GetInventoryData`,
-config/enablement, tests) apply regardless of which option is chosen.
+(per-platform `GetInventoryData`, config/enablement, tests) apply regardless of
+which option is chosen.
 
-- Extract the shared `PopulateCoreFields` seam into `inventoryagent` and have
-  both the core agent and this component call it, replacing the local
-  `populateCoreFields` placeholder. Requires the field contract with the
-  pipeline owners (which fields are required) and the shape (method vs.
-  package function).
+- Confirm the `PopulateCoreFields` field contract with the pipeline owners
+  (which fields are required) and trim the seam's field set to the minimal
+  required set if it is narrower than today's. The seam itself is built
+  (`comp/metadata/internal/util.PopulateCoreFields`, called by both the core
+  agent and this component); only the exact membership remains open.
 - Implement per-platform `CloudService.GetInventoryData()` (workload_type,
   CCRID/resource_id, resource_name, region, gcp/azure deployment types,
   runtime).
 - Add the remaining `Fields`: DD_* passthrough, `agent_version_base`,
   `agent_commit`, `wrapped_command`.
-- Wire real `install_method_*` values into `populateCoreFields`.
+- Wire real `install_method_*` values into `PopulateCoreFields` (currently
+  placeholder values).
 - Config/enablement: remove `full-agent-only:true` from the `inventories_*`
   keys so they exist in the serverless schema, add `serverless.inventory_enabled`
   (default false) as the ramp gate replacing the hardcoded `enabled()`, force
@@ -454,7 +476,8 @@ config/enablement, tests) apply regardless of which option is chosen.
   (`dda inv schema.codegen`), and update `TestServerlessConfigInit` /
   `TestAgentConfigInit`.
 - Tests: unit tests (payload/field mapping, prefix, flavor, enablement gating,
-  `PopulateCoreFields` output) and a fakeintake e2e asserting the payload lands
+  `PopulateCoreFields` output — the util-package tests exist; extend as the
+  field set firms up) and a fakeintake e2e asserting the payload lands
   with `flavor: serverless-init` and expected fields across platforms (at
   minimum Cloud Run; extend per `write-e2e` / `e2e-audit`).
 - Rollout: validate volume, then flip the enablement default to on.

--- a/cmd/serverless-init/INVENTORY_METADATA_PLAN.md
+++ b/cmd/serverless-init/INVENTORY_METADATA_PLAN.md
@@ -255,23 +255,26 @@ per process lifetime is sufficient.
   has enough data.
 - Sending is non-blocking during the run: we do not want to hold up the
   customer's workload or the rest of serverless-init on metadata delivery.
-- At shutdown, check that at least one send has occurred. If one already has,
-  do nothing (no blocking final flush). If none has, attempt a best-effort
-  final send within the shutdown budget.
+- The at-least-one-send guarantee rests on the runner firing early (delay=0)
+  plus the forwarder's shutdown drain (`forwarder_stop_timeout`), not on a
+  manual final flush at shutdown.
 - No "force send" retry loop for short-lived workloads in v1 — revisit only if
   e2e shows the at-least-one-send guarantee is unreliable for Cloud Run Jobs /
   very short containers.
 
-Trigger mechanism: serverless-init does not wire `comp/metadata/runner`, and
-`InventoryPayload.collect()` is unexported. So we either wire the runner, or
-drive sends ourselves by calling `demux.Serializer().SendMetadata(getPayload())`
-directly. Driving it ourselves bypasses the util's `firstRunDelay` / interval /
-`forceRefresh` ordering, which only exists to avoid a backend host-creation
-race that does not apply to serverless (no host-metadata pipeline) — so the
-bypass is acceptable and gives us direct control over the early send and the
-non-blocking / at-least-one-send behavior. Note the util's serializer-nil skip
-is dead code here: `demux.Serializer()` is always non-nil, so send suppression
-must come from the enablement gate, not from a missing serializer.
+Trigger mechanism (decided): wire `comp/metadata/runner` and let it drive
+`collect()` on the normal schedule, with `inventories_first_run_delay` forced to
+`0` (via `setOverride`, see Config / enablement) so the first send happens
+promptly. We deliberately do **not** add a `ForceCollect` / synchronous-send
+hook to the shared `inventoryagent` / `util.InventoryPayload` code: the shared
+metadata pipeline stays untouched, and the early send comes purely from the
+runner + delay=0. This is simpler than a bespoke `SendMetadata` loop and avoids
+any shared-code change to the metadata agent. (The prototype added an
+`InventoryPayload.ForceCollect()` shared hook to force an immediate synchronous
+send at startup; we are not adopting that.) The util's `firstRunDelay` /
+interval / `forceRefresh` ordering exists to avoid a backend host-creation race
+that does not apply to serverless (no host-metadata pipeline), so running the
+runner as-is with delay=0 is safe.
 
 ## Config / enablement
 
@@ -339,6 +342,10 @@ first; `setOverride` sets a value, not schema membership.
 
 All supported serverless-init platforms/modes: Cloud Run, Cloud Run Jobs,
 Container Apps, App Service; init and sidecar modes.
+
+serverless-init is Linux-only. Windows-based Azure environments are not
+supported by serverless-init (a different instrumentation mechanism covers
+them), so no Windows build path is required here.
 
 ## Testing
 

--- a/cmd/serverless-init/INVENTORY_METADATA_PLAN.md
+++ b/cmd/serverless-init/INVENTORY_METADATA_PLAN.md
@@ -1,6 +1,9 @@
 # Plan: serverless-init inventory metadata collection
 
-Status: planning — no implementation started.
+Status: two approaches under evaluation. Option B (a new `serverlessinventory`
+component) is built and wired here with specialized field/enablement logic
+stubbed; Option A (reuse the `inventoryagent` component) is being spiked on a
+separate branch. See "Architecture" and "Alternative under evaluation" below.
 
 ## Goal
 
@@ -16,6 +19,67 @@ Design principles:
 - Even if we build our own component, do **not** drift from the normal agent
   metadata pipeline for the fields the pipeline requires (see
   `PopulateCoreFields` below).
+
+## Architecture (Option B, built here)
+
+A `comp/metadata/serverlessinventory` component owns the payload and its
+submission; a `cmd/serverless-init` adapter supplies the serverless- and
+cloud-specific fields. The split is required because
+`comp/metadata/internal/util` (`InventoryPayload`, `InventoryEnabled`) is an
+internal package reachable only from `comp/metadata/...`, while a `comp`
+package must not depend on `cmd`. The adapter is injected through a
+`FieldProvider` interface, so the component reuses the shared inventory
+machinery without importing serverless code.
+
+### Component (`comp/metadata/serverlessinventory`, team `serverless-azure-gcp`)
+
+- `def/component.go`:
+  - `Component` interface (`Refresh()`).
+  - `Fields` struct — the typed, single-source-of-truth contract for the
+    serverless-specific fields. Each JSON tag is the downstream key name
+    (unprefixed); the component applies the `serverless_` prefix uniformly.
+  - `FieldProvider` interface (`GetInventoryFields() Fields`) — the seam that
+    keeps serverless field derivation in `cmd` while the component stays
+    generic.
+- `impl/serverlessinventory.go`:
+  - Embeds `util.InventoryPayload`, reusing scheduling, `SendMetadata`, and
+    flare (the same pattern as `inventoryhost`).
+  - Owns its `Payload` envelope: empty `hostname`, a per-process `uuid.New()`
+    (not the shared host GUID), and the `agent_metadata` map.
+  - `getPayload` = `populateCoreFields` + `addPrefixedFields`; the latter
+    flattens the typed `Fields` through a JSON round-trip and prefixes each
+    key, so adding a field to `Fields` needs no change here.
+  - `Enabled` is set from a local `enabled()` gate, overriding the cached
+    `util.InventoryEnabled` (which reads `inventories_enabled`, absent from the
+    serverless schema).
+- `fx/fx.go` — standard `fxutil.ProvideComponentConstructor` module.
+
+### serverless-init side
+
+- `cmd/serverless-init/inventory/fieldprovider.go` — implements `FieldProvider`
+  by mapping `cloudservice.InventoryData` + `mode.Conf` + extension version
+  into the typed `Fields`.
+- `cmd/serverless-init/cloudservice/{service.go,inventory.go}` —
+  `GetInventoryData()` on the `CloudService` interface, plus an `InventoryData`
+  struct and a per-service implementation on each platform.
+- `cmd/serverless-init/main.go` — wires `runnerfx.Module()` +
+  `serverlessinventoryfx.Module()`, a
+  `Demultiplexer → serializer.MetricSerializer` adapter, and the `FieldProvider`
+  provider built from the detected cloud service and run mode.
+
+### Stubbed, pending the sections below
+
+- `populateCoreFields` is a local placeholder for the shared
+  `PopulateCoreFields` seam (see below); `install_method_*` are placeholder
+  values.
+- Every `CloudService.GetInventoryData()` returns the zero struct; per-platform
+  derivation (workload_type, CCRID, region, deployment types, runtime) is not
+  implemented.
+- `enabled()` returns `false` (disabled by default); no serverless config key
+  exists yet.
+- `Fields` does not yet carry DD_* passthrough, core lineage duplicates
+  (`agent_version_base`, `agent_commit`), or `wrapped_command`.
+- No config-schema changes yet (`inventories_*`, `serverless.inventory_enabled`).
 
 ## Key findings that constrain the design
 
@@ -90,13 +154,20 @@ pipeline requires, not necessarily all of `initData`), and whether it is an
 exported method on the component or a package-level function operating on the
 `agent_metadata` map.
 
-## Reuse vs. new component (Phase 1 decision)
+## Alternative under evaluation: reuse the existing `inventoryagent` component
 
-Both options reuse `PopulateCoreFields` so neither drifts on core fields. We
-build both to a "compiles + emits a payload to a local fakeintake" level, then
-compare and pick one. Current lean is Option B.
+Two approaches are being explored in parallel:
 
-### Option A — Reuse the existing `inventoryagent` component
+- **Option B (built here):** a new `serverlessinventory` component that reuses
+  `util.InventoryPayload` but not the `inventoryagent` component itself (see
+  "Architecture").
+- **Option A (spiked on a separate branch):** reuse the `inventoryagent`
+  component directly, for automatic parity with future core-agent inventory
+  fields.
+
+The two will be compared once both reach a compiles-and-emits level. Option A
+requires the work and carries the risks below.
+
 - Needs (fx graph): three of the six `Requires` are NOT in the serverless-init
   graph today and would fail construction:
   - `serializer.MetricSerializer` is only reachable via `demux.Serializer()`,
@@ -124,22 +195,9 @@ compare and pick one. Current lean is Option B.
     `getPayload`/`Payload` struct (it hardcodes `uuid.GetUUID()`), a shared-code
     hook.
   - Serverless fields still injected via `Set(...)`; more shared-code coupling.
-- Benefit: automatic parity with future core-agent inventory fields.
-
-### Option B — New serverless-init-local payload reusing `PopulateCoreFields` + `util.InventoryPayload`
-- Needs: a small builder in `cmd/serverless-init` that calls
-  `PopulateCoreFields`, layers serverless fields, embeds
-  `util.InventoryPayload` (or calls `SendMetadata` directly with our own
-  scheduling), and registers a periodic trigger.
-- Risks: we own any schema drift beyond the shared core fields.
-- Benefit: no changes to shared `inventoryagent` behavior; only serverless-
-  relevant fields; simplest deps; logic stays in serverless-init. Best fit for
-  "minimal hooks."
-
-Each sketch must answer: (a) enablement/intervals given the missing config
-keys, (b) how the `serverless-init` flavor is set, (c) how serverless fields +
-resource id are injected, (d) how first-send/scheduling works, (e) exactly
-which lines of shared code change.
+- Benefit: automatic parity with future core-agent inventory fields. Under
+  Option B, the `PopulateCoreFields` seam (below) is what keeps the shared
+  fields from drifting.
 
 ## Serverless field derivation: delegate to the CloudService structs
 
@@ -371,17 +429,32 @@ them), so no Windows build path is required here.
 - Whether the downstream extractor prefers `hostname: null` over empty string
   (would push toward a serverless-owned payload struct with a pointer field).
 
-## Phasing
+## Remaining work
 
-0. Spikes: define the `PopulateCoreFields` contract with pipeline owners;
-   `full_configuration` content/size spike; finalize field list.
-1. Build both sketches (A and B) on top of `PopulateCoreFields` to
-   local-fakeintake level; compare; pick one.
-2. Implement chosen approach (flavor injected via `PopulateCoreFields`, payload
-   builder, resource id, enablement gate disabled-by-default, early send).
-   Includes: remove `full-agent-only:true` from the `inventories_*` keys, add
-   `serverless.inventory_enabled`, regenerate `all_settings.go`
-   (`dda inv schema.codegen`), and update `TestServerlessConfigInit` /
-   `TestAgentConfigInit`.
-3. Tests (unit + e2e across platforms).
-4. Rollout (validate volume, then flip default to enabled).
+Compare Option A and Option B once both reach a compiles-and-emits level and
+settle on one. The items below carry the Option B build forward; several
+(`PopulateCoreFields` extraction, per-platform `GetInventoryData`,
+config/enablement, tests) apply regardless of which option is chosen.
+
+- Extract the shared `PopulateCoreFields` seam into `inventoryagent` and have
+  both the core agent and this component call it, replacing the local
+  `populateCoreFields` placeholder. Requires the field contract with the
+  pipeline owners (which fields are required) and the shape (method vs.
+  package function).
+- Implement per-platform `CloudService.GetInventoryData()` (workload_type,
+  CCRID/resource_id, resource_name, region, gcp/azure deployment types,
+  runtime).
+- Add the remaining `Fields`: DD_* passthrough, `agent_version_base`,
+  `agent_commit`, `wrapped_command`.
+- Wire real `install_method_*` values into `populateCoreFields`.
+- Config/enablement: remove `full-agent-only:true` from the `inventories_*`
+  keys so they exist in the serverless schema, add `serverless.inventory_enabled`
+  (default false) as the ramp gate replacing the hardcoded `enabled()`, force
+  `inventories_first_run_delay=0` via `setOverride`, regenerate `all_settings.go`
+  (`dda inv schema.codegen`), and update `TestServerlessConfigInit` /
+  `TestAgentConfigInit`.
+- Tests: unit tests (payload/field mapping, prefix, flavor, enablement gating,
+  `PopulateCoreFields` output) and a fakeintake e2e asserting the payload lands
+  with `flavor: serverless-init` and expected fields across platforms (at
+  minimum Cloud Run; extend per `write-e2e` / `e2e-audit`).
+- Rollout: validate volume, then flip the enablement default to on.

--- a/cmd/serverless-init/cloudservice/inventory.go
+++ b/cmd/serverless-init/cloudservice/inventory.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cloudservice
+
+// InventoryData holds the per-platform serverless fields that feed the
+// serverless-init inventory metadata payload. Each CloudService implementation
+// derives these from its own environment so the payload builder stays thin and
+// the derivation lives next to the existing tag logic.
+//
+// The zero value of every field is a valid "not applicable / unknown" value.
+// Nullable downstream columns map from empty strings here.
+type InventoryData struct {
+	// WorkloadType is the canonical workload type, e.g. cloud_run_service,
+	// cloud_run_job, cloud_function_gen2, azure_container_app,
+	// azure_app_service.
+	WorkloadType string
+
+	// ResourceID is the Canonical Cloud Resource ID (CCRID); the first
+	// component of the downstream composite key.
+	ResourceID string
+
+	// ResourceName is the platform display name (app / job / revision). It is
+	// never substituted with dd_service.
+	ResourceName string
+
+	// Region is the GCP or Azure region.
+	Region string
+
+	// GCPProjectID is set for GCP platforms; empty for Azure.
+	GCPProjectID string
+
+	// AzureSubscriptionID is set for Azure platforms; empty for GCP.
+	AzureSubscriptionID string
+
+	// GCPDeploymentType is one of Function|Source|Container|Repo; empty for
+	// non-GCP.
+	GCPDeploymentType string
+
+	// AzureHostingPlan is one of Consumption|Flex; empty for non-Azure.
+	AzureHostingPlan string
+
+	// AzureDeploymentType is one of Code|Container; empty for non-Azure.
+	AzureDeploymentType string
+
+	// WorkloadRuntime is the detected workload runtime; likely empty in
+	// sidecar mode.
+	WorkloadRuntime string
+}
+
+// GetInventoryData returns the inventory metadata fields for this cloud
+// service. The default implementation returns an empty struct; each platform
+// overrides it with real derivation.
+//
+// TODO(SVLS): derive real per-platform inventory fields.
+func (l *LocalService) GetInventoryData() InventoryData { return InventoryData{} }
+
+// GetInventoryData returns the inventory metadata fields for Cloud Run
+// (service, function).
+//
+// TODO(SVLS): derive workload_type (service vs cloud_function_gen2), CCRID,
+// region, project id, and GCP deployment type from the Cloud Run environment.
+func (c *CloudRun) GetInventoryData() InventoryData { return InventoryData{} }
+
+// GetInventoryData returns the inventory metadata fields for Cloud Run Jobs.
+//
+// TODO(SVLS): derive cloud_run_job workload_type, CCRID, region, and project id.
+func (c *CloudRunJobs) GetInventoryData() InventoryData { return InventoryData{} }
+
+// GetInventoryData returns the inventory metadata fields for Azure Container
+// Apps.
+//
+// TODO(SVLS): derive azure_container_app workload_type, CCRID, region,
+// subscription id, hosting plan, and deployment type.
+func (c *ContainerApp) GetInventoryData() InventoryData { return InventoryData{} }
+
+// GetInventoryData returns the inventory metadata fields for Azure App Service.
+//
+// TODO(SVLS): derive azure_app_service workload_type, CCRID, region,
+// subscription id, hosting plan, and deployment type.
+func (a *AppService) GetInventoryData() InventoryData { return InventoryData{} }

--- a/cmd/serverless-init/cloudservice/service.go
+++ b/cmd/serverless-init/cloudservice/service.go
@@ -83,6 +83,10 @@ type CloudService interface {
 
 	// AddStartMetric adds the start (and legacy start, if any) metric to the metric agent
 	AddStartMetric(metricAgent *serverlessMetrics.ServerlessMetricAgent)
+
+	// GetInventoryData returns the per-platform serverless fields for the
+	// inventory metadata payload.
+	GetInventoryData() InventoryData
 }
 
 //nolint:revive // TODO(SERV) Fix revive linter

--- a/cmd/serverless-init/inventory/fieldprovider.go
+++ b/cmd/serverless-init/inventory/fieldprovider.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+// Package inventory adapts serverless-init's cloud-platform knowledge into the
+// serverlessinventory.FieldProvider interface consumed by the
+// comp/metadata/serverlessinventory component. All serverless- and
+// platform-specific derivation lives here (and in the CloudService structs it
+// delegates to); the component stays generic.
+package inventory
+
+import (
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
+	serverlessinventory "github.com/DataDog/datadog-agent/comp/metadata/serverlessinventory/def"
+	serverlessTags "github.com/DataDog/datadog-agent/pkg/serverless/tags"
+)
+
+// fieldProvider implements serverlessinventory.FieldProvider by combining the
+// per-platform CloudService inventory data with process-level serverless
+// context (run mode, extension version).
+type fieldProvider struct {
+	cloudService cloudservice.CloudService
+	modeConf     mode.Conf
+}
+
+// NewFieldProvider builds a serverlessinventory.FieldProvider for the detected
+// cloud service and run mode. It is supplied to the serverlessinventory
+// component via fx.
+func NewFieldProvider(cloudService cloudservice.CloudService, modeConf mode.Conf) serverlessinventory.FieldProvider {
+	return &fieldProvider{cloudService: cloudService, modeConf: modeConf}
+}
+
+// GetInventoryFields returns the typed serverless-specific fields; the
+// component applies the serverless_ prefix.
+func (p *fieldProvider) GetInventoryFields() serverlessinventory.Fields {
+	inv := p.cloudService.GetInventoryData()
+
+	return serverlessinventory.Fields{
+		InitVersion:  serverlessTags.GetExtensionVersion(),
+		ResourceID:   inv.ResourceID,
+		ResourceName: inv.ResourceName,
+		WorkloadType: inv.WorkloadType,
+
+		Region:              inv.Region,
+		GCPProjectID:        inv.GCPProjectID,
+		AzureSubscriptionID: inv.AzureSubscriptionID,
+
+		DeploymentModel:     p.deploymentModel(),
+		GCPDeploymentType:   inv.GCPDeploymentType,
+		AzureHostingPlan:    inv.AzureHostingPlan,
+		AzureDeploymentType: inv.AzureDeploymentType,
+		WorkloadRuntime:     inv.WorkloadRuntime,
+	}
+}
+
+// deploymentModel maps the run mode to the downstream deployment_model value.
+func (p *fieldProvider) deploymentModel() string {
+	if p.modeConf.SidecarMode {
+		return "sidecar"
+	}
+	return "in-container"
+}

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -52,12 +52,17 @@ import (
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
+	runnerfx "github.com/DataDog/datadog-agent/comp/metadata/runner/fx"
+	serverlessinventory "github.com/DataDog/datadog-agent/comp/metadata/serverlessinventory/def"
+	serverlessinventoryfx "github.com/DataDog/datadog-agent/comp/metadata/serverlessinventory/fx"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
 
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
 	enhancedmetrics "github.com/DataDog/datadog-agent/cmd/serverless-init/enhanced-metrics"
+	serverlessInitInventory "github.com/DataDog/datadog-agent/cmd/serverless-init/inventory"
 	serverlessInitTag "github.com/DataDog/datadog-agent/cmd/serverless-init/tag"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -308,6 +313,17 @@ func main() {
 		fx.Provide(func() cloudservice.CloudService { return cloudService }),
 		fx.Supply(tagConfig),
 		fx.Supply(metricTags),
+		// The serverlessinventory component and metadata runner reuse the
+		// shared metadata pipeline. The runner drives collect() on the normal
+		// schedule; the serializer is reached through the demultiplexer rather
+		// than as a distinct fx type. The FieldProvider adapter supplies the
+		// serverless-specific fields from the cloud service and run mode.
+		fx.Provide(func(d aggregator.Demultiplexer) serializer.MetricSerializer { return d.Serializer() }),
+		fx.Provide(func(cs cloudservice.CloudService) serverlessinventory.FieldProvider {
+			return serverlessInitInventory.NewFieldProvider(cs, modeConf)
+		}),
+		runnerfx.Module(),
+		serverlessinventoryfx.Module(),
 		delegatedauthfx.Module(),
 		healthplatform.Bundle(),
 		fx.Provide(func(config coreconfig.Component) healthprobeDef.Options {

--- a/comp/metadata/internal/util/core_fields.go
+++ b/comp/metadata/internal/util/core_fields.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package util
+
+import (
+	"slices"
+
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// installinfoGet is a package var so tests can stub it.
+var installinfoGet = installinfo.Get
+
+// PopulateCoreFields sets the subset of agent-metadata fields required for a
+// payload to be recognized and processed as an agent-metadata payload by the
+// inventory pipeline. It populates only fields with no cross-process
+// dependency; callers layer their own component-specific and config-fetched
+// fields on top.
+//
+// It lives here, in the shared inventory util package, so both the core-agent
+// inventoryagent component and the serverlessinventory component have one
+// source of truth without the serverless component importing the core-agent
+// component's cross-process machinery.
+//
+// flavor is a parameter rather than flavor.GetFlavor() so a caller can emit a
+// payload flavor (e.g. "serverless-init") without changing the process-global
+// flavor, which the aggregator captures once for its heartbeat metric.
+//
+// hostnameSource is only recorded when non-empty: callers with no resolvable
+// host (serverless) pass "" and the key is omitted, matching the core agent's
+// conditional behavior.
+func PopulateCoreFields(data map[string]interface{}, conf model.Reader, flavor string, hostnameSource string) {
+	tool := "undefined"
+	toolVersion := ""
+	installerVersion := ""
+
+	install, err := installinfoGet(conf)
+	if err == nil {
+		tool = install.Tool
+		toolVersion = install.ToolVersion
+		installerVersion = install.InstallerVersion
+	}
+	data["install_method_tool"] = tool
+	data["install_method_tool_version"] = toolVersion
+	data["install_method_installer_version"] = installerVersion
+
+	if hostnameSource != "" {
+		data["hostname_source"] = hostnameSource
+	}
+
+	data["agent_version"] = version.AgentVersion
+	data["package_version"] = version.AgentPackageVersion
+	data["agent_startup_time_ms"] = conf.StartTime().UnixMilli()
+	data["flavor"] = flavor
+
+	infraMode, _ := scrubber.ScrubString(conf.GetString("infrastructure_mode"))
+	// fleet-automation: This validation should be done by the Config once we have such mechanism
+	if !slices.Contains([]string{"full", "end_user_device", "basic", "cloud_cost_only", "none"}, infraMode) {
+		log.Warnf("invalid value for 'infrastructure_mode': '%s' (defaulting to 'full')", infraMode)
+		infraMode = "full"
+	}
+	data["infrastructure_mode"] = infraMode
+}

--- a/comp/metadata/internal/util/core_fields_test.go
+++ b/comp/metadata/internal/util/core_fields_test.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package util
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
+)
+
+func TestPopulateCoreFieldsInstallInfo(t *testing.T) {
+	defer func() { installinfoGet = installinfo.Get }()
+
+	conf := configmock.New(t)
+
+	installinfoGet = func(model.Reader) (*installinfo.InstallInfo, error) {
+		return nil, errors.New("some error")
+	}
+	data := map[string]interface{}{}
+	PopulateCoreFields(data, conf, "agent", "")
+	assert.Equal(t, "undefined", data["install_method_tool"])
+	assert.Equal(t, "", data["install_method_tool_version"])
+	assert.Equal(t, "", data["install_method_installer_version"])
+
+	installinfoGet = func(model.Reader) (*installinfo.InstallInfo, error) {
+		return &installinfo.InstallInfo{
+			Tool:             "test_tool",
+			ToolVersion:      "1.2.3",
+			InstallerVersion: "4.5.6",
+		}, nil
+	}
+	data = map[string]interface{}{}
+	PopulateCoreFields(data, conf, "agent", "")
+	assert.Equal(t, "test_tool", data["install_method_tool"])
+	assert.Equal(t, "1.2.3", data["install_method_tool_version"])
+	assert.Equal(t, "4.5.6", data["install_method_installer_version"])
+}
+
+func TestPopulateCoreFieldsFlavorAndHostnameSource(t *testing.T) {
+	conf := configmock.New(t)
+
+	// hostnameSource is omitted when empty and recorded when set; flavor is
+	// injected verbatim.
+	data := map[string]interface{}{}
+	PopulateCoreFields(data, conf, "serverless-init", "")
+	assert.Equal(t, "serverless-init", data["flavor"])
+	_, ok := data["hostname_source"]
+	assert.False(t, ok)
+
+	data = map[string]interface{}{}
+	PopulateCoreFields(data, conf, "agent", "gce")
+	assert.Equal(t, "agent", data["flavor"])
+	assert.Equal(t, "gce", data["hostname_source"])
+}

--- a/comp/metadata/inventoryagent/impl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/impl/inventoryagent.go
@@ -12,7 +12,6 @@ import (
 	"maps"
 	"net/http"
 	"reflect"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -42,16 +41,13 @@ import (
 	ecsmeta "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
-	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 	"github.com/DataDog/datadog-agent/pkg/util/uuid"
-	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 var (
 	// for testing
-	installinfoGet      = installinfo.Get
 	fetchSecurityConfig = configFetcher.SecurityAgentConfig
 	fetchProcessConfig  = func(cfg model.Reader, client ipc.HTTPClient) (string, error) {
 		return configFetcher.ProcessAgentConfig(cfg, client, true)
@@ -145,41 +141,17 @@ func scrub(s string) string {
 }
 
 func (ia *inventoryagent) initData() {
-	tool := "undefined"
-	toolVersion := ""
-	installerVersion := ""
-
-	install, err := installinfoGet(ia.conf)
-	if err == nil {
-		tool = install.Tool
-		toolVersion = install.ToolVersion
-		installerVersion = install.InstallerVersion
-	}
-	ia.data["install_method_tool"] = tool
-	ia.data["install_method_tool_version"] = toolVersion
-	ia.data["install_method_installer_version"] = installerVersion
-
+	hostnameSource := ""
 	data, err := ia.hostnameComp.GetWithProvider(context.Background())
 	if err == nil {
 		if data.Provider != "" && !data.FromFargate() {
-			ia.data["hostname_source"] = data.Provider
+			hostnameSource = data.Provider
 		}
 	} else {
 		ia.log.Warnf("could not fetch 'hostname_source': %v", err)
 	}
 
-	ia.data["agent_version"] = version.AgentVersion
-	ia.data["package_version"] = version.AgentPackageVersion
-	ia.data["agent_startup_time_ms"] = ia.conf.StartTime().UnixMilli()
-	ia.data["flavor"] = flavor.GetFlavor()
-
-	infraMode := scrub(ia.conf.GetString("infrastructure_mode"))
-	// fleet-automation: This validation should be done by the Config once we have such mechanism
-	if !slices.Contains([]string{"full", "end_user_device", "basic", "cloud_cost_only", "none"}, infraMode) {
-		ia.log.Warnf("invalid value for 'infrastructure_mode': '%s' (defaulting to 'full')", infraMode)
-		infraMode = "full"
-	}
-	ia.data["infrastructure_mode"] = infraMode
+	util.PopulateCoreFields(ia.data, ia.conf, flavor.GetFlavor(), hostnameSource)
 }
 
 type configGetter interface {

--- a/comp/metadata/inventoryagent/impl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/impl/inventoryagent_test.go
@@ -38,7 +38,6 @@ import (
 	sysprobecfg "github.com/DataDog/datadog-agent/pkg/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -110,33 +109,6 @@ func TestGetPayload(t *testing.T) {
 	assert.True(t, payload.Timestamp > startTime)
 	assert.Equal(t, "hostname-for-test", payload.Hostname)
 	assert.Equal(t, 1234, payload.Metadata["test"])
-}
-
-func TestInitDataErrorInstallInfo(t *testing.T) {
-	defer func() { installinfoGet = installinfo.Get }()
-	installinfoGet = func(config.Reader) (*installinfo.InstallInfo, error) {
-		return nil, errors.New("some error")
-	}
-
-	ia := getTestInventoryPayload(t, nil, nil)
-
-	ia.initData()
-	assert.Equal(t, "undefined", ia.data["install_method_tool"])
-	assert.Equal(t, "", ia.data["install_method_tool_version"])
-	assert.Equal(t, "", ia.data["install_method_installer_version"])
-
-	installinfoGet = func(config.Reader) (*installinfo.InstallInfo, error) {
-		return &installinfo.InstallInfo{
-			Tool:             "test_tool",
-			ToolVersion:      "1.2.3",
-			InstallerVersion: "4.5.6",
-		}, nil
-	}
-
-	ia.initData()
-	assert.Equal(t, "test_tool", ia.data["install_method_tool"])
-	assert.Equal(t, "1.2.3", ia.data["install_method_tool_version"])
-	assert.Equal(t, "4.5.6", ia.data["install_method_installer_version"])
 }
 
 func TestInitData(t *testing.T) {

--- a/comp/metadata/serverlessinventory/def/component.go
+++ b/comp/metadata/serverlessinventory/def/component.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package serverlessinventory exposes the interface for the component that
+// generates the serverless-init inventory metadata payload.
+package serverlessinventory
+
+// team: serverless-azure-gcp
+
+// Component is the component type.
+type Component interface {
+	// Refresh triggers a new payload to be sent while still respecting the
+	// minimal interval between two updates.
+	Refresh()
+}
+
+// Fields is the typed contract for the serverless-specific inventory fields.
+// It is the single source of truth for the field set: each JSON tag is the
+// downstream key name (without the serverless_ prefix, which the component
+// applies uniformly). The zero value of a field maps to a nullable/unknown
+// downstream column.
+//
+// TODO(SVLS): additional fields are added here as they are wired up: DD_*
+// passthrough (dd_env, dd_site, dd_version, dd_service), core lineage
+// duplicates (agent_version_base, agent_commit), and wrapped_command.
+type Fields struct {
+	// InitVersion is the serverless-init extension version. It is REQUIRED and
+	// gates emission. The serverless_ prefix applied by the component makes the
+	// final key serverless_serverless_init_version (intentional double prefix).
+	InitVersion string `json:"serverless_init_version"`
+
+	// ResourceID is the Canonical Cloud Resource ID (CCRID); REQUIRED, first
+	// component of the downstream composite key.
+	ResourceID string `json:"resource_id"`
+	// ResourceName is the platform display name (app/job/revision); REQUIRED.
+	ResourceName string `json:"resource_name"`
+	// WorkloadType is the canonical workload type; REQUIRED.
+	WorkloadType string `json:"workload_type"`
+
+	// Region is the GCP or Azure region.
+	Region string `json:"region"`
+	// GCPProjectID is set for GCP platforms; empty for Azure.
+	GCPProjectID string `json:"gcp_project_id"`
+	// AzureSubscriptionID is set for Azure platforms; empty for GCP.
+	AzureSubscriptionID string `json:"azure_subscription_id"`
+
+	// DeploymentModel is sidecar or in-container.
+	DeploymentModel string `json:"deployment_model"`
+	// GCPDeploymentType is one of Function|Source|Container|Repo; empty for non-GCP.
+	GCPDeploymentType string `json:"gcp_deployment_type"`
+	// AzureHostingPlan is one of Consumption|Flex; empty for non-Azure.
+	AzureHostingPlan string `json:"azure_hosting_plan"`
+	// AzureDeploymentType is one of Code|Container; empty for non-Azure.
+	AzureDeploymentType string `json:"azure_deployment_type"`
+	// WorkloadRuntime is the detected workload runtime; likely empty in sidecar mode.
+	WorkloadRuntime string `json:"workload_runtime"`
+}
+
+// FieldProvider supplies the serverless-specific fields that are layered into
+// the payload's agent_metadata map. It is implemented outside this component
+// (in cmd/serverless-init) so all serverless- and cloud-platform-specific
+// derivation stays there; the component only knows how to assemble and submit
+// a payload.
+type FieldProvider interface {
+	// GetInventoryFields returns the serverless-specific fields for this
+	// process.
+	GetInventoryFields() Fields
+}

--- a/comp/metadata/serverlessinventory/fx/fx.go
+++ b/comp/metadata/serverlessinventory/fx/fx.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package fx provides the fx module for the serverlessinventory component.
+package fx
+
+import (
+	serverlessinventoryimpl "github.com/DataDog/datadog-agent/comp/metadata/serverlessinventory/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			serverlessinventoryimpl.NewComponent,
+		),
+	)
+}

--- a/comp/metadata/serverlessinventory/impl/serverlessinventory.go
+++ b/comp/metadata/serverlessinventory/impl/serverlessinventory.go
@@ -1,0 +1,183 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package serverlessinventoryimpl implements a component to generate the
+// serverless-init inventory metadata payload.
+//
+// The payload envelope, scheduling, submission, and wiring reuse the shared
+// inventory machinery (comp/metadata/internal/util.InventoryPayload); the
+// serverless-specific fields are delegated to the injected FieldProvider,
+// which is implemented in cmd/serverless-init so all cloud-platform derivation
+// stays there.
+package serverlessinventoryimpl
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/comp/metadata/internal/util"
+	runnerdef "github.com/DataDog/datadog-agent/comp/metadata/runner/def"
+	serverlessinventory "github.com/DataDog/datadog-agent/comp/metadata/serverlessinventory/def"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// flavorValue is the payload flavor for serverless-init. It carries the dash
+// intentionally and is injected only into the payload. We do not change the
+// process-global flavor (flavor.SetFlavor), which stays "agent": the
+// aggregator captures the flavor once at construction for the
+// datadog.<flavor>.running / .up heartbeat metric and service check, so
+// renaming it process-wide would break agent-host identification and existing
+// monitors.
+const flavorValue = "serverless-init"
+
+// serverlessFieldPrefix is applied uniformly to every serverless-specific key
+// in agent_metadata.
+const serverlessFieldPrefix = "serverless_"
+
+// Payload is the serverless-init inventory metadata payload. It is owned here
+// (rather than reusing the inventoryagent Payload) so serverless controls the
+// envelope: a per-process uuid, an empty hostname, and no shared host GUID.
+type Payload struct {
+	Hostname  string                 `json:"hostname"`
+	Timestamp int64                  `json:"timestamp"`
+	Metadata  map[string]interface{} `json:"agent_metadata"`
+	UUID      string                 `json:"uuid"`
+}
+
+// MarshalJSON serializes a Payload to JSON.
+func (p *Payload) MarshalJSON() ([]byte, error) {
+	type payloadAlias Payload
+	return json.Marshal((*payloadAlias)(p))
+}
+
+type serverlessInventory struct {
+	util.InventoryPayload
+
+	log    log.Component
+	conf   config.Component
+	fields serverlessinventory.FieldProvider
+	uuid   string
+}
+
+// Requires defines the dependencies for the serverlessinventory component.
+type Requires struct {
+	Log        log.Component
+	Config     config.Component
+	Serializer serializer.MetricSerializer
+	Fields     serverlessinventory.FieldProvider
+}
+
+// Provides defines the output of the serverlessinventory component.
+type Provides struct {
+	Comp          serverlessinventory.Component
+	Provider      runnerdef.Provider
+	FlareProvider flaretypes.Provider
+}
+
+// NewComponent creates a new serverlessinventory component.
+func NewComponent(deps Requires) Provides {
+	si := &serverlessInventory{
+		conf:   deps.Config,
+		log:    deps.Log,
+		fields: deps.Fields,
+		// A per-process uuid: serverless containers do not share the host
+		// machine GUID that uuid.GetUUID() returns.
+		uuid: uuid.New().String(),
+	}
+	si.InventoryPayload = util.CreateInventoryPayload(deps.Config, deps.Log, deps.Serializer, si.getPayload, "serverless-init.json")
+
+	// CreateInventoryPayload caches its Enabled flag from util.InventoryEnabled,
+	// which reads inventories_enabled (not present in the serverless config
+	// schema) and does not consult any serverless-specific gate. Override it
+	// here so emission is controlled by enabled() below.
+	si.Enabled = enabled(deps.Config)
+
+	return Provides{
+		Comp:          si,
+		Provider:      si.MetadataProvider(),
+		FlareProvider: si.FlareProvider(),
+	}
+}
+
+// enabled reports whether serverless-init inventory emission is on. It is
+// disabled by default while the feature ramps.
+//
+// TODO(SVLS): gate on a serverless-scoped config key
+// (DD_SERVERLESS_INIT_INVENTORY_ENABLED) once it is added to the serverless
+// config schema, combined with the shared metadata-collection switch.
+func enabled(_ config.Component) bool {
+	return false
+}
+
+// getPayload is the PayloadGetter callback invoked by the metadata runner. The
+// payload content does not change between sends, so a single successful send
+// per process lifetime is sufficient.
+func (si *serverlessInventory) getPayload() marshaler.JSONMarshaler {
+	data := make(map[string]interface{})
+
+	populateCoreFields(data, si.conf, flavorValue)
+	addPrefixedFields(data, si.fields.GetInventoryFields())
+
+	return &Payload{
+		Hostname:  "", // empty for serverless; no host identity
+		Timestamp: time.Now().UnixNano(),
+		Metadata:  data,
+		UUID:      si.uuid,
+	}
+}
+
+// Refresh implements serverlessinventory.Component.
+func (si *serverlessInventory) Refresh() {
+	si.InventoryPayload.Refresh()
+}
+
+// addPrefixedFields flattens the typed Fields into data, applying the
+// serverless_ prefix to each key. The Fields JSON tags are the single source
+// of truth for the key names, so this stays generic and never enumerates
+// fields by hand.
+func addPrefixedFields(data map[string]interface{}, fields serverlessinventory.Fields) {
+	raw, err := json.Marshal(fields)
+	if err != nil {
+		return
+	}
+	var flat map[string]interface{}
+	if err := json.Unmarshal(raw, &flat); err != nil {
+		return
+	}
+	for key, value := range flat {
+		data[serverlessFieldPrefix+key] = value
+	}
+}
+
+// populateCoreFields sets the subset of agent-metadata fields required for a
+// payload to be recognized and processed as an agent-metadata payload by the
+// inventory pipeline. The flavor is injected rather than read from
+// flavor.GetFlavor() so serverless-init can emit its own flavor without
+// changing the process-global one.
+//
+// These fields mirror the no-cross-process-dependency core fields the core
+// agent's inventoryagent component sets. Fields that depend on cross-process
+// fetchers (security/process/trace/system-probe) or config dumps must NOT be
+// added here.
+//
+// TODO(SVLS): the install_method_* values are placeholders; wire them from the
+// install-info the core agent reads.
+func populateCoreFields(data map[string]interface{}, conf config.Component, flavor string) {
+	data["agent_version"] = version.AgentVersion
+	data["package_version"] = version.AgentPackageVersion
+	data["agent_startup_time_ms"] = conf.StartTime().UnixMilli()
+	data["flavor"] = flavor
+
+	data["install_method_tool"] = "undefined"
+	data["install_method_tool_version"] = ""
+	data["install_method_installer_version"] = ""
+}

--- a/comp/metadata/serverlessinventory/impl/serverlessinventory.go
+++ b/comp/metadata/serverlessinventory/impl/serverlessinventory.go
@@ -27,7 +27,6 @@ import (
 	serverlessinventory "github.com/DataDog/datadog-agent/comp/metadata/serverlessinventory/def"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
-	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 // flavorValue is the payload flavor for serverless-init. It carries the dash
@@ -124,7 +123,11 @@ func enabled(_ config.Component) bool {
 func (si *serverlessInventory) getPayload() marshaler.JSONMarshaler {
 	data := make(map[string]interface{})
 
-	populateCoreFields(data, si.conf, flavorValue)
+	// The shared seam keeps the core agent-metadata fields in sync with the
+	// core-agent inventory component. Serverless has no resolvable host, so it
+	// passes an empty hostname source and injects its own flavor without
+	// touching the process-global flavor.
+	util.PopulateCoreFields(data, si.conf, flavorValue, "")
 	addPrefixedFields(data, si.fields.GetInventoryFields())
 
 	return &Payload{
@@ -156,28 +159,4 @@ func addPrefixedFields(data map[string]interface{}, fields serverlessinventory.F
 	for key, value := range flat {
 		data[serverlessFieldPrefix+key] = value
 	}
-}
-
-// populateCoreFields sets the subset of agent-metadata fields required for a
-// payload to be recognized and processed as an agent-metadata payload by the
-// inventory pipeline. The flavor is injected rather than read from
-// flavor.GetFlavor() so serverless-init can emit its own flavor without
-// changing the process-global one.
-//
-// These fields mirror the no-cross-process-dependency core fields the core
-// agent's inventoryagent component sets. Fields that depend on cross-process
-// fetchers (security/process/trace/system-probe) or config dumps must NOT be
-// added here.
-//
-// TODO(SVLS): the install_method_* values are placeholders; wire them from the
-// install-info the core agent reads.
-func populateCoreFields(data map[string]interface{}, conf config.Component, flavor string) {
-	data["agent_version"] = version.AgentVersion
-	data["package_version"] = version.AgentPackageVersion
-	data["agent_startup_time_ms"] = conf.StartTime().UnixMilli()
-	data["flavor"] = flavor
-
-	data["install_method_tool"] = "undefined"
-	data["install_method_tool_version"] = ""
-	data["install_method_installer_version"] = ""
 }


### PR DESCRIPTION
### What does this PR do?
Wires up our own inventory component, with a shared bit of code for reusing some of the required bits from the existing inventory agent.

### Motivation
We'd like to see if working with the existing inventory agent would be okay for serverless-init (the other PR https://github.com/DataDog/datadog-agent/pull/55323 ) or if we can create our own, more focused component (this PR).

### Describe how you validated your changes
No live validation yet. This PR is intended as a draft for us to compare to the other one before we decide on an approach.

### Additional Notes
@nina9753 's original prototype PRs: https://github.com/DataDog/datadog-agent/pull/54537 , https://github.com/DataDog/datadog-agent/pull/54538 , https://github.com/DataDog/datadog-agent/pull/54543