### PR TITLE
Fix invalid type when calling Set on the config

### DIFF
--- a/cmd/agent/subcommands/flare/command_test.go
+++ b/cmd/agent/subcommands/flare/command_test.go
@@ -122,7 +122,7 @@ func (c *commandTestSuite) TestReadProfileData() {
 	mockConfig.SetInTest("expvar_port", port)
 	mockConfig.SetInTest("apm_config.enabled", true)
 	mockConfig.SetInTest("apm_config.debug.port", httpsPort)
-	mockConfig.SetInTest("apm_config.receiver_timeout", "10")
+	mockConfig.SetInTest("apm_config.receiver_timeout", 10)
 	mockConfig.SetInTest("process_config.expvar_port", port)
 	mockConfig.SetInTest("security_agent.expvar_port", port)
 
@@ -193,7 +193,7 @@ func (c *commandTestSuite) TestReadProfileDataNoTraceAgent() {
 	mockConfig.SetInTest("expvar_port", port)
 	mockConfig.SetInTest("apm_config.enabled", true)
 	mockConfig.SetInTest("apm_config.debug.port", 0)
-	mockConfig.SetInTest("apm_config.receiver_timeout", "10")
+	mockConfig.SetInTest("apm_config.receiver_timeout", 10)
 	mockConfig.SetInTest("process_config.expvar_port", port)
 	mockConfig.SetInTest("security_agent.expvar_port", port)
 
@@ -258,7 +258,7 @@ func (c *commandTestSuite) TestReadProfileDataErrors() {
 	mockConfig.SetInTest("security_agent.expvar_port", 0)
 	mockConfig.SetInTest("apm_config.enabled", true)
 	mockConfig.SetInTest("apm_config.debug.port", 0)
-	mockConfig.SetInTest("process_config.enabled", true)
+	mockConfig.SetInTest("process_config.enabled", "true")
 	mockConfig.SetInTest("process_config.expvar_port", 0)
 
 	mockSysProbeConfig := configmock.NewSystemProbe(t)

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -277,7 +277,7 @@ func runJmxCommandConsole(config config.Component,
 	// This prevents log-spam from "comp/core/workloadmeta/collectors/internal/remote/process_collector/process_collector.go"
 	// It appears that this collector creates some contention in AD.
 	// Disabling it is both more efficient and gets rid of this log spam
-	config.Set("language_detection.enabled", "false", model.SourceAgentRuntime)
+	config.Set("language_detection.enabled", false, model.SourceAgentRuntime)
 
 	// The Autoconfig instance setup happens in the workloadmeta start hook
 	// create and setup the Collector and others.

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
@@ -53,7 +53,7 @@ func TestGetNodeAnnotations(t *testing.T) {
 	// we need to do this because the default behavior for /annotations/node/{node}
 	// applies a filter based on this config
 	mockConfig := configmock.New(t)
-	mockConfig.SetInTest("kubernetes_node_annotations_as_host_aliases", "annotation1")
+	mockConfig.SetInTest("kubernetes_node_annotations_as_host_aliases", []string{"annotation1"})
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		getNodeAnnotations(w, r, mockStore)

--- a/comp/core/profiler/impl/profiler_test.go
+++ b/comp/core/profiler/impl/profiler_test.go
@@ -56,7 +56,7 @@ func createGenericConfig(t *testing.T) model.Config {
 	mockConfig.SetInTest("process_config.expvar_port", port)
 	mockConfig.SetInTest("security_agent.expvar_port", port)
 
-	mockConfig.SetInTest("process_config.enabled", false)
+	mockConfig.SetInTest("process_config.enabled", "false")
 	mockConfig.SetInTest("process_config.container_collection.enabled", false)
 	mockConfig.SetInTest("process_config.process_collection.enabled", false)
 	mockConfig.SetInTest("apm_config.enabled", false)

--- a/comp/core/workloadfilter/impl/filter_mock_test.go
+++ b/comp/core/workloadfilter/impl/filter_mock_test.go
@@ -45,7 +45,7 @@ func TestNewMock_ProvidesMockFilter(t *testing.T) {
 
 func TestNewMock_UsesMockConfig(t *testing.T) {
 	cfg := config.NewMock(t)
-	cfg.SetInTest("container_exclude", "name:excluded-container")
+	cfg.SetInTest("container_exclude", []string{"name:excluded-container"})
 
 	logger := logmock.New(t)
 	telemetry := fxutil.Test[telemetry.Mock](t, mocktelemetry.Module())

--- a/comp/core/workloadmeta/collectors/internal/containerd/containerd_test.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/containerd_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestIgnoreContainer(t *testing.T) {
 	mockConfig := configmock.New(t)
-	mockConfig.SetInTest("container_exclude", "name:agent-excluded")
+	mockConfig.SetInTest("container_exclude", []string{"name:agent-excluded"})
 	mockFilterStore := workloadfilterfxmock.SetupMockFilter(t)
 
 	containerID := "123"

--- a/comp/forwarder/defaultforwarder/impl/domain_forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/impl/domain_forwarder_test.go
@@ -127,8 +127,8 @@ func TestDomainForwarderHAPreFailover(t *testing.T) {
 
 func syncTestDomainForwarderHAPreFailover(t *testing.T) {
 	mockConfig := mock.New(t)
-	mockConfig.SetInTest("multi_region_failover.enabled", "true")
-	mockConfig.SetInTest("multi_region_failover.failover_metrics", "false")
+	mockConfig.SetInTest("multi_region_failover.enabled", true)
+	mockConfig.SetInTest("multi_region_failover.failover_metrics", false)
 	mockConfig.SetInTest("multi_region_failover.apikey", "foo")
 	mockConfig.SetInTest("multi_region_failover.site", "bar.ddhq.com")
 
@@ -172,8 +172,8 @@ func syncTestDomainForwarderHAPreFailover(t *testing.T) {
 
 func TestDomainForwarderHAFailover(t *testing.T) {
 	mockConfig := mock.New(t)
-	mockConfig.SetInTest("multi_region_failover.enabled", "true")
-	mockConfig.SetInTest("multi_region_failover.failover_metrics", "true")
+	mockConfig.SetInTest("multi_region_failover.enabled", true)
+	mockConfig.SetInTest("multi_region_failover.failover_metrics", true)
 	mockConfig.SetInTest("multi_region_failover.apikey", "foo")
 	mockConfig.SetInTest("multi_region_failover.site", "bar.ddhq.com")
 

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -653,7 +653,7 @@ func (suite *ConfigTestSuite) TestEndpointsSetDDSite() {
 
 	suite.config.SetInTest("site", "mydomain.com")
 	suite.config.SetInTest("compliance_config.endpoints_batch_wait", "mydomain.com")
-	suite.config.SetInTest("compliance_config.endpoints.batch_wait", "10")
+	suite.config.SetInTest("compliance_config.endpoints.batch_wait", 10.0)
 
 	logsConfig := NewLogsConfigKeys("compliance_config.endpoints.", suite.config)
 	endpoints, err := BuildHTTPEndpointsWithConfig(suite.config, logsConfig, "default-intake.logs.", "test-track", "test-proto", "test-source")

--- a/comp/logs/agent/config/endpoints_test.go
+++ b/comp/logs/agent/config/endpoints_test.go
@@ -256,17 +256,17 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWhenMigratingToA
 func (suite *EndpointsTestSuite) TestBuildEndpointsShouldTakeIntoAccountHTTPConnectivity() {
 
 	resetHTTPConfigValuesToFalse := func() {
-		suite.config.SetInTest("logs_config.use_tcp", "false")
-		suite.config.SetInTest("logs_config.force_use_tcp", "false")
-		suite.config.SetInTest("logs_config.use_http", "false")
-		suite.config.SetInTest("logs_config.force_use_http", "false")
+		suite.config.SetInTest("logs_config.use_tcp", false)
+		suite.config.SetInTest("logs_config.force_use_tcp", false)
+		suite.config.SetInTest("logs_config.use_http", false)
+		suite.config.SetInTest("logs_config.force_use_http", false)
 		suite.config.SetInTest("logs_config.socks5_proxy_address", "")
 		suite.config.SetInTest("logs_config.additional_endpoints", []map[string]interface{}{})
 	}
 
 	suite.Run("When use_http is true always create HTTP endpoints", func() {
 		defer resetHTTPConfigValuesToFalse()
-		suite.config.SetInTest("logs_config.use_http", "true")
+		suite.config.SetInTest("logs_config.use_http", true)
 		endpoints, err := BuildEndpoints(suite.config, HTTPConnectivitySuccess, "test-track", "test-proto", "test-source")
 		suite.Nil(err)
 		suite.True(endpoints.UseHTTP)
@@ -277,7 +277,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldTakeIntoAccountHTTPConn
 
 	suite.Run("When force_use_http is true always create HTTP endpoints", func() {
 		defer resetHTTPConfigValuesToFalse()
-		suite.config.SetInTest("logs_config.force_use_http", "true")
+		suite.config.SetInTest("logs_config.force_use_http", true)
 		endpoints, err := BuildEndpoints(suite.config, HTTPConnectivitySuccess, "test-track", "test-proto", "test-source")
 		suite.Nil(err)
 		suite.True(endpoints.UseHTTP)
@@ -288,7 +288,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldTakeIntoAccountHTTPConn
 
 	suite.Run("When use_tcp is true always create TCP endpoints", func() {
 		defer resetHTTPConfigValuesToFalse()
-		suite.config.SetInTest("logs_config.use_tcp", "true")
+		suite.config.SetInTest("logs_config.use_tcp", true)
 		endpoints, err := BuildEndpoints(suite.config, HTTPConnectivitySuccess, "test-track", "test-proto", "test-source")
 		suite.Nil(err)
 		suite.False(endpoints.UseHTTP)
@@ -299,7 +299,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldTakeIntoAccountHTTPConn
 
 	suite.Run("When force_use_tcp is true always create TCP endpoints", func() {
 		defer resetHTTPConfigValuesToFalse()
-		suite.config.SetInTest("logs_config.force_use_tcp", "true")
+		suite.config.SetInTest("logs_config.force_use_tcp", true)
 		endpoints, err := BuildEndpoints(suite.config, HTTPConnectivitySuccess, "test-track", "test-proto", "test-source")
 		suite.Nil(err)
 		suite.False(endpoints.UseHTTP)
@@ -458,7 +458,7 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpointsUseSSLTCPMainEndpointTru
 		err       error
 	)
 
-	suite.config.SetInTest("logs_config.logs_no_ssl", "true")
+	suite.config.SetInTest("logs_config.logs_no_ssl", true)
 	suite.config.SetInTest("logs_config.logs_dd_url", "rand_url.com:1")
 
 	suite.config.SetInTest("logs_config.additional_endpoints", []map[string]interface{}{{"host": "a", "api_key": "1"}, {"host": "b", "api_key": "2", "use_ssl": true}, {"host": "c", "api_key": "3", "use_ssl": false}})
@@ -477,7 +477,7 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpointsUseSSLTCPMainEndpointFal
 		err       error
 	)
 
-	suite.config.SetInTest("logs_config.logs_no_ssl", "false")
+	suite.config.SetInTest("logs_config.logs_no_ssl", false)
 	suite.config.SetInTest("logs_config.logs_dd_url", "rand_url.com:1")
 
 	suite.config.SetInTest("logs_config.additional_endpoints", []map[string]interface{}{{"host": "a", "api_key": "1"}, {"host": "b", "api_key": "2", "use_ssl": true}, {"host": "c", "api_key": "3", "use_ssl": false}})
@@ -496,8 +496,8 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpointsUseSSLHTTPMainEndpointTr
 		err       error
 	)
 
-	suite.config.SetInTest("logs_config.logs_no_ssl", "true")
-	suite.config.SetInTest("logs_config.use_http", "true")
+	suite.config.SetInTest("logs_config.logs_no_ssl", true)
+	suite.config.SetInTest("logs_config.use_http", true)
 	suite.config.SetInTest("logs_config.logs_dd_url", "http://rand_url.com:1")
 
 	suite.config.SetInTest("logs_config.additional_endpoints", []map[string]interface{}{{"host": "a", "api_key": "1"}, {"host": "b", "api_key": "2", "use_ssl": true}, {"host": "c", "api_key": "3", "use_ssl": false}})
@@ -516,8 +516,8 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpointsUseSSLHTTPMainEndpointFa
 		err       error
 	)
 
-	suite.config.SetInTest("logs_config.logs_no_ssl", "false")
-	suite.config.SetInTest("logs_config.use_http", "true")
+	suite.config.SetInTest("logs_config.logs_no_ssl", false)
+	suite.config.SetInTest("logs_config.use_http", true)
 	suite.config.SetInTest("logs_config.logs_dd_url", "http://rand_url.com:1")
 
 	suite.config.SetInTest("logs_config.additional_endpoints", []map[string]interface{}{{"host": "a", "api_key": "1"}, {"host": "b", "api_key": "2", "use_ssl": true}, {"host": "c", "api_key": "3", "use_ssl": false}})

--- a/comp/otelcol/collector/impl-pipeline/flare_filler_test.go
+++ b/comp/otelcol/collector/impl-pipeline/flare_filler_test.go
@@ -130,7 +130,7 @@ func TestOTelExtFlareBuilder(t *testing.T) {
 
 	cfg := config.NewMock(t)
 	cfg.Set("otelcollector.enabled", true, pkgconfigmodel.SourceAgentRuntime)
-	cfg.Set("otelcollector.extension_url", 7777, pkgconfigmodel.SourceAgentRuntime)
+	cfg.Set("otelcollector.extension_url", "https://localhost:7777", pkgconfigmodel.SourceAgentRuntime)
 
 	reqs := Requires{
 		Lc:     compdef.NewTestLifecycle(t),

--- a/comp/trace/agent/impl/run_test.go
+++ b/comp/trace/agent/impl/run_test.go
@@ -20,7 +20,7 @@ func TestProfilingConfig(t *testing.T) {
 	tconfig := tracecfg.New()
 	cconfig := configmock.New(t)
 	cconfig.SetInTest("apm_config.internal_profiling.enabled", true)
-	cconfig.SetInTest("internal_profiling.extra_tags", "k1:v1 k2:v2")
+	cconfig.SetInTest("internal_profiling.extra_tags", []string{"k1:v1", "k2:v2"})
 	cconfig.SetInTest("internal_profiling.period", 30*time.Second)
 	cconfig.SetInTest("internal_profiling.cpu_duration", 15*time.Second)
 	cconfig.SetInTest("internal_profiling.mutex_profile_fraction", 7)

--- a/comp/trace/config/impl/config_test.go
+++ b/comp/trace/config/impl/config_test.go
@@ -286,7 +286,7 @@ func TestConfigHostname(t *testing.T) {
 	t.Run("fail", func(t *testing.T) {
 		coreConfig := configcomp.NewMockFromYAMLFile(t, "./testdata/site_override.yaml")
 		coreConfig.SetInTest("apm_config.dd_agent_bin", "/not/exist")
-		coreConfig.SetInTest("cmd_port", "-1")
+		coreConfig.SetInTest("cmd_port", -1)
 
 		fallbackHostnameFunc = func() (string, error) {
 			return "", errors.New("could not get hostname")
@@ -329,7 +329,7 @@ func TestConfigHostname(t *testing.T) {
 
 		coreConfig := configcomp.NewMockFromYAMLFile(t, "./testdata/site_override.yaml")
 		coreConfig.SetInTest("apm_config.dd_agent_bin", "/not/exist")
-		coreConfig.SetInTest("cmd_port", "-1")
+		coreConfig.SetInTest("cmd_port", -1)
 		config := buildComponent(t, false, coreConfig)
 
 		cfg := config.Object()

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar_test.go
@@ -837,7 +837,7 @@ func TestDefaultSidecarTemplateClusterAgentEnvVars(t *testing.T) {
 				mockConfig.SetInTest("admission_controller.agent_sidecar.container_registry", commonRegistry)
 				mockConfig.SetInTest("cluster_agent.cmd_port", 12345)
 				mockConfig.SetInTest("cluster_agent.kubernetes_service_name", "test-service-name")
-				mockConfig.SetInTest("language_detection.enabled", "false")
+				mockConfig.SetInTest("language_detection.enabled", false)
 				return mockConfig
 			},
 			expectedEnvVars: []corev1.EnvVar{

--- a/pkg/collector/check/stats/stats_test.go
+++ b/pkg/collector/check/stats/stats_test.go
@@ -92,7 +92,7 @@ func TestNewStats(t *testing.T) {
 
 func TestNewStatsStateTelemetryInitialized(t *testing.T) {
 	mockConfig := configmock.New(t)
-	mockConfig.SetInTest("telemetry.checks", "*")
+	mockConfig.SetInTest("telemetry.checks", []string{"*"})
 
 	NewStats(newMockCheck())
 
@@ -113,7 +113,7 @@ func TestNewStatsStateTelemetryInitialized(t *testing.T) {
 
 func TestFirstExecutionTimeMetric(t *testing.T) {
 	mockConfig := configmock.New(t)
-	mockConfig.SetInTest("telemetry.checks", "*")
+	mockConfig.SetInTest("telemetry.checks", []string{"*"})
 
 	stats := NewStats(newMockCheck())
 	haagent := haagentmock.NewMockHaAgent()

--- a/pkg/collector/corechecks/containers/kubelet/provider/kubelet/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/kubelet/provider_test.go
@@ -289,7 +289,7 @@ func (suite *ProviderTestSuite) TestPVCMetricsExcludedByNamespace() {
 	}
 
 	mockConfig := configmock.New(suite.T())
-	mockConfig.SetInTest("container_exclude", "kube_namespace:default")
+	mockConfig.SetInTest("container_exclude", []string{"kube_namespace:default"})
 	mockFilterStore := workloadfilterfxmock.SetupMockFilter(suite.T())
 	suite.provider.containerFilter = mockFilterStore.GetContainerSharedMetricFilters()
 	suite.provider.podFilter = mockFilterStore.GetPodSharedMetricFilters()

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
@@ -90,7 +90,7 @@ func (suite *ProviderTestSuite) SetupTest() {
 		fx.Provide(func() ipc.Component { return ipcmock.New(suite.T()) }),
 	))
 
-	mockConfig.SetInTest("container_exclude", "name:agent-excluded")
+	mockConfig.SetInTest("container_exclude", []string{"name:agent-excluded"})
 	mockFilterStore := workloadfilterfxmock.SetupMockFilter(suite.T())
 
 	suite.provider = NewProvider(mockFilterStore, wmeta, config, common.NewPodUtils(fakeTagger), fakeTagger, nil)

--- a/pkg/collector/corechecks/containers/kubelet/provider/probe/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/probe/provider_test.go
@@ -307,7 +307,7 @@ func TestProvider_Provide(t *testing.T) {
 			}
 
 			mockConfig := configmock.New(t)
-			mockConfig.SetInTest("container_exclude", "name:fluentbit-gke")
+			mockConfig.SetInTest("container_exclude", []string{"name:fluentbit-gke"})
 			mockFilterStore := workloadfilterfxmock.SetupMockFilter(t)
 
 			p, err := NewProvider(

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
@@ -645,7 +645,7 @@ func (suite *FilteringTestSuite) TestContainerNameFiltering() {
 	suite.setupFilteredTestData()
 
 	// Configure workload filter to exclude istio-proxy containers using config
-	suite.mockConfig.SetInTest("container_exclude", "name:istio-proxy")
+	suite.mockConfig.SetInTest("container_exclude", []string{"name:istio-proxy"})
 	suite.createProviderWithFilters()
 
 	// Provide metrics
@@ -668,7 +668,7 @@ func (suite *FilteringTestSuite) TestNamespaceFiltering() {
 	suite.setupFilteredTestData()
 
 	// Configure workload filter to exclude kube-system namespace pods using config
-	suite.mockConfig.SetInTest("container_exclude", "kube_namespace:kube-system")
+	suite.mockConfig.SetInTest("container_exclude", []string{"kube_namespace:kube-system"})
 	suite.createProviderWithFilters()
 
 	// Provide metrics
@@ -715,7 +715,7 @@ func (suite *FilteringTestSuite) TestSpecificImageNameFiltering() {
 	suite.setupFilteredTestData()
 
 	// Configure workload filter to exclude containers with specific image name
-	suite.mockConfig.SetInTest("container_exclude", "image:istio/proxy")
+	suite.mockConfig.SetInTest("container_exclude", []string{"image:istio/proxy"})
 	suite.createProviderWithFilters()
 
 	// Provide metrics

--- a/pkg/collector/python/test_containers.go
+++ b/pkg/collector/python/test_containers.go
@@ -29,7 +29,7 @@ func testIsContainerExcluded(t *testing.T) {
 
 	mockConfig := configmock.New(t)
 	mockConfig.SetInTest("container_exclude", []string{"image:bar", "kube_namespace:black"})
-	mockConfig.SetInTest("container_include", "kube_namespace:white")
+	mockConfig.SetInTest("container_include", []string{"kube_namespace:white"})
 	filterStore := workloadfilterfxmock.SetupMockFilter(t)
 	collectoraggregator.ScopeInitCheckContext(sender.GetSenderManager(), logReceiver, tagger, filterStore)
 

--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -162,7 +162,7 @@ func testSetUp(t *testing.T) model.Config {
 
 func TestNewRunner(t *testing.T) {
 	mockConfig := testSetUp(t)
-	mockConfig.SetInTest("check_runners", "3")
+	mockConfig.SetInTest("check_runners", 3)
 
 	r := NewRunner(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent())
 	require.NotNil(t, r)
@@ -176,7 +176,7 @@ func TestNewRunner(t *testing.T) {
 
 func TestRunnerAddWorker(t *testing.T) {
 	mockConfig := testSetUp(t)
-	mockConfig.SetInTest("check_runners", "1")
+	mockConfig.SetInTest("check_runners", 1)
 
 	r := NewRunner(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent())
 	require.NotNil(t, r)
@@ -191,7 +191,7 @@ func TestRunnerAddWorker(t *testing.T) {
 
 func TestRunnerStaticUpdateNumWorkers(t *testing.T) {
 	mockConfig := testSetUp(t)
-	mockConfig.SetInTest("check_runners", "2")
+	mockConfig.SetInTest("check_runners", 2)
 
 	r := NewRunner(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent())
 	require.NotNil(t, r)
@@ -210,7 +210,7 @@ func TestRunnerStaticUpdateNumWorkers(t *testing.T) {
 
 func TestRunnerDynamicUpdateNumWorkers(t *testing.T) {
 	mockConfig := testSetUp(t)
-	mockConfig.SetInTest("check_runners", "0")
+	mockConfig.SetInTest("check_runners", 0)
 
 	testCases := [][]int{
 		{0, 10, 4},
@@ -262,7 +262,7 @@ func TestRunner(t *testing.T) {
 
 func TestRunnerShadowWorkerUsesShadowChannel(t *testing.T) {
 	mockConfig := testSetUp(t)
-	mockConfig.SetInTest("check_runners", "1")
+	mockConfig.SetInTest("check_runners", 1)
 
 	inner := newCheck(t, "mycheck:123", false, nil)
 	shadow := check.NewShadowCheck(inner, time.Second)
@@ -288,7 +288,7 @@ func TestRunnerShadowWorkerUsesShadowChannel(t *testing.T) {
 
 func TestRunnerStopStopsShadowWorkers(t *testing.T) {
 	mockConfig := testSetUp(t)
-	mockConfig.SetInTest("check_runners", "0")
+	mockConfig.SetInTest("check_runners", 0)
 
 	inner := newCheck(t, "mycheck:123", false, nil)
 	inner.RunLock.Lock()
@@ -340,7 +340,7 @@ func TestRunnerStopStopsShadowWorkers(t *testing.T) {
 func TestRunnerStop(t *testing.T) {
 	mockConfig := testSetUp(t)
 
-	mockConfig.SetInTest("check_runners", "10")
+	mockConfig.SetInTest("check_runners", 10)
 	numChecks := 8
 
 	checks := make([]*testCheck, numChecks)
@@ -397,7 +397,7 @@ func TestRunnerConfigurableValues(t *testing.T) {
 	mockConfig.SetInTest("check_runner_utilization_threshold", 0.85)
 	mockConfig.SetInTest("check_runner_utilization_monitor_interval", "30s")
 	mockConfig.SetInTest("check_runner_utilization_warning_cooldown", "5m")
-	mockConfig.SetInTest("check_runners", "1")
+	mockConfig.SetInTest("check_runners", 1)
 
 	r := NewRunner(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent())
 	require.NotNil(t, r)
@@ -418,7 +418,7 @@ func TestRunnerConfigurableValues(t *testing.T) {
 
 func TestRunnerDefaultConfigurableValues(t *testing.T) {
 	mockConfig := testSetUp(t)
-	mockConfig.SetInTest("check_runners", "1")
+	mockConfig.SetInTest("check_runners", 1)
 
 	// Set default values for the mock config
 	mockConfig.SetInTest("check_runner_utilization_threshold", 0.95)
@@ -445,7 +445,7 @@ func TestRunnerDefaultConfigurableValues(t *testing.T) {
 func TestRunnerStopWithStuckCheck(t *testing.T) {
 	mockConfig := testSetUp(t)
 
-	mockConfig.SetInTest("check_runners", "10")
+	mockConfig.SetInTest("check_runners", 10)
 	numChecks := 8
 
 	checks := make([]*testCheck, numChecks)
@@ -501,7 +501,7 @@ func TestRunnerStopWithStuckCheck(t *testing.T) {
 
 func TestRunnerStopCheck(t *testing.T) {
 	mockConfig := testSetUp(t)
-	mockConfig.SetInTest("check_runners", "3")
+	mockConfig.SetInTest("check_runners", 3)
 
 	testCheck := newCheck(t, "mycheck:123", false, nil)
 	blockedCheck := newCheck(t, "mycheck2:123", false, nil)
@@ -549,7 +549,7 @@ func TestRunnerStopCheck(t *testing.T) {
 
 func TestRunnerScheduler(t *testing.T) {
 	mockConfig := testSetUp(t)
-	mockConfig.SetInTest("check_runners", "3")
+	mockConfig.SetInTest("check_runners", 3)
 
 	sched1 := newScheduler()
 	sched2 := newScheduler()
@@ -569,7 +569,7 @@ func TestRunnerScheduler(t *testing.T) {
 
 func TestRunnerShouldAddCheckStats(t *testing.T) {
 	mockConfig := testSetUp(t)
-	mockConfig.SetInTest("check_runners", "3")
+	mockConfig.SetInTest("check_runners", 3)
 
 	testCheck := newCheck(t, "test", false, nil)
 	sched := newScheduler()

--- a/pkg/collector/worker/worker_test.go
+++ b/pkg/collector/worker/worker_test.go
@@ -524,7 +524,7 @@ func TestWorkerServiceCheckSending(t *testing.T) {
 	expvars.Reset()
 	mockConfig := configmock.New(t)
 	mockConfig.SetInTest("hostname", "myhost")
-	mockConfig.SetInTest("integration_check_status_enabled", "true")
+	mockConfig.SetInTest("integration_check_status_enabled", true)
 
 	var wg sync.WaitGroup
 
@@ -614,7 +614,7 @@ func TestShadowWorkerDoesNotSendServiceCheck(t *testing.T) {
 	expvars.Reset()
 	mockConfig := configmock.New(t)
 	mockConfig.SetInTest("hostname", "myhost")
-	mockConfig.SetInTest("integration_check_status_enabled", "true")
+	mockConfig.SetInTest("integration_check_status_enabled", true)
 
 	checksTracker := tracker.NewRunningChecksTracker()
 	pendingChecksChan := make(chan check.Check, 1)

--- a/pkg/config/schema/yaml/admission_controller.yaml
+++ b/pkg/config/schema/yaml/admission_controller.yaml
@@ -491,8 +491,8 @@ properties:
         properties:
           enabled:
             node_type: setting
-            type: string
-            default: 'true'
+            type: boolean
+            default: true
           tls_verification:
             node_type: section
             type: object

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -641,7 +641,7 @@ properties:
     - template_section:Common
   forwarder_backoff_base:
     node_type: setting
-    type: integer
+    type: number
     default: 2
     visibility: public
     description: |-
@@ -650,9 +650,10 @@ properties:
       higher rate of exponential growth.
     tags:
     - template_section:Common
+    - golang_type:float64
   forwarder_backoff_max:
     node_type: setting
-    type: integer
+    type: number
     default: 64
     visibility: public
     description: |-
@@ -661,6 +662,7 @@ properties:
       higher maximum backoff time.
     tags:
     - template_section:Common
+    - golang_type:float64
   cloud_provider_metadata:
     node_type: setting
     type: array
@@ -7527,8 +7529,10 @@ properties:
     comment: in minutes
   forwarder_backoff_factor:
     node_type: setting
-    type: integer
+    type: number
     default: 2
+    tags:
+      - golang_type:float64
   forwarder_connection_reset_interval:
     node_type: setting
     type: integer

--- a/pkg/jmxfetch/jmxfetch_nix_test.go
+++ b/pkg/jmxfetch/jmxfetch_nix_test.go
@@ -48,7 +48,7 @@ func TestGetPreferredDSDEndpointNix(t *testing.T) {
 	t.Run("DSD disabled falls back to UDP", func(t *testing.T) {
 		sockPath := createSocket(t)
 		cfg.SetInTest("dogstatsd_socket", sockPath)
-		cfg.SetInTest("dogstatsd_port", "8125")
+		cfg.SetInTest("dogstatsd_port", 8125)
 		cfg.SetInTest("use_dogstatsd", false)
 
 		j := NewJMXFetch(nil, nil)

--- a/pkg/jmxfetch/jmxfetch_test.go
+++ b/pkg/jmxfetch/jmxfetch_test.go
@@ -74,7 +74,7 @@ func TestGetPreferredDSDEndpoint(t *testing.T) {
 
 	t.Run("UDS configured but not available", func(t *testing.T) {
 		cfg.SetInTest("dogstatsd_socket", "/tmp/nonexistent-dsd-test.sock")
-		cfg.SetInTest("dogstatsd_port", "8125")
+		cfg.SetInTest("dogstatsd_port", 8125)
 		cfg.SetInTest("use_dogstatsd", true)
 
 		j := NewJMXFetch(nil, nil)
@@ -83,7 +83,7 @@ func TestGetPreferredDSDEndpoint(t *testing.T) {
 
 	t.Run("UDS not configured", func(t *testing.T) {
 		cfg.SetInTest("dogstatsd_socket", "")
-		cfg.SetInTest("dogstatsd_port", "8125")
+		cfg.SetInTest("dogstatsd_port", 8125)
 		cfg.SetInTest("use_dogstatsd", true)
 
 		j := NewJMXFetch(nil, nil)
@@ -92,7 +92,7 @@ func TestGetPreferredDSDEndpoint(t *testing.T) {
 
 	t.Run("bind host 0.0.0.0 normalized to localhost", func(t *testing.T) {
 		cfg.SetInTest("dogstatsd_socket", "")
-		cfg.SetInTest("dogstatsd_port", "8125")
+		cfg.SetInTest("dogstatsd_port", 8125)
 		cfg.SetInTest("use_dogstatsd", true)
 		cfg.SetInTest("bind_host", "0.0.0.0")
 
@@ -102,7 +102,7 @@ func TestGetPreferredDSDEndpoint(t *testing.T) {
 
 	t.Run("custom bind host and port", func(t *testing.T) {
 		cfg.SetInTest("dogstatsd_socket", "")
-		cfg.SetInTest("dogstatsd_port", "9125")
+		cfg.SetInTest("dogstatsd_port", 9125)
 		cfg.SetInTest("use_dogstatsd", true)
 		cfg.SetInTest("bind_host", "127.0.0.2")
 

--- a/pkg/logs/internal/tag/provider_test.go
+++ b/pkg/logs/internal/tag/provider_test.go
@@ -36,7 +36,7 @@ func TestProviderExpectedTags(t *testing.T) {
 	m.SetInTest("tags", tags)
 	defer m.SetInTest("tags", nil)
 
-	m.SetInTest("logs_config.tagger_warmup_duration", "2")
+	m.SetInTest("logs_config.tagger_warmup_duration", 2)
 
 	expectedTagsDuration := 5 * time.Second
 	m.SetInTest("logs_config.expected_tags_duration", "5s")

--- a/pkg/orchestrator/config/config_test.go
+++ b/pkg/orchestrator/config/config_test.go
@@ -261,7 +261,7 @@ func (suite *YamlConfigTestSuite) TestNoEnvConfigArgsScrubbing() {
 }
 
 func (suite *YamlConfigTestSuite) TestOnlyEnvConfigArgsScrubbing() {
-	suite.config.SetInTest("orchestrator_explorer.custom_sensitive_words", `["token","consul"]`)
+	suite.config.SetInTest("orchestrator_explorer.custom_sensitive_words", []string{"token", "consul"})
 
 	orchestratorCfg := NewDefaultOrchestratorConfig(nil)
 	err := orchestratorCfg.Load()
@@ -284,7 +284,7 @@ func (suite *YamlConfigTestSuite) TestOnlyEnvConfigArgsScrubbing() {
 }
 
 func (suite *YamlConfigTestSuite) TestOnlyEnvContainsConfigArgsScrubbing() {
-	suite.config.SetInTest("orchestrator_explorer.custom_sensitive_words", `["token","consul"]`)
+	suite.config.SetInTest("orchestrator_explorer.custom_sensitive_words", []string{"token", "consul"})
 
 	orchestratorCfg := NewDefaultOrchestratorConfig(nil)
 	err := orchestratorCfg.Load()

--- a/pkg/process/checks/process_test.go
+++ b/pkg/process/checks/process_test.go
@@ -659,7 +659,7 @@ func TestProcessCheckZombieToggleTrue(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, CombinedRunResult{}, first)
 
-	cfg.SetInTest("process_config.ignore_zombie_processes", "true")
+	cfg.SetInTest("process_config.ignore_zombie_processes", true)
 	processCheck.ignoreZombieProcesses = processCheck.config.GetBool(configIgnoreZombies)
 	expected := []model.MessageBody{
 		&model.CollectorProc{

--- a/pkg/process/metadata/workloadmeta/grpc_test.go
+++ b/pkg/process/metadata/workloadmeta/grpc_test.go
@@ -39,7 +39,7 @@ func TestGetGRPCStreamPort(t *testing.T) {
 
 	t.Run("valid port", func(t *testing.T) {
 		cfg := configmock.New(t)
-		cfg.SetInTest("process_config.language_detection.grpc_port", "1234")
+		cfg.SetInTest("process_config.language_detection.grpc_port", 1234)
 
 		assert.Equal(t, 1234, getGRPCStreamPort(cfg))
 	})

--- a/pkg/process/util/containers/containers_test.go
+++ b/pkg/process/util/containers/containers_test.go
@@ -730,7 +730,7 @@ func TestGetContainersExcludesFilteredContainers(t *testing.T) {
 
 	// Configure container exclusion by name
 	mockConfig := configmock.New(t)
-	mockConfig.SetInTest("container_exclude", "name:excluded-container-name")
+	mockConfig.SetInTest("container_exclude", []string{"name:excluded-container-name"})
 
 	filterStore := workloadfilterfxmock.SetupMockFilter(t)
 	filter := filterStore.GetContainerSharedMetricFilters()


### PR DESCRIPTION
### What does this PR do?

The value being set must match the type of the setting. This commit fixes invalid calls to set and a few invalid types in the schema.
