### PR TITLE
fix(logs): hand the path over sequentially after a log rotation

### DIFF
--- a/pkg/config/schema/yaml/logs_config.yaml
+++ b/pkg/config/schema/yaml/logs_config.yaml
@@ -148,6 +148,19 @@ properties:
       after it has been rotated.
     comment: maximum time that the unix tailer will hold a log file open after it
       has been rotated
+  rotation_handoff_quiet_period:
+    node_type: setting
+    type: integer
+    default: 2
+    description: |-
+      The number of seconds a rotated file must stop producing data before the Agent
+      stops reading it and reopens the path.
+
+      This only applies to file sources that set `fingerprint_config.open_flags`, for
+      which the Agent reads the rotated and the new file one after the other rather
+      than in parallel. Set it to `0` to always wait for `close_timeout` instead.
+    comment: a shorter quiet period hands the path over faster, at the risk of ending
+      the drain while the writer is only briefly idle
   open_files_limit:
     node_type: setting
     type: integer

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -367,6 +367,12 @@ func (s *Launcher) resolveActiveTailers(files []*tailer.File) {
 // scan. A file that is not fingerprinted still gets its effective config so the
 // status page can display it.
 func (s *Launcher) resolveFingerprint(file *tailer.File) (*types.Fingerprint, bool) {
+	// Computing a fingerprint is itself an open on the path, so the sequential
+	// handoff barrier has to come before it.
+	if s.drainingOnPath(file) && s.sequentialHandoffActive(file) {
+		return nil, false
+	}
+
 	if !s.fingerprinter.ShouldFileFingerprint(file) {
 		fpConfig := s.fingerprinter.GetEffectiveConfigForFile(file)
 		if fpConfig == nil {
@@ -383,6 +389,36 @@ func (s *Launcher) resolveFingerprint(file *tailer.File) (*types.Fingerprint, bo
 		return nil, false
 	}
 	return fingerprint, true
+}
+
+// sequentialHandoffActive reports whether a replacement tailer for this file must
+// wait for a rotated tailer on the same path to finish. Direct fingerprint reads are
+// the configuration that exposes CIFS handle reuse.
+//
+// This deliberately asks whether the source configured open_flags, not whether they
+// are honoured on this platform: O_DIRECT is Linux-only, but gating the barrier on
+// that would give the same source different rotation semantics per platform, and
+// open_flags is accepted everywhere precisely so one configuration stays portable.
+func (s *Launcher) sequentialHandoffActive(file *tailer.File) bool {
+	cfg := s.fingerprinter.GetEffectiveConfigForFile(file)
+	return cfg != nil && len(cfg.OpenFlags) > 0
+}
+
+// drainingOnPath reports whether a rotated tailer on this file's path is still
+// draining. Tailer.Identifier() is "file:"+path, so two tailers on one path -- for
+// example a dead and a fresh container -- compare equal here, which is what the
+// barrier needs.
+func (s *Launcher) drainingOnPath(file *tailer.File) bool {
+	if len(s.rotatedTailers) == 0 {
+		return false
+	}
+	id := file.Identifier()
+	for _, t := range s.rotatedTailers {
+		if t.Identifier() == id && !t.IsFinished() {
+			return true
+		}
+	}
+	return false
 }
 
 // cleanUpRotatedTailers removes any rotated tailers that have stopped from the list
@@ -604,7 +640,11 @@ func (s *Launcher) stopTailer(tailer *tailer.Tailer) {
 
 func (s *Launcher) rotateTailerWithoutRestart(oldTailer *tailer.Tailer, file *tailer.File) bool {
 	log.Info("Log rotation happened to ", file.Path)
-	oldTailer.StopAfterFileRotation()
+	if s.sequentialHandoffActive(file) {
+		oldTailer.StopAfterFileRotationForHandoff()
+	} else {
+		oldTailer.StopAfterFileRotation()
+	}
 
 	// Remove the draining tailer from the active map; it will keep draining via rotatedTailers.
 	s.tailers.Remove(oldTailer)

--- a/pkg/logs/launchers/file/launcher_test.go
+++ b/pkg/logs/launchers/file/launcher_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
@@ -1610,4 +1611,183 @@ func (suite *LauncherTestSuite) TestFingerprintOpenFlagsErrorClearsWhenFileDisap
 
 	_, present := disappearedSource.GetInfoStatus()[fingerprintOpenFlagsInfoKey]
 	suite.False(present, "a file that no longer fails must leave no stale error")
+}
+
+type sequentialHandoffFixture struct {
+	t          *testing.T
+	launcher   *Launcher
+	logSources []*sources.LogSource
+	path       string
+	file       *os.File
+}
+
+// newSequentialHandoffFixture builds a launcher tailing one file through as many
+// sources as identifiers are given. open_flags on the fingerprint config is what
+// turns the sequential handoff on, so passing none exercises parallel rotation.
+func newSequentialHandoffFixture(t *testing.T, openFlags []types.FileOpenFlag, identifiers ...string) *sequentialHandoffFixture {
+	mockConfig := configmock.New(t)
+	// A rotated tailer that drains on its own would hide the barrier, so keep it
+	// draining until the test ends it explicitly.
+	mockConfig.SetInTest("logs_config.close_timeout", 60)
+
+	launcher := createLauncher(t, launcherTestOptions{
+		fingerprintConfig: &types.FingerprintConfig{
+			FingerprintStrategy: types.FingerprintStrategyLineChecksum,
+			Count:               1,
+			CountToSkip:         0,
+			MaxBytes:            256,
+			OpenFlags:           openFlags,
+		},
+	})
+	launcher.pipelineProvider = mock.NewMockProvider()
+	launcher.registry = auditorMock.NewMockRegistry()
+
+	// The mock pipeline channel is unbuffered, so a tailer that is never read
+	// from blocks forever when it is stopped. Nothing here asserts on content.
+	outputChan := launcher.pipelineProvider.NextPipelineChan()
+	stopDraining := make(chan struct{})
+	t.Cleanup(func() { close(stopDraining) })
+	go func() {
+		for {
+			select {
+			case <-outputChan:
+			case <-stopDraining:
+				return
+			}
+		}
+	}()
+
+	path := t.TempDir() + "/launcher.log"
+	file, err := os.Create(path)
+	require.NoError(t, err)
+
+	logSources := make([]*sources.LogSource, 0, len(identifiers))
+	for _, identifier := range identifiers {
+		logSources = append(logSources, sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Identifier: identifier, Path: path}))
+	}
+	launcher.activeSources = append(launcher.activeSources, logSources...)
+
+	status.Clear()
+	status.InitStatus(mockConfig, testutils.CreateSources(logSources))
+	t.Cleanup(func() {
+		launcher.cleanup()
+		file.Close()
+		status.Clear()
+	})
+
+	return &sequentialHandoffFixture{t: t, launcher: launcher, logSources: logSources, path: path, file: file}
+}
+
+func (f *sequentialHandoffFixture) scan() {
+	l := f.launcher
+	l.resolveActiveTailers(l.fileProvider.FilesToTail(context.Background(), l.validatePodContainerID, l.activeSources, l.registry))
+}
+
+func (f *sequentialHandoffFixture) write(content string) {
+	_, err := f.file.WriteString(content)
+	require.NoError(f.t, err)
+	require.NoError(f.t, f.file.Sync())
+}
+
+// rotate renames the file away and puts different content at the original path,
+// which is what the fingerprint comparison sees as a rotation.
+func (f *sequentialHandoffFixture) rotate(content string) {
+	require.NoError(f.t, os.Rename(f.path, f.path+".1"))
+
+	rotated, err := os.Create(f.path)
+	require.NoError(f.t, err)
+	f.t.Cleanup(func() { rotated.Close() })
+
+	_, err = rotated.WriteString(content)
+	require.NoError(f.t, err)
+	require.NoError(f.t, rotated.Sync())
+}
+
+func TestSequentialHandoffDefersReplacementUntilRotatedTailerFinishes(t *testing.T) {
+	fixture := newSequentialHandoffFixture(t, []types.FileOpenFlag{types.FileOpenFlagDirect}, "")
+	launcher := fixture.launcher
+	scanKey := getScanKey(fixture.path, fixture.logSources[0])
+
+	fixture.write("hello world\n")
+	fixture.scan()
+	rotatedTailer, found := launcher.tailers.Get(scanKey)
+	require.True(t, found, "the initial tailer should be running")
+
+	fixture.rotate("hello again\n")
+	fixture.scan()
+
+	assert.Equal(t, 0, launcher.tailers.Count(), "the replacement must wait for the rotated tailer to release its descriptor")
+	require.Len(t, launcher.rotatedTailers, 1)
+	assert.Same(t, rotatedTailer, launcher.rotatedTailers[0])
+	assert.Contains(t, launcher.oldInfoMap, scanKey, "a deferred scan must keep the info the replacement inherits")
+
+	rotatedTailer.Stop()
+	fixture.scan()
+
+	replacement, found := launcher.tailers.Get(scanKey)
+	require.True(t, found, "the replacement should start once the rotated tailer is finished")
+	assert.NotSame(t, rotatedTailer, replacement)
+	assert.Same(t, rotatedTailer.GetInfo(), replacement.GetInfo(), "the replacement inherits the rotated tailer's info registry")
+}
+
+func TestSequentialHandoffDoesNotDeferWithoutOpenFlags(t *testing.T) {
+	fixture := newSequentialHandoffFixture(t, nil, "")
+	launcher := fixture.launcher
+	scanKey := getScanKey(fixture.path, fixture.logSources[0])
+
+	fixture.write("hello world\n")
+	fixture.scan()
+	rotatedTailer, found := launcher.tailers.Get(scanKey)
+	require.True(t, found, "the initial tailer should be running")
+
+	fixture.rotate("hello again\n")
+	fixture.scan()
+
+	replacement, found := launcher.tailers.Get(scanKey)
+	require.True(t, found, "without open_flags the replacement starts in the same scan as the rotation")
+	assert.NotSame(t, rotatedTailer, replacement)
+	assert.Len(t, launcher.rotatedTailers, 1)
+}
+
+func TestSequentialHandoffDefersLaunchTailers(t *testing.T) {
+	fixture := newSequentialHandoffFixture(t, []types.FileOpenFlag{types.FileOpenFlagDirect}, "")
+	launcher := fixture.launcher
+
+	fixture.write("hello world\n")
+	fixture.scan()
+
+	fixture.rotate("hello again\n")
+	fixture.scan()
+	require.Len(t, launcher.rotatedTailers, 1)
+
+	// A source added or reloaded mid-drain reaches the file through launchTailers
+	// rather than a scan, so it needs the same barrier.
+	launcher.launchTailers(fixture.logSources[0])
+	assert.Equal(t, 0, launcher.tailers.Count(), "launchTailers must not reopen a path that is still draining")
+
+	launcher.rotatedTailers[0].Stop()
+	launcher.launchTailers(fixture.logSources[0])
+	assert.Equal(t, 1, launcher.tailers.Count(), "launchTailers starts the tailer once the drain is over")
+}
+
+func TestSequentialHandoffBlocksEveryScanKeyOnPath(t *testing.T) {
+	fixture := newSequentialHandoffFixture(t, []types.FileOpenFlag{types.FileOpenFlagDirect}, "container-1", "container-2")
+	launcher := fixture.launcher
+
+	fixture.write("hello world\n")
+	fixture.scan()
+	require.Equal(t, 2, launcher.tailers.Count(), "both containers tail the same path")
+
+	fixture.rotate("hello again\n")
+	fixture.scan()
+
+	assert.Equal(t, 0, launcher.tailers.Count(), "both scan keys are blocked by a drain on their shared path")
+	require.Len(t, launcher.rotatedTailers, 2)
+
+	for _, rotatedTailer := range launcher.rotatedTailers {
+		rotatedTailer.Stop()
+	}
+	fixture.scan()
+
+	assert.Equal(t, 2, launcher.tailers.Count(), "both replacements start once the path is free")
 }

--- a/pkg/logs/tailers/file/tailer.go
+++ b/pkg/logs/tailers/file/tailer.go
@@ -86,6 +86,12 @@ type Tailer struct {
 	// reading and processing any remaining log lines in the file.
 	closeTimeout time.Duration
 
+	// rotationHandoffQuietPeriod is how long a rotated file must stop producing
+	// data before a drain that another tailer is waiting on treats it as fully
+	// read.  Zero or less disables that early exit, leaving closeTimeout as the
+	// only bound.
+	rotationHandoffQuietPeriod time.Duration
+
 	// windowsOpenFileTimeout (Windows only) is the duration the tailer will
 	// hold a file open while waiting for the downstream logs pipeline to
 	// clear.  Setting this to too short a time may result in data in rotated
@@ -170,6 +176,7 @@ func NewTailer(opts *TailerOptions) *Tailer {
 
 	forwardContext, stopForward := context.WithCancel(context.Background())
 	closeTimeout := pkgconfigsetup.Datadog().GetDuration("logs_config.close_timeout") * time.Second
+	rotationHandoffQuietPeriod := pkgconfigsetup.Datadog().GetDuration("logs_config.rotation_handoff_quiet_period") * time.Second
 	windowsOpenFileTimeout := pkgconfigsetup.Datadog().GetDuration("logs_config.windows_open_file_timeout") * time.Second
 
 	bytesRead := status.NewCountInfo("Bytes Read")
@@ -191,6 +198,7 @@ func NewTailer(opts *TailerOptions) *Tailer {
 		decodedOffset:                atomic.NewInt64(0),
 		sleepDuration:                opts.SleepDuration,
 		closeTimeout:                 closeTimeout,
+		rotationHandoffQuietPeriod:   rotationHandoffQuietPeriod,
 		windowsOpenFileTimeout:       windowsOpenFileTimeout,
 		stop:                         make(chan struct{}, 1),
 		done:                         make(chan struct{}, 1),
@@ -306,12 +314,31 @@ func (t *Tailer) Stop() {
 // StopAfterFileRotation prepares the tailer to stop after a timeout
 // to finish reading its file that has been log-rotated
 func (t *Tailer) StopAfterFileRotation() {
+	t.stopAfterFileRotation(false)
+}
+
+// StopAfterFileRotationForHandoff prepares the tailer to stop after it has
+// finished reading its file that has been log-rotated, for callers that hand the
+// path over to a replacement tailer.
+//
+// The replacement tailer cannot open the path until this tailer releases its
+// descriptor, so the drain ends once the rotated file has been quiet for
+// rotationHandoffQuietPeriod rather than always waiting out closeTimeout.
+func (t *Tailer) StopAfterFileRotationForHandoff() {
+	t.stopAfterFileRotation(true)
+}
+
+func (t *Tailer) stopAfterFileRotation(endWhenIdle bool) {
 	t.didFileRotate.Store(true)
 	bytesReadAtRotationTime := t.bytesRead.Get()
 	go func() {
-		time.Sleep(t.closeTimeout)
+		timedOut := t.waitForRotationDrain(endWhenIdle)
 		if newBytesRead := t.bytesRead.Get() - bytesReadAtRotationTime; newBytesRead > 0 {
-			log.Infof("After rotation close timeout (%s), an additional %d bytes were read from file %q", t.closeTimeout, newBytesRead, t.file.Path)
+			if timedOut {
+				log.Infof("After rotation close timeout (%s), an additional %d bytes were read from file %q", t.closeTimeout, newBytesRead, t.file.Path)
+			} else {
+				log.Infof("After the rotated file %q produced no data for the rotation handoff quiet period (%s), an additional %d bytes were read", t.file.Path, t.rotationHandoffQuietPeriod, newBytesRead)
+			}
 			if t.osFile != nil {
 				fileStat, err := t.osFile.Stat()
 				if err != nil {
@@ -324,7 +351,11 @@ func (t *Tailer) StopAfterFileRotation() {
 					if remainingBytes > 0 {
 						metrics.BytesMissed.Add(remainingBytes)
 						metrics.TlmBytesMissed.Add(float64(remainingBytes))
-						log.Warnf("After rotation close timeout (%s), there were %d bytes remaining unread for file %q. These unread logs are now lost. Consider increasing DD_LOGS_CONFIG_CLOSE_TIMEOUT", t.closeTimeout, remainingBytes, t.file.Path)
+						if timedOut {
+							log.Warnf("After rotation close timeout (%s), there were %d bytes remaining unread for file %q. These unread logs are now lost. Consider increasing DD_LOGS_CONFIG_CLOSE_TIMEOUT", t.closeTimeout, remainingBytes, t.file.Path)
+						} else {
+							log.Warnf("After the rotated file %q produced no data for the rotation handoff quiet period (%s), there were %d bytes remaining unread. These unread logs are now lost. Consider increasing DD_LOGS_CONFIG_ROTATION_HANDOFF_QUIET_PERIOD", t.file.Path, t.rotationHandoffQuietPeriod, remainingBytes)
+						}
 					}
 				}
 			}
@@ -336,6 +367,49 @@ func (t *Tailer) StopAfterFileRotation() {
 		}
 	}()
 	t.file.Source.RemoveInput(t.file.Path)
+}
+
+// waitForRotationDrain blocks until the rotated file is finished being read, or
+// until closeTimeout elapses, whichever comes first. It reports whether it
+// returned because closeTimeout elapsed rather than because the file stopped
+// producing data, so callers can tell the operator which limit ended the drain.
+func (t *Tailer) waitForRotationDrain(endWhenIdle bool) (timedOut bool) {
+	quietPeriod := t.rotationHandoffQuietPeriod
+	if !endWhenIdle || quietPeriod <= 0 {
+		time.Sleep(t.closeTimeout)
+		return true
+	}
+
+	pollInterval := t.sleepDuration
+	// Only reachable for tailers constructed without a sleep duration.
+	if pollInterval <= 0 {
+		pollInterval = time.Second
+	}
+
+	deadline := time.Now().Add(t.closeTimeout)
+	lastBytesRead := t.bytesRead.Get()
+	lastChange := time.Now()
+
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return true
+		}
+		if remaining < pollInterval {
+			time.Sleep(remaining)
+		} else {
+			time.Sleep(pollInterval)
+		}
+
+		if current := t.bytesRead.Get(); current != lastBytesRead {
+			lastBytesRead = current
+			lastChange = time.Now()
+			continue
+		}
+		if time.Since(lastChange) >= quietPeriod {
+			return false
+		}
+	}
 }
 
 // readForever lets the tailer tail the content of a file

--- a/pkg/logs/tailers/file/tailer_test.go
+++ b/pkg/logs/tailers/file/tailer_test.go
@@ -149,6 +149,34 @@ func (suite *TailerTestSuite) TestTailerTimeDurationConfig() {
 	tailer.Stop()
 }
 
+func (suite *TailerTestSuite) TestTailerRotationHandoffQuietPeriodConfig() {
+	mockConfig := configmock.New(suite.T())
+	// To satisfy the suite level tailer
+	suite.tailer.StartFromBeginning()
+
+	tailer := NewTailer(suite.createTailerOptions(nil))
+	suite.Equal(2*time.Second, tailer.rotationHandoffQuietPeriod)
+
+	mockConfig.SetInTest("logs_config.rotation_handoff_quiet_period", 7)
+
+	tailer = NewTailer(suite.createTailerOptions(nil))
+	tailer.StartFromBeginning()
+
+	suite.Equal(7*time.Second, tailer.rotationHandoffQuietPeriod)
+	tailer.Stop()
+}
+
+// The setting is undocumented, so it is absent from the generated config
+// templates and the env var is the only way an operator can reach it.
+func TestRotationHandoffQuietPeriodEnvVar(t *testing.T) {
+	t.Setenv("DD_LOGS_CONFIG_ROTATION_HANDOFF_QUIET_PERIOD", "9")
+
+	quietPeriod := configmock.New(t).GetDuration("logs_config.rotation_handoff_quiet_period") * time.Second
+	if quietPeriod != 9*time.Second {
+		t.Errorf("read a quiet period of %s from the environment, expected %s", quietPeriod, 9*time.Second)
+	}
+}
+
 func (suite *TailerTestSuite) TestTailFromBeginning() {
 	lines := []string{"hello world\n", "hello again\n", "good bye\n"}
 
@@ -688,4 +716,205 @@ func TestNoGoLeakWithNonBlockingStop(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// The deferred goleak.VerifyNone() will detect if goroutine leaked
+}
+
+// newDrainTestTailer builds the minimal state waitForRotationDrain reads, so the
+// drain timing can be exercised without a file or a running pipeline.
+func newDrainTestTailer(closeTimeout, sleepDuration, quietPeriod time.Duration) *Tailer {
+	return &Tailer{
+		closeTimeout:               closeTimeout,
+		sleepDuration:              sleepDuration,
+		rotationHandoffQuietPeriod: quietPeriod,
+		bytesRead:                  status.NewCountInfo("Bytes Read"),
+	}
+}
+
+func TestWaitForRotationDrainEndsWhenFileGoesIdle(t *testing.T) {
+	t.Parallel()
+
+	quietPeriod := 40 * time.Millisecond
+	// The close timeout is far larger than the quiet period, so a drain that
+	// ends quickly can only have ended on the quiet period.
+	tailer := newDrainTestTailer(30*time.Second, 20*time.Millisecond, quietPeriod)
+
+	start := time.Now()
+	timedOut := tailer.waitForRotationDrain(true)
+	elapsed := time.Since(start)
+
+	if timedOut {
+		t.Errorf("drain reported a close timeout, expected it to report that the file went idle")
+	}
+	if elapsed < quietPeriod {
+		t.Errorf("drain ended after %s, before the quiet period of %s elapsed", elapsed, quietPeriod)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("drain took %s, expected it to end on the quiet period rather than on the close timeout of %s",
+			elapsed, tailer.closeTimeout)
+	}
+}
+
+func TestWaitForRotationDrainKeepsReadingWhileFileProducesData(t *testing.T) {
+	t.Parallel()
+
+	pollInterval := 20 * time.Millisecond
+	tailer := newDrainTestTailer(30*time.Second, pollInterval, 40*time.Millisecond)
+
+	// Produce a byte far more often than the poll interval, so every poll during
+	// this window observes growth and the quiet period never accumulates.
+	producing := 300 * time.Millisecond
+	lastByteAt := time.Now().Add(producing)
+	go func() {
+		for time.Now().Before(lastByteAt) {
+			tailer.bytesRead.Add(1)
+			time.Sleep(pollInterval / 10)
+		}
+	}()
+
+	start := time.Now()
+	timedOut := tailer.waitForRotationDrain(true)
+	elapsed := time.Since(start)
+
+	if timedOut {
+		t.Errorf("drain reported a close timeout, expected it to report that the file went idle")
+	}
+	if elapsed < producing {
+		t.Errorf("drain ended after %s, but the file was still producing data for %s", elapsed, producing)
+	}
+	if elapsed > producing+5*time.Second {
+		t.Errorf("drain took %s, expected it to end a quiet period after the last byte", elapsed)
+	}
+}
+
+func TestWaitForRotationDrainHonorsConfiguredQuietPeriod(t *testing.T) {
+	t.Parallel()
+
+	pollInterval := 20 * time.Millisecond
+	shortQuietPeriod := 50 * time.Millisecond
+	longQuietPeriod := time.Second
+
+	// Both files are idle from the start, so the only thing that can separate
+	// the two drains is the configured quiet period.
+	start := time.Now()
+	newDrainTestTailer(30*time.Second, pollInterval, shortQuietPeriod).waitForRotationDrain(true)
+	shortElapsed := time.Since(start)
+
+	start = time.Now()
+	newDrainTestTailer(30*time.Second, pollInterval, longQuietPeriod).waitForRotationDrain(true)
+	longElapsed := time.Since(start)
+
+	if shortElapsed < shortQuietPeriod {
+		t.Errorf("drain ended after %s, before the configured quiet period of %s", shortElapsed, shortQuietPeriod)
+	}
+	if shortElapsed > longQuietPeriod/2 {
+		t.Errorf("a %s quiet period ended the drain after %s, close to the %s one; the setting does not appear to be honored",
+			shortQuietPeriod, shortElapsed, longQuietPeriod)
+	}
+	if longElapsed < longQuietPeriod {
+		t.Errorf("drain ended after %s, before the configured quiet period of %s", longElapsed, longQuietPeriod)
+	}
+}
+
+func TestWaitForRotationDrainIsBoundedByCloseTimeout(t *testing.T) {
+	t.Parallel()
+
+	pollInterval := 20 * time.Millisecond
+	tailer := newDrainTestTailer(300*time.Millisecond, pollInterval, 40*time.Millisecond)
+
+	stopProducing := make(chan struct{})
+	defer close(stopProducing)
+	go func() {
+		for {
+			select {
+			case <-stopProducing:
+				return
+			default:
+				tailer.bytesRead.Add(1)
+				time.Sleep(pollInterval / 10)
+			}
+		}
+	}()
+
+	start := time.Now()
+	timedOut := tailer.waitForRotationDrain(true)
+	elapsed := time.Since(start)
+
+	if !timedOut {
+		t.Errorf("drain reported that the file went idle, expected it to report the close timeout")
+	}
+	if elapsed < tailer.closeTimeout {
+		t.Errorf("drain ended after %s, before the close timeout of %s", elapsed, tailer.closeTimeout)
+	}
+	if elapsed > tailer.closeTimeout+5*time.Second {
+		t.Errorf("drain took %s, expected the close timeout of %s to bound a file that never goes idle",
+			elapsed, tailer.closeTimeout)
+	}
+}
+
+func TestWaitForRotationDrainCloseTimeoutOutranksQuietPeriod(t *testing.T) {
+	t.Parallel()
+
+	// The file is idle from the start, but the quiet period it would have to stay
+	// idle for is longer than the close timeout, which still has the last word.
+	tailer := newDrainTestTailer(300*time.Millisecond, 20*time.Millisecond, 30*time.Second)
+
+	start := time.Now()
+	timedOut := tailer.waitForRotationDrain(true)
+	elapsed := time.Since(start)
+
+	if !timedOut {
+		t.Errorf("drain reported that the file went idle, expected it to report the close timeout")
+	}
+	if elapsed < tailer.closeTimeout {
+		t.Errorf("drain ended after %s, before the close timeout of %s", elapsed, tailer.closeTimeout)
+	}
+	if elapsed > tailer.closeTimeout+5*time.Second {
+		t.Errorf("drain took %s, expected the close timeout of %s to bound a quiet period of %s",
+			elapsed, tailer.closeTimeout, tailer.rotationHandoffQuietPeriod)
+	}
+}
+
+func TestWaitForRotationDrainWithoutQuietPeriodAlwaysWaitsCloseTimeout(t *testing.T) {
+	t.Parallel()
+
+	// A quiet period of zero turns the early exit off, so even an idle file has
+	// to wait out the whole close timeout.
+	tailer := newDrainTestTailer(300*time.Millisecond, 20*time.Millisecond, 0)
+
+	start := time.Now()
+	timedOut := tailer.waitForRotationDrain(true)
+	elapsed := time.Since(start)
+
+	if !timedOut {
+		t.Errorf("drain reported that the file went idle, expected it to report the close timeout")
+	}
+	if elapsed < tailer.closeTimeout {
+		t.Errorf("drain ended after %s, expected the full close timeout of %s even though the file was idle",
+			elapsed, tailer.closeTimeout)
+	}
+	if elapsed > tailer.closeTimeout+5*time.Second {
+		t.Errorf("drain took %s, expected roughly the close timeout of %s", elapsed, tailer.closeTimeout)
+	}
+}
+
+func TestWaitForRotationDrainWithoutIdleEndAlwaysWaitsCloseTimeout(t *testing.T) {
+	t.Parallel()
+
+	// The file never produces anything, so a drain that does not end when idle
+	// has to wait out the whole close timeout.
+	tailer := newDrainTestTailer(300*time.Millisecond, 20*time.Millisecond, 40*time.Millisecond)
+
+	start := time.Now()
+	timedOut := tailer.waitForRotationDrain(false)
+	elapsed := time.Since(start)
+
+	if !timedOut {
+		t.Errorf("drain reported that the file went idle, expected it to report the close timeout")
+	}
+	if elapsed < tailer.closeTimeout {
+		t.Errorf("drain ended after %s, expected the full close timeout of %s even though the file was idle",
+			elapsed, tailer.closeTimeout)
+	}
+	if elapsed > tailer.closeTimeout+5*time.Second {
+		t.Errorf("drain took %s, expected roughly the close timeout of %s", elapsed, tailer.closeTimeout)
+	}
 }

--- a/releasenotes/notes/sequential-rotation-handoff-6f2a1c8b4d3e7095.yaml
+++ b/releasenotes/notes/sequential-rotation-handoff-6f2a1c8b4d3e7095.yaml
@@ -1,0 +1,17 @@
+---
+fixes:
+  - |
+    File log sources that use direct fingerprint reads
+    (``fingerprint_config.open_flags``) now wait for a rotated tailer to
+    release its descriptor before reopening the same path. On CIFS/SMB
+    shares, opening a path while a previous descriptor on it is still open
+    can return a stale handle, which duplicated or lost log lines across a
+    rotation. Sources without ``open_flags`` keep tailing the rotated and
+    the new file as before.
+
+    The handoff ends once the rotated file has been quiet for two seconds,
+    rather than always waiting out ``logs_config.close_timeout``. If a
+    rotation logs a warning about bytes remaining unread, that wait can be
+    lengthened with ``DD_LOGS_CONFIG_ROTATION_HANDOFF_QUIET_PERIOD``, in
+    seconds; ``0`` waits for the full close timeout instead. Deployments
+    that do not see the warning have no reason to set it.


### PR DESCRIPTION
### What does this PR do?

**Stage 2 of a three-part fix** for log rotation on CIFS / Azure Files (AKS). Stage 1 ([#55318](https://github.com/DataDog/datadog-agent/pull/55318)) fixes rotation **detection** with optional `O_DIRECT` fingerprint reads. **This PR fixes replacement:** what happens after rotation is detected.

On CIFS/SMB (for example Azure Files on AKS), opening a path while another descriptor on that same path is still open can return a **stale handle**. After a log rotation, a replacement tailer can then read the **rotated file’s bytes** instead of the new file’s. That duplicates or drops log lines.

This PR **serialises the handoff**: a replacement tailer cannot open the path while a rotated tailer on that path is still draining. After the old tailer finishes and closes its descriptor, the path is opened fresh.

**Who is affected.** file sources that set `fingerprint_config.open_flags` (the direct fingerprint setting from #55318 — the config that exposes this CIFS handle-reuse behaviour). All other file sources are unchanged and still tail the rotated file and the new file in parallel, as today.

**Behaviour change**

This PR adds one Agent setting:

| | |
|---|---|
| **Key** | `logs_config.rotation_handoff_quiet_period` |
| **Env var** | `DD_LOGS_CONFIG_ROTATION_HANDOFF_QUIET_PERIOD` |
| **Type** | integer (seconds) |
| **Default** | `2` |
| **Applies when** | A file source sets `fingerprint_config.open_flags` (from #55318) and the Agent is doing a sequential rotation handoff |
| **Purpose** | End the rotated tailer’s drain once the file has produced **no new bytes** for this many seconds, instead of always waiting the full `close_timeout` (60s by default) |

The config allows the agent to serialises the handoff for sources that opt in via:
1. Rotation is detected (stage 1).
2. **The old tailer drains the rotated file on its existing descriptor.**
3. **No replacement tailer opens the path** until that drain finishes.
4. The replacement tailer then opens the path fresh.

Sources without open_flags are unchanged — they still tail the rotated file and the new file in parallel.
**Relationship to #55318.** PR1 covers direct fingerprint I/O, operator status when fingerprinting fails, and restart reuse. PR1 also keeps an **active** tailer reading when fingerprinting fails (rotation detection blocked). **This PR** applies when fingerprinting **succeeds**, rotation is detected, and a **new** tailer must open the path — that is when the sequential barrier matters.

### Motivation

Application logs on AKS often live on Azure Files, mounted as CIFS/SMB. After `close()`, the Linux SMB client may defer sending SMB CLOSE for up to `closetimeo` seconds so a quick reopen can reuse a cached handle. If a replacement `open()` on the active pathname happens while an older descriptor is still alive (or its handle is still cached), the client can hand back a reused handle — and the replacement tailer reads the **previous** file instead of the new one. Operators see duplicated lines and rotated files that are never collected in full.

Direct fingerprint reads (#55318) fix **whether** the Agent notices rotation. They do **not** fix **overlap during replacement**: the Agent can still open the new tailer while the rotated one is draining. This PR removes that overlap for sources with `open_flags` configured.

### Describe how you validated your changes

```
dda inv test --targets=./pkg/logs/launchers/file/...,./pkg/logs/tailers/file/...
dda inv linter.go --targets=<same packages>
```

### Additional Notes
- On Azure Files, mount with `closetimeo=0` so the client sends SMB CLOSE promptly after the draining tailer closes its fd (complements both this PR and #55318).

**Reference material for the SMB behaviour this works around:**

- [Deferred close and dual-protocol access](https://learn.microsoft.com/en-us/azure/storage/files/storage-how-to-use-files-linux#deferred-close-and-dual-protocol-access) — handle caching after `close()`, and the `closetimeo=0` recommendation
- [mount.cifs(8)](https://www.man7.org/linux/man-pages/man8/mount.cifs.8.html) — `closetimeo=arg`: how long the CIFS client defers the final SMB3 close when it holds a handle lease
- [Linux CIFS kernel (Samba Wiki)](https://wiki.samba.org/index.php/LinuxCIFSKernel) — deferred-close / handle-cache behaviour in the kernel client
