### PR TITLE
fix(data-race): hold agentMapMu until callAgentsForService goroutines finish

### DIFF
--- a/comp/core/remoteagentregistry/impl/client.go
+++ b/comp/core/remoteagentregistry/impl/client.go
@@ -285,9 +285,6 @@ func callAgentsForService[PbType any, StructuredType any](
 		}()
 	}
 
-	// Release the registry lock before waiting on the RPCs. The goroutines
-	// use the snapshotted registeredAgent and the remoteAgent pointer
-	// (for gRPC calls only), neither of which races with RefreshRemoteAgent.
 	registry.agentMapMu.Unlock()
 
 	wg.Wait()

--- a/comp/core/remoteagentregistry/impl/client.go
+++ b/comp/core/remoteagentregistry/impl/client.go
@@ -15,7 +15,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/mdlayher/vsock"
@@ -47,9 +46,8 @@ type remoteAgentClient struct {
 	remoteagentregistry.RegisteredAgent
 
 	// health tracking
-	unhealthy       atomic.Bool // marks agent for removal during next cleanup cycle
-	unhealthyReason error       // stores the reason the agent was marked unhealthy (for logging)
-	unhealthyMu     sync.Mutex  // guards unhealthyReason
+	unhealthyReason error      // non-nil marks agent for removal during next cleanup cycle
+	unhealthyMu     sync.Mutex // guards unhealthyReason
 
 	// gRPC relative
 	pb.FlareProviderClient
@@ -274,7 +272,6 @@ func callAgentsForService[PbType any, StructuredType any](
 					registry.telemetryStore.remoteAgentActionError.Inc(registeredAgent.SanitizedDisplayName, service, sessionIDMismatch)
 
 					// Mark agent as unhealthy for removal during next cleanup cycle
-					remoteAgent.unhealthy.Store(true)
 					remoteAgent.unhealthyMu.Lock()
 					remoteAgent.unhealthyReason = validationErr
 					remoteAgent.unhealthyMu.Unlock()

--- a/comp/core/remoteagentregistry/impl/client.go
+++ b/comp/core/remoteagentregistry/impl/client.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/mdlayher/vsock"
@@ -46,8 +47,9 @@ type remoteAgentClient struct {
 	remoteagentregistry.RegisteredAgent
 
 	// health tracking
-	unhealthy       bool  // marks agent for removal during next cleanup cycle
-	unhealthyReason error // stores the reason the agent was marked unhealthy (for logging)
+	unhealthy       atomic.Bool // marks agent for removal during next cleanup cycle
+	unhealthyReason error       // stores the reason the agent was marked unhealthy (for logging)
+	unhealthyMu     sync.Mutex  // guards unhealthyReason
 
 	// gRPC relative
 	pb.FlareProviderClient
@@ -243,13 +245,17 @@ func callAgentsForService[PbType any, StructuredType any](
 
 	wg.Add(agentsLen)
 	for _, remoteAgent := range filteredAgents {
+		// Snapshot the RegisteredAgent value under the lock so the goroutines
+		// don't race with RefreshRemoteAgent writing LastSeen. The gRPC
+		// client methods on remoteAgent use the conn, not RegisteredAgent.
+		registeredAgent := remoteAgent.RegisteredAgent
 		go func() {
 			start := time.Now()
 			defer func() {
 				wg.Done()
 				registry.telemetryStore.remoteAgentActionDuration.Observe(
 					time.Since(start).Seconds(),
-					remoteAgent.RegisteredAgent.SanitizedDisplayName,
+					registeredAgent.SanitizedDisplayName,
 					service,
 				)
 			}()
@@ -259,31 +265,33 @@ func callAgentsForService[PbType any, StructuredType any](
 			resp, err := grpcCall(ctx, remoteAgent, grpc.WaitForReady(true), grpc.Header(&responseHeader))
 
 			if err != nil {
-				registry.telemetryStore.remoteAgentActionError.Inc(remoteAgent.RegisteredAgent.SanitizedDisplayName, service, grpcErrorMessage(err))
+				registry.telemetryStore.remoteAgentActionError.Inc(registeredAgent.SanitizedDisplayName, service, grpcErrorMessage(err))
 			} else {
 				// Validate session ID if no error occurred
 				if validationErr := remoteAgent.validateSessionID(responseHeader); validationErr != nil {
 					// wrap error in gRPC status
 					err = validationErr
-					registry.telemetryStore.remoteAgentActionError.Inc(remoteAgent.RegisteredAgent.SanitizedDisplayName, service, sessionIDMismatch)
+					registry.telemetryStore.remoteAgentActionError.Inc(registeredAgent.SanitizedDisplayName, service, sessionIDMismatch)
 
 					// Mark agent as unhealthy for removal during next cleanup cycle
-					remoteAgent.unhealthy = true
+					remoteAgent.unhealthy.Store(true)
+					remoteAgent.unhealthyMu.Lock()
 					remoteAgent.unhealthyReason = validationErr
+					remoteAgent.unhealthyMu.Unlock()
 				}
 			}
 
 			// Append the result to the result slice
 			resultLock.Lock()
-			resultSlice = append(resultSlice, resultProcessor(remoteAgent.RegisteredAgent, resp, err))
+			resultSlice = append(resultSlice, resultProcessor(registeredAgent, resp, err))
 			resultLock.Unlock()
 		}()
 	}
 
-	// Keep agentMapMu held until the goroutines finish. They read remoteAgent.RegisteredAgent
-	// fields (e.g. SanitizedDisplayName for telemetry) which race with RefreshRemoteAgent
-	// writing RegisteredAgent.LastSeen under the same lock.
-	defer registry.agentMapMu.Unlock()
+	// Release the registry lock before waiting on the RPCs. The goroutines
+	// use the snapshotted registeredAgent and the remoteAgent pointer
+	// (for gRPC calls only), neither of which races with RefreshRemoteAgent.
+	registry.agentMapMu.Unlock()
 
 	wg.Wait()
 

--- a/comp/core/remoteagentregistry/impl/client.go
+++ b/comp/core/remoteagentregistry/impl/client.go
@@ -280,7 +280,10 @@ func callAgentsForService[PbType any, StructuredType any](
 		}()
 	}
 
-	registry.agentMapMu.Unlock()
+	// Keep agentMapMu held until the goroutines finish. They read remoteAgent.RegisteredAgent
+	// fields (e.g. SanitizedDisplayName for telemetry) which race with RefreshRemoteAgent
+	// writing RegisteredAgent.LastSeen under the same lock.
+	defer registry.agentMapMu.Unlock()
 
 	wg.Wait()
 

--- a/comp/core/remoteagentregistry/impl/registry.go
+++ b/comp/core/remoteagentregistry/impl/registry.go
@@ -319,7 +319,10 @@ func (ra *remoteAgentRegistry) start() {
 
 				agentsToRemove := make([]string, 0)
 				for sessionID, details := range ra.agentMap {
-					if time.Since(details.RegisteredAgent.LastSeen) > remoteAgentIdleTimeout || details.unhealthy.Load() {
+					details.unhealthyMu.Lock()
+					isUnhealthy := details.unhealthyReason != nil
+					details.unhealthyMu.Unlock()
+					if time.Since(details.RegisteredAgent.LastSeen) > remoteAgentIdleTimeout || isUnhealthy {
 						agentsToRemove = append(agentsToRemove, sessionID)
 					}
 				}
@@ -327,10 +330,10 @@ func (ra *remoteAgentRegistry) start() {
 				for _, sessionID := range agentsToRemove {
 					remoteAgentClient, ok := ra.agentMap[sessionID]
 					if ok {
-						if remoteAgentClient.unhealthy.Load() {
-							remoteAgentClient.unhealthyMu.Lock()
-							reason := remoteAgentClient.unhealthyReason
-							remoteAgentClient.unhealthyMu.Unlock()
+						remoteAgentClient.unhealthyMu.Lock()
+						reason := remoteAgentClient.unhealthyReason
+						remoteAgentClient.unhealthyMu.Unlock()
+						if reason != nil {
 							log.Warnf("Remote agent '%s' deregistered: %v", remoteAgentClient.RegisteredAgent.DisplayName, reason)
 						} else {
 							log.Infof("Remote agent '%s' deregistered after being idle for %s.", remoteAgentClient.RegisteredAgent.DisplayName, remoteAgentIdleTimeout)

--- a/comp/core/remoteagentregistry/impl/registry.go
+++ b/comp/core/remoteagentregistry/impl/registry.go
@@ -319,7 +319,7 @@ func (ra *remoteAgentRegistry) start() {
 
 				agentsToRemove := make([]string, 0)
 				for sessionID, details := range ra.agentMap {
-					if time.Since(details.RegisteredAgent.LastSeen) > remoteAgentIdleTimeout || details.unhealthy {
+					if time.Since(details.RegisteredAgent.LastSeen) > remoteAgentIdleTimeout || details.unhealthy.Load() {
 						agentsToRemove = append(agentsToRemove, sessionID)
 					}
 				}
@@ -327,8 +327,11 @@ func (ra *remoteAgentRegistry) start() {
 				for _, sessionID := range agentsToRemove {
 					remoteAgentClient, ok := ra.agentMap[sessionID]
 					if ok {
-						if remoteAgentClient.unhealthy {
-							log.Warnf("Remote agent '%s' deregistered: %v", remoteAgentClient.RegisteredAgent.DisplayName, remoteAgentClient.unhealthyReason)
+						if remoteAgentClient.unhealthy.Load() {
+							remoteAgentClient.unhealthyMu.Lock()
+							reason := remoteAgentClient.unhealthyReason
+							remoteAgentClient.unhealthyMu.Unlock()
+							log.Warnf("Remote agent '%s' deregistered: %v", remoteAgentClient.RegisteredAgent.DisplayName, reason)
 						} else {
 							log.Infof("Remote agent '%s' deregistered after being idle for %s.", remoteAgentClient.RegisteredAgent.DisplayName, remoteAgentIdleTimeout)
 						}

--- a/comp/core/remoteagentregistry/impl/registry.go
+++ b/comp/core/remoteagentregistry/impl/registry.go
@@ -317,30 +317,18 @@ func (ra *remoteAgentRegistry) start() {
 			case <-ticker.C:
 				ra.agentMapMu.Lock()
 
-				agentsToRemove := make([]string, 0)
 				for sessionID, details := range ra.agentMap {
 					details.unhealthyMu.Lock()
-					isUnhealthy := details.unhealthyReason != nil
+					reason := details.unhealthyReason
 					details.unhealthyMu.Unlock()
-					if time.Since(details.RegisteredAgent.LastSeen) > remoteAgentIdleTimeout || isUnhealthy {
-						agentsToRemove = append(agentsToRemove, sessionID)
-					}
-				}
-
-				for _, sessionID := range agentsToRemove {
-					remoteAgentClient, ok := ra.agentMap[sessionID]
-					if ok {
-						remoteAgentClient.unhealthyMu.Lock()
-						reason := remoteAgentClient.unhealthyReason
-						remoteAgentClient.unhealthyMu.Unlock()
+					if time.Since(details.RegisteredAgent.LastSeen) > remoteAgentIdleTimeout || reason != nil {
 						if reason != nil {
-							log.Warnf("Remote agent '%s' deregistered: %v", remoteAgentClient.RegisteredAgent.DisplayName, reason)
+							log.Warnf("Remote agent '%s' deregistered: %v", details.RegisteredAgent.DisplayName, reason)
 						} else {
-							log.Infof("Remote agent '%s' deregistered after being idle for %s.", remoteAgentClient.RegisteredAgent.DisplayName, remoteAgentIdleTimeout)
+							log.Infof("Remote agent '%s' deregistered after being idle for %s.", details.RegisteredAgent.DisplayName, remoteAgentIdleTimeout)
 						}
-						ra.telemetryStore.remoteAgentRegistered.Dec(remoteAgentClient.RegisteredAgent.SanitizedDisplayName)
-						// close the remote agent client and remove it from the registry
-						_ = remoteAgentClient.close()
+						ra.telemetryStore.remoteAgentRegistered.Dec(details.RegisteredAgent.SanitizedDisplayName)
+						_ = details.close()
 						delete(ra.agentMap, sessionID)
 					}
 				}


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Fixes a data race in `callAgentsForService` between the per-agent goroutines reading `remoteAgent.RegisteredAgent` fields and `RefreshRemoteAgent` writing `RegisteredAgent.LastSeen` under `agentMapMu`.

Snapshots `RegisteredAgent` while holding `agentMapMu`, then releases the lock **before** the RPC goroutines run — so slow/unreachable remote agents no longer block `RefreshRemoteAgent` and new registrations for the entire RPC timeout. The goroutines use the snapshotted `RegisteredAgent` value for telemetry and `resultProcessor`, and the `remoteAgent` pointer only for gRPC calls (which use the `conn`, not `RegisteredAgent`).

Also simplifies the `unhealthy`/`unhealthyReason` fields: `unhealthy` was strictly equivalent to `unhealthyReason != nil` (always set together, never cleared), so it's removed. `unhealthyReason` is guarded by a single mutex (`unhealthyMu`) so the check and the value are always consistent under the same lock.

### Motivation

`callAgentsForService` spawned goroutines that read `remoteAgent.RegisteredAgent` fields (e.g. `SanitizedDisplayName` for telemetry) and then unlocked `agentMapMu` before `wg.Wait()`. The goroutines therefore raced with `RefreshRemoteAgent`, which writes `RegisteredAgent.LastSeen` under the same lock.

```
WARNING: DATA RACE
Read at ... by goroutine 33512:
  callAgentsForService[...].func1()  client.go:278
  ... GetRegisteredAgentsTelemetry -> registryCollector.Collect -> prometheus Registry.Gather
Previous write at ... by goroutine 33598:
  (*remoteAgentRegistry).RefreshRemoteAgent()  registry.go:247
  ... gRPC RemoteAgent.RefreshRemoteAgent handler
```

### Describe how you validated your changes

CI