### PR TITLE
Fix missing position for buffered logs

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -237,9 +237,9 @@ func (c *ntmConfig) Set(key string, newValue interface{}, source model.Source) {
 
 	if !c.isKnownKey(key) {
 		if c.allowDynamicSchema.Load() {
-			log.Errorf("set value for unknown key '%s'", key)
+			_ = log.ErrorfStackDepth(2, "set value for unknown key '%s'", key)
 		} else {
-			log.Errorf("could not set '%s' unknown key", key)
+			_ = log.ErrorfStackDepth(2, "could not set '%s' unknown key", key)
 			c.Unlock()
 			return
 		}
@@ -258,9 +258,9 @@ func (c *ntmConfig) Set(key string, newValue interface{}, source model.Source) {
 				typePair := fmt.Sprintf("%T->%T", newValue, converted)
 				isIntWidthConversion := typePair == "int64->int" || typePair == "int->int64"
 				if isIntWidthConversion && c.setTypeWarnings[typePair] {
-					log.Debugf("Set('%s'): converting value from %T to %T to match default type", key, newValue, converted)
+					log.DebugfStackDepth(2, "Set('%s'): converting value from %T to %T to match default type", key, newValue, converted)
 				} else {
-					log.Warnf("Set('%s'): converting value from %T to %T to match default type", key, newValue, converted)
+					log.WarnfStackDepth(2, "Set('%s'): converting value from %T to %T to match default type", key, newValue, converted)
 					if isIntWidthConversion {
 						c.setTypeWarnings[typePair] = true
 					}
@@ -278,7 +278,7 @@ func (c *ntmConfig) Set(key string, newValue interface{}, source model.Source) {
 
 	newTree, err := c.insertValueIntoTree(key, newValue, source)
 	if err != nil {
-		log.Errorf("could not insert value: %s", err)
+		_ = log.ErrorfStackDepth(2, "could not insert value: %s", err)
 		c.Unlock()
 		return
 	} else if newTree != nil {

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
 dd_agent_go_test(
     name = "log_test",
     srcs = [
+        "caller_position_test.go",
         "klog_redirect_test.go",
         "log_bench_test.go",
         "log_limit_test.go",

--- a/pkg/util/log/caller_position_test.go
+++ b/pkg/util/log/caller_position_test.go
@@ -1,0 +1,348 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package log
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newBufferedLogger returns a trace level logger writing to b, and its writer to flush.
+func newBufferedLogger(t *testing.T, b *bytes.Buffer) (LoggerInterface, *bufio.Writer) {
+	t.Helper()
+
+	w := bufio.NewWriter(b)
+	l, err := LoggerFromWriterWithMinLevelAndLvlFuncMsgFormat(w, TraceLvl)
+	require.NoError(t, err)
+
+	return l, w
+}
+
+// replayBuffered emits a log entry while no logger is set up, then initializes one and returns
+// what the buffered entry produced once replayed.
+func replayBuffered(t *testing.T, emit func()) string {
+	t.Helper()
+
+	logsBuffer = []func(){}
+	logger.Store(nil)
+
+	emit()
+	require.Len(t, logsBuffer, 1, "the log entry should have been buffered")
+
+	var b bytes.Buffer
+	l, w := newBufferedLogger(t, &b)
+
+	SetupLogger(l, TraceStr)
+	w.Flush()
+
+	return b.String()
+}
+
+// TestBufferedLogsKeepCallerPosition checks that a log entry emitted before the logger is set
+// up is replayed with the position of its original call site, and not of the flush loop.
+//
+// It covers every combination of level and helper family, because the position is derived from
+// a frame count that depends on both: 'depth' does not mean the same thing for the log and the
+// logContext families, see bufferLog.
+func TestBufferedLogsKeepCallerPosition(t *testing.T) {
+	tests := []struct {
+		name string
+		// wantMsg is the message expected next to the position, "hello" when empty
+		wantMsg string
+		// emit logs and returns the line its call site is expected to point at
+		emit func() int
+	}{
+		// Plain functions: the direct caller is the call site.
+		{name: "Trace", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			Trace("hello")
+			return line + 1
+		}},
+		{name: "Debug", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			Debug("hello")
+			return line + 1
+		}},
+		{name: "Info", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			Info("hello")
+			return line + 1
+		}},
+		{name: "Warn", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = Warn("hello")
+			return line + 1
+		}},
+		{name: "Error", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = Error("hello")
+			return line + 1
+		}},
+		{name: "Critical", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = Critical("hello")
+			return line + 1
+		}},
+
+		// Format functions.
+		{name: "Tracef", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			Tracef("%s", "hello")
+			return line + 1
+		}},
+		{name: "Debugf", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			Debugf("%s", "hello")
+			return line + 1
+		}},
+		{name: "Infof", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			Infof("%s", "hello")
+			return line + 1
+		}},
+		{name: "Warnf", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = Warnf("%s", "hello")
+			return line + 1
+		}},
+		{name: "Errorf", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = Errorf("%s", "hello")
+			return line + 1
+		}},
+		{name: "Criticalf", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = Criticalf("%s", "hello")
+			return line + 1
+		}},
+		// The message is formatted once, when the entry is buffered: a verb coming from the
+		// parameters must not be expanded again at replay time.
+		{name: "Warnf with a verb in a parameter", wantMsg: "hello %d", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = Warnf("hello %s", "%d")
+			return line + 1
+		}},
+
+		// Context functions, they go through the logContext family.
+		{name: "Tracec", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			Tracec("hello", "key", "value")
+			return line + 1
+		}},
+		{name: "Debugc", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			Debugc("hello", "key", "value")
+			return line + 1
+		}},
+		{name: "Infoc", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			Infoc("hello", "key", "value")
+			return line + 1
+		}},
+		{name: "Warnc", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = Warnc("hello", "key", "value")
+			return line + 1
+		}},
+		{name: "Errorc", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = Errorc("hello", "key", "value")
+			return line + 1
+		}},
+		{name: "Criticalc", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = Criticalc("hello", "key", "value")
+			return line + 1
+		}},
+
+		// *StackDepth functions called directly: depth 1 designates the direct caller.
+		{name: "TraceStackDepth", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			TraceStackDepth(1, "hello")
+			return line + 1
+		}},
+		{name: "DebugStackDepth", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			DebugStackDepth(1, "hello")
+			return line + 1
+		}},
+		{name: "InfoStackDepth", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			InfoStackDepth(1, "hello")
+			return line + 1
+		}},
+		{name: "WarnStackDepth", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = WarnStackDepth(1, "hello")
+			return line + 1
+		}},
+		{name: "ErrorStackDepth", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = ErrorStackDepth(1, "hello")
+			return line + 1
+		}},
+		{name: "CriticalStackDepth", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = CriticalStackDepth(1, "hello")
+			return line + 1
+		}},
+
+		// *fStackDepth functions called directly. Trace and Debug are missing on purpose: they
+		// are dropped before being buffered, as GetLogLevel defaults to info when the logger is
+		// not set up yet.
+		{name: "InfofStackDepth", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			InfofStackDepth(1, "%s", "hello")
+			return line + 1
+		}},
+		{name: "WarnfStackDepth", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = WarnfStackDepth(1, "%s", "hello")
+			return line + 1
+		}},
+		{name: "ErrorfStackDepth", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = ErrorfStackDepth(1, "%s", "hello")
+			return line + 1
+		}},
+		{name: "CriticalfStackDepth", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = CriticalfStackDepth(1, "%s", "hello")
+			return line + 1
+		}},
+
+		// *cStackDepth functions called directly: unlike the log family, depth 0 designates the
+		// direct caller there.
+		{name: "InfocStackDepth", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			InfocStackDepth("hello", 0, "key", "value")
+			return line + 1
+		}},
+		{name: "WarncStackDepth", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			_ = WarncStackDepth("hello", 0, "key", "value")
+			return line + 1
+		}},
+
+		// The *StackDepth functions exist to be called from a wrapper: the position must then
+		// point at the caller of the wrapper, like the logger does once initialized.
+		{name: "TraceStackDepth through a wrapper", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			traceWrapper("hello")
+			return line + 1
+		}},
+		{name: "DebugStackDepth through a wrapper", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			debugWrapper("hello")
+			return line + 1
+		}},
+		{name: "WarnfStackDepth through a wrapper", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			warnfWrapper("%s", "hello")
+			return line + 1
+		}},
+		{name: "ErrorcStackDepth through a wrapper", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			errorcWrapper("hello")
+			return line + 1
+		}},
+		{name: "CriticalcStackDepth through a wrapper", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			criticalcWrapper("hello")
+			return line + 1
+		}},
+
+		// The *Func variants wrap *StackDepth with a depth of 2. Trace and Debug are missing for
+		// the same reason as the *fStackDepth ones.
+		{name: "InfoFunc", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			InfoFunc(func() string { return "hello" })
+			return line + 1
+		}},
+		{name: "WarnFunc", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			WarnFunc(func() string { return "hello" })
+			return line + 1
+		}},
+		{name: "ErrorFunc", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			ErrorFunc(func() string { return "hello" })
+			return line + 1
+		}},
+		{name: "CriticalFunc", emit: func() int {
+			_, _, line, _ := runtime.Caller(0)
+			CriticalFunc(func() string { return "hello" })
+			return line + 1
+		}},
+	}
+
+	_, file, _, _ := runtime.Caller(0)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wantMsg := tc.wantMsg
+			if wantMsg == "" {
+				wantMsg = "hello"
+			}
+
+			var line int
+			out := replayBuffered(t, func() { line = tc.emit() })
+
+			assert.Contains(t, out, fmt.Sprintf("%s:%d %s", file, line, wantMsg))
+		})
+	}
+}
+
+// TestLogsAfterSetupHaveNoCallerPosition checks that the position is only added to buffered
+// entries: once the logger is initialized it reports the call site on its own, and prepending it
+// to the message would duplicate it.
+func TestLogsAfterSetupHaveNoCallerPosition(t *testing.T) {
+	logsBuffer = []func(){}
+
+	var b bytes.Buffer
+	l, w := newBufferedLogger(t, &b)
+	SetupLogger(l, TraceStr)
+
+	Trace("hello")
+	Debug("hello")
+	Info("hello")
+	_ = Warnf("%s", "hello")
+	_ = Errorc("hello", "key", "value")
+	InfoStackDepth(1, "hello")
+	_ = CriticalfStackDepth(1, "%s", "hello")
+	w.Flush()
+
+	out := b.String()
+	assert.Equal(t, 7, strings.Count(out, "hello"))
+	assert.NotContains(t, out, ".go:")
+}
+
+func traceWrapper(v ...interface{}) {
+	TraceStackDepth(2, v...)
+}
+
+func debugWrapper(v ...interface{}) {
+	DebugStackDepth(2, v...)
+}
+
+func warnfWrapper(format string, params ...interface{}) {
+	_ = WarnfStackDepth(2, format, params...)
+}
+
+func errorcWrapper(message string) {
+	_ = ErrorcStackDepth(message, 1, "key", "value")
+}
+
+func criticalcWrapper(message string) {
+	_ = CriticalcStackDepth(message, 1, "key", "value")
+}

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -115,11 +116,18 @@ func setupCommonLogger(i LoggerInterface, level *slog.LevelVar) {
 	}
 }
 
-func addLogToBuffer(logHandle func()) {
+func addLogToBuffer(bufferFunc func(callerPos string), callerDepth int) {
+	var callerPos string
+	// +2 to skip this function and the log helper calling it, -1 as callerDepth already counts
+	// the frame of the log function itself
+	if _, file, line, ok := runtime.Caller(callerDepth + 2); ok {
+		callerPos = fmt.Sprintf("%s:%d ", file, line)
+	}
+
 	bufferMutex.Lock()
 	defer bufferMutex.Unlock()
 
-	logsBuffer = append(logsBuffer, logHandle)
+	logsBuffer = append(logsBuffer, func() { bufferFunc(callerPos) })
 }
 
 func (sw *DatadogLogger) scrub(s string) string {
@@ -238,12 +246,13 @@ func (sw *loggerPointer) flush() {
  */
 
 // log logs a message at the given level, using either bufferFunc (if logging is not yet set up) or
-// scrubAndLogFunc, and treating the variadic args as the message.
-func log(logLevel LogLevel, bufferFunc func(), scrubAndLogFunc func(string), v ...interface{}) {
+// scrubAndLogFunc, and treating the variadic args as the message. 'callerDepth' is only used for
+// buffered entries, see addLogToBuffer.
+func log(logLevel LogLevel, bufferFunc func(string), scrubAndLogFunc func(string), callerDepth int, v ...interface{}) {
 	l := logger.Load()
 
 	if l == nil {
-		addLogToBuffer(bufferFunc)
+		addLogToBuffer(bufferFunc, callerDepth)
 		return
 	}
 
@@ -251,17 +260,17 @@ func log(logLevel LogLevel, bufferFunc func(), scrubAndLogFunc func(string), v .
 	defer l.l.Unlock()
 
 	if l.inner == nil {
-		addLogToBuffer(bufferFunc)
+		addLogToBuffer(bufferFunc, callerDepth)
 	} else if l.shouldLog(logLevel) {
 		s := BuildLogEntry(v...)
 		scrubAndLogFunc(s)
 	}
 }
-func logWithError(logLevel LogLevel, bufferFunc func(), scrubAndLogFunc func(string) error, fallbackStderr bool, v ...interface{}) error {
+func logWithError(logLevel LogLevel, bufferFunc func(string), scrubAndLogFunc func(string) error, fallbackStderr bool, callerDepth int, v ...interface{}) error {
 	l := logger.Load()
 
 	if l == nil {
-		addLogToBuffer(bufferFunc)
+		addLogToBuffer(bufferFunc, callerDepth)
 		err := formatError(v...)
 		if fallbackStderr {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", logLevel.String(), err.Error())
@@ -275,7 +284,7 @@ func logWithError(logLevel LogLevel, bufferFunc func(), scrubAndLogFunc func(str
 
 	if isInnerNil {
 		if !fallbackStderr {
-			addLogToBuffer(bufferFunc)
+			addLogToBuffer(bufferFunc, callerDepth)
 		}
 	} else if l.shouldLog(logLevel) {
 		defer l.l.Unlock()
@@ -300,11 +309,11 @@ func logWithError(logLevel LogLevel, bufferFunc func(), scrubAndLogFunc func(str
 *	logFormat functions
  */
 
-func logFormat(logLevel LogLevel, bufferFunc func(), scrubAndLogFunc func(string, ...interface{}), format string, params ...interface{}) {
+func logFormat(logLevel LogLevel, bufferFunc func(string), scrubAndLogFunc func(string, ...interface{}), format string, callerDepth int, params ...interface{}) {
 	l := logger.Load()
 
 	if l == nil {
-		addLogToBuffer(bufferFunc)
+		addLogToBuffer(bufferFunc, callerDepth)
 		return
 	}
 
@@ -312,16 +321,16 @@ func logFormat(logLevel LogLevel, bufferFunc func(), scrubAndLogFunc func(string
 	defer l.l.Unlock()
 
 	if l.inner == nil {
-		addLogToBuffer(bufferFunc)
+		addLogToBuffer(bufferFunc, callerDepth)
 	} else if l.shouldLog(logLevel) {
 		scrubAndLogFunc(format, params...)
 	}
 }
-func logFormatWithError(logLevel LogLevel, bufferFunc func(), scrubAndLogFunc func(string, ...interface{}) error, format string, fallbackStderr bool, params ...interface{}) error {
+func logFormatWithError(logLevel LogLevel, bufferFunc func(string), scrubAndLogFunc func(string, ...interface{}) error, format string, fallbackStderr bool, callerDepth int, params ...interface{}) error {
 	l := logger.Load()
 
 	if l == nil {
-		addLogToBuffer(bufferFunc)
+		addLogToBuffer(bufferFunc, callerDepth)
 		err := formatErrorf(format, params...)
 		if fallbackStderr {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", logLevel.String(), err.Error())
@@ -335,7 +344,7 @@ func logFormatWithError(logLevel LogLevel, bufferFunc func(), scrubAndLogFunc fu
 
 	if isInnerNil {
 		if !fallbackStderr {
-			addLogToBuffer(bufferFunc)
+			addLogToBuffer(bufferFunc, callerDepth)
 		}
 	} else if l.shouldLog(logLevel) {
 		defer l.l.Unlock()
@@ -359,11 +368,11 @@ func logFormatWithError(logLevel LogLevel, bufferFunc func(), scrubAndLogFunc fu
 *	logContext functions
  */
 
-func logContext(logLevel LogLevel, bufferFunc func(), scrubAndLogFunc func(string), message string, depth int, context ...interface{}) {
+func logContext(logLevel LogLevel, bufferFunc func(string), scrubAndLogFunc func(string), message string, depth int, context ...interface{}) {
 	l := logger.Load()
 
 	if l == nil {
-		addLogToBuffer(bufferFunc)
+		addLogToBuffer(bufferFunc, depth+1)
 		return
 	}
 
@@ -371,7 +380,7 @@ func logContext(logLevel LogLevel, bufferFunc func(), scrubAndLogFunc func(strin
 	defer l.l.Unlock()
 
 	if l.inner == nil {
-		addLogToBuffer(bufferFunc)
+		addLogToBuffer(bufferFunc, depth+1)
 	} else if l.shouldLog(logLevel) {
 		l.inner.SetContext(context)
 		_ = l.inner.SetAdditionalStackDepth(defaultStackDepth + depth)
@@ -380,11 +389,11 @@ func logContext(logLevel LogLevel, bufferFunc func(), scrubAndLogFunc func(strin
 		_ = l.inner.SetAdditionalStackDepth(defaultStackDepth)
 	}
 }
-func logContextWithError(logLevel LogLevel, bufferFunc func(), scrubAndLogFunc func(string) error, message string, fallbackStderr bool, depth int, context ...interface{}) error {
+func logContextWithError(logLevel LogLevel, bufferFunc func(string), scrubAndLogFunc func(string) error, message string, fallbackStderr bool, depth int, context ...interface{}) error {
 	l := logger.Load()
 
 	if l == nil {
-		addLogToBuffer(bufferFunc)
+		addLogToBuffer(bufferFunc, depth+1)
 		err := formatErrorc(message, context...)
 		if fallbackStderr {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", logLevel.String(), err.Error())
@@ -398,7 +407,7 @@ func logContextWithError(logLevel LogLevel, bufferFunc func(), scrubAndLogFunc f
 
 	if isInnerNil {
 		if !fallbackStderr {
-			addLogToBuffer(bufferFunc)
+			addLogToBuffer(bufferFunc, depth+1)
 		}
 	} else if l.shouldLog(logLevel) {
 		l.inner.SetContext(context)
@@ -651,12 +660,12 @@ func formatErrorc(message string, context ...interface{}) error {
 
 // Trace logs at the trace level
 func Trace(v ...interface{}) {
-	log(TraceLvl, func() { Trace(v...) }, logger.trace, v...)
+	log(TraceLvl, func(callerPos string) { Trace(callerPos + BuildLogEntry(v...)) }, logger.trace, 1, v...)
 }
 
 // Tracef logs with format at the trace level
 func Tracef(format string, params ...interface{}) {
-	logFormat(TraceLvl, func() { Tracef(format, params...) }, logger.tracef, format, params...)
+	logFormat(TraceLvl, func(callerPos string) { Trace(callerPos + fmt.Sprintf(format, params...)) }, logger.tracef, format, 1, params...)
 }
 
 // TracefStackDepth logs with format at the trace level and the current stack depth plus the given depth
@@ -666,14 +675,14 @@ func TracefStackDepth(depth int, format string, params ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, params...)
-	log(TraceLvl, func() { TraceStackDepth(depth, msg) }, func(s string) {
+	log(TraceLvl, func(callerPos string) { Trace(callerPos + msg) }, func(s string) {
 		logger.traceStackDepth(s, depth)
-	}, msg)
+	}, depth, msg)
 }
 
 // TracecStackDepth logs at the trace level with context and the current stack depth plus the additional given one
 func TracecStackDepth(message string, depth int, context ...interface{}) {
-	logContext(TraceLvl, func() { Tracec(message, context...) }, logger.trace, message, depth, context...)
+	logContext(TraceLvl, func(callerPos string) { Tracec(callerPos+message, context...) }, logger.trace, message, depth, context...)
 }
 
 // Tracec logs at the trace level with context
@@ -691,12 +700,12 @@ func TraceFunc(logFunc func() string) {
 
 // Debug logs at the debug level
 func Debug(v ...interface{}) {
-	log(DebugLvl, func() { Debug(v...) }, logger.debug, v...)
+	log(DebugLvl, func(callerPos string) { Debug(callerPos + BuildLogEntry(v...)) }, logger.debug, 1, v...)
 }
 
 // Debugf logs with format at the debug level
 func Debugf(format string, params ...interface{}) {
-	logFormat(DebugLvl, func() { Debugf(format, params...) }, logger.debugf, format, params...)
+	logFormat(DebugLvl, func(callerPos string) { Debug(callerPos + fmt.Sprintf(format, params...)) }, logger.debugf, format, 1, params...)
 }
 
 // DebugfStackDepth logs with format at the debug level and the current stack depth plus the given depth
@@ -706,14 +715,14 @@ func DebugfStackDepth(depth int, format string, params ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, params...)
-	log(DebugLvl, func() { DebugStackDepth(depth, msg) }, func(s string) {
+	log(DebugLvl, func(callerPos string) { Debug(callerPos + msg) }, func(s string) {
 		logger.debugStackDepth(s, depth)
-	}, msg)
+	}, depth, msg)
 }
 
 // DebugcStackDepth logs at the debug level with context and the current stack depth plus the additional given one
 func DebugcStackDepth(message string, depth int, context ...interface{}) {
-	logContext(DebugLvl, func() { Debugc(message, context...) }, logger.debug, message, depth, context...)
+	logContext(DebugLvl, func(callerPos string) { Debugc(callerPos+message, context...) }, logger.debug, message, depth, context...)
 }
 
 // Debugc logs at the debug level with context
@@ -731,12 +740,12 @@ func DebugFunc(logFunc func() string) {
 
 // Info logs at the info level
 func Info(v ...interface{}) {
-	log(InfoLvl, func() { Info(v...) }, logger.info, v...)
+	log(InfoLvl, func(callerPos string) { Info(callerPos + BuildLogEntry(v...)) }, logger.info, 1, v...)
 }
 
 // Infof logs with format at the info level
 func Infof(format string, params ...interface{}) {
-	logFormat(InfoLvl, func() { Infof(format, params...) }, logger.infof, format, params...)
+	logFormat(InfoLvl, func(callerPos string) { Info(callerPos + fmt.Sprintf(format, params...)) }, logger.infof, format, 1, params...)
 }
 
 // InfofStackDepth logs with format at the info level and the current stack depth plus the given depth
@@ -746,14 +755,14 @@ func InfofStackDepth(depth int, format string, params ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, params...)
-	log(InfoLvl, func() { InfoStackDepth(depth, msg) }, func(s string) {
+	log(InfoLvl, func(callerPos string) { Info(callerPos + msg) }, func(s string) {
 		logger.infoStackDepth(s, depth)
-	}, msg)
+	}, depth, msg)
 }
 
 // InfocStackDepth logs at the info level with context and the current stack depth plus the additional given one
 func InfocStackDepth(message string, depth int, context ...interface{}) {
-	logContext(InfoLvl, func() { Infoc(message, context...) }, logger.info, message, depth, context...)
+	logContext(InfoLvl, func(callerPos string) { Infoc(callerPos+message, context...) }, logger.info, message, depth, context...)
 }
 
 // Infoc logs at the info level with context
@@ -771,25 +780,25 @@ func InfoFunc(logFunc func() string) {
 
 // Warn logs at the warn level and returns an error containing the formated log message
 func Warn(v ...interface{}) error {
-	return logWithError(WarnLvl, func() { _ = Warn(v...) }, logger.warn, false, v...)
+	return logWithError(WarnLvl, func(callerPos string) { _ = Warn(callerPos + BuildLogEntry(v...)) }, logger.warn, false, 1, v...)
 }
 
 // Warnf logs with format at the warn level and returns an error containing the formated log message
 func Warnf(format string, params ...interface{}) error {
-	return logFormatWithError(WarnLvl, func() { _ = Warnf(format, params...) }, logger.warnf, format, false, params...)
+	return logFormatWithError(WarnLvl, func(callerPos string) { _ = Warn(callerPos + fmt.Sprintf(format, params...)) }, logger.warnf, format, false, 1, params...)
 }
 
 // WarnfStackDepth logs with format at the warn level and the current stack depth plus the given depth
 func WarnfStackDepth(depth int, format string, params ...interface{}) error {
 	msg := fmt.Sprintf(format, params...)
-	return logWithError(WarnLvl, func() { _ = WarnStackDepth(depth, msg) }, func(s string) error {
+	return logWithError(WarnLvl, func(callerPos string) { _ = Warn(callerPos + msg) }, func(s string) error {
 		return logger.warnStackDepth(s, depth)
-	}, false, msg)
+	}, false, depth, msg)
 }
 
 // WarncStackDepth logs at the warn level with context and the current stack depth plus the additional given one and returns an error containing the formated log message
 func WarncStackDepth(message string, depth int, context ...interface{}) error {
-	return logContextWithError(WarnLvl, func() { _ = Warnc(message, context...) }, logger.warn, message, false, depth, context...)
+	return logContextWithError(WarnLvl, func(callerPos string) { _ = Warnc(callerPos+message, context...) }, logger.warn, message, false, depth, context...)
 }
 
 // Warnc logs at the warn level with context and returns an error containing the formated log message
@@ -807,25 +816,25 @@ func WarnFunc(logFunc func() string) {
 
 // Error logs at the error level and returns an error containing the formated log message
 func Error(v ...interface{}) error {
-	return logWithError(ErrorLvl, func() { _ = Error(v...) }, logger.error, true, v...)
+	return logWithError(ErrorLvl, func(callerPos string) { _ = Error(callerPos + BuildLogEntry(v...)) }, logger.error, true, 1, v...)
 }
 
 // Errorf logs with format at the error level and returns an error containing the formated log message
 func Errorf(format string, params ...interface{}) error {
-	return logFormatWithError(ErrorLvl, func() { _ = Errorf(format, params...) }, logger.errorf, format, true, params...)
+	return logFormatWithError(ErrorLvl, func(callerPos string) { _ = Error(callerPos + fmt.Sprintf(format, params...)) }, logger.errorf, format, true, 1, params...)
 }
 
 // ErrorfStackDepth logs with format at the error level and the current stack depth plus the given depth
 func ErrorfStackDepth(depth int, format string, params ...interface{}) error {
 	msg := fmt.Sprintf(format, params...)
-	return logWithError(ErrorLvl, func() { _ = ErrorStackDepth(depth, msg) }, func(s string) error {
+	return logWithError(ErrorLvl, func(callerPos string) { _ = Error(callerPos + msg) }, func(s string) error {
 		return logger.errorStackDepth(s, depth)
-	}, true, msg)
+	}, true, depth, msg)
 }
 
 // ErrorcStackDepth logs at the error level with context and the current stack depth plus the additional given one and returns an error containing the formated log message
 func ErrorcStackDepth(message string, depth int, context ...interface{}) error {
-	return logContextWithError(ErrorLvl, func() { _ = Errorc(message, context...) }, logger.error, message, true, depth, context...)
+	return logContextWithError(ErrorLvl, func(callerPos string) { _ = Errorc(callerPos+message, context...) }, logger.error, message, true, depth, context...)
 }
 
 // Errorc logs at the error level with context and returns an error containing the formated log message
@@ -843,25 +852,25 @@ func ErrorFunc(logFunc func() string) {
 
 // Critical logs at the critical level and returns an error containing the formated log message
 func Critical(v ...interface{}) error {
-	return logWithError(CriticalLvl, func() { _ = Critical(v...) }, logger.critical, true, v...)
+	return logWithError(CriticalLvl, func(callerPos string) { _ = Critical(callerPos + BuildLogEntry(v...)) }, logger.critical, true, 1, v...)
 }
 
 // Criticalf logs with format at the critical level and returns an error containing the formated log message
 func Criticalf(format string, params ...interface{}) error {
-	return logFormatWithError(CriticalLvl, func() { _ = Criticalf(format, params...) }, logger.criticalf, format, true, params...)
+	return logFormatWithError(CriticalLvl, func(callerPos string) { _ = Critical(callerPos + fmt.Sprintf(format, params...)) }, logger.criticalf, format, true, 1, params...)
 }
 
 // CriticalfStackDepth logs with format at the critical level and the current stack depth plus the given depth
 func CriticalfStackDepth(depth int, format string, params ...interface{}) error {
 	msg := fmt.Sprintf(format, params...)
-	return logWithError(CriticalLvl, func() { _ = CriticalStackDepth(depth, msg) }, func(s string) error {
+	return logWithError(CriticalLvl, func(callerPos string) { _ = Critical(callerPos + msg) }, func(s string) error {
 		return logger.criticalStackDepth(s, depth)
-	}, false, msg)
+	}, false, depth, msg)
 }
 
 // CriticalcStackDepth logs at the critical level with context and the current stack depth plus the additional given one and returns an error containing the formated log message
 func CriticalcStackDepth(message string, depth int, context ...interface{}) error {
-	return logContextWithError(CriticalLvl, func() { _ = Criticalc(message, context...) }, logger.critical, message, true, depth, context...)
+	return logContextWithError(CriticalLvl, func(callerPos string) { _ = Criticalc(callerPos+message, context...) }, logger.critical, message, true, depth, context...)
 }
 
 // Criticalc logs at the critical level with context and returns an error containing the formated log message
@@ -879,42 +888,42 @@ func CriticalFunc(logFunc func() string) {
 
 // InfoStackDepth logs at the info level and the current stack depth plus the additional given one
 func InfoStackDepth(depth int, v ...interface{}) {
-	log(InfoLvl, func() { InfoStackDepth(depth, v...) }, func(s string) {
+	log(InfoLvl, func(callerPos string) { Info(callerPos + BuildLogEntry(v...)) }, func(s string) {
 		logger.infoStackDepth(s, depth)
-	}, v...)
+	}, depth, v...)
 }
 
 // WarnStackDepth logs at the warn level and the current stack depth plus the additional given one and returns an error containing the formated log message
 func WarnStackDepth(depth int, v ...interface{}) error {
-	return logWithError(WarnLvl, func() { _ = WarnStackDepth(depth, v...) }, func(s string) error {
+	return logWithError(WarnLvl, func(callerPos string) { _ = Warn(callerPos + BuildLogEntry(v...)) }, func(s string) error {
 		return logger.warnStackDepth(s, depth)
-	}, false, v...)
+	}, false, depth, v...)
 }
 
 // DebugStackDepth logs at the debug level and the current stack depth plus the additional given one and returns an error containing the formated log message
 func DebugStackDepth(depth int, v ...interface{}) {
-	log(DebugLvl, func() { DebugStackDepth(depth, v...) }, func(s string) {
+	log(DebugLvl, func(callerPos string) { Debug(callerPos + BuildLogEntry(v...)) }, func(s string) {
 		logger.debugStackDepth(s, depth)
-	}, v...)
+	}, depth, v...)
 }
 
 // TraceStackDepth logs at the trace level and the current stack depth plus the additional given one and returns an error containing the formated log message
 func TraceStackDepth(depth int, v ...interface{}) {
-	log(TraceLvl, func() { TraceStackDepth(depth, v...) }, func(s string) {
+	log(TraceLvl, func(callerPos string) { Trace(callerPos + BuildLogEntry(v...)) }, func(s string) {
 		logger.traceStackDepth(s, depth)
-	}, v...)
+	}, depth, v...)
 }
 
 // ErrorStackDepth logs at the error level and the current stack depth plus the additional given one and returns an error containing the formated log message
 func ErrorStackDepth(depth int, v ...interface{}) error {
-	return logWithError(ErrorLvl, func() { _ = ErrorStackDepth(depth, v...) }, func(s string) error {
+	return logWithError(ErrorLvl, func(callerPos string) { _ = Error(callerPos + BuildLogEntry(v...)) }, func(s string) error {
 		return logger.errorStackDepth(s, depth)
-	}, true, v...)
+	}, true, depth, v...)
 }
 
 // CriticalStackDepth logs at the critical level and the current stack depth plus the additional given one and returns an error containing the formated log message
 func CriticalStackDepth(depth int, v ...interface{}) error {
-	return logWithError(CriticalLvl, func() { _ = CriticalStackDepth(depth, v...) }, func(s string) error {
+	return logWithError(CriticalLvl, func(callerPos string) { _ = Critical(callerPos + BuildLogEntry(v...)) }, func(s string) error {
 		return logger.criticalStackDepth(s, depth)
-	}, true, v...)
+	}, true, depth, v...)
 }


### PR DESCRIPTION
### What does this PR do?

When logging before the logger is initialized the log are buffered. This place all those logs at 'pkg/util/log/log.go:748 in func1'.

We can't use a specific stack position to find the correct line where they were emited since it goes through 'fx' and 'dig' which are external dependencies (change their would break our logs).

This saves the log position when added to the buffer and use that as a prefix when emited.

Logs like this:
```
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:748 in func1) | Using '/home/name/dev/go/src/github.com/DataDog/datadog-agent/embedded' as Python home
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:743 in func1) | Starting to load the configuration
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:743 in func1) | Loading proxy settings
    2026-08-25 15:31:59 CEST | CORE | WARN | (pkg/util/log/log.go:794 in func1) | Set('proxy.no_proxy'): converting value from []interface {} to []string to match default type
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:743 in func1) | Starting to resolve secrets
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:743 in func1) | Finished resolving secrets
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:748 in func1) | Agent found cri socket at: /var/run/containerd/containerd.sock but socket not reachable (permissions?)
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:748 in func1) | Agent did not find PodResources socket at /var/lib/kubelet/pod-resources/kubelet.sock
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:748 in func1) | 2 Features detected from environment: docker,process
    2026-08-25 15:31:59 CEST | CORE | INFO | (comp/core/ipc/impl/ipc.go:76 in NewComponent) | starting to load the IPC auth primitives (timeout: 30s)
    2026-08-25 15:31:59 CEST | CORE | WARN | (pkg/api/security/cert/cert_getter.go:37 in getCertFilepath) | IPC cert/key created or retrieved next to auth_token_file_path location: /home/name/dev/go/src/github.com/DataDog/datadog-agent/ipc_cert.pem
```

Now look like this:
```
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:748 in func1) | github.com/DataDog/datadog-agent/pkg/collector/python/init.go:337 Using '/home/name/dev/go/src/github.com/DataDog/datadog-agent/embedded' as Python home
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:743 in func1) | github.com/DataDog/datadog-agent/pkg/config/setup/config.go:548 Starting to load the configuration
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:743 in func1) | github.com/DataDog/datadog-agent/pkg/config/setup/config.go:166 Loading proxy settings
    2026-08-25 15:31:59 CEST | CORE | WARN | (pkg/util/log/log.go:794 in func1) | github.com/DataDog/datadog-agent/pkg/config/setup/config.go:233 Set('proxy.no_proxy'): converting value from []interface {} to []string to match default type
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:743 in func1) | github.com/DataDog/datadog-agent/pkg/config/setup/config.go:706 Starting to resolve secrets
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:743 in func1) | github.com/DataDog/datadog-agent/pkg/config/setup/config.go:757 Finished resolving secrets
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:748 in func1) | github.com/DataDog/datadog-agent/pkg/config/env/environment_containers.go:176 Agent found cri socket at: /var/run/containerd/containerd.sock but socket not reachable (permissions?)
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:748 in func1) | github.com/DataDog/datadog-agent/pkg/config/env/environment_containers.go:293 Agent did not find PodResources socket at /var/lib/kubelet/pod-resources/kubelet.sock
    2026-08-25 15:31:59 CEST | CORE | INFO | (pkg/util/log/log.go:748 in func1) | github.com/DataDog/datadog-agent/pkg/config/env/environment_detection.go:124 2 Features detected from environment: docker,process
    2026-08-25 15:31:59 CEST | CORE | INFO | (comp/core/ipc/impl/ipc.go:76 in NewComponent) | starting to load the IPC auth primitives (timeout: 30s)
    2026-08-25 15:31:59 CEST | CORE | WARN | (pkg/api/security/cert/cert_getter.go:37 in getCertFilepath) | IPC cert/key created or retrieved next to auth_token_file_path location: /home/name/dev/go/src/github.com/DataDog/datadog-agent/ipc_cert.pem
```

The extra position is only used for buffered logs.