### PR TITLE
[Backport 7.82.x] pkg/util/trivy: bump Trivy fork to skip unreadable static paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1174,7 +1174,7 @@ replace github.com/hashicorp/vault/sdk => github.com/hashicorp/vault/sdk v0.19.1
 // Use custom Trivy fork to reduce binary size
 // Pull in replacements needed by upstream Trivy
 // Maps to Trivy fork https://github.com/DataDog/trivy/tree/djc/main-dd-069
-replace github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20260519102929-2926d6041e57
+replace github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20260825100148-e0f972f90308
 
 // Stub the progress UI in trivy-db; cheggaaa/pb/v3 transitively activates
 // reflect.MethodByName via text/template, defeating Go's linker DCE.

--- a/go.sum
+++ b/go.sum
@@ -2583,8 +2583,8 @@ github.com/DataDog/rshell v0.0.23 h1:SswT3UUSHu3wFZIcWiV1sBze3JC8bROUG9B1seB5oYE
 github.com/DataDog/rshell v0.0.23/go.mod h1:DOG14otU3LPZ7P0L9Kdk4nWEbQMMpgk21C9vEdGI/bg=
 github.com/DataDog/sketches-go v1.4.8 h1:pFk9BNn+Rzv8IMIoPUttoOpOr3bJOqU3P6EP5wK+Lv8=
 github.com/DataDog/sketches-go v1.4.8/go.mod h1:a/wjRUqzqtGS8qRHRPDCs4EAQfmvPDZGDlMIF5mxXOE=
-github.com/DataDog/trivy v0.0.0-20260519102929-2926d6041e57 h1:NjLZ7nbzMN1MsTotfQ6/W5a9WpHTREEB2acJOauyoQE=
-github.com/DataDog/trivy v0.0.0-20260519102929-2926d6041e57/go.mod h1:2cDQBIACLxt3NpCZ0Sthx4kLp9QmaiZC/5+fPP5Bz7Q=
+github.com/DataDog/trivy v0.0.0-20260825100148-e0f972f90308 h1:sKvh8DPnRpmDYJVaoe3PNU4mCb8jwyhseyVJCIBNtZ8=
+github.com/DataDog/trivy v0.0.0-20260825100148-e0f972f90308/go.mod h1:2cDQBIACLxt3NpCZ0Sthx4kLp9QmaiZC/5+fPP5Bz7Q=
 github.com/DataDog/vault/api/auth/aws v0.0.0-20250716193101-44fb30472101 h1:aatle7zFb175XJ6iJvyr9a7Ipr1Dvpw4oy4MqL9v4GA=
 github.com/DataDog/vault/api/auth/aws v0.0.0-20250716193101-44fb30472101/go.mod h1:GRki58GuFuDh0GFVg280DZt3oCYxZG02ldDPtQ5FBoo=
 github.com/DataDog/watermarkpodautoscaler/apis v0.0.0-20250108152814-82e58d0231d1 h1:9hiwoIk8FOsXDkdcdgNJ48iYaPfn+/7bXEwAnnfKjTc=

--- a/releasenotes/notes/sbom-host-scan-unreadable-path-2b91f7d0c4a6e358.yaml
+++ b/releasenotes/notes/sbom-host-scan-unreadable-path-2b91f7d0c4a6e358.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed the host SBOM scan (``sbom.host.enabled``) reporting no packages when
+    the Agent runs as ``dd-agent``. The scan walks the paths the enabled
+    analyzers declare, one of which is ``/root/buildinfo/content_manifests``,
+    and ``/root`` is only traversable by root. Such a path is now skipped and
+    the scan reports the packages it found.


### PR DESCRIPTION
A host scan enables the OS analyzers alone, and every one of them
declares the paths it reads, so Trivy walks one root per declared path
instead of traversing the filesystem. One of those paths is
root/buildinfo/content_manifests, where Red Hat images keep their
content sets. A package install runs the core Agent as dd-agent and
/root is 0700, so the stat of that path returns EACCES and the whole
scan failed:

    Scan error: unable to marshal report to sbom format, err: unable to
    scan rootfs, err: trivy scan failed: failed analysis: analyze with
    static paths: analyze with traversal: failed to stat root
    /root/buildinfo/content_manifests: permission denied

Hosts reported no packages at all while container images kept scanning,
since a containerized Agent runs as root. The fork now treats a declared
path it cannot read like an absent one and analyzes the rest.

The pin is the fork commit this branch already carried plus that one
change, so the analyzer deferral and the remote image fix that main took
with the same bump stay out of a patch release.

Backport of #55349.
