### PR TITLE
docs(gpu): add known issue for A100 nvlink_fields check delay

### DIFF
--- a/releasenotes/notes/gpu-a100-nvlink-fields-known-issue-afa6fe8552af5007.yaml
+++ b/releasenotes/notes/gpu-a100-nvlink-fields-known-issue-afa6fe8552af5007.yaml
@@ -1,0 +1,7 @@
+---
+issues:
+  - |
+    GPU Monitoring: 7.83 and previous versions could see longer check run times under
+    specific workloads on A100 GPUs. If GPU metrics are appearing delayed, set
+    ``gpu.disabled_collectors: [nvlink_fields]`` to mitigate the issue. This will be
+    fixed in a future release.


### PR DESCRIPTION


<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Document longer GPU check run times on A100 GPUs under specific workloads and the gpu.disabled_collectors mitigation for the 7.83.x release notes.

### Motivation

### Describe how you validated your changes

changelog only

### Additional Notes
