### PR TITLE
fix(e2e): wire mirror hardening into step-by-step suite

### DIFF
--- a/test/new-e2e/tests/agent-platform/tests/step_by_step_test.go
+++ b/test/new-e2e/tests/agent-platform/tests/step_by_step_test.go
@@ -20,6 +20,7 @@ import (
 	filemanager "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common/file-manager"
 	helpers "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common/helper"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/platforms"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
 
 	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
@@ -33,6 +34,21 @@ type stepByStepSuite struct {
 	osVersion    float64
 	osDesc       e2eos.Descriptor
 	cwsSupported bool
+}
+
+func (is *stepByStepSuite) SetupSuite() {
+	is.BaseSuite.SetupSuite()
+	// SetupSuite needs to defer is.CleanupOnSetupFailure() if what comes after BaseSuite.SetupSuite() can fail.
+	defer is.CleanupOnSetupFailure()
+
+	// Harden apt/yum against package-mirror outages before the install steps run. On CentOS 7
+	// this repoints the EOL base/updates/extras repos away from the now-403ing vault.centos.org
+	// /centos/7/ path (incident 58780); on Ubuntu/Debian it bounds apt's timeout/retries and adds
+	// mirror fallbacks. Each call is a no-op on the other's package manager. Same helper already
+	// used by the installer and ddot install suites.
+	h := host.New(is.T, is.Env().RemoteHost, is.osDesc, is.osDesc.Architecture)
+	h.ConfigureYumMirrors()
+	h.ConfigureAptMirrors()
 }
 
 func TestStepByStepScript(t *testing.T) {

--- a/test/new-e2e/tests/agent-platform/tests/step_by_step_test.go
+++ b/test/new-e2e/tests/agent-platform/tests/step_by_step_test.go
@@ -41,6 +41,14 @@ func (is *stepByStepSuite) SetupSuite() {
 	// SetupSuite needs to defer is.CleanupOnSetupFailure() if what comes after BaseSuite.SetupSuite() can fail.
 	defer is.CleanupOnSetupFailure()
 
+	// host.New() always probes systemd (setSystemdVersion) on Linux, which fatals on CentOS 6:
+	// that descriptor runs Upstart, not systemd (see the initctl branch below and in
+	// ConfigureAndRunAgentService). Mirror hardening is only needed for CentOS 7 anyway
+	// (ConfigureYumMirrors no-ops on any other version), so skip host construction entirely here.
+	if is.osDesc.Flavor == e2eos.CentOS && is.osVersion == 6.10 {
+		return
+	}
+
 	// Harden apt/yum against package-mirror outages before the install steps run. On CentOS 7
 	// this repoints the EOL base/updates/extras repos away from the now-403ing vault.centos.org
 	// /centos/7/ path (incident 58780); on Ubuntu/Debian it bounds apt's timeout/retries and adds


### PR DESCRIPTION
## Summary

Backport of #55358 to `7.83.x` (alongside #55359 for `7.82.x`).

- The `step-by-step` suite (`test/new-e2e/tests/agent-platform/tests/step_by_step_test.go`) installs packages directly via `VMclient` and never builds an `installer/host.Host`, so it never got the CentOS 7 `vault.centos.org` fix (#54987) or the Ubuntu apt-mirror fix (#54459 / #55229).
- CentOS 7's `install_rhel` step fails with the same `403 Forbidden` / `No more mirrors to try` signature those PRs already fixed elsewhere — see the [7.82.x job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1977865870) (`TestStepByStepScript/test_step_by_step_on_centos-x86-64-79/TestStepByStep/install_rhel`).
- Adds a `SetupSuite` to `stepByStepSuite` that builds an `installer/host.Host` and calls the existing `ConfigureYumMirrors()` / `ConfigureAptMirrors()` helpers before any install step runs, matching the pattern already used by `ddotInstallSuite`. Each call is a no-op on the other package manager.

## Test plan

- [x] `dda inv new-e2e-tests.run --targets=./tests/agent-platform/tests` compiles cleanly (verified with a non-matching `--run` filter).
- [ ] CI: confirm `TestStepByStepScript/.../install_rhel` on CentOS 7 no longer hits the vault 403.