### PR TITLE
[overhead] compact observer storage point buckets

### DIFF
--- a/comp/anomalydetection/observer/AGENTS.md
+++ b/comp/anomalydetection/observer/AGENTS.md
@@ -34,7 +34,7 @@ and the testbench use the same engine.
 | `def/component.go` | Component interface (GetHandle, RecordSamplerDropped, DumpMetrics) |
 | `def/types.go` | Handle, View types, Detector, Correlator, StorageReader, Anomaly, CorrelatorEvent, etc. |
 | `impl/engine.go` | Pipeline orchestration: ingest, advance, detect, correlate, replay |
-| `impl/storage.go` | In-memory columnar time-series storage (1s buckets, read-time aggregation) |
+| `impl/storage.go` | In-memory bucketed time-series storage (1s buckets, read-time aggregation) |
 | `impl/scheduler.go` | Scheduling policy: when to advance analysis |
 | `impl/observer.go` | Fx component: lifecycle, channel loop, handle creation, log tap |
 | `impl/component_catalog.go` | Registry of all detectors, correlators, extractors |

--- a/comp/anomalydetection/observer/impl/log_pattern_extractor_test.go
+++ b/comp/anomalydetection/observer/impl/log_pattern_extractor_test.go
@@ -443,7 +443,7 @@ func TestLogPatternExtractor_TagGroupCapEvictsLRUGroup(t *testing.T) {
 // TestEngine_LogPatternLRUEvictionFreesStorage is the end-to-end proof that
 // the structural leak is fixed: when the extractor's LRU evicts a cluster,
 // the engine no longer just drops its contextRefs entry — it also calls
-// storage.RemoveSeriesByKeys so the per-series tags slice + columnar arrays
+// storage.RemoveSeriesByKeys so the per-series tags slice + bucket data
 // + sample buffer are actually freed. Before this fix, timeSeriesStorage.series
 // grew monotonically for the lifetime of the agent, regardless of LRU caps.
 func TestEngine_LogPatternLRUEvictionFreesStorage(t *testing.T) {

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -140,9 +140,15 @@ type tagInternEntry struct {
 	count int
 }
 
+// pointBucket contains the summary statistics for one one-second bucket.
+type pointBucket struct {
+	timestamp int64
+	sum       float64
+	count     int64
+}
+
 // seriesStats contains accumulated statistics for a time series (internal).
-// Data is stored in columnar layout: parallel arrays indexed by point position.
-// Timestamps are stored in sorted order, enabling binary search for range queries.
+// Buckets are stored in timestamp order, enabling binary search for range queries.
 type seriesStats struct {
 	Namespace string
 	Name      string
@@ -166,10 +172,7 @@ type seriesStats struct {
 	// same-bucket merges into an existing point.
 	writeGeneration int64
 
-	// Columnar storage — all slices have the same length, indexed by point position.
-	timestamps []int64
-	sums       []float64
-	counts     []int64
+	buckets []pointBucket
 }
 
 func aggregateMask(agg observer.Aggregate) uint8 {
@@ -178,15 +181,15 @@ func aggregateMask(agg observer.Aggregate) uint8 {
 
 // pointCount returns the number of stored points.
 func (s *seriesStats) pointCount() int {
-	return len(s.timestamps)
+	return len(s.buckets)
 }
 
 // sampleCount returns the total number of samples for a series.
 // A point can contain multiple samples if it is aggregated.
 func (s *seriesStats) sampleCount() int64 {
 	count := int64(0)
-	for _, c := range s.counts {
-		count += c
+	for _, bucket := range s.buckets {
+		count += bucket.count
 	}
 	return count
 }
@@ -201,45 +204,19 @@ const (
 	AggregateCount   = observer.AggregateCount
 )
 
-// aggregateColumn returns the pre-materialized column values for a given aggregate.
-// For Average, it computes sum/count on the fly. For others, it returns the column directly.
-func (s *seriesStats) aggregateColumn(agg Aggregate) []float64 {
-	switch agg {
-	case AggregateSum:
-		return s.sums
-	case AggregateCount:
-		vals := make([]float64, len(s.counts))
-		for i, c := range s.counts {
-			vals[i] = float64(c)
-		}
-		return vals
-	case AggregateAverage:
-		vals := make([]float64, len(s.sums))
-		for i := range s.sums {
-			if s.counts[i] == 0 {
-				vals[i] = 0
-			} else {
-				vals[i] = s.sums[i] / float64(s.counts[i])
-			}
-		}
-		return vals
-	default:
-		return make([]float64, len(s.timestamps))
-	}
-}
-
 // aggregateAt extracts the specified statistic at index i.
 func (s *seriesStats) aggregateAt(i int, agg Aggregate) float64 {
+	bucket := s.buckets[i]
 	switch agg {
 	case AggregateAverage:
-		if s.counts[i] == 0 {
+		if bucket.count == 0 {
 			return 0
 		}
-		return s.sums[i] / float64(s.counts[i])
+		return bucket.sum / float64(bucket.count)
 	case AggregateSum:
-		return s.sums[i]
+		return bucket.sum
 	case AggregateCount:
-		return float64(s.counts[i])
+		return float64(bucket.count)
 	default:
 		return 0
 	}
@@ -249,11 +226,10 @@ func (s *seriesStats) aggregateAt(i int, agg Aggregate) float64 {
 func (s *seriesStats) toSeries(agg Aggregate) observer.Series {
 	n := s.pointCount()
 	points := make([]observer.Point, n)
-	col := s.aggregateColumn(agg)
 	for i := 0; i < n; i++ {
 		points[i] = observer.Point{
-			Timestamp: s.timestamps[i],
-			Value:     col[i],
+			Timestamp: s.buckets[i].timestamp,
+			Value:     s.aggregateAt(i, agg),
 		}
 	}
 	return observer.Series{
@@ -264,10 +240,10 @@ func (s *seriesStats) toSeries(agg Aggregate) observer.Series {
 	}
 }
 
-// searchAfter returns the index of the first timestamp > value using binary search.
-func searchAfter(timestamps []int64, value int64) int {
-	return sort.Search(len(timestamps), func(i int) bool {
-		return timestamps[i] > value
+// searchAfter returns the index of the first bucket timestamp > value using binary search.
+func searchAfter(buckets []pointBucket, value int64) int {
+	return sort.Search(len(buckets), func(i int) bool {
+		return buckets[i].timestamp > value
 	})
 }
 
@@ -368,28 +344,30 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 	}
 	res := AddResult{IsNew: !exists, Ref: stats.ref}
 	stats.writeGeneration++
-	if len(stats.timestamps) == 0 || timestamp > stats.lastActivityTimestamp {
+	if len(stats.buckets) == 0 || timestamp > stats.lastActivityTimestamp {
 		stats.lastActivityTimestamp = timestamp
 	}
 
 	// Bucket by second.
 	bucket := timestamp
 
-	// Binary search for the bucket in the sorted timestamps array.
-	idx := sort.Search(len(stats.timestamps), func(i int) bool {
-		return stats.timestamps[i] >= bucket
+	// Binary search for the bucket in the sorted bucket array.
+	idx := sort.Search(len(stats.buckets), func(i int) bool {
+		return stats.buckets[i].timestamp >= bucket
 	})
 
-	if idx < len(stats.timestamps) && stats.timestamps[idx] == bucket {
+	if idx < len(stats.buckets) && stats.buckets[idx].timestamp == bucket {
 		// Update existing bucket in-place.
-		stats.sums[idx] += value
-		stats.counts[idx]++
+		stats.buckets[idx].sum += value
+		stats.buckets[idx].count++
 		return res
 	}
 
-	stats.timestamps = insertInt64(stats.timestamps, idx, bucket)
-	stats.sums = insertFloat64(stats.sums, idx, value)
-	stats.counts = insertInt64(stats.counts, idx, 1)
+	stats.buckets = insertBucket(stats.buckets, idx, pointBucket{
+		timestamp: bucket,
+		sum:       value,
+		count:     1,
+	})
 
 	retentionSecs := s.cfg.PointRetentionSecs
 	if stats.retentionOverrideSecs > 0 {
@@ -399,19 +377,15 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		// Trim points outside the retention window. Use the series' latest
 		// timestamp (not the incoming bucket) so that backfilled/out-of-order
 		// points don't shift the cutoff backwards and over-retain stale data.
-		latestTS := stats.timestamps[len(stats.timestamps)-1]
-		if trim := searchAfter(stats.timestamps, latestTS-retentionSecs-1); trim > 0 {
-			stats.timestamps = trimFront(stats.timestamps, trim)
-			stats.sums = trimFront(stats.sums, trim)
-			stats.counts = trimFront(stats.counts, trim)
+		latestTS := stats.buckets[len(stats.buckets)-1].timestamp
+		if trim := searchAfter(stats.buckets, latestTS-retentionSecs-1); trim > 0 {
+			stats.buckets = trimFront(stats.buckets, trim)
 		}
 	}
 	if s.cfg.MaxPointsPerSeries > 0 {
 		physicalCapacity := s.cfg.MaxPointsPerSeries + 1
-		if trim := len(stats.timestamps) - physicalCapacity; trim > 0 {
-			stats.timestamps = trimFront(stats.timestamps, trim)
-			stats.sums = trimFront(stats.sums, trim)
-			stats.counts = trimFront(stats.counts, trim)
+		if trim := len(stats.buckets) - physicalCapacity; trim > 0 {
+			stats.buckets = trimFront(stats.buckets, trim)
 		}
 	}
 	return res
@@ -425,17 +399,9 @@ func trimFront[T any](s []T, n int) []T {
 	return s[:keep]
 }
 
-// insertInt64 inserts v at position idx in s, maintaining order.
-func insertInt64(s []int64, idx int, v int64) []int64 {
-	s = append(s, 0)
-	copy(s[idx+1:], s[idx:])
-	s[idx] = v
-	return s
-}
-
-// insertFloat64 inserts v at position idx in s, maintaining order.
-func insertFloat64(s []float64, idx int, v float64) []float64 {
-	s = append(s, 0)
+// insertBucket inserts v at position idx in s, maintaining timestamp order.
+func insertBucket(s []pointBucket, idx int, v pointBucket) []pointBucket {
+	s = append(s, pointBucket{})
 	copy(s[idx+1:], s[idx:])
 	s[idx] = v
 	return s
@@ -514,13 +480,13 @@ func (s *timeSeriesStorage) GetSeriesSince(namespace, name string, tags []string
 	}
 
 	// Binary search for the first timestamp > since.
-	startIdx := searchAfter(stats.timestamps, since)
+	startIdx := searchAfter(stats.buckets, since)
 
 	n := stats.pointCount()
 	points := make([]observer.Point, 0, n-startIdx)
 	for i := startIdx; i < n; i++ {
 		points = append(points, observer.Point{
-			Timestamp: stats.timestamps[i],
+			Timestamp: stats.buckets[i].timestamp,
 			Value:     stats.aggregateAt(i, agg),
 		})
 	}
@@ -585,12 +551,12 @@ func (s *timeSeriesStorage) TimeBounds() (minTs int64, maxTs int64, ok bool) {
 		}
 		// Timestamps are sorted, but some series may start with default/non-data
 		// zero timestamps. Ignore only the non-positive prefix, not the series.
-		firstIdx := searchAfter(stats.timestamps, 0)
+		firstIdx := searchAfter(stats.buckets, 0)
 		if firstIdx >= n {
 			continue
 		}
-		first := stats.timestamps[firstIdx]
-		last := stats.timestamps[n-1]
+		first := stats.buckets[firstIdx].timestamp
+		last := stats.buckets[n-1].timestamp
 		if !found {
 			min = first
 			max = last
@@ -619,7 +585,7 @@ func (s *timeSeriesStorage) MaxTimestamp() int64 {
 			continue
 		}
 		if n := stats.pointCount(); n > 0 {
-			if t := stats.timestamps[n-1]; t > max {
+			if t := stats.buckets[n-1].timestamp; t > max {
 				max = t
 			}
 		}
@@ -999,9 +965,9 @@ func (s *timeSeriesStorage) DumpToFile(path string) error {
 		n := st.pointCount()
 		for i := 0; i < n; i++ {
 			ds.Points = append(ds.Points, dumpPoint{
-				Timestamp: st.timestamps[i],
-				Sum:       st.sums[i],
-				Count:     st.counts[i],
+				Timestamp: st.buckets[i].timestamp,
+				Sum:       st.buckets[i].sum,
+				Count:     st.buckets[i].count,
 			})
 		}
 		out = append(out, ds)
@@ -1024,8 +990,8 @@ func (s *timeSeriesStorage) DataTimestamps() []int64 {
 		if stats == nil {
 			continue
 		}
-		for _, ts := range stats.timestamps {
-			seen[ts] = struct{}{}
+		for _, bucket := range stats.buckets {
+			seen[bucket.timestamp] = struct{}{}
 		}
 	}
 	// Include observation timestamps (e.g., from logs that produced no virtual metrics).
@@ -1422,7 +1388,7 @@ func (s *timeSeriesStorage) PointCountUpTo(ref observer.SeriesRef, endTime int64
 	if stats == nil || stats.pointCount() == 0 {
 		return 0
 	}
-	return searchAfter(stats.timestamps, endTime)
+	return searchAfter(stats.buckets, endTime)
 }
 
 // RecordObservationTime records that an observation occurred at the given timestamp.
@@ -1463,7 +1429,7 @@ func (s *timeSeriesStorage) BulkSeriesStatus(refs []observer.SeriesRef, endTime 
 			continue
 		}
 		result[i] = seriesStatus{
-			pointCount:      searchAfter(stats.timestamps, endTime),
+			pointCount:      searchAfter(stats.buckets, endTime),
 			writeGeneration: stats.writeGeneration,
 		}
 	}
@@ -1509,7 +1475,7 @@ func matchesSeriesFilter(stats *seriesStats, filter observer.SeriesFilter) bool 
 
 // GetSeriesRange returns points within a time range (start, end].
 // Start is exclusive, end is inclusive. Use start=0 to read from the beginning.
-// Uses binary search on the timestamps column for O(log N) range lookup.
+// Uses binary search on the ordered buckets for O(log N) range lookup.
 func (s *timeSeriesStorage) GetSeriesRange(ref observer.SeriesRef, start, end int64, agg Aggregate) *observer.Series {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1520,11 +1486,11 @@ func (s *timeSeriesStorage) GetSeriesRange(ref observer.SeriesRef, start, end in
 	}
 
 	// Binary search: find first index where timestamp > start
-	lo := searchAfter(stats.timestamps, start)
+	lo := searchAfter(stats.buckets, start)
 	// Binary search: find first index where timestamp > end
-	hi := searchAfter(stats.timestamps, end)
+	hi := searchAfter(stats.buckets, end)
 
-	// Range is [lo, hi) in the arrays, corresponding to (start, end] in time.
+	// Range is [lo, hi) in the bucket slice, corresponding to (start, end] in time.
 	resultLen := hi - lo
 	points := make([]observer.Point, resultLen)
 
@@ -1533,21 +1499,21 @@ func (s *timeSeriesStorage) GetSeriesRange(ref observer.SeriesRef, start, end in
 	case AggregateSum:
 		for i := 0; i < resultLen; i++ {
 			points[i] = observer.Point{
-				Timestamp: stats.timestamps[lo+i],
-				Value:     stats.sums[lo+i],
+				Timestamp: stats.buckets[lo+i].timestamp,
+				Value:     stats.buckets[lo+i].sum,
 			}
 		}
 	case AggregateCount:
 		for i := 0; i < resultLen; i++ {
 			points[i] = observer.Point{
-				Timestamp: stats.timestamps[lo+i],
-				Value:     float64(stats.counts[lo+i]),
+				Timestamp: stats.buckets[lo+i].timestamp,
+				Value:     float64(stats.buckets[lo+i].count),
 			}
 		}
 	default: // AggregateAverage and any unknown
 		for i := 0; i < resultLen; i++ {
 			points[i] = observer.Point{
-				Timestamp: stats.timestamps[lo+i],
+				Timestamp: stats.buckets[lo+i].timestamp,
 				Value:     stats.aggregateAt(lo+i, agg),
 			}
 		}
@@ -1618,7 +1584,7 @@ func (s *timeSeriesStorage) ForEachLastPoints(
 		pointBufPool.Put(bufp)
 		return false
 	}
-	endIndex := searchAfter(stats.timestamps, end)
+	endIndex := searchAfter(stats.buckets, end)
 	startIndex := max(0, endIndex-n)
 	series := observer.Series{Namespace: stats.Namespace, Name: stats.Name, Tags: stats.Tags}
 	buf = snapshotPoints(stats, startIndex, endIndex, agg, buf)
@@ -1634,8 +1600,8 @@ func (s *timeSeriesStorage) ForEachLastPoints(
 }
 
 // SumRange returns the aggregate total over the time range (start, end] without
-// allocating any intermediate slices. It operates directly on the columnar
-// data arrays, using binary search to locate the range boundaries.
+// allocating any intermediate slices. It operates directly on the bucket
+// slice, using binary search to locate the range boundaries.
 // Returns 0 if the series is not found or the range is empty.
 func (s *timeSeriesStorage) SumRange(ref observer.SeriesRef, start, end int64, agg Aggregate) float64 {
 	s.mu.RLock()
@@ -1646,8 +1612,8 @@ func (s *timeSeriesStorage) SumRange(ref observer.SeriesRef, start, end int64, a
 		return 0
 	}
 
-	lo := searchAfter(stats.timestamps, start)
-	hi := searchAfter(stats.timestamps, end)
+	lo := searchAfter(stats.buckets, start)
+	hi := searchAfter(stats.buckets, end)
 	if lo >= hi {
 		return 0
 	}
@@ -1655,12 +1621,12 @@ func (s *timeSeriesStorage) SumRange(ref observer.SeriesRef, start, end int64, a
 	var total float64
 	switch agg {
 	case AggregateSum:
-		for _, v := range stats.sums[lo:hi] {
-			total += v
+		for _, bucket := range stats.buckets[lo:hi] {
+			total += bucket.sum
 		}
 	case AggregateCount:
-		for _, c := range stats.counts[lo:hi] {
-			total += float64(c)
+		for _, bucket := range stats.buckets[lo:hi] {
+			total += float64(bucket.count)
 		}
 	default: // AggregateAverage
 		for i := lo; i < hi; i++ {
@@ -1685,8 +1651,8 @@ func (s *timeSeriesStorage) snapshotRange(
 		return observer.Series{}, buf, false
 	}
 
-	lo := searchAfter(stats.timestamps, start)
-	hi := searchAfter(stats.timestamps, end)
+	lo := searchAfter(stats.buckets, start)
+	hi := searchAfter(stats.buckets, end)
 	buf = snapshotPoints(stats, lo, hi, agg, buf)
 
 	return observer.Series{
@@ -1707,7 +1673,7 @@ func snapshotPoints(stats *seriesStats, lo, hi int, agg Aggregate, buf []observe
 	}
 	for i := range buf {
 		buf[i] = observer.Point{
-			Timestamp: stats.timestamps[lo+i],
+			Timestamp: stats.buckets[lo+i].timestamp,
 			Value:     stats.aggregateAt(lo+i, agg),
 		}
 	}

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -235,11 +235,9 @@ func TestTimeSeriesStorage_AllSeries(t *testing.T) {
 }
 
 func TestSeriesStats_AggregateAt(t *testing.T) {
-	// Build a seriesStats with known columnar data to test aggregation.
+	// Build a seriesStats with known bucket data to test aggregation.
 	ss := &seriesStats{
-		timestamps: []int64{1000},
-		sums:       []float64{100.0},
-		counts:     []int64{4},
+		buckets: []pointBucket{{timestamp: 1000, sum: 100.0, count: 4}},
 	}
 
 	assert.Equal(t, 25.0, ss.aggregateAt(0, AggregateAverage))
@@ -248,9 +246,7 @@ func TestSeriesStats_AggregateAt(t *testing.T) {
 
 	// Zero count returns 0 for average
 	ss2 := &seriesStats{
-		timestamps: []int64{1000},
-		sums:       []float64{10.0},
-		counts:     []int64{0},
+		buckets: []pointBucket{{timestamp: 1000, sum: 10.0}},
 	}
 	assert.Equal(t, 0.0, ss2.aggregateAt(0, AggregateAverage))
 }


### PR DESCRIPTION
### What does this PR do?

Stores each Observer one-second point as a single `{timestamp, sum, count}` bucket instead of three parallel slices. No changes to observer behavior

### Motivation

Finding optimizations where we can. This cuts unnecessary allocations and retained memory (which scales with the amount of series there are). 

### Describe how you validated your changes

ran existing benchmarks: 
- Ingestion bytes/op improved 12.6-14.9%
- Ingestion allocations/op improved 37.6-39.8%
- Ingestion CPU ranged from -1.4% to +0.9%
- Storage read benchmarks were flat to 6.7% faster, except the small ForEachPoint case at +2.9%

SMP validation on very high load:
- [SMP run](https://github.com/DataDog/smp-playground/pull/475#issuecomment-5416298359)
- Observer memory delta improved from +44.77% to +41.27% versus each run's own 7.78 baseline
- This is 3.50 percentage points less excess memory, 2.42% lower baseline-normalized total PSS, and 7.82% less Observer excess
- Runtime telemetry independently shows about 2.7% lower normalized live heap, 3.1% fewer normalized live heap objects, 2.3% lower normalized heap-object bytes, and 1.0% lower normalized process RSS

Note: this is for a very high load, so the performance improvements will not be dramatic on our relatively modest payload sizes (since we are tracking only a subset of metrics that could come in for now). 

