### PR TITLE
fix(trace/writer): fail tests instead of panicking on an undecodable payload

### DIFF
--- a/pkg/trace/writer/stats_test.go
+++ b/pkg/trace/writer/stats_test.go
@@ -39,7 +39,8 @@ const (
 	testEnv      = "testing"
 )
 
-func assertPayload(assert *assert.Assertions, testSets []*pb.StatsPayload, payloads []*payload) {
+func assertPayload(t *testing.T, testSets []*pb.StatsPayload, payloads []*payload) {
+	t.Helper()
 	expectedHeaders := map[string]string{
 		"X-Datadog-Reported-Languages": strings.Join(info.Languages(), "|"),
 		"Content-Type":                 "application/msgpack",
@@ -50,11 +51,11 @@ func assertPayload(assert *assert.Assertions, testSets []*pb.StatsPayload, paylo
 	for _, p := range payloads {
 		var statsPayload pb.StatsPayload
 		r, err := gzip.NewReader(p.body)
-		assert.NoError(err)
-		err = msgp.Decode(r, &statsPayload)
-		assert.NoError(err)
+		require.NoError(t, err, "payload body is not valid gzip")
+		require.NoError(t, msgp.Decode(r, &statsPayload))
+		require.NoError(t, r.Close())
 		for k, v := range expectedHeaders {
-			assert.Equal(v, p.headers[k])
+			assert.Equal(t, v, p.headers[k])
 		}
 		decoded = append(decoded, &statsPayload)
 	}
@@ -63,13 +64,12 @@ func assertPayload(assert *assert.Assertions, testSets []*pb.StatsPayload, paylo
 		return decoded[i].AgentEnv < decoded[j].AgentEnv
 	})
 	for i, p := range decoded {
-		assert.Equal(testSets[i].String(), p.String())
+		assert.Equal(t, testSets[i].String(), p.String())
 	}
 }
 
 func TestStatsWriter(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
-		assert := assert.New(t)
 		sw, srv := testStatsWriter()
 		go sw.Run()
 
@@ -106,7 +106,7 @@ func TestStatsWriter(t *testing.T) {
 		sw.Write(testSets[0])
 		sw.Write(testSets[1])
 		sw.Stop()
-		assertPayload(assert, testSets, srv.Payloads())
+		assertPayload(t, testSets, srv.Payloads())
 	})
 
 	t.Run("race", func(_ *testing.T) {
@@ -378,11 +378,10 @@ func TestStatsSyncWriter(t *testing.T) {
 		assert.Nil(err)
 		sw.Stop()
 		srv.Close()
-		assertPayload(assert, testSets, srv.Payloads())
+		assertPayload(t, testSets, srv.Payloads())
 	})
 
 	t.Run("stop", func(t *testing.T) {
-		assert := assert.New(t)
 		sw, srv := testStatsSyncWriter()
 		go sw.Run()
 
@@ -414,7 +413,7 @@ func TestStatsSyncWriter(t *testing.T) {
 		sw.Write(testSets[1])
 		sw.Stop()
 		srv.Close()
-		assertPayload(assert, testSets, srv.Payloads())
+		assertPayload(t, testSets, srv.Payloads())
 	})
 }
 
@@ -485,7 +484,7 @@ func TestStatsWriterInfo(t *testing.T) {
 	err := sw.FlushSync()
 	assert.Nil(err)
 
-	assertPayload(assert, testSets, srv.Payloads())
+	assertPayload(t, testSets, srv.Payloads())
 
 	assert.NotEmpty(sw.statsLastMinute.Bytes.Load())
 	assert.Empty(sw.statsLastMinute.Errors.Load())

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -165,21 +165,18 @@ func payloadsContain(t *testing.T, payloads []*payload, sampledSpans []*SampledC
 	t.Helper()
 	var all pb.AgentPayload
 	for _, p := range payloads {
-		assert := assert.New(t)
-		var slurp []byte
-
 		reader, err := compressor.NewReader(p.body)
-		assert.NoError(err)
-		defer reader.Close()
+		require.NoError(t, err, "payload body is not valid %s", compressor.Encoding())
 
-		slurp, err = io.ReadAll(reader)
+		slurp, readErr := io.ReadAll(reader)
+		closeErr := reader.Close()
+		require.NoError(t, readErr)
+		require.NoError(t, closeErr)
 
-		assert.NoError(err)
 		var payload pb.AgentPayload
-		err = proto.Unmarshal(slurp, &payload)
-		assert.NoError(err)
-		assert.Equal(payload.HostName, testHostname)
-		assert.Equal(payload.Env, testEnv)
+		require.NoError(t, proto.Unmarshal(slurp, &payload))
+		assert.Equal(t, testHostname, payload.HostName)
+		assert.Equal(t, testEnv, payload.Env)
 		all.TracerPayloads = append(all.TracerPayloads, payload.TracerPayloads...)
 	}
 	for _, ss := range sampledSpans {

--- a/pkg/trace/writer/tracev1_test.go
+++ b/pkg/trace/writer/tracev1_test.go
@@ -278,20 +278,18 @@ func randomSampledSpansV1(spans, events int) *SampledChunksV1 {
 func mapPayloads(t *testing.T, payloads []*payload, compressor compression.Component, f func(*pb.AgentPayload)) {
 	all := &pb.AgentPayload{}
 	for _, p := range payloads {
-		var slurp []byte
-		assert := assert.New(t)
 		reader, err := compressor.NewReader(p.body)
-		assert.NoError(err)
-		defer reader.Close()
+		require.NoError(t, err, "payload body is not valid %s", compressor.Encoding())
 
-		slurp, err = io.ReadAll(reader)
+		slurp, readErr := io.ReadAll(reader)
+		closeErr := reader.Close()
+		require.NoError(t, readErr)
+		require.NoError(t, closeErr)
 
-		assert.NoError(err)
 		var payload pb.AgentPayload
-		err = proto.Unmarshal(slurp, &payload)
-		assert.NoError(err)
-		assert.Equal(payload.HostName, testHostname)
-		assert.Equal(payload.Env, testEnv)
+		require.NoError(t, proto.Unmarshal(slurp, &payload))
+		assert.Equal(t, testHostname, payload.HostName)
+		assert.Equal(t, testEnv, payload.Env)
 		all.IdxTracerPayloads = append(all.IdxTracerPayloads, payload.IdxTracerPayloads...)
 	}
 	f(all)


### PR DESCRIPTION
### What does this PR do?

Makes the payload-decoding test helpers in `pkg/trace/writer` fail the test instead of panicking when a recorded payload cannot be decompressed.

### Motivation

`TestTraceWriterMultipleEndpointsConcurrent` failed on `main` ([job 1977041561](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1977041561)) with:

```
=== FAIL: pkg/trace/writer TestTraceWriterMultipleEndpointsConcurrent (5.11s)
    trace_test.go:172: Received unexpected error: gzip: invalid header
panic: runtime error: invalid memory address or nil pointer dereference
  compress/gzip.(*Reader).Read(0x0, ...)
  io.ReadAll -> writer.payloadsContain (trace_test.go:175)
```

The error was checked with `assert.NoError`, so the helper continued with a nil `*gzip.Reader` and segfaulted. The panic then made the harness abort the reruns — `ERROR rerun aborted because previous run had a suspected panic and some test may not have run` — so `--rerun-fails=2` and test-washer were bypassed and one rare flake failed the entire job.

This PR only removes the panic, so the next occurrence reports the assertion, gets retried, and stays diagnosable.

### Describe how you validated your changes

- `dda inv test-new --targets=./pkg/trace/writer --race` → PASSED
- Targeted `-test.v` run of every test that exercises the three helpers (`TestStatsWriter`, `TestStatsSyncWriter`, `TestStatsWriterInfo`, `TestTraceWriter`, `TestTraceWriterMultipleEndpointsConcurrent`, `TestTraceWriterV1`, `TestTraceWriterV1PayloadSplitting`) → all PASS
- `gofmt -l pkg/trace/writer/` clean
- Reproduction attempt for the underlying flake: race-instrumented package binary, 240 full-suite runs, 6 concurrent copies on 16 cores — 0 failures, so the flake is well below 1-in-240 on macOS/arm64 and the fix cannot be validated by reproducing the original panic locally.

### Additional Notes
