### PR TITLE
[otlp/metrics] Fix panic on exponential histograms with unrepresentable bucket boundaries

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/metrics/BUILD.bazel
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/BUILD.bazel
@@ -51,6 +51,7 @@ dd_agent_go_test(
         "consume_host_test.go",
         "consumer_test.go",
         "dimensions_test.go",
+        "exponential_histograms_translator_test.go",
         "histograms_test.go",
         "key_hash_cache_test.go",
         "lossless_mapper_test.go",

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/default_mapper.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/default_mapper.go
@@ -524,6 +524,12 @@ func (m *defaultMapper) exponentialHistogramToDDSketch(
 		return nil, errors.New("cumulative exponential histograms are not supported")
 	}
 
+	// Bucket boundaries that are not representable as finite float64 values panic
+	// further down in DDSketch.ChangeMapping, so reject them before building the sketch.
+	if err := checkExponentialHistogramBounds(p, p.Scale(), 1); err != nil {
+		return nil, err
+	}
+
 	// Create the DDSketch stores
 	positiveStore := toStore(p.Positive())
 	negativeStore := toStore(p.Negative())

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/exponential_histograms_translator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/exponential_histograms_translator.go
@@ -15,9 +15,15 @@
 package metrics
 
 import (
+	"fmt"
+	"math"
+
 	"github.com/DataDog/sketches-go/ddsketch/store"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
+
+// maxFiniteLog2 is the largest base-2 exponent of a finite float64: 2^1024 overflows to +Inf.
+const maxFiniteLog2 = 1023
 
 func toStore(b pmetric.ExponentialHistogramDataPointBuckets) store.Store {
 	offset := b.Offset()
@@ -31,4 +37,65 @@ func toStore(b pmetric.ExponentialHistogramDataPointBuckets) store.Store {
 		store.AddWithCount(index, float64(bucketCounts.At(j)))
 	}
 	return store
+}
+
+// maxPopulatedIndex returns the highest bucket index with a non-zero count, and
+// whether any such bucket exists. Zero-count buckets are excluded because
+// DenseStore.AddWithCount discards them, so they never reach the mapping.
+func maxPopulatedIndex(b pmetric.ExponentialHistogramDataPointBuckets) (int, bool) {
+	offset := int(b.Offset())
+	bucketCounts := b.BucketCounts()
+	for j := bucketCounts.Len() - 1; j >= 0; j-- {
+		if bucketCounts.At(j) > 0 {
+			return j + offset, true
+		}
+	}
+	return 0, false
+}
+
+// checkExponentialHistogramBounds reports whether the populated bucket boundaries
+// of p can be represented as finite float64 values at the given scale.
+//
+// The boundary of bucket index i is gamma^i, with gamma = 2^(2^-scale), so its
+// base-2 logarithm is i * 2^-scale. boundaryScaleFactor is an additional factor
+// applied to every boundary by the caller (1 when there is none); its logarithm is
+// added to the bound because it can overflow a boundary that is representable on
+// its own.
+//
+// Boundaries that overflow to +Inf, and a gamma that itself overflows (scale <= -10,
+// which makes the mapping's multiplier zero and the boundary of index 0 a NaN), both
+// end up feeding a non-finite value to LogarithmicMapping.Index — either directly in
+// toStoreFromExponentialBucketsWithUnitScale, or via DDSketch.ChangeMapping when the
+// sketch is converted to an Agent sketch. Converting +Inf or NaN to an int is
+// architecture dependent: on amd64 NaN and +Inf both yield math.MinInt64, on arm64
+// the conversion saturates. Either way DenseStore uses the result as a slice offset
+// and panics. Reject such points here instead.
+//
+// Underflow on the negative side is not rejected: boundaries that round down to
+// zero leave ChangeMapping's remapping loop empty rather than panicking.
+func checkExponentialHistogramBounds(p pmetric.ExponentialHistogramDataPoint, scale int32, boundaryScaleFactor float64) error {
+	// gamma = 2^(2^-scale) overflows for any scale <= -10. The mapping is then
+	// unusable for every index, including the negative ones, so reject outright.
+	if gamma := math.Pow(2, math.Pow(2, float64(-scale))); math.IsInf(gamma, 0) {
+		return fmt.Errorf("exponential histogram scale %d is too small: gamma overflows float64", scale)
+	}
+
+	log2ScaleFactor := math.Log2(boundaryScaleFactor)
+
+	for _, buckets := range []pmetric.ExponentialHistogramDataPointBuckets{p.Positive(), p.Negative()} {
+		maxIndex, ok := maxPopulatedIndex(buckets)
+		if !ok {
+			continue
+		}
+		// The remapping reads the boundary of maxIndex+1 as the bucket's upper bound.
+		// math.Ldexp computes (maxIndex+1) * 2^-scale without an intermediate overflow.
+		log2Bound := math.Ldexp(float64(maxIndex+1), int(-scale)) + log2ScaleFactor
+		if log2Bound > maxFiniteLog2 {
+			return fmt.Errorf(
+				"exponential histogram bucket index %d is out of range for scale %d: boundary 2^%g overflows float64",
+				maxIndex, scale, log2Bound,
+			)
+		}
+	}
+	return nil
 }

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/exponential_histograms_translator_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/exponential_histograms_translator_test.go
@@ -8,9 +8,11 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
+	"github.com/DataDog/sketches-go/ddsketch"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -189,4 +191,81 @@ func TestCreateDDSketchFromExponentialHistogramOfDurationUnitOverflow(t *testing
 	sketch, err := CreateDDSketchFromExponentialHistogramOfDuration(nil, 0, "s")
 	require.NoError(t, err)
 	require.NotNil(t, sketch)
+}
+
+// TestCreateDDSketchFromExponentialHistogramOfDurationUnderflowToZeroBin checks that
+// boundaries too small for the mapping to index are counted in the zero bin instead
+// of being passed to LogarithmicMapping.Index, where Log(0) = -Inf used to panic in
+// DenseStore.
+func TestCreateDDSketchFromExponentialHistogramOfDurationUnderflowToZeroBin(t *testing.T) {
+	for _, half := range []string{"positive", "negative"} {
+		t.Run(half, func(t *testing.T) {
+			// base^math.MinInt32 underflows to 0 at any scale.
+			md := newExpHistogramMetrics(0, 0, nil)
+			dp := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
+				ExponentialHistogram().DataPoints().At(0)
+			buckets := dp.Positive()
+			if half == "negative" {
+				buckets = dp.Negative()
+			}
+			buckets.SetOffset(math.MinInt32)
+			buckets.BucketCounts().Append(1)
+			buckets.BucketCounts().Append(1)
+
+			// The bounds check allows underflow: it is only the overflow side that
+			// produces a non-finite boundary.
+			require.NoError(t, checkExponentialHistogramBounds(dp, 0, float64(time.Second)))
+
+			var sketch *ddsketch.DDSketch
+			var err error
+			require.NotPanics(t, func() {
+				sketch, err = CreateDDSketchFromExponentialHistogramOfDuration(&dp, 0, "s")
+			})
+			require.NoError(t, err)
+			require.NotNil(t, sketch)
+			// Both observations are preserved, in the zero bin.
+			assert.Equal(t, 2.0, sketch.GetCount())
+			assert.Equal(t, 2.0, sketch.GetZeroCount())
+		})
+	}
+}
+
+// TestCreateDDSketchFromExponentialHistogramOfDurationDegenerateMapping checks the
+// case where the clamped gamma sits so close to 1 that the mapping's multiplier
+// explodes and its indexable range inverts. mapping.Index then returns an index far
+// too large for DenseStore to allocate, which used to panic with
+// "growslice: len out of range".
+func TestCreateDDSketchFromExponentialHistogramOfDurationDegenerateMapping(t *testing.T) {
+	// 2^(2^-52) is 1+1.5e-16, below the 1.01/0.99 clamp, so the clamp does not apply.
+	// Scale 53 rounds gamma to exactly 1, which NewLogarithmicMappingWithGamma rejects.
+	for _, scale := range []int32{40, 52} {
+		t.Run(fmt.Sprintf("scale%d", scale), func(t *testing.T) {
+			md := newExpHistogramMetrics(scale, 0, []uint64{1, 1})
+			dp := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
+				ExponentialHistogram().DataPoints().At(0)
+
+			// The boundaries themselves are perfectly representable.
+			require.NoError(t, checkExponentialHistogramBounds(dp, scale, float64(time.Second)))
+
+			require.NotPanics(t, func() {
+				sketch, err := CreateDDSketchFromExponentialHistogramOfDuration(&dp, scale, "s")
+				assert.Error(t, err)
+				assert.Nil(t, sketch)
+			})
+		})
+	}
+
+	// In-spec scales are unaffected: their indexable range still covers nanosecond
+	// magnitudes.
+	for _, scale := range []int32{-4, 0, 10, 20} {
+		t.Run(fmt.Sprintf("inspec_scale%d", scale), func(t *testing.T) {
+			md := newExpHistogramMetrics(scale, 0, []uint64{1, 1})
+			dp := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
+				ExponentialHistogram().DataPoints().At(0)
+			sketch, err := CreateDDSketchFromExponentialHistogramOfDuration(&dp, scale, "s")
+			require.NoError(t, err)
+			require.NotNil(t, sketch)
+			assert.Equal(t, 2.0, sketch.GetCount())
+		})
+	}
 }

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/exponential_histograms_translator_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/exponential_histograms_translator_test.go
@@ -1,0 +1,192 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+// newExpHistogramMetrics builds a single-datapoint delta exponential histogram with
+// the given scale and positive bucket layout.
+func newExpHistogramMetrics(scale int32, offset int32, counts []uint64) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	m := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("expohist.test")
+	eh := m.SetEmptyExponentialHistogram()
+	eh.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+
+	dp := eh.DataPoints().AppendEmpty()
+	dp.SetTimestamp(seconds(0))
+	dp.SetScale(scale)
+
+	var total uint64
+	pos := dp.Positive()
+	pos.SetOffset(offset)
+	for _, c := range counts {
+		pos.BucketCounts().Append(c)
+		total += c
+	}
+	dp.SetCount(total)
+	dp.SetSum(0.627158)
+	dp.SetMin(0.143741)
+	dp.SetMax(0.327218)
+	return md
+}
+
+// TestExponentialHistogramOutOfRangeBoundsNoPanic covers
+// https://github.com/DataDog/datadog-agent/issues/55140: bucket boundaries that
+// overflow float64 used to reach DDSketch.ChangeMapping as +Inf or NaN, which
+// converts them to math.MinInt64 on amd64 and panics inside DenseStore.
+//
+// The overflowing points must now be dropped with an error, and the representable
+// ones must still produce a sketch.
+func TestExponentialHistogramOutOfRangeBoundsNoPanic(t *testing.T) {
+	tests := []struct {
+		name string
+		// scale and offset of the datapoint. Three populated buckets are used, so the
+		// highest boundary evaluated is 2^((offset+3) * 2^-scale).
+		scale  int32
+		offset int32
+		// expectError is whether the boundaries are out of float64 range.
+		expectError bool
+		// expectSketch is whether MapMetrics still emits a sketch. A point can pass the
+		// bounds check and yet be dropped further down by the Agent sketch's own index
+		// limit (pkg/util/quantile maxIndex), which is pre-existing behaviour.
+		expectSketch bool
+	}{
+		// Scales reported in the issue: gamma = 2^(2^-scale) overflows at scale <= -10,
+		// and the boundary of bucket 3 already overflows at scale -9.
+		{name: "scale -10 gamma overflows", scale: -10, offset: 0, expectError: true},
+		{name: "scale -9 boundary overflows", scale: -9, offset: 0, expectError: true},
+		// In-spec scales are equally affected: the bucket offset alone pushes the
+		// boundary out of range. offset is a sint32 in OTLP, so this is well-formed input.
+		{name: "scale 0 offset in range", scale: 0, offset: 1000, expectError: false, expectSketch: false},
+		{name: "scale 0 offset overflows", scale: 0, offset: 1023, expectError: true},
+		{name: "scale 3 offset overflows", scale: 3, offset: 8192, expectError: true},
+		{name: "scale 20 offset overflows", scale: 20, offset: 2000000000, expectError: true},
+		// Representable points must keep working, including negative offsets whose
+		// boundaries round down towards zero rather than overflowing.
+		{name: "scale 0 offset zero", scale: 0, offset: 0, expectError: false, expectSketch: true},
+		{name: "scale 4 offset zero", scale: 4, offset: 0, expectError: false, expectSketch: true},
+		{name: "scale 0 negative offset", scale: 0, offset: -1024, expectError: false, expectSketch: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md := newExpHistogramMetrics(tt.scale, tt.offset, []uint64{1, 1, 1})
+			dp := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
+				ExponentialHistogram().DataPoints().At(0)
+
+			err := checkExponentialHistogramBounds(dp, tt.scale, 1)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// The whole translation must not panic either way.
+			tr := newTranslator(t, zap.NewNop())
+			consumer := &mockFullConsumer{}
+			require.NotPanics(t, func() {
+				_, err := tr.MapMetrics(context.Background(), md, consumer, nil)
+				require.NoError(t, err)
+			})
+
+			if tt.expectSketch {
+				assert.NotEmpty(t, consumer.sketches, "representable point should still produce a sketch")
+			} else {
+				assert.Empty(t, consumer.sketches, "point should be dropped")
+			}
+
+			// CreateDDSketchFromExponentialHistogramOfDuration shares the same
+			// unbounded boundary computation and must not panic either. It scales every
+			// boundary to nanoseconds, so it rejects at least as much as the check above.
+			require.NotPanics(t, func() {
+				sketch, err := CreateDDSketchFromExponentialHistogramOfDuration(&dp, tt.scale, "s")
+				if tt.expectError {
+					assert.Error(t, err)
+					assert.Nil(t, sketch)
+				}
+			})
+		})
+	}
+}
+
+func TestCheckExponentialHistogramBoundsZeroCountBuckets(t *testing.T) {
+	// Trailing zero-count buckets are discarded by DenseStore.AddWithCount, so they
+	// must not make an otherwise representable point fail the check.
+	md := newExpHistogramMetrics(0, 1000, []uint64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0})
+	dp := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
+		ExponentialHistogram().DataPoints().At(0)
+	require.NoError(t, checkExponentialHistogramBounds(dp, 0, 1))
+
+	// The negative buckets are checked as well.
+	dp.Negative().SetOffset(2000)
+	dp.Negative().BucketCounts().Append(1)
+	require.Error(t, checkExponentialHistogramBounds(dp, 0, 1))
+}
+
+func TestMaxPopulatedIndex(t *testing.T) {
+	tests := []struct {
+		offset  int32
+		counts  []uint64
+		wantIdx int
+		wantAny bool
+	}{
+		{offset: 0, counts: nil, wantIdx: 0, wantAny: false},
+		{offset: 0, counts: []uint64{0, 0}, wantIdx: 0, wantAny: false},
+		{offset: 0, counts: []uint64{1, 1, 1}, wantIdx: 2, wantAny: true},
+		{offset: 5, counts: []uint64{1, 0, 0}, wantIdx: 5, wantAny: true},
+		{offset: -10, counts: []uint64{0, 3}, wantIdx: -9, wantAny: true},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("case%d", i), func(t *testing.T) {
+			b := pmetric.NewExponentialHistogramDataPointBuckets()
+			b.SetOffset(tt.offset)
+			for _, c := range tt.counts {
+				b.BucketCounts().Append(c)
+			}
+			idx, ok := maxPopulatedIndex(b)
+			assert.Equal(t, tt.wantAny, ok)
+			if tt.wantAny {
+				assert.Equal(t, tt.wantIdx, idx)
+			}
+		})
+	}
+}
+
+// TestCreateDDSketchFromExponentialHistogramOfDurationUnitOverflow covers the
+// boundary overflow that only the duration path can hit: a bucket boundary that is
+// representable on its own but overflows once scaled to nanoseconds.
+func TestCreateDDSketchFromExponentialHistogramOfDurationUnitOverflow(t *testing.T) {
+	// 2^1000 is finite, but 2^1000 * 1e9 (seconds to nanoseconds) is not.
+	md := newExpHistogramMetrics(0, 1000, []uint64{1, 1, 1})
+	dp := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
+		ExponentialHistogram().DataPoints().At(0)
+
+	require.NoError(t, checkExponentialHistogramBounds(dp, 0, 1))
+	require.Error(t, checkExponentialHistogramBounds(dp, 0, float64(time.Second)))
+
+	require.NotPanics(t, func() {
+		sketch, err := CreateDDSketchFromExponentialHistogramOfDuration(&dp, 0, "s")
+		assert.Error(t, err)
+		assert.Nil(t, sketch)
+	})
+
+	// A nil datapoint keeps returning an empty sketch.
+	sketch, err := CreateDDSketchFromExponentialHistogramOfDuration(nil, 0, "s")
+	require.NoError(t, err)
+	require.NotNil(t, sketch)
+}

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/histograms.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/histograms.go
@@ -144,29 +144,60 @@ func CreateDDSketchFromHistogramOfDuration(dp *pmetric.HistogramDataPoint, unit 
 	return newSketch, nil
 }
 
-func toStoreFromExponentialBucketsWithUnitScale(b pmetric.ExponentialHistogramDataPointBuckets, mapping *mapping.LogarithmicMapping, base float64, scaleToNanos float64) store.Store {
+// toStoreFromExponentialBucketsWithUnitScale converts the buckets of one half of an
+// exponential histogram into a DDSketch store, returning the store alongside the
+// count of observations that were too small to be indexed and therefore belong in
+// the sketch's zero bin.
+//
+// Every boundary is checked against the mapping's indexable range before being
+// handed to mapping.Index. Index does not validate its argument: it computes
+// Log(value)*multiplier + indexOffset and converts the result to an int, so a value
+// outside the range yields either a non-finite intermediate (Log(0) is -Inf) or an
+// index far too large for DenseStore to allocate. Both crash in DenseStore rather
+// than returning an error.
+func toStoreFromExponentialBucketsWithUnitScale(b pmetric.ExponentialHistogramDataPointBuckets, mapping *mapping.LogarithmicMapping, base float64, scaleToNanos float64) (store.Store, float64, error) {
 	offset := b.Offset()
 	bucketCounts := b.BucketCounts()
 
+	minIndexable := mapping.MinIndexableValue()
+	maxIndexable := mapping.MaxIndexableValue()
+
 	store := store.NewDenseStore()
+	var underflowCount float64
 	for j := 0; j < bucketCounts.Len(); j++ {
 		bucketIndex := j + int(offset)
 		count := bucketCounts.At(j)
 
-		if count > 0 {
-			// Calculate the actual bucket boundary value
-			bucketValue := math.Pow(base, float64(bucketIndex))
+		if count == 0 {
+			continue
+		}
 
-			// Scale the bucket value to nanoseconds
-			scaledValue := bucketValue * scaleToNanos
+		// Calculate the actual bucket boundary value
+		bucketValue := math.Pow(base, float64(bucketIndex))
 
+		// Scale the bucket value to nanoseconds
+		scaledValue := bucketValue * scaleToNanos
+
+		switch {
+		case math.IsNaN(scaledValue):
+			return nil, 0, fmt.Errorf("exponential histogram bucket %d has a non-numeric boundary", bucketIndex)
+		case scaledValue > maxIndexable:
+			return nil, 0, fmt.Errorf(
+				"exponential histogram bucket %d boundary %g exceeds the maximum indexable value %g",
+				bucketIndex, scaledValue, maxIndexable,
+			)
+		case scaledValue < minIndexable:
+			// Indistinguishable from zero at this mapping's resolution. DDSketch
+			// tracks such values in the zero bin.
+			underflowCount += float64(count)
+		default:
 			// Convert back to the index in the nanosecond space
 			// Using the same gamma since we're keeping the same precision
 			scaledIndex := mapping.Index(scaledValue)
 			store.AddWithCount(scaledIndex, float64(count))
 		}
 	}
-	return store
+	return store, underflowCount, nil
 }
 
 // CreateDDSketchFromExponentialHistogramOfDuration creates a DDSketch from exponential histogram data point
@@ -194,15 +225,33 @@ func CreateDDSketchFromExponentialHistogramOfDuration(p *pmetric.ExponentialHist
 		return nil, fmt.Errorf("couldn't create LogarithmicMapping for DDSketch: %w", err)
 	}
 
+	// A scale fine enough that gamma is barely above 1 gives the mapping a multiplier
+	// so large that its indexable range inverts, leaving no value it can represent.
+	// Reject rather than folding every observation into the zero bin.
+	if mapping.MinIndexableValue() > mapping.MaxIndexableValue() {
+		return nil, fmt.Errorf(
+			"exponential histogram scale %d leaves no indexable values for unit %q: indexable range is [%g, %g]",
+			scale, unit, mapping.MinIndexableValue(), mapping.MaxIndexableValue(),
+		)
+	}
+
 	// Calculate the base for the exponential histogram
 	base := math.Pow(2, math.Pow(2, float64(-scale)))
 	var positiveStore store.Store
 	var negativeStore store.Store
 	var zeroCount float64
 	if p != nil {
-		positiveStore = toStoreFromExponentialBucketsWithUnitScale(p.Positive(), mapping, base, scaleToNanos)
-		negativeStore = toStoreFromExponentialBucketsWithUnitScale(p.Negative(), mapping, base, scaleToNanos)
-		zeroCount = float64(p.ZeroCount())
+		var posUnderflow, negUnderflow float64
+		positiveStore, posUnderflow, err = toStoreFromExponentialBucketsWithUnitScale(p.Positive(), mapping, base, scaleToNanos)
+		if err != nil {
+			return nil, err
+		}
+		negativeStore, negUnderflow, err = toStoreFromExponentialBucketsWithUnitScale(p.Negative(), mapping, base, scaleToNanos)
+		if err != nil {
+			return nil, err
+		}
+		// Observations too small to index belong in the zero bin, on both halves.
+		zeroCount = float64(p.ZeroCount()) + posUnderflow + negUnderflow
 	} else {
 		positiveStore = store.NewDenseStore()
 		negativeStore = store.NewDenseStore()

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/histograms.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/histograms.go
@@ -174,6 +174,16 @@ func CreateDDSketchFromExponentialHistogramOfDuration(p *pmetric.ExponentialHist
 	// Create the DDSketch stores
 	scaleToNanos := getTimeUnitScaleToNanos(unit)
 
+	// toStoreFromExponentialBucketsWithUnitScale computes each bucket boundary as
+	// base^bucketIndex * scaleToNanos with an unclamped base, so out-of-range indices
+	// reach LogarithmicMapping.Index as +Inf and panic in DenseStore. The gamma clamp
+	// below only bounds the output mapping and does not protect against this.
+	if p != nil {
+		if err := checkExponentialHistogramBounds(*p, scale, scaleToNanos); err != nil {
+			return nil, err
+		}
+	}
+
 	// Create the DDSketch mapping that corresponds to the ExponentialHistogram settings
 	gammaWithOnePercentAccuracy := 1.01 / 0.99
 	gamma := math.Pow(2, math.Pow(2, float64(-scale)))

--- a/releasenotes/notes/fix-otlp-expohist-gamma-overflow-panic-3f1c9d47a2b8e6d0.yaml
+++ b/releasenotes/notes/fix-otlp-expohist-gamma-overflow-panic-3f1c9d47a2b8e6d0.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fix a panic in the OTLP metrics pipeline when an exponential histogram data
+    point has bucket boundaries that are not representable as ``float64``, either
+    because ``scale`` is small enough that ``2^(2^-scale)`` overflows or because
+    the bucket ``offset`` places a populated bucket beyond the ``float64`` range.
+    Such data points are now rejected with an error instead of crashing the
+    Agent.

--- a/releasenotes/notes/fix-otlp-expohist-gamma-overflow-panic-3f1c9d47a2b8e6d0.yaml
+++ b/releasenotes/notes/fix-otlp-expohist-gamma-overflow-panic-3f1c9d47a2b8e6d0.yaml
@@ -7,3 +7,9 @@ fixes:
     the bucket ``offset`` places a populated bucket beyond the ``float64`` range.
     Such data points are now rejected with an error instead of crashing the
     Agent.
+  - |
+    Fix a panic when converting an exponential histogram of durations whose
+    bucket boundaries fall outside the range its DDSketch mapping can index.
+    Boundaries too small to index are now counted in the sketch's zero bin, and a
+    ``scale`` fine enough to leave the mapping with no indexable values at all is
+    rejected with an error.


### PR DESCRIPTION
### What does this PR do?

Fixes three panics in the OTLP exponential histogram conversion path, across two commits.

**1. `checkExponentialHistogramBounds`** (`exponential_histograms_translator.go`), called from both places that build a DDSketch out of an OTLP exponential histogram — `exponentialHistogramToDDSketch` (`default_mapper.go`, the path reported in #55140) and `CreateDDSketchFromExponentialHistogramOfDuration` (`histograms.go`). Data points whose bucket boundaries cannot be represented as finite `float64` values are rejected with an error instead of panicking. In `default_mapper.go` the error flows into the existing `continue` + debug-log path, so the point is dropped the same way other unconvertible exponential histograms already are.

**2. Indexable-range validation in `toStoreFromExponentialBucketsWithUnitScale`** (`histograms.go`). Each boundary is now checked against the mapping's own indexable range before being handed to `mapping.Index`. Boundaries too small to index are counted in the zero bin; boundaries too large, and a mapping whose indexable range has inverted, are rejected.

### Motivation

Reported in #55140: a producer that downscales to its floor takes the whole collector down, because the panic lands in an exporter-queue goroutine where nothing upstream can recover it.

#### Non-finite boundaries (commit 1)

An exponential histogram bucket boundary is `gamma^index`, with `gamma = 2^(2^-scale)`. Neither `scale` nor the bucket `offset` was validated, so two things can go wrong:

- `gamma` itself overflows for any `scale <= -10`. `NewLogarithmicMappingWithGamma` accepts `+Inf` (it only rejects `gamma <= 1`), which makes `multiplier = 1/Log(+Inf) = 0`, and then `LowerBound(0) = Exp(0/0) = NaN`.
- A boundary overflows to `+Inf` even at an in-spec scale, once `index * 2^-scale` exceeds 1024.

Either way a non-finite `float64` reaches `LogarithmicMapping.Index`, which converts it to an `int`. The result is architecture dependent: on amd64 both `NaN` and `+Inf` yield `math.MinInt64`, on arm64 the conversion saturates. `DenseStore` then uses that as a slice offset and panics.

```
DenseStore.AddWithCount(0x…, 0x8000000000000000, 0xfff8000000000000)   // index=MinInt64, count=NaN
  ddsketch.changeStoreMapping → DDSketch.ChangeMapping
  quantile.createDDSketchWithSketchMapping   pkg/util/quantile/ddsketch.go:56
  quantile.ConvertDDSketchIntoSketch         pkg/util/quantile/ddsketch.go:223
  metrics.(*defaultMapper).MapExponentialHistogramMetrics   default_mapper.go:300
```

**The trigger is not limited to a low `scale`.** The panic fires whenever the upper boundary of the highest populated bucket overflows, i.e. roughly `(maxIndex+1) * 2^-scale > 1024`. Since `offset` is a `sint32` in OTLP, an entirely in-spec scale is enough. Measured on amd64 before the fix, with three populated buckets:

| scale | offset | before |
|---|---|---|
| -10 | 0 | panic (as reported) |
| -9 | 0 | panic |
| 0 | 1000 | dropped (`index value 46045 exceeds the maximum supported index value (32767)`) |
| 0 | 1023 | panic |
| 3 | 8192 | panic |
| 20 | 2000000000 | panic |

So a guard keyed only on `scale` would leave the panic reachable. `scale = -10` is in spec either way — `go-expohisto`, a direct dependency of this module, documents `MinScale = -10` / `MaxScale = 20`.

`CreateDDSketchFromExponentialHistogramOfDuration` needs the same guard, plus a scaling term: `toStoreFromExponentialBucketsWithUnitScale` calls `mapping.Index` directly on `math.Pow(base, bucketIndex) * scaleToNanos`, and `base` is deliberately unclamped (`histograms.go:188`). The `math.Min(gamma, 1.01/0.99)` clamp above it bounds only the output mapping, so it does not help. The unit scaling can also overflow a boundary that is representable on its own: at `scale = 0`, `offset = 1000`, `2^1000` is finite but `2^1000 * 1e9` is not. That case panics on both architectures. Hence the `boundaryScaleFactor` parameter on the check.

#### Out-of-range but finite boundaries (commit 2)

Probing the edges of the first commit surfaced two further panics, both pre-existing, both `growslice: len out of range`, both reachable only through the exported duration function. `mapping.Index` does not validate its argument — it computes `Log(value)*multiplier + indexOffset` and converts to an `int`:

- **Underflow to zero.** `math.Pow(base, math.MinInt32)` is `0`, so `Log(0)` is `-Inf` and the index becomes `math.MinInt64`. Reachable with any sufficiently negative bucket offset, on either half of the histogram.
- **Degenerate mapping.** At `scale = 52`, `gamma` is `1+1.5e-16` — *below* the `1.01/0.99` clamp, so the clamp is a no-op. `multiplier` becomes `6.5e15` and `Index(1e9)` returns `9.3e16`: finite, so the first commit's check passes it, but `DenseStore` then tries to allocate that many bins. The mapping is in fact unusable — its indexable range has inverted:

  | scale | MinIndexableValue | MaxIndexableValue | inverted |
  |---|---|---|---|
  | 20 | 2.2e-308 | 1.27e308 | no |
  | 26 | 6.3e-10 | 1.58e9 | no |
  | 30 | 0.68 | 1.47 | no |
  | 40 | 2.718 | 0.368 | yes |
  | 52 | 2.718 | 0.368 | yes |

Checking each boundary against `MinIndexableValue`/`MaxIndexableValue` covers both. Underflowing boundaries go to the zero bin — that is where DDSketch tracks values it cannot distinguish from zero, so the observations are preserved rather than dropped. An inverted range is rejected outright rather than silently folding every observation to zero. In-spec scales are unaffected: their indexable range still spans nanosecond magnitudes.

### Describe how you validated your changes

New `exponential_histograms_translator_test.go`:

- `TestExponentialHistogramOutOfRangeBoundsNoPanic` — the table above plus representable controls (`scale 0/4` at `offset 0`, and `offset -1024`). Asserts `NotPanics` through both `MapMetrics` and `CreateDDSketchFromExponentialHistogramOfDuration`, that overflowing points now error, and that representable points still emit a sketch.
- `TestCreateDDSketchFromExponentialHistogramOfDurationUnitOverflow` — pins the `scaleToNanos` overflow.
- `TestCreateDDSketchFromExponentialHistogramOfDurationUnderflowToZeroBin` — `offset = math.MinInt32` on the positive and negative halves; asserts no panic and that both observations survive in the zero bin.
- `TestCreateDDSketchFromExponentialHistogramOfDurationDegenerateMapping` — scales 40 and 52 rejected; scales -4, 0, 10, 20 still convert and keep their count.
- `TestCheckExponentialHistogramBoundsZeroCountBuckets` — trailing zero-count buckets must not fail an otherwise representable point, and negative buckets are checked too.
- `TestMaxPopulatedIndex` — unit coverage for the helper.

Two of the three panics only manifest on amd64, so the suite was run under both architectures:

```
GOARCH=amd64 go test -count=1 ./...   ok   (all 4 packages)
GOARCH=arm64 go test -count=1 ./...   ok   (all 4 packages)
gofmt: clean       go vet: clean
```

Before the fix, `GOARCH=amd64` reproduced the reported crash argument-for-argument — `AddWithCount(index=0x8000000000000000, count=0xfff8000000000000)`.

Beyond the committed tests, a throwaway probe ran 19 edge cases through both conversion paths and compared pre- and post-fix behaviour: exact `log2 == 1023` vs `1024` boundaries, single-observation points (which take the `GetCount() == 1` shortcut in `createDDSketchWithSketchMapping` and bypass `ChangeMapping` entirely), zero-count-only and fully empty points, `scale` and `offset` at both `int32` extremes, negative-store-only variants, and each supported unit. That probe is what surfaced the two panics in commit 2; it confirmed both were already present before commit 1.

### Additional Notes

- The boundary check runs in log2 space via `math.Ldexp`, so the validation itself cannot overflow.
- Zero-count buckets are excluded from the index scan: `DenseStore.AddWithCount` early-returns on `count == 0` and `ForEach` skips empty bins, so those buckets never reach the mapping.
- Underflow is deliberately *not* rejected by `checkExponentialHistogramBounds`. In the default mapper path, boundaries that round down to zero make `changeStoreMapping`'s remapping loop exit immediately rather than panicking, and such points convert correctly today (`scale 0`, `offset -1024` is covered in the test). The duration path needs the separate indexable-range check because it calls `Index` directly.
- The bound uses `maxIndex+1` because that is the boundary the remapping reads as the bucket's upper bound. This is conservative by at most one power of two relative to `maxIndex`, which only matters right at the overflow edge.
- Behaviour change worth flagging: a single-observation histogram with an out-of-range offset previously took the `GetCount() == 1` shortcut and never called `ChangeMapping`, so it did not panic. It is now rejected. The shortcut path used `GetSum()`, which iterates `ForEach` over non-finite `Value(index)` results, so the value it produced was not meaningful.
- `scale = math.MinInt32` survives only incidentally: `-scale` wraps back to `math.MinInt32`, `2^-2.1e9` underflows to `0`, `gamma` becomes exactly `1`, and `NewLogarithmicMappingWithGamma` rejects it. Nothing in the code intends that, but it is not a crash.
- Pre-existing behaviour left untouched: several inputs that pass these checks are still dropped further down by the Agent sketch's own `maxIndex` limit (`pkg/util/quantile`, `MaxInt16`) with a debug-level log only. That silent drop is out of scope here — this PR only stops the crashes.

Fixes #55140