### PR TITLE
fix(data-race): lock ntmConfig.GetNode for concurrent access

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -885,6 +885,9 @@ func (c *ntmConfig) nodeAtPathFromNode(key string, curr *nodeImpl) *nodeImpl {
 
 // GetNode returns a *nodeImpl for the given key
 func (c *ntmConfig) GetNode(key string) (Node, error) {
+	c.RLock()
+	defer c.RUnlock()
+
 	if !c.isReady() && !c.allowDynamicSchema.Load() {
 		return nil, log.Errorf("attempt to read key before config is constructed: %s", key)
 	}


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Adds `c.RLock()` / `defer c.RUnlock()` to `ntmConfig.GetNode()`.

### Motivation

`GetNode()` reads `c.root` and traverses the tree without the read lock, racing with `Set()` which modifies the tree under the write lock.

```
WARNING: DATA RACE
Read at ... by goroutine A:
  (*ntmConfig).GetNode()  config.go:894   // curr.GetChild(part)
  ... configstreamconsumer.streamLoop -> applyUpdate -> IsSetting
Previous write at ... by goroutine B:
  (*ntmConfig).Set()  config.go:265   // c.root.Merge(newTree)
  ... configstreamconsumer.applyUpdate
```

### Describe how you validated your changes

CI

### Additional Notes

`GetNode` is only called from `IsSetting()` (no lock held), so adding `RLock` introduces no deadlock risk.