### PR TITLE
Align memory usage for all pre-init jobs

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -325,8 +325,8 @@ new-e2e-containers-eks-init:
     E2E_INIT_ONLY: "true"
     SHOULD_RUN_IN_FLAKES_FINDER: "false"
     PRE_BUILT_BINARIES_FLAG: ""
-    KUBERNETES_MEMORY_REQUEST: 20Gi
-    KUBERNETES_MEMORY_LIMIT: 20Gi
+    KUBERNETES_MEMORY_REQUEST: 24Gi
+    KUBERNETES_MEMORY_LIMIT: 24Gi
   allow_failure: true
   retry: !reference [.retry_only_infra_failure, retry]
 
@@ -372,8 +372,8 @@ new-e2e-containers-openshift-init:
     SHOULD_RUN_IN_FLAKES_FINDER: "false"
     PRE_BUILT_BINARIES_FLAG: ""
     # Same as new-e2e-containers-eks-init.
-    KUBERNETES_MEMORY_REQUEST: 20Gi
-    KUBERNETES_MEMORY_LIMIT: 20Gi
+    KUBERNETES_MEMORY_REQUEST: 24Gi
+    KUBERNETES_MEMORY_LIMIT: 24Gi
   allow_failure: true
   retry: !reference [.retry_only_infra_failure, retry]
 
@@ -567,8 +567,8 @@ new-e2e-npm-eks-init:
     E2E_INIT_ONLY: "true"
     SHOULD_RUN_IN_FLAKES_FINDER: "false"
     PRE_BUILT_BINARIES_FLAG: ""
-    KUBERNETES_MEMORY_REQUEST: 12Gi
-    KUBERNETES_MEMORY_LIMIT: 16Gi
+    KUBERNETES_MEMORY_REQUEST: 24Gi
+    KUBERNETES_MEMORY_LIMIT: 24Gi
   allow_failure: true
   retry: !reference [.retry_only_infra_failure, retry]
 
@@ -1082,8 +1082,8 @@ new-e2e-otel-eks-init:
     E2E_INIT_ONLY: "true"
     SHOULD_RUN_IN_FLAKES_FINDER: "false"
     PRE_BUILT_BINARIES_FLAG: ""
-    KUBERNETES_MEMORY_REQUEST: 12Gi
-    KUBERNETES_MEMORY_LIMIT: 16Gi
+    KUBERNETES_MEMORY_REQUEST: 24Gi
+    KUBERNETES_MEMORY_LIMIT: 24Gi
   allow_failure: true
   retry: !reference [.retry_only_infra_failure, retry]
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Bump and align memory limit for all the init jobs.

### Motivation

Fix high failure rate we still observe on those jobs, timeout that are due to OOMKills probably.
For example one job that ends up with timeout:
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1979473109 

https://app.datadoghq.com/notebook/5902745/ci-benchmarks?refresh_mode=paused&tpl_var_pod_name=runner-3zq8bbp3y-project-4670-concurrent-1-bf0b7424&from_ts=1787618029257&to_ts=1787620458569

### Describe how you validated your changes

### Additional Notes
