### PR TITLE
[CONTP-2002] fix bug with kubernetes namespace annotations as tags

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -239,6 +239,8 @@ func getLabelToMatchForKind(kind string) []string {
 		return []string{"node"}
 	case "persistentvolume": // persistent volumes are not namespaced
 		return []string{"persistentvolume"}
+	case "namespace": // the `namespace` label already matches on its own, no need to duplicate it
+		return []string{"namespace"}
 	default:
 		return []string{kind, "namespace"}
 	}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_label_joins.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_label_joins.go
@@ -176,7 +176,7 @@ func (lj *labelJoiner) insertMetric(metric ksmstore.DDMetric, config *joinsConfi
 	// Fill the `labelsToAdd` on the leaf node.
 	if config.getAllLabels {
 		if current.labelsToAdd == nil {
-			current.labelsToAdd = make([]label, 0, len(metric.Labels)-len(config.labelsToMatch))
+			current.labelsToAdd = make([]label, 0, max(0, len(metric.Labels)-len(config.labelsToMatch)))
 		}
 
 		for labelName, labelValue := range metric.Labels {

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_label_joins_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_label_joins_test.go
@@ -433,6 +433,42 @@ func Test_labelJoiner(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Regression test for a crash (`makeslice: cap out of range`) triggered by a
+			// wildcard annotations-as-tags/labels-as-tags config on an un-annotated namespace,
+			// when labelsToMatch has more entries than metric.Labels (e.g. due to a duplicated
+			// "namespace" entry in labelsToMatch).
+			name: "Wildcard join with more labels to match than metric labels doesn't panic",
+			config: map[string]*joinsConfig{
+				"kube_namespace_annotations": {
+					labelsToMatch: []string{"namespace", "namespace"},
+					getAllLabels:  true,
+				},
+			},
+			families: map[string][]ksmstore.DDMetricsFam{
+				"uuid1": {
+					{
+						Name: "kube_namespace_annotations",
+						ListMetrics: []ksmstore.DDMetric{
+							{
+								Labels: map[string]string{
+									"namespace": "default",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []struct {
+				inputLabels map[string]string
+				labelsToAdd []label
+			}{
+				{
+					inputLabels: map[string]string{"namespace": "default"},
+					labelsToAdd: []label{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -1597,6 +1597,27 @@ func TestKSMCheck_processAnnotationsAsTags(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Regression test: a wildcard on the "namespace" kind must not
+			// duplicate the "namespace" entry in labelsToMatch, or insertMetric panics
+			// (`makeslice: cap out of range`) on any un-annotated namespace.
+			name: "With wildcard template on namespace kind",
+			config: &KSMConfig{
+				labelJoins:   map[string]*joinsConfig{},
+				LabelsMapper: map[string]string{},
+				AnnotationsAsTags: map[string]map[string]string{
+					"namespace": {"*": "%%annotation%%"},
+				},
+			},
+			expectedJoins: map[string]*joinsConfig{
+				"kube_namespace_annotations": {
+					labelsToMatch:    []string{"namespace"},
+					labelsToGet:      map[string]string{},
+					getAllLabels:     true,
+					wildcardTemplate: "%%annotation%%",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/releasenotes-dca/notes/fix-ksm-namespace-annotations-wildcard-panic-afd01df274cb17d6.yaml
+++ b/releasenotes-dca/notes/fix-ksm-namespace-annotations-wildcard-panic-afd01df274cb17d6.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix a crash in the ``kubernetes_state_core`` check (Cluster Agent or Cluster Check Runner)
+    that occurred when using a wildcard entry (``"*"``) in ``kubernetes_namespace_annotations_as_tags``
+    or the equivalent ``kubernetes_resources_annotations_as_tags`` namespace configuration, on any
+    namespace without annotations.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Setting a wildcard ("*") entry in kubernetes_namespace_annotations_as_tags (or the equivalent kubernetes_resources_annotations_as_tags: {namespaces: {"*": ...}}) crashes the process running the kubernetes_state_core check (the Cluster Agent, or a Cluster Check Runner if the check is dispatched there) with a panic. The crash happens as soon as any namespace with zero annotations is processed (e.g. default, kube-system in a stock cluster), so it reproduces on virtually any real cluster.

### Describe how you validated your changes

added Unit tests

E2E tests already exist.
