### PR TITLE
fix(data-race): protect ActionStore.stopCh with sync.Once

### DIFF
--- a/comp/kubeactions/helmactions/impl/action_store.go
+++ b/comp/kubeactions/helmactions/impl/action_store.go
@@ -109,8 +109,9 @@ type ActionStore struct {
 	jobs     map[types.UID]JobRecord
 	pods     map[types.UID]PodRecord
 	// mu guards above mentioned
-	mu     sync.RWMutex
-	stopCh chan struct{}
+	mu       sync.RWMutex
+	stopCh   chan struct{}
+	stopOnce sync.Once
 }
 
 // NewActionStore creates a new ActionStore and starts the background cleanup goroutine.
@@ -412,6 +413,7 @@ func (s *ActionStore) RunCleanup(ctx context.Context) {
 
 // Stop shuts down the cleanup goroutine.
 func (s *ActionStore) StopCleanup() {
-	close(s.stopCh)
-	s.stopCh = nil
+	s.stopOnce.Do(func() {
+		close(s.stopCh)
+	})
 }


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Replaces `close(s.stopCh); s.stopCh = nil` in `StopCleanup()` with a `sync.Once`-guarded close, dropping the nil assignment.

### Motivation

`StopCleanup()` wrote `s.stopCh = nil` after closing, racing with `cleanupLoop()` reading `s.stopCh` in its `select`. The channel is set once in `RunCleanup` before the goroutine starts, so once we stop niling it the field is never written again and concurrent reads are safe. `sync.Once` prevents double-close.

```
WARNING: DATA RACE
Write at ... by goroutine A:
  (*ActionStore).StopCleanup()  action_store.go:416   // s.stopCh = nil
Previous read at ... by goroutine B:
  (*ActionStore).cleanupLoop()  action_store.go:354   // <-s.stopCh
```

### Describe how you validated your changes

CI