### PR TITLE
fix(data-race): make conntrackerTelemetry.lastRegisters atomic

### DIFF
--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"net/netip"
+	"sync/atomic"
 	"time"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -62,7 +63,7 @@ var conntrackerTelemetry = struct {
 	getsTotal           telemetryComp.Counter
 	unregistersTotal    telemetryComp.Counter
 	registersTotal      *prometheus.Desc
-	lastRegisters       uint64
+	lastRegisters       atomic.Uint64
 }{
 	telemetryimpl.GetCompatComponent().NewHistogram(ebpfConntrackerModuleName, "gets_duration_nanoseconds", []string{}, "Histogram measuring the time spent retrieving connection tuples from the EBPF map", defaultBuckets),
 	telemetryimpl.GetCompatComponent().NewHistogram(ebpfConntrackerModuleName, "unregisters_duration_nanoseconds", []string{}, "Histogram measuring the time spent deleting connection tuples from the EBPF map", defaultBuckets),
@@ -411,8 +412,9 @@ func (e *ebpfConntracker) Collect(ch chan<- prometheus.Metric) {
 	if err := e.telemetryMap.Lookup(&zero, ebpfTelemetry); err != nil {
 		log.Tracef("error retrieving the telemetry struct: %s", err)
 	} else {
-		delta := ebpfTelemetry.Registers - conntrackerTelemetry.lastRegisters
-		conntrackerTelemetry.lastRegisters = ebpfTelemetry.Registers
+		last := conntrackerTelemetry.lastRegisters.Load()
+		delta := ebpfTelemetry.Registers - last
+		conntrackerTelemetry.lastRegisters.Store(ebpfTelemetry.Registers)
 		ch <- prometheus.MustNewConstMetric(conntrackerTelemetry.registersTotal, prometheus.CounterValue, float64(delta))
 	}
 }


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Makes `conntrackerTelemetry.lastRegisters` an `atomic.Uint64` and uses `Load`/`Store` in `Collect()`.

### Motivation

`Collect()` reads and writes `conntrackerTelemetry.lastRegisters` (a `uint64`) without synchronization. It is called by the prometheus `Registry.Gather()`, which can run concurrently, causing a data race on the read-modify-write.

```
WARNING: DATA RACE
Write at ... by goroutine A:
  (*ebpfConntracker).Collect()  ebpf_conntracker.go:414/415
  ... prometheus Registry.Gather -> telemetryImpl.Gather
Previous read at ... by goroutine B:
  (*ebpfConntracker).Collect()  ebpf_conntracker.go:414
```

### Describe how you validated your changes

CI