### PR TITLE
docs: fix typos in metadata component and how-to docs

### DIFF
--- a/comp/metadata/inventoryagent/README.md
+++ b/comp/metadata/inventoryagent/README.md
@@ -118,17 +118,17 @@ The payload is a JSON dict with the following fields
     as well as any settings explicitly set by the agent (for example the number of workers is dynamically set by the
     agent itself based on the load).
   - `file_configuration` - **string**: the Agent configuration specified by the configuration file (scrubbed), as a YAML string.
-    Only the settings written in the configuration file are included, and their value might not match what's applyed by the agent because they can be overriden by other sources.
+    Only the settings written in the configuration file are included, and their value might not match what's applied by the agent because they can be overridden by other sources.
   - `environment_variable_configuration` - **string**: the Agent configuration specified by the environment variables (scrubbed), as a YAML string.
-    Only the settings written in the environment variables are included, and their value might not match what's applyed by the agent because they can be overriden by other sources.
+    Only the settings written in the environment variables are included, and their value might not match what's applied by the agent because they can be overridden by other sources.
   - `agent_runtime_configuration` - **string**: the Agent configuration set by the agent itself (scrubbed), as a YAML string.
-    Only the settings set by the agent itself are included, and their value might not match what's applyed by the agent because they can be overriden by other sources.
+    Only the settings set by the agent itself are included, and their value might not match what's applied by the agent because they can be overridden by other sources.
   - `remote_configuration` - **string**: the Agent configuration specified by the Remote Configuration (scrubbed), as a YAML string.
-    Only the settings currently used by Remote Configuration are included, and their value might not match what's applyed by the agent because they can be overriden by other sources.
+    Only the settings currently used by Remote Configuration are included, and their value might not match what's applied by the agent because they can be overridden by other sources.
   - `fleet_policies_configuration` - **string**: the Agent configuration specified by the Fleet Automation Policies (scrubbed), as a YAML string.
-    Only the settings currently used by Fleet Automation Policies are included, and their value might not match what's applyed by the agent since they can be overriden by other sources.
+    Only the settings currently used by Fleet Automation Policies are included, and their value might not match what's applied by the agent since they can be overridden by other sources.
   - `cli_configuration` - **string**: the Agent configuration specified by the CLI (scrubbed), as a YAML string.
-    Only the settings set in the CLI are included, they cannot be overriden by any other sources.
+    Only the settings set in the CLI are included, they cannot be overridden by any other sources.
   - `source_local_configuration` - **string**: the Agent configuration synchronized from the local Agent process, as a YAML string.
   - `ecs_fargate_task_arn` - **string**: if the Agent runs in ECS Fargate, contains the Agent's Task ARN. Else, is empty.
   - `ecs_fargate_cluster_name` - **string**: if the Agent runs in ECS Fargate, contains the Agent's cluster name. Else, is empty.

--- a/comp/metadata/securityagent/README.md
+++ b/comp/metadata/securityagent/README.md
@@ -27,15 +27,15 @@ The payload is a JSON dict with the following fields
   - `provided_configuration` - **string**: the current Security-Agent configuration (scrubbed), without the defaults, as a YAML
     string. This includes the settings configured by the user (throuh the configuration file, the environment, CLI...).
   - `file_configuration` - **string**: the Security-Agent configuration specified by the configuration file (scrubbed), as a YAML string.
-    Only the settings written in the configuration file are included, and their value might not match what's applyed by the agent since they can be overriden by other sources.
+    Only the settings written in the configuration file are included, and their value might not match what's applied by the agent since they can be overridden by other sources.
   - `environment_variable_configuration` - **string**: the Security-Agent configuration specified by the environment variables (scrubbed), as a YAML string.
-    Only the settings written in the environment variables are included, and their value might not match what's applyed by the agent somce they can be overriden by other sources.
+    Only the settings written in the environment variables are included, and their value might not match what's applied by the agent somce they can be overridden by other sources.
   - `agent_runtime_configuration` - **string**: the Security-Agent configuration set by the agent itself (scrubbed), as a YAML string.
-    Only the settings set by the agent itself are included, and their value might not match what's applyed by the agent since they can be overriden by other sources.
+    Only the settings set by the agent itself are included, and their value might not match what's applied by the agent since they can be overridden by other sources.
   - `remote_configuration` - **string**: the Security-Agent configuration specified by the Remote Configuration (scrubbed), as a YAML string.
-    Only the settings currently used by Remote Configuration are included, and their value might not match what's applyed by the agent since they can be overriden by other sources.
+    Only the settings currently used by Remote Configuration are included, and their value might not match what's applied by the agent since they can be overridden by other sources.
   - `fleet_policies_configuration` - **string**: the Security-Agent configuration specified by the Fleet Automation Policies (scrubbed), as a YAML string.
-    Only the settings currently used by Fleet Automation Policies are included, and their value might not match what's applyed by the agent since they can be overriden by other sources.
+    Only the settings currently used by Fleet Automation Policies are included, and their value might not match what's applied by the agent since they can be overridden by other sources.
   - `cli_configuration` - **string**: the Security-Agent configuration specified by the CLI (scrubbed), as a YAML string.
     Only the settings set in the CLI are included.
   - `source_local_configuration` - **string**: the Security-Agent configuration synchronized from the local Agent process, as a YAML string.

--- a/comp/metadata/systemprobe/README.md
+++ b/comp/metadata/systemprobe/README.md
@@ -27,15 +27,15 @@ The payload is a JSON dict with the following fields
   - `provided_configuration` - **string**: the current System-Probe configuration (scrubbed), without the defaults, as a YAML
     string. This includes the settings configured by the user (throuh the configuration file, the environment, CLI...).
   - `file_configuration` - **string**: the System-Probe configuration specified by the configuration file (scrubbed), as a YAML string.
-    Only the settings written in the configuration file are included, and their value might not match what's applyed by the agent since they can be overriden by other sources.
+    Only the settings written in the configuration file are included, and their value might not match what's applied by the agent since they can be overridden by other sources.
   - `environment_variable_configuration` - **string**: the System-Probe configuration specified by the environment variables (scrubbed), as a YAML string.
-    Only the settings written in the environment variables are included, and their value might not match what's applyed by the agent somce they can be overriden by other sources.
+    Only the settings written in the environment variables are included, and their value might not match what's applied by the agent somce they can be overridden by other sources.
   - `agent_runtime_configuration` - **string**: the System-Probe configuration set by the agent itself (scrubbed), as a YAML string.
-    Only the settings set by the agent itself are included, and their value might not match what's applyed by the agent since they can be overriden by other sources.
+    Only the settings set by the agent itself are included, and their value might not match what's applied by the agent since they can be overridden by other sources.
   - `remote_configuration` - **string**: the System-Probe configuration specified by the Remote Configuration (scrubbed), as a YAML string.
-    Only the settings currently used by Remote Configuration are included, and their value might not match what's applyed by the agent since they can be overriden by other sources.
+    Only the settings currently used by Remote Configuration are included, and their value might not match what's applied by the agent since they can be overridden by other sources.
   - `fleet_policies_configuration` - **string**: the Security-Agent configuration specified by the Fleet Automation Policies (scrubbed), as a YAML string.
-    Only the settings currently used by Fleet Automation Policies are included, and their value might not match what's applyed by the agent since they can be overriden by other sources.
+    Only the settings currently used by Fleet Automation Policies are included, and their value might not match what's applied by the agent since they can be overridden by other sources.
   - `cli_configuration` - **string**: the System-Probe configuration specified by the CLI (scrubbed), as a YAML string.
     Only the settings set in the CLI are included.
   - `source_local_configuration` - **string**: the System-Probe configuration synchronized from the local Agent process, as a YAML string.

--- a/docs/dev/checks/README.md
+++ b/docs/dev/checks/README.md
@@ -1,6 +1,6 @@
 # Custom checks developer guide
 
-For more informations about what a Custom check is and whether they are a good
+For more information about what a Custom check is and whether they are a good
 fit for your use case, please [refer to the official documentation][custom-checks].
 
 ## JMX-based checks

--- a/docs/dev/checks/builtins/kubeutil.md
+++ b/docs/dev/checks/builtins/kubeutil.md
@@ -19,7 +19,7 @@ kubernetes clusters.
 ```python
 
     def get_connection_info():
-        """Get kubelet connection informations.
+        """Get kubelet connection information.
 
         Returns:
             A dictionary containing connection info, can be empty.

--- a/docs/public/how-to/go/modules.md
+++ b/docs/public/how-to/go/modules.md
@@ -156,7 +156,7 @@ For each module, you can specify:
 * `default` - for modules with default attribute values
 * `ignored` - for ignored modules.
 
-To create a special configuration, the attributes of the `GoModule` class can be overriden - see the definition <<<repo("tasks/libs/common/gomodules.py", "here")>>> for the list of attributes and their details.
+To create a special configuration, the attributes of the `GoModule` class can be overridden - see the definition <<<repo("tasks/libs/common/gomodules.py", "here")>>> for the list of attributes and their details.
 
 /// tip
 This file can be linted and checked by using `dda inv modules.validate [--fix-format]`.

--- a/docs/public/how-to/memory-profiling/overview.md
+++ b/docs/public/how-to/memory-profiling/overview.md
@@ -17,8 +17,8 @@ results. A good example of a tool that becomes difficult to use in this
 environment is Valgrind. The problem is Valgrind will account for all
 allocations in the Go and CPython spaces, and these being garbage collected
 can make the reports a little hard to understand. You can also try to use a
-supression file to supress some of the allocations in Python or Go, but it is
-difficult to find a supression file.
+suppression file to suppress some of the allocations in Python or Go, but it is
+difficult to find a suppression file.
 
 This guide covers Go and Python have facilities for tracking and troubleshooting.
 Datadog also offers some C/C++ facilities to help you track allocations.

--- a/docs/public/how-to/memory-profiling/python.md
+++ b/docs/public/how-to/memory-profiling/python.md
@@ -118,7 +118,7 @@ That will print out some memory information to screen, for instance:
     ...
 ```
 
-But will also store the profiling information for futher inspection if
+But will also store the profiling information for further inspection if
 necessary.
 
 There are additional hidden flags available when performing the memory


### PR DESCRIPTION
Typo fixes across component and how-to documentation.

| Typo | → | Files |
|---|---|---|
| `overriden` | `overridden` | `comp/metadata/inventoryagent/README.md`, `comp/metadata/securityagent/README.md`, `comp/metadata/systemprobe/README.md`, `docs/public/how-to/go/modules.md` |
| `applyed` | `applied` | the same three `comp/metadata/*/README.md` files |
| `informations` | `information` | `docs/dev/checks/README.md`, `docs/dev/checks/builtins/kubeutil.md` |
| `supress`/`supression` | `suppress`/`suppression` | `docs/public/how-to/memory-profiling/overview.md` |
| `futher` | `further` | `docs/public/how-to/memory-profiling/python.md` |

Documentation prose only — no config keys, field names, or code changed. (`informations` and `supression` are not English plurals/spellings; `information` is uncountable.)
