### PR TITLE
ci: temporarily disable trace-agent_microbenchmarks job

### DIFF
--- a/.gitlab/test/benchmarks/benchmarks.yml
+++ b/.gitlab/test/benchmarks/benchmarks.yml
@@ -3,7 +3,10 @@ benchmark:
   # This base image is created here: https://gitlab.ddbuild.io/DataDog/apm-reliability/benchmarking-platform
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:trace-agent_microbenchmarks
   timeout: 1h
-  rules: !reference [.on_trace_agent_changes_or_manual]
+  # TODO(andrew.glaude): temporarily disabled, causing flaky failures. Re-enable by
+  # restoring `rules: !reference [.on_trace_agent_changes_or_manual]`.
+  rules:
+    - when: never
   interruptible: true
   needs: ["setup_agent_version"]
   retry: !reference [.retry_only_infra_failure, retry]


### PR DESCRIPTION
### What does this PR do?
Temporarily disables the `trace-agent_microbenchmarks` CI job (`benchmark` in `.gitlab/test/benchmarks/benchmarks.yml`) by setting its rules to `when: never`.

### Motivation
The job has been causing flaky failures in CI. Disabling it temporarily to unblock pipelines while the flakiness is investigated. The original rules are preserved in a comment for easy re-enabling.

### Describe how you validated your changes
N/A - CI config change only, no code changes.

### Additional Notes
No changelog entry needed (CI-only change).