### PR TITLE
[ABLD-536] Bazelify `golangci-lint` usage

### DIFF
--- a/.github/actions/bazel-cache/action.yml
+++ b/.github/actions/bazel-cache/action.yml
@@ -20,5 +20,6 @@ runs:
         path: |
           .cache/bazel/*/cache
           .cache/go
+          .cache/golangci-lint
           .cache/ms-go
           .cache/pip

--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -28,6 +28,7 @@
       paths:
         - .cache/bazel/*/cache
         - .cache/go
+        - .cache/golangci-lint
         - .cache/ms-go
         - .cache/pip
       policy: pull$BAZEL_CACHE_POLICY_SUFFIX

--- a/.gitlab/build/lint/cross.yml
+++ b/.gitlab/build/lint/cross.yml
@@ -5,8 +5,8 @@
 
 .cross_lint:
   stage: lint
-  extends: .linux_x64
-  needs: ["go_deps", "go_tools_deps"]
+  extends: [.linux_x64, .bazel:defs:cache:progressive]
+  needs: ["go_deps"]
   variables:
     FLAVORS: "--flavor base"
     KUBERNETES_CPU_REQUEST: 16
@@ -14,7 +14,6 @@
     KUBERNETES_MEMORY_LIMIT: 32Gi
   before_script:
     - !reference [.retrieve_linux_go_deps]
-    - !reference [.retrieve_linux_go_tools_deps]
 
 lint_cross_windows-x64:
   extends: .cross_lint

--- a/.gitlab/build/lint/linux.yml
+++ b/.gitlab/build/lint/linux.yml
@@ -3,8 +3,9 @@
   - dda inv -- -e linter.go --cpus $KUBERNETES_CPU_REQUEST --debug $FLAVORS $EXTRA_OPTS
 
 .linux_lint:
+  extends: .bazel:defs:cache:progressive
   stage: lint
-  needs: ["go_deps", "go_tools_deps"]
+  needs: ["go_deps"]
   variables:
     FLAVORS: '--flavor base'
     KUBERNETES_CPU_REQUEST: 16
@@ -12,7 +13,6 @@
     KUBERNETES_MEMORY_LIMIT: 32Gi
   before_script:
     - !reference [.retrieve_linux_go_deps]
-    - !reference [.retrieve_linux_go_tools_deps]
   script:
     - !reference [.lint_script]
 
@@ -33,10 +33,6 @@ lint_linux-arm64:
   extends:
     - .linux_lint
     - .linux_arm64
-  needs: ["go_deps", "go_tools_deps_arm64"]
-  before_script:
-    - !reference [.retrieve_linux_go_deps]
-    - !reference [.retrieve_linux_go_tools_deps_arm64]
 
 lint_flavor_iot_linux-x64:
   extends:

--- a/.gitlab/build/source_test/ebpf.yml
+++ b/.gitlab/build/source_test/ebpf.yml
@@ -11,14 +11,13 @@
 .tests_linux_ebpf:
   stage: source_test
   extends: .unit_test_base
-  needs: ["go_deps", "go_tools_deps"]
+  needs: ["go_deps"]
   variables:
     KUBERNETES_MEMORY_REQUEST: "24Gi"
     KUBERNETES_MEMORY_LIMIT: "24Gi"
     KUBERNETES_CPU_REQUEST: 8
   before_script:
     - !reference [.retrieve_linux_go_deps]
-    - !reference [.retrieve_linux_go_tools_deps]
   script:
     - dda inv -- -e system-probe.object-files
     - dda inv -- -e linter.go --build system-probe-unit-tests --cpus $KUBERNETES_CPU_REQUEST --targets ./pkg
@@ -43,10 +42,6 @@ tests_ebpf_arm64:
   timeout: 25m
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]
-  needs: ["go_deps", "go_tools_deps_arm64"]
-  before_script:
-    - !reference [.retrieve_linux_go_deps]
-    - !reference [.retrieve_linux_go_tools_deps_arm64]
   variables:
     ARCH: arm64
     TASK_ARCH: arm64

--- a/.gitlab/test/e2e/e2e_containers.yml
+++ b/.gitlab/test/e2e/e2e_containers.yml
@@ -103,7 +103,6 @@ new-e2e-containers-eks-init:
   extends: .new_e2e_template
   needs:
     - go_e2e_deps
-    - go_tools_deps
     - !reference [.needs_fakeintake_publish]
   rules:
     - !reference [.on_container_or_e2e_changes]
@@ -141,7 +140,6 @@ new-e2e-containers-openshift-init:
   extends: .new_e2e_template
   needs:
     - go_e2e_deps
-    - go_tools_deps
     - !reference [.needs_fakeintake_publish]
   rules:
     - !reference [.on_e2e_main_release_or_rc]

--- a/.gitlab/test/e2e/e2e_devx.yml
+++ b/.gitlab/test/e2e/e2e_devx.yml
@@ -33,7 +33,6 @@ new-e2e-base-coverage:
     - go_e2e_deps
     - job: go_e2e_test_binaries
       artifacts: false
-    - go_tools_deps
     - agent_deb-x64-a7
   rules:
     - !reference [.except_mergequeue]
@@ -47,7 +46,6 @@ new-e2e-base:
   extends: .new_e2e_template
   needs:
     - go_e2e_deps
-    - go_tools_deps
     - job: go_e2e_test_binaries
       artifacts: false
     - agent_deb-x64-a7

--- a/.gitlab/test/e2e/e2e_npm.yml
+++ b/.gitlab/test/e2e/e2e_npm.yml
@@ -37,7 +37,6 @@ new-e2e-npm-eks-init:
   extends: .new_e2e_template
   needs:
     - go_e2e_deps
-    - go_tools_deps
     - !reference [.needs_fakeintake_publish]
   rules:
     - !reference [.on_npm_or_e2e_changes]

--- a/.gitlab/test/e2e/e2e_otel.yml
+++ b/.gitlab/test/e2e/e2e_otel.yml
@@ -10,7 +10,6 @@ new-e2e-otel-eks-init:
     - !reference [.manual]
   needs:
     - go_e2e_deps
-    - go_tools_deps
     - !reference [.needs_fakeintake_publish]
   variables:
     TARGETS: ./tests/otel

--- a/.gitlab/test/e2e/e2e_ssi.yml
+++ b/.gitlab/test/e2e/e2e_ssi.yml
@@ -36,7 +36,6 @@
   extends: .new_e2e_template
   needs:
     - go_e2e_deps
-    - go_tools_deps
     - !reference [.needs_fakeintake_publish]
   rules:
     - !reference [.on_e2e_main_release_or_rc]

--- a/.gitlab/test/e2e/e2e_templates.yml
+++ b/.gitlab/test/e2e/e2e_templates.yml
@@ -12,7 +12,6 @@
   before_script:
     - !reference [.retrieve_linux_go_e2e_deps]
     - !reference [.retrieve_linux_pulumi_plugins]
-    - !reference [.retrieve_linux_go_tools_deps]
     # Setup AWS Credentials
     - mkdir -p ~/.aws
     - |
@@ -154,7 +153,6 @@
   - go_e2e_deps
   - job: go_e2e_test_binaries
     artifacts: false
-  - go_tools_deps
   - job: new-e2e-base-coverage
     optional: true
   - !reference [.needs_fakeintake_publish]

--- a/internal/tools/BUILD.bazel
+++ b/internal/tools/BUILD.bazel
@@ -4,6 +4,11 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 load("//bazel/rules/go_shim:defs.bzl", "go_shim")
 
 go_shim(
+    name = "golangci-lint",
+    tool = "@com_github_golangci_golangci_lint_v2//cmd/golangci-lint",
+)
+
+go_shim(
     name = "gotestsum",
     tool = "@tools_gotest_gotestsum//:gotestsum",
 )

--- a/internal/tools/BUILD.bazel
+++ b/internal/tools/BUILD.bazel
@@ -8,6 +8,17 @@ go_shim(
     tool = "@com_github_golangci_golangci_lint_v2//cmd/golangci-lint",
 )
 
+pkg_files(
+    name = "golangci-lint_exe",
+    srcs = ["@com_github_golangci_golangci_lint_v2//cmd/golangci-lint"],
+    attributes = pkg_attributes(mode = "0755"),
+)
+
+pkg_install(
+    name = "install_golangci-lint",
+    srcs = [":golangci-lint_exe"],
+)
+
 go_shim(
     name = "gotestsum",
     tool = "@tools_gotest_gotestsum//:gotestsum",

--- a/tasks/devcontainer.py
+++ b/tasks/devcontainer.py
@@ -127,7 +127,7 @@ def setup(
                 # they are intentionally left unset here.
                 "go.buildTags": local_build_tags,
                 "go.testTags": local_build_tags,
-                "go.lintTool": "golangci-lint",
+                "go.lintTool": "golangci-lint-v2",  # not "golangci-lint" to bypass the v1/v2 detection heuristic
                 "go.lintOnSave": "package",
                 "go.lintFlags": [
                     "--build-tags",
@@ -153,6 +153,8 @@ def setup(
         " && git config --global --add safe.directory /workspaces/${localWorkspaceFolderBasename}"
         " && dda config set github.auth.token \"$GITHUB_TOKEN\""
         " && dda inv -- -e install-tools && dda inv -- -e deps"
+        ' && golangci_lint="$(go list -f {{.Target}} github.com/golangci/golangci-lint/v2/cmd/golangci-lint)"'
+        ' && bazel run //internal/tools:install_golangci-lint -- --destdir="$(dirname "$golangci_lint")"'
     )
 
     devcontainer["containerEnv"] = {

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -77,21 +77,31 @@ def run_golangci_lint(
         include_python="python" in tags,
     )
 
-    verbosity = "-v" if verbose else ""
-    concurrency_arg = "" if concurrency is None else f"--concurrency {concurrency}"
     tags_arg = ",".join(sorted(set(tags)))
     timeout_arg_value = "25m0s" if not timeout else f"{timeout}m0s"
     # Compose the targets string for the command
-    targets_rec = [f"{target}/..." if not target.endswith("/...") else target for target in targets]
-    targets_str = " ".join(targets_rec if recursive else targets)
-    cmd = (
-        f'golangci-lint run {verbosity} --timeout {timeout_arg_value} {concurrency_arg} '
-        f'--build-tags "{tags_arg}" --path-prefix "{base_path}" {golangci_lint_kwargs} {targets_str}'
-    )
+    target_patterns = [t if t.endswith("/...") else f"{t}/..." for t in targets] if recursive else targets
+    targets_str = " ".join(target_patterns)
+    cmd = ["run"]
+    if verbose:
+        cmd.append("-v")
+    cmd += ["--timeout", timeout_arg_value]
+    if concurrency is not None:
+        cmd += ["--concurrency", str(concurrency)]
+    cmd += ["--build-tags", tags_arg, "--path-prefix", base_path] + golangci_lint_kwargs.split() + target_patterns
     if not headless_mode:
         print(f"running golangci-lint on: {targets_str}")
     result, time_result = TimedOperationResult.run(
-        lambda: ctx.run(cmd, env=env, warn=True), "golangci-lint", f"Lint {targets_str}"
+        lambda: bazel(
+            "run",
+            *(f"--run_env={k}={v}" for k, v in env.items()),
+            "//internal/tools:golangci-lint",
+            "--",
+            *cmd,
+            ignore_errors=True,
+        ),
+        "golangci-lint",
+        f"Lint {targets_str}",
     )
     return [result], [time_result]
 

--- a/tasks/install_tasks.py
+++ b/tasks/install_tasks.py
@@ -14,7 +14,6 @@ from tasks.libs.common.utils import environ, get_gobin, gitlab_section, link_or_
 TOOL_LIST = [
     'github.com/frapposelli/wwhrd',
     'github.com/go-enry/go-license-detector/v4/cmd/license-detector',
-    'github.com/golangci/golangci-lint/v2/cmd/golangci-lint',
     'github.com/goware/modvendor',
     'github.com/vektra/mockery/v3',
     'github.com/wadey/gocovmerge',

--- a/tasks/libs/common/check_tools_version.py
+++ b/tasks/libs/common/check_tools_version.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import sys
 
 from invoke import Context, Exit
@@ -10,7 +9,6 @@ from tasks.libs.common.utils import gitlab_section
 
 # VPATH as in version path
 GO_VPATH = ".go-version"
-GOLANGCI_LINT_VPATH = "internal/tools/go.mod"
 
 
 def expected_go_repo_v() -> str:
@@ -29,28 +27,6 @@ def current_go_v(ctx: Context) -> str:
     return ctx.run(cmd, hide=True).stdout.split(' ')[2][2:]
 
 
-def expected_golangci_lint_repo_v(ctx: Context) -> str:
-    """
-    Returns the installed golangci-lint version by parsing the internal/tools/go.mod file.
-    """
-    mod_name = "github.com/golangci/golangci-lint/v2"
-    go_mod_json = json.loads(ctx.run(f"go mod edit -json {GOLANGCI_LINT_VPATH}", hide=True).stdout)
-    for mod in go_mod_json['Require']:
-        if mod['Path'] == mod_name:
-            return mod['Version'].lstrip('v')
-    return ""
-
-
-def current_golangci_lint_v(ctx: Context, debug: bool = False) -> str:
-    """
-    Returns the current user golangci-lint version by running golangci-lint --version
-    """
-    debug_flag = "--debug" if debug else ""
-    cmd = f"golangci-lint version {debug_flag}"
-    version_output = ctx.run(cmd, hide=True).stdout
-    return version_output if debug else version_output.split(' ')[3]
-
-
 def check_tools_version(ctx: Context, tools_list: list[str], debug: bool = False) -> bool:
     """
     Check that each installed tool in tools_list is the version expected for the repo.
@@ -63,13 +39,6 @@ def check_tools_version(ctx: Context, tools_list: list[str], debug: bool = False
             'debug': '' if not debug else current_go_v(ctx),
             'exit_on_error': False,
             'error_msg': "Warning: If you have linter errors it might be due to version mismatches.",
-        },
-        'golangci-lint': {
-            'current_v': current_golangci_lint_v(ctx),
-            'expected_v': expected_golangci_lint_repo_v(ctx),
-            'debug': '' if not debug else current_golangci_lint_v(ctx, debug=debug),
-            'exit_on_error': True,
-            'error_msg': "Error: The golanci-lint version you are using is not the correct one. Please run dda inv -e setup to install the correct version.",
         },
     }
     for tool in tools_list:

--- a/tasks/libs/linter/go.py
+++ b/tasks/libs/linter/go.py
@@ -97,7 +97,7 @@ def lint_flavor(
     )
     for lint_result in lint_results:
         result.lint_outputs.append(lint_result)
-        if lint_result.exited != 0:
+        if lint_result.returncode != 0:
             result.failed = True
 
     return result, execution_times

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -95,14 +95,14 @@ def go(
     Args:
         timeout: Number of minutes after which the linter should time out.
         headless_mode: Allows you to output the result in a single json file.
-        debug: prints the go version and the golangci-lint debug information to help debugging lint discrepancies between versions.
+        debug: prints the go version to help debugging lint discrepancies between versions.
 
     Example invokation:
         $ dda inv linter.go --targets=./pkg/collector/check,./pkg/aggregator
         $ dda inv linter.go --module=.
     """
 
-    check_tools_version(ctx, ['golangci-lint', 'go'], debug=debug)
+    check_tools_version(ctx, ['go'], debug=debug)
 
     # Compute the tags golangci-lint will run with once, and hand them to package
     # discovery too: a modified package whose files are all excluded by them has

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -366,7 +366,7 @@ def build_functional_tests(
         results, _ = run_golangci_lint(ctx, base_path="", targets=targets, build_tags=build_tags)
         for result in results:
             # golangci exits with status 1 when it finds an issue
-            if result.exited != 0:
+            if result.returncode != 0:
                 raise Exit(code=1)
         print("golangci-lint found no issues")
 

--- a/tasks/test_core.py
+++ b/tasks/test_core.py
@@ -51,7 +51,7 @@ class LintResult(ExecResult):
             failure_string = self.failure_string(flavor)
             failure_string += "Linter failures:\n"
             for lint_output in self.lint_outputs:
-                if lint_output.exited != 0:
+                if lint_output.returncode != 0:
                     failure_string = f"{failure_string}{lint_output.stdout}\n" if lint_output.stdout else failure_string
                     failure_string = f"{failure_string}{lint_output.stderr}\n" if lint_output.stderr else failure_string
 

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -24,6 +24,7 @@ if defined XDG_CACHE_HOME (
   set "XDG_CACHE_HOME=!XDG_CACHE_HOME:/=\!"
   if "!XDG_CACHE_HOME:~1,2!" neq ":\" if "!XDG_CACHE_HOME:~0,2!" neq "\\" goto :error_xdg_cache_home_must_be_absolute
   set "GOCACHE=!XDG_CACHE_HOME!\go-build"
+  set "GOLANGCI_LINT_CACHE=!XDG_CACHE_HOME!\golangci-lint"
   set "GOMODCACHE=!XDG_CACHE_HOME!\go\mod"
   set "PIP_CACHE_DIR=!XDG_CACHE_HOME!\pip"
   :: https://github.com/bazelbuild/bazel/issues/27808


### PR DESCRIPTION
### What does this PR do?
Wrap `golangci-lint` in a `go_shim` target and route `run_golangci_lint` through `bazel run //internal/tools:golangci-lint` instead of a `go install`-ed, PATH-resolved binary, and drop it from `install-tools`'s `TOOL_LIST` - therefore contributing [ABLD-536](https://datadoghq.atlassian.net/browse/ABLD-536).

Wire `golangci-lint`'s own analysis cache into the existing cache setup:
- `.linux_lint` and `.cross_lint` now extend `.bazel:defs:cache:progressive`,
- `.cache/golangci-lint` joins `bazel_cache`'s persisted paths,
- `tools/bazel.bat` sets `GOLANGCI_LINT_CACHE` alongside its `GOCACHE`/`GOMODCACHE` siblings.

Since jobs now reach `golangci-lint` through `bazel run` (cached binary), vestigial `go_tools_deps[_arm64]` are removed from:
- `.cross_lint`,
- `.linux_lint`,
- `.new_e2e_template`,
- `.tests_linux_ebpf`,
- `lint_linux-arm64`,
- `tests_ebpf_arm64`,
- the `e2e` jobs that spell out their own `needs`:
  - `new-e2e-base[-coverage]`,
  - `new-e2e-otel`,
  - `*-init` jobs.

### Motivation
`golangci-lint`'s version drift was tracked only by `check_tools_version.py` running `golangci-lint version` against `internal/tools/go.mod`, the same "tracked by a runtime version check" shape `gotestsum` had before #54107.

Unlike most other `TOOL_LIST` entries, it gates nearly every lint job, so a wrong-version or wrong-arch binary has a broader blast radius.

`golangci-lint`'s own cache is ~500M against a ~50G `GOCACHE` and ~100G Bazel disk cache, so persisting it costs nothing meaningful in GitLab's S3-backed cache transfer time or storage.

### Describe how you validated your changes
Ran a full, untargeted `dda inv linter.go` (every module) 5 times to validate at CI scale and characterize the cache stack:
1. 1140.6s cold,
2. 1043.4s after rebasing onto a different branch with many changes,
3. 12.6s full hit,
4. 341.9s after clearing only `golangci-lint`'s own cache,
5. 11.8s on a repeat full hit.

### Additional Notes
Adopting `nogo` [instead](https://github.com/bazel-contrib/rules_go/blob/master/go/nogo.rst#should-i-use-nogo-or-golangci-lint), as already flagged as a TODO in `deps/go.MODULE.bazel`, is a separate, larger decision left for its own follow-up.

[ABLD-536]: https://datadoghq.atlassian.net/browse/ABLD-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ