### PR TITLE
When failing to download OCB: Include the exception in the string printed at exit

### DIFF
--- a/tasks/collector.py
+++ b/tasks/collector.py
@@ -206,7 +206,7 @@ def generate(ctx):
             print(f"Downloaded to {binary_path}")
         except Exception as e:
             raise Exit(
-                color_message("Error: Failed to download the binary", Color.RED),
+                color_message(f"Error: Failed to download the binary from {binary_url}: {e}", Color.RED),
                 code=1,
             ) from e
 


### PR DESCRIPTION
### What does this PR do?

Print reason of failure to download the OCB binary

### Motivation

In CI logs, we want the reason for the failure, not just `Failed to download the binary`

