### PR TITLE
fix(data-race): guard Controller.isFallbackEnabled

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
@@ -86,6 +87,7 @@ type Controller struct {
 	localSender sender.Sender
 
 	isFallbackEnabled bool
+	fallbackMu        sync.Mutex // guards isFallbackEnabled
 
 	metricsStore *metricsstore.MetricsStore[*model.PodAutoscalerInternal]
 }
@@ -657,7 +659,11 @@ func (c *Controller) updateLocalFallbackEnabled(_ *model.PodAutoscalerInternal, 
 		return
 	}
 
-	// Logic when local fallback is activated/deactivated for horizontal scaling
+	// Logic when local fallback is activated/deactivated for horizontal scaling.
+	// Multiple worker goroutines call Process() concurrently, so guard the
+	// read-modify-write of isFallbackEnabled.
+	c.fallbackMu.Lock()
+	defer c.fallbackMu.Unlock()
 	if c.isFallbackEnabled && *activeHorizontalSource == datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource {
 		log.Debugf("Product horizontal scaling values are no longer stale, deactivating local fallback")
 		c.isFallbackEnabled = false


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Adds a dedicated `sync.Mutex` (`fallbackMu`) and locks the read-modify-write of `isFallbackEnabled` in `updateLocalFallbackEnabled`.

### Motivation

`Controller.Run` spawns `numWorkers` workers, each calling `Process → handleScaling → updateLocalFallbackEnabled`, which reads and writes `c.isFallbackEnabled` with no synchronization.

```
WARNING: DATA RACE
Read at ... by goroutine 1474:
  (*Controller).updateLocalFallbackEnabled()  controller.go:661
  ... Process -> handleScaling -> syncPodAutoscaler
Previous write at ... by goroutine 1475:
  (*Controller).updateLocalFallbackEnabled()  controller.go:666
  ... Process -> handleScaling -> syncPodAutoscaler
```

### Describe how you validated your changes

CI

### Additional Notes

Distinct from #54976 (which fixed `autoscalingValuesProcessor.state`).