### PR TITLE
[AAD] Optimize Holt residual

### DIFF
--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
@@ -682,21 +682,6 @@ func pushTimestamp(state *holtSeriesState, ts int64) {
 	state.recentTimestamps[len(state.recentTimestamps)-1] = ts
 }
 
-// medianOfTail returns the median of the last n entries of buf. If buf has
-// fewer than n entries, uses everything available. Returns 0 on an empty
-// buf — the caller (post-fire path) will then push a zero residual, which
-// is a sane neutral value: it does not bias the threshold up or down.
-func medianOfTail(buf []float64, n int) float64 {
-	if len(buf) == 0 {
-		return 0
-	}
-	if n > len(buf) {
-		n = len(buf)
-	}
-	tail := buf[len(buf)-n:]
-	return detectorMedian(tail)
-}
-
 // ensureDefaults fills zero-valued config fields with sensible defaults so the
 // detector behaves sanely when constructed via reflective paths that bypass
 // NewHoltResidualDetector.

--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
@@ -8,6 +8,7 @@ package observerimpl
 import (
 	"fmt"
 	"math"
+	"sort"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -143,6 +144,10 @@ type HoltResidualDetector struct {
 	// every series' metadata and tag slice for Holt's lifetime.
 	cachedRefs []observer.SeriesRef
 	cachedGen  uint64
+
+	// scratch is reused by the single-threaded detection loop for median/MAD
+	// calculations. It never aliases series state windows.
+	scratch []float64
 }
 
 // HoltResidualConfig holds catalog/testbench tunables for HoltResidualDetector.
@@ -218,6 +223,7 @@ func (d *HoltResidualDetector) Reset() {
 	d.series = make(map[holtStateKey]*holtSeriesState)
 	d.cachedRefs = nil
 	d.cachedGen = 0
+	d.scratch = d.scratch[:0]
 	d.ready = false
 }
 
@@ -432,16 +438,14 @@ func (d *HoltResidualDetector) processPoint(
 	// post-refractory fires once the smoother is mid-adaptation. Using
 	// 5% of the observed value range as a noise floor keeps the threshold
 	// proportional to the data's natural scale.
-	medianResidual := detectorMedian(state.resWin)
-	sigmaResidual := detectorMAD(state.resWin, medianResidual, true)
+	medianResidual, sigmaResidual := d.medianMAD(state.resWin)
 	sigmaResidual = floorSigma(sigmaResidual, state.resWin)
 	z := (residual - medianResidual) / sigmaResidual
 
 	// σ_value gate denominator: rolling MAD over raw values. Same window
 	// size, same scaleToSigma=true → MAD ≈ σ. Uses the same range-based
 	// floor for the same bimodal-distribution reason.
-	medianValue := detectorMedian(state.valWin)
-	sigmaValue := detectorMAD(state.valWin, medianValue, true)
+	_, sigmaValue := d.medianMAD(state.valWin)
 	sigmaValue = floorSigma(sigmaValue, state.valWin)
 	devMAD := math.Abs(p.Value-state.level) / sigmaValue
 
@@ -484,7 +488,7 @@ func (d *HoltResidualDetector) processPoint(
 	// blinding us to subsequent shifts.
 	residualForWindow := residual
 	if fire {
-		residualForWindow = medianOfTail(state.resWin, holtPostFireSampleN)
+		residualForWindow = d.medianOfTail(state.resWin, holtPostFireSampleN)
 	}
 	pushFIFO(&state.resWin, d.ResidualWindow, residualForWindow)
 	pushFIFO(&state.valWin, d.ResidualWindow, p.Value)
@@ -532,6 +536,56 @@ func (d *HoltResidualDetector) processPoint(
 	state.refractoryRemaining = d.Refractory
 
 	return anomaly, true
+}
+
+// medianMAD returns the median and normal-sigma-scaled MAD without allocating.
+// Detect is single-writer, so one detector-owned scratch buffer is sufficient.
+func (d *HoltResidualDetector) medianMAD(vals []float64) (float64, float64) {
+	if len(vals) == 0 {
+		return 0, 0
+	}
+	if cap(d.scratch) < len(vals) {
+		d.scratch = make([]float64, len(vals))
+	} else {
+		d.scratch = d.scratch[:len(vals)]
+	}
+	copy(d.scratch, vals)
+	sort.Float64s(d.scratch)
+	n := len(d.scratch)
+	median := d.scratch[n/2]
+	if n%2 == 0 {
+		median = (d.scratch[n/2-1] + median) / 2
+	}
+	for i, v := range vals {
+		d.scratch[i] = math.Abs(v - median)
+	}
+	sort.Float64s(d.scratch)
+	mad := d.scratch[n/2]
+	if n%2 == 0 {
+		mad = (d.scratch[n/2-1] + mad) / 2
+	}
+	return median, mad * 1.4826
+}
+
+func (d *HoltResidualDetector) medianOfTail(buf []float64, n int) float64 {
+	if len(buf) == 0 {
+		return 0
+	}
+	if n > len(buf) {
+		n = len(buf)
+	}
+	tail := buf[len(buf)-n:]
+	if cap(d.scratch) < n {
+		d.scratch = make([]float64, n)
+	} else {
+		d.scratch = d.scratch[:n]
+	}
+	copy(d.scratch, tail)
+	sort.Float64s(d.scratch)
+	if n%2 == 0 {
+		return (d.scratch[n/2-1] + d.scratch[n/2]) / 2
+	}
+	return d.scratch[n/2]
 }
 
 // seedLevelTrend bootstraps the smoother from warmup aggregates using the

--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
@@ -96,12 +96,6 @@ type holtSeriesState struct {
 	consecutiveNeg      int
 	refractoryRemaining int
 
-	// captured series metadata (first non-empty observation suffices)
-	seriesMetaCaptured bool
-	seriesNamespace    string
-	seriesName         string
-	seriesTags         []string
-
 	// recentTimestamps is a small ring of the most recently ingested point
 	// timestamps; used by medianTimestampInterval to estimate the sampling
 	// cadence for downstream correlators. We don't need a full window —
@@ -356,17 +350,6 @@ func (d *HoltResidualDetector) ingestNewPoints(
 
 	storage.ForEachPoint(ref, startTime, dataTime, agg, func(s *observer.Series, p observer.Point) {
 		pointsSeen = true
-		// Capture series metadata once.
-		if !state.seriesMetaCaptured {
-			state.seriesNamespace = s.Namespace
-			state.seriesName = s.Name
-			if len(s.Tags) > 0 {
-				tagsCopy := make([]string, len(s.Tags))
-				copy(tagsCopy, s.Tags)
-				state.seriesTags = tagsCopy
-			}
-			state.seriesMetaCaptured = true
-		}
 		state.lastSeenTimestamp = p.Timestamp
 		state.lastProcessedTime = p.Timestamp
 		state.lastProcessedValue = p.Value
@@ -391,7 +374,7 @@ func (d *HoltResidualDetector) ingestNewPoints(
 			return
 		}
 
-		anomaly, hasFire := d.processPoint(state, p, agg, allowFire)
+		anomaly, hasFire := d.processPoint(state, s, p, agg, allowFire)
 		if len(state.resWin) >= d.ResidualWindow && len(state.valWin) >= d.ResidualWindow {
 			d.ready = true
 		}
@@ -428,6 +411,7 @@ func holtCursorPointChanged(storage observer.StorageReader, ref observer.SeriesR
 // advance so the level/trend track new regimes through and after fires.
 func (d *HoltResidualDetector) processPoint(
 	state *holtSeriesState,
+	series *observer.Series,
 	p observer.Point,
 	agg observer.Aggregate,
 	allowFire bool,
@@ -511,13 +495,17 @@ func (d *HoltResidualDetector) processPoint(
 
 	// 7. Build the anomaly using the common metric-detector anomaly shape.
 	score := math.Abs(z)
-	seriesName := state.seriesName + ":" + aggSuffix(agg)
+	seriesName := series.Name + ":" + aggSuffix(agg)
+	var tags []string
+	if len(series.Tags) > 0 {
+		tags = append([]string(nil), series.Tags...)
+	}
 	anomaly := observer.Anomaly{
 		Type: observer.AnomalyTypeMetric,
 		Source: observer.SeriesDescriptor{
-			Namespace: state.seriesNamespace,
-			Name:      state.seriesName,
-			Tags:      state.seriesTags,
+			Namespace: series.Namespace,
+			Name:      series.Name,
+			Tags:      tags,
 			Aggregate: agg,
 		},
 		DetectorName: d.Name(),

--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
@@ -145,10 +145,10 @@ type HoltResidualDetector struct {
 	// per-series state keyed by ref+agg
 	series map[holtStateKey]*holtSeriesState
 
-	// cache the discovered series list across Detect calls (mirrors the
-	// scanwelch / scanmw / bocpd pattern).
-	cachedSeries []observer.SeriesMeta
-	cachedGen    uint64
+	// Cache compact refs across Detect calls. Keeping only refs avoids retaining
+	// every series' metadata and tag slice for Holt's lifetime.
+	cachedRefs []observer.SeriesRef
+	cachedGen  uint64
 }
 
 // HoltResidualConfig holds catalog/testbench tunables for HoltResidualDetector.
@@ -222,7 +222,7 @@ func (d *HoltResidualDetector) DetectorPointWindow() observer.DetectorPointWindo
 // Reset clears all per-series state for replay/reanalysis.
 func (d *HoltResidualDetector) Reset() {
 	d.series = make(map[holtStateKey]*holtSeriesState)
-	d.cachedSeries = nil
+	d.cachedRefs = nil
 	d.cachedGen = 0
 	d.ready = false
 }
@@ -240,7 +240,7 @@ func (d *HoltResidualDetector) RemoveSeries(refs []observer.SeriesRef) {
 			delete(d.series, holtStateKey{ref: ref, agg: agg})
 		}
 	}
-	d.cachedSeries = nil
+	d.cachedRefs = nil
 	d.cachedGen = 0
 }
 
@@ -250,27 +250,23 @@ func (d *HoltResidualDetector) Detect(storage observer.StorageReader, dataTime i
 	d.ensureDefaults()
 
 	gen := storage.SeriesGeneration()
-	if d.cachedSeries == nil || gen != d.cachedGen {
-		d.cachedSeries = storage.ListSeries(observer.WorkloadSeriesFilter())
+	if d.cachedRefs == nil || gen != d.cachedGen {
+		d.cachedRefs = workloadSeriesRefs(storage, d.cachedRefs)
 		d.cachedGen = gen
 	}
 
-	refs := make([]observer.SeriesRef, len(d.cachedSeries))
-	for i, meta := range d.cachedSeries {
-		refs[i] = meta.Ref
-	}
-	bulkStatus := bulkSeriesStatus(storage, refs, dataTime)
+	bulkStatus := bulkSeriesStatus(storage, d.cachedRefs, dataTime)
 
 	var allAnomalies []observer.Anomaly
 
-	for i, meta := range d.cachedSeries {
+	for i, ref := range d.cachedRefs {
 		status := bulkStatus[i]
 
 		for _, agg := range d.Aggregations {
-			if !supportsSeriesAggregate(storage, meta.Ref, agg) {
+			if !supportsSeriesAggregate(storage, ref, agg) {
 				continue
 			}
-			sk := holtStateKey{ref: meta.Ref, agg: agg}
+			sk := holtStateKey{ref: ref, agg: agg}
 			state, exists := d.series[sk]
 			if !exists && status.pointCount < d.WarmupPoints {
 				continue
@@ -286,23 +282,23 @@ func (d *HoltResidualDetector) Detect(storage observer.StorageReader, dataTime i
 			}
 			startTime := state.lastProcessedTime
 			countIncreased := status.pointCount > state.lastProcessedCount
-			prefixCount := storage.PointCountUpTo(meta.Ref, state.lastProcessedTime)
+			prefixCount := storage.PointCountUpTo(ref, state.lastProcessedTime)
 			// A full point window can evict an old bucket while appending a new
 			// one. That changes the generation without changing the total count;
 			// the smaller prefix shows the lost bucket was before our cursor.
 			mergeOccurred := status.pointCount == state.lastProcessedCount && status.writeGeneration != state.lastWriteGen &&
 				prefixCount >= state.lastProcessedCount
 			cursorBucketChangedWithAppend := countIncreased && status.writeGeneration != state.lastWriteGen &&
-				prefixCount == state.lastProcessedCount && holtCursorPointChanged(storage, meta.Ref, agg, state)
+				prefixCount == state.lastProcessedCount && holtCursorPointChanged(storage, ref, agg, state)
 			if mergeOccurred || prefixCount > state.lastProcessedCount || cursorBucketChangedWithAppend {
 				state = d.newState()
 				d.series[sk] = state
 				startTime = 0
 			}
 
-			anomalies, pointsSeen := d.ingestNewPoints(storage, meta.Ref, agg, state, startTime, dataTime, status.pointCount >= d.WarmupPoints)
+			anomalies, pointsSeen := d.ingestNewPoints(storage, ref, agg, state, startTime, dataTime, status.pointCount >= d.WarmupPoints)
 			for j := range anomalies {
-				anomalies[j].SourceRef = &observer.QueryHandle{Ref: meta.Ref, Aggregate: agg}
+				anomalies[j].SourceRef = &observer.QueryHandle{Ref: ref, Aggregate: agg}
 			}
 			allAnomalies = append(allAnomalies, anomalies...)
 

--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual_test.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual_test.go
@@ -504,17 +504,18 @@ func TestHoltResidual_ConfirmationStartsAfterWindowsReady(t *testing.T) {
 		valWin:   []float64{0, 0, 0},
 	}
 
-	_, fired := d.processPoint(state, observer.Point{Timestamp: 1, Value: 100}, observer.AggregateAverage, true)
+	series := &observer.Series{Name: "metric"}
+	_, fired := d.processPoint(state, series, observer.Point{Timestamp: 1, Value: 100}, observer.AggregateAverage, true)
 	require.False(t, fired)
 	assert.Zero(t, state.consecutivePos, "under-filled windows must not pre-arm confirmation")
 	assert.Zero(t, state.consecutiveNeg)
 
-	_, fired = d.processPoint(state, observer.Point{Timestamp: 2, Value: 100}, observer.AggregateAverage, true)
+	_, fired = d.processPoint(state, series, observer.Point{Timestamp: 2, Value: 100}, observer.AggregateAverage, true)
 	require.False(t, fired, "first ready-window breach should only arm confirmation")
 	assert.Equal(t, 1, state.consecutivePos)
 	assert.Zero(t, state.consecutiveNeg)
 
-	_, fired = d.processPoint(state, observer.Point{Timestamp: 3, Value: 100}, observer.AggregateAverage, true)
+	_, fired = d.processPoint(state, series, observer.Point{Timestamp: 3, Value: 100}, observer.AggregateAverage, true)
 	require.True(t, fired, "second ready-window breach should satisfy ConfirmM")
 }
 

--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual_test.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual_test.go
@@ -247,7 +247,7 @@ func TestHoltResidual_RemoveSeries(t *testing.T) {
 
 	d.RemoveSeries([]observer.SeriesRef{ref})
 	assert.Empty(t, d.series, "RemoveSeries must drop per-series state for freed refs")
-	assert.Nil(t, d.cachedSeries, "RemoveSeries should invalidate the series cache")
+	assert.Nil(t, d.cachedRefs, "RemoveSeries should invalidate the series cache")
 }
 
 // TestHoltResidual_Reset confirms that Reset wipes per-series state.
@@ -261,7 +261,7 @@ func TestHoltResidual_Reset(t *testing.T) {
 
 	d.Reset()
 	assert.Empty(t, d.series, "Reset must clear per-series state")
-	assert.Nil(t, d.cachedSeries, "Reset must clear cached series")
+	assert.Nil(t, d.cachedRefs, "Reset must clear cached series")
 }
 
 // TestHoltResidual_DefaultsApplied confirms ensureDefaults populates a


### PR DESCRIPTION
### What does this PR do?

Reduces holt residual memory footprint with 3 optimizations:

1. Store only series ref, not all meta
2. Remove useless series metadata (namespace, tags etc.)
3. Use a single scratch buffer (reduces GC allocs)

We have ~-50% live heap memory (for this component) and ~-90% allocated memory.

This is lossless, the output is the same as before (same F1).

[SMP](https://app.datadoghq.com/profiling/comparison?query=env%3Asingle-machine-performance%20service%3Adatadog-agent%20job_id%3A1cd13b7f-b5c0-4d5f-b265-6903ba139502%20experiment%3Aquality_gate_metrics_logs%20runtime%3Ago%20version%3A7.84.0-devel_git.263.1b8d582&compare_end_A=1787657097754&compare_end_B=1787657095995&compare_query_A=env%3Asingle-machine-performance%20service%3Adatadog-agent%20job_id%3A413a9f50-f553-412a-bc5c-3c5f7b759dc0%20runtime%3Ago%20version%3A%2A442%2A%20experiment%3A%2Ametrics%2A&compare_query_B=env%3Asingle-machine-performance%20service%3Adatadog-agent%20job_id%3A413a9f50-f553-412a-bc5c-3c5f7b759dc0%20runtime%3Ago%20version%3A%2A445%2A%20experiment%3A%2Ametrics%2A&compare_start_A=1787646297754&compare_start_B=1787646295995&compareValuesMode=absolute&comparisonViz=flamegraph&my_code=enabled&profiling-flame-graph__filter=focus_on%28package%3A%2Aanomalydetection%2A%29&viz=flame_graph&start=1787141460000&end=1787141699999&paused=true) (metrics + logs gate, metrics scoped to this component):

| Metric | Before | After |
| - | - | - |
| Heap live size | 9MiB | 5MiB |
| Allocated memory | 414MiB | 40MiB |
| CPU Time | 1.64s | 1.55s |

### Motivation

### Describe how you validated your changes

### Additional Notes

Scenario | Holt live baseline → tip | Live Δ | Holt alloc baseline → tip | Alloc Δ
-- | -- | -- | -- | --
block-building-outage | 2.50 MiB → 669 KiB | -73.9% | 2.32 GiB → 653 MiB | -72.5%
byzantine-fault-cascade | 13.07 MiB → 7.50 MiB | -42.6% | 2.90 GiB → 762 MiB | -74.3%
cascading-payment-failure | 971 KiB → 1.00 MiB | +5.5% | 699 MiB → 285 MiB | -59.2%
cassandra-repair-degradation | 4.30 MiB → 1.14 MiB | -73.5% | 2.18 GiB → 623 MiB | -72.1%
dns-upstream-outage | 1.63 MiB → 1.50 MiB | -8.1% | 2.05 GiB → 869 MiB | -58.6%
kafka-partition-saturation | 1.85 MiB → 637 KiB | -66.4% | 2.66 GiB → 774 MiB | -71.6%
lock-contention | 0 → 0 | — | 453 MiB → 218 MiB | -51.9%
memcached-saturation | 512 KiB → 1.04 MiB | +107.2% | 435 MiB → 167 MiB | -61.5%
pool-saturation | 512 KiB → 0 | -100.0% | 533 MiB → 233 MiB | -56.3%
redis-cascade-billing | 2.44 MiB → 587 KiB | -76.5% | 1.69 GiB → 492 MiB | -71.6%
redis-cpu-saturation | 977 KiB → 0 | -100.0% | 579 MiB → 269 MiB | -53.4%
tiered-cache-header-corruption | 0 → 0 | — | 402 MiB → 188 MiB | -53.4%
**Aggregate** | **28.7 MiB → 14.0 MiB** | **-51.1%** | **16.84 GiB → 5.40 GiB** | **-67.9%**
