### PR TITLE
Allow dd_agent_go_test's default target to take extra gotags

### DIFF
--- a/bazel/rules/go/dd_agent_go_test.bzl
+++ b/bazel/rules/go/dd_agent_go_test.bzl
@@ -49,11 +49,13 @@ def _excluded_os(gotags):
         excluded.append("aix")
     return excluded
 
-def _test_tag_set_tags(gotags = None):
-    if gotags == None:
-        tags = BASE_TEST_TAGS
-    else:
-        tags = sorted(set(BASE_TEST_TAGS) | set(gotags))
+def _test_tag_set_tags(gotags = None, extra_gotags = None):
+    tags = set(BASE_TEST_TAGS)
+    if gotags != None:
+        tags = tags | set(gotags)
+    if extra_gotags:
+        tags = tags | set(extra_gotags)
+    tags = sorted(tags)
 
     # Windows builds always define WINDOWS_INCLUDED_TAGS, as
     # filter_incompatible_tags() does in tasks/build_tags.py. Without them,
@@ -98,6 +100,7 @@ def _test_tag_set_target_compatible_with(gotags):
 
 def dd_agent_go_test(
         name,
+        extra_gotags = None,
         gotags_sets = None,
         include_default = True,
         tags = None,
@@ -107,6 +110,9 @@ def dd_agent_go_test(
 
     Args:
         name: Default target name and prefix for gotags-set variants.
+        extra_gotags: Extra Go build tags merged into every generated variant
+              (including the default), without affecting target naming or
+              platform compatibility.
         gotags_sets: Lists of Go build tags, such as [["zlib", "zstd"]].
         include_default: Whether to emit the minimally tagged default test.
         tags: Optional user-supplied Bazel tags.
@@ -121,7 +127,7 @@ def dd_agent_go_test(
         _test_tag_set_check_name(name)
         go_test(
             name = name,
-            gotags = _test_tag_set_tags(),
+            gotags = _test_tag_set_tags(extra_gotags = extra_gotags),
             tags = user_tags + ["dd_agent_go_test"],
             target_compatible_with = user_tcw,
             **kwargs
@@ -132,7 +138,7 @@ def dd_agent_go_test(
         _test_tag_set_check_name(name + "_" + suffix, gotags)
         go_test(
             name = name + "_" + suffix,
-            gotags = _test_tag_set_tags(gotags),
+            gotags = _test_tag_set_tags(gotags, extra_gotags),
             tags = user_tags + ["dd_agent_go_test", "tagset_" + suffix],
             target_compatible_with = user_tcw + _test_tag_set_target_compatible_with(gotags),
             **kwargs


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Allow test targets to take an additional extra_gotags that gets added to all generated test targets.

### Motivation

This allows us to get finer grain control over the test dependencies build tags. See https://github.com/DataDog/datadog-agent/pull/54846 for an existing use case

### Describe how you validated your changes

The PR linked just above successfully builds by passing the `kustomize_disable_go_plugin_support` build tag when building `sigs.k8s.io/kustomize/api`

### Additional Notes
