### PR TITLE
Disable `kustomize`'s Go-plugin loader via a module patch

### DIFF
--- a/bazel/patches/kustomize-disable-go-plugin-loader.patch
+++ b/bazel/patches/kustomize-disable-go-plugin-loader.patch
@@ -1,0 +1,25 @@
+diff --git a/internal/plugins/loader/BUILD.bazel b/internal/plugins/loader/BUILD.bazel
+index 425036c..509eeb1 100644
+--- a/internal/plugins/loader/BUILD.bazel
++++ b/internal/plugins/loader/BUILD.bazel
+@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+ go_library(
+     name = "loader",
+     srcs = [
+-        "load_go_plugin.go",
++        "load_go_plugin_disabled.go",
+         "loader.go",
+     ],
+     importpath = "sigs.k8s.io/kustomize/api/internal/plugins/loader",
+diff --git a/internal/plugins/loader/load_go_plugin_disabled.go b/internal/plugins/loader/load_go_plugin_disabled.go
+index 5531b79..04577dd 100644
+--- a/internal/plugins/loader/load_go_plugin_disabled.go
++++ b/internal/plugins/loader/load_go_plugin_disabled.go
+@@ -9,7 +9,6 @@
+ // to the population of ELF's sections such as .dynsym and .dynstr.
+ // By utilizing this flag, applications have the flexibility to exclude the
+ // import if they do not require support for dynamic Go plugins.
+-//go:build kustomize_disable_go_plugin_support
+ 
+ package loader
+ 

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -542,6 +542,17 @@ go_deps.module_override(
     path = "github.com/godror/godror",
 )
 
+# kustomize's native Go-plugin loader flips the linker into dynlinking mode (-Wl,-z,nocopyreloc), breaking
+# github.com/DataDog/zstd's copy-relocation-dependent cgo (#54846). A gotags-based exclusion doesn't work here:
+# rules_go's own compile-time constraint filter re-evaluates //go:build tags using each consumer's real (transitively
+# propagated) gotags, independent of what Gazelle put in srcs, so the disabled stub would get silently dropped again.
+# Patch out the build-tag guard itself so there's nothing left to get wrong.
+go_deps.module_override(
+    patch_strip = 1,
+    patches = ["//bazel/patches:kustomize-disable-go-plugin-loader.patch"],
+    path = "sigs.k8s.io/kustomize/api",
+)
+
 inject_repo(go_deps, "systemd")
 
 use_repo_rule("//bazel/rules/go_fast:repo.bzl", "go_fast")(name = "go_fast")


### PR DESCRIPTION
### What does this PR do?
Patch `sigs.k8s.io/kustomize/api` to always select its Go-plugin disabled loader stub, instead of adding a per-target `extra_gotags` escape hatch to `dd_agent_go_test` (#55347).

### Motivation
`kustomize/api`'s plugin loader forces `-Wl,-z,nocopyreloc` on the linker, breaking `github.com/DataDog/zstd`'s copy-relocation-dependent cgo (#54846).

#55347 fixes this per test target via `extra_gotags`, but it also flags that the fix is scoped to one target and the same conflict could recur for any future target combining `kustomize/api` with another copy-relocation-sensitive cgo dependency.

Patching `kustomize/api` once, at the dependency level, closes that gap instead of requiring every future consumer to rediscover and reapply the same workaround.

### Describe how you validated your changes
Built and ran a throwaway target embedding both `kustomize/api`'s `krusty` package and `zstd` with `bazel test`, with no `gotags` override, reproducing and then confirming the fix for the original link failure.
The patch applies without exposing `io_k8s_sigs_kustomize_api` via `use_repo`, matching how #54846's `helm_test` actually reaches it: transitively, through `sh_helm_helm_v3`.

### Additional Notes
Alas, a `gazelle:build_tags` and `gazelle:exclude` combination **does not work**, since `rules_go`'s compile-time constraint filter re-evaluates `//go:build` tags against each consumer's real `gotags`, independent of what `gazelle` wrote into `srcs`.