### PR TITLE
chore(packaging): Remove build-only artifacts from Linux Agent

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -114,6 +114,11 @@ build do
             # cleanup clutter
             delete "#{install_dir}/etc"
 
+            # Build toolchains need these files while assembling the Agent, but the shipped
+            # Linux runtime and wheel-only integration installer do not.
+            command "bazel run #{omnibazel_flags} -- //packages/agent/linux:cleanup_build_artifacts --install-dir=#{install_dir}",
+                :live_stream => Omnibus.logger.live_stream(:info)
+
             # The prerm and preinst scripts of the package will use this list to detect which files
             # have been setup by the installer, this way, on removal, we'll be able to delete only files
             # which have not been created by the package.

--- a/packages/agent/linux/BUILD.bazel
+++ b/packages/agent/linux/BUILD.bazel
@@ -10,6 +10,8 @@ load(
 )
 load("@rules_pkg//pkg:rpm.bzl", "pkg_rpm")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_test.bzl", "py_test")
 load("//bazel/rules:compression.bzl", "get_compression_level")
 load("//bazel/rules:dd_agent_pkg_mklink.bzl", "dd_agent_pkg_mklink")
 load("//compliance:package_licenses.bzl", "package_licenses")
@@ -28,6 +30,20 @@ package_name_selector = {
     "//packages/agent:linux_heroku": "datadog-heroku-agent",
     "//conditions:default": "datadog-agent",
 }
+
+py_binary(
+    name = "cleanup_build_artifacts",
+    srcs = ["cleanup_build_artifacts.py"],
+)
+
+py_test(
+    name = "cleanup_build_artifacts_test",
+    srcs = [
+        "cleanup_build_artifacts.py",
+        "cleanup_build_artifacts_test.py",
+    ],
+    main = "cleanup_build_artifacts_test.py",
+)
 
 # This is everything in the distro. All the things that were explicit
 # in datadog-agent-dependencies.rb should show up here.

--- a/packages/agent/linux/cleanup_build_artifacts.py
+++ b/packages/agent/linux/cleanup_build_artifacts.py
@@ -1,0 +1,43 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+
+import argparse
+import shutil
+from pathlib import Path
+
+_BUILD_SOURCE_SUFFIXES = frozenset({".c", ".h", ".hpp", ".pxd", ".pxi", ".pyx"})
+_CMAKE_FILENAMES = frozenset({"CMakeLists.txt"})
+_CMAKE_SUFFIXES = (".cmake", ".cmake.in")
+
+
+def _is_build_only_site_packages_file(path: Path) -> bool:
+    return path.suffix in _BUILD_SOURCE_SUFFIXES or path.name in _CMAKE_FILENAMES or path.name.endswith(_CMAKE_SUFFIXES)
+
+
+def cleanup_build_artifacts(install_dir: Path) -> None:
+    embedded_dir = install_dir / "embedded"
+    if not embedded_dir.is_dir():
+        raise FileNotFoundError(f"embedded Agent directory does not exist: {embedded_dir}")
+
+    include_dir = embedded_dir / "include"
+    if include_dir.exists():
+        shutil.rmtree(include_dir)
+    (embedded_dir / "lib/libpcap.a").unlink(missing_ok=True)
+
+    for site_packages in (embedded_dir / "lib").glob("python*/site-packages"):
+        for path in site_packages.rglob("*"):
+            if path.is_file() and _is_build_only_site_packages_file(path):
+                path.unlink()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Remove build-only files from a staged Linux Agent installation")
+    parser.add_argument("--install-dir", required=True, type=Path)
+    args = parser.parse_args()
+    cleanup_build_artifacts(args.install_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/agent/linux/cleanup_build_artifacts_test.py
+++ b/packages/agent/linux/cleanup_build_artifacts_test.py
@@ -1,0 +1,84 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from packages.agent.linux.cleanup_build_artifacts import cleanup_build_artifacts
+
+
+class CleanupBuildArtifactsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.install_dir = Path(self.temporary_directory.name)
+        self.embedded_dir = self.install_dir / "embedded"
+        self.site_packages = self.embedded_dir / "lib/python3.13/site-packages"
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def create_file(self, relative_path: str, content: bytes = b"content") -> Path:
+        path = self.install_dir / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        return path
+
+    def test_removes_linux_agent_build_artifacts(self) -> None:
+        removed_paths = [
+            "embedded/include/python3.13/Python.h",
+            "embedded/include/openssl/ssl.h",
+            "embedded/lib/libpcap.a",
+            "embedded/lib/python3.13/site-packages/psycopg_c/_psycopg.c",
+            "embedded/lib/python3.13/site-packages/psycopg_c/pq.c",
+            "embedded/lib/python3.13/site-packages/package/header.h",
+            "embedded/lib/python3.13/site-packages/package/header.hpp",
+            "embedded/lib/python3.13/site-packages/package/module.pyx",
+            "embedded/lib/python3.13/site-packages/package/declaration.pxd",
+            "embedded/lib/python3.13/site-packages/package/include.pxi",
+            "embedded/lib/python3.13/site-packages/package/CMakeLists.txt",
+            "embedded/lib/python3.13/site-packages/package/build.cmake",
+            "embedded/lib/python3.13/site-packages/package/config.cmake.in",
+        ]
+        for path in removed_paths:
+            self.create_file(path)
+
+        cleanup_build_artifacts(self.install_dir)
+
+        for path in removed_paths:
+            self.assertFalse((self.install_dir / path).exists(), path)
+
+    def test_preserves_runtime_and_wheel_metadata(self) -> None:
+        preserved_paths = [
+            "embedded/lib/python3.13/site-packages/package/__init__.py",
+            "embedded/lib/python3.13/site-packages/package/api.pyi",
+            "embedded/lib/python3.13/site-packages/package/extension.so",
+            "embedded/lib/python3.13/site-packages/package/config.yaml",
+            "embedded/lib/python3.13/site-packages/package/LICENSE",
+            "embedded/lib/python3.13/site-packages/package-1.0.dist-info/METADATA",
+            "embedded/lib/python3.13/site-packages/package-1.0.dist-info/RECORD",
+            "embedded/lib/python3.13/site-packages/package/cmake_runtime.py",
+            "embedded/lib/runtime.c",
+            "embedded/share/system-probe/ebpf/runtime/runtime-security.c",
+            "etc/datadog-agent/datadog.yaml.example",
+        ]
+        for path in preserved_paths:
+            self.create_file(path)
+        self.create_file("embedded/include/python3.13/Python.h")
+
+        cleanup_build_artifacts(self.install_dir)
+
+        for path in preserved_paths:
+            self.assertTrue((self.install_dir / path).is_file(), path)
+
+    def test_handles_absent_optional_artifacts(self) -> None:
+        self.site_packages.mkdir(parents=True)
+
+        cleanup_build_artifacts(self.install_dir)
+        cleanup_build_artifacts(self.install_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What does this PR do?

Adds a Bazel-owned Linux Agent finalization tool and invokes it from the existing Omnibus Linux packaging seam before `.installed_by_pkg.txt` is generated.

The cleanup removes build-only content that is not needed by the shipped runtime or by wheel-only `datadog-agent integration install`:

- `.c`, `.h`, `.hpp`, `.pyx`, `.pxd`, and `.pxi` files below embedded Python `site-packages`
- `CMakeLists.txt`, `*.cmake`, and `*.cmake.in` metadata below `site-packages`
- the staged `embedded/include` tree
- `embedded/lib/libpcap.a`

It deliberately retains `.pyi` files, dist-info metadata, shared libraries, runtime eBPF C sources, configuration, and licenses. Windows and macOS finalization are unchanged.

### Motivation

These files are required while building dependencies but do not serve the installed Linux Agent. Removing them from a representative package audit tree reduced extracted logical size by **16,815,563 bytes (16.037 MiB)**, including the 6.30 MiB generated psycopg C sources, without removing runtime content.

### Describe how you validated your changes

- `bazel test --config=no-remote-cache //packages/agent/linux:cleanup_build_artifacts_test` — focused removal, preservation, absent-artifact, and idempotence coverage
- `bazel run --config=no-remote-cache //bazel/buildifier`
- `dda run i ruff format --check ...` and `dda run i ruff check ...`
- `ruby -c omnibus/config/software/datadog-agent-finalize.rb`
- Ran the cleanup against a copy of `/tmp/dd-agent-size-audit/root`:
  - zero targeted artifacts remained
  - SHA-256 inventories were unchanged for 92 `.pyi` files, 9 runtime eBPF C files, 351 shared libraries, 10 configs, 237 licenses, and 1,452 dist-info files
  - measured 16,815,563 logical bytes saved
- In a Linux/amd64 container, imported psycopg, lxml, wrapt, bson, mmh3, ddtrace, cryptography, and yaml from the cleaned embedded runtime and ran `python -m pip check` successfully

### Additional Notes

This is a packaging-sensitive change. A full Linux package build and upgrade/uninstall validation were not run locally and remain appropriate RC/package QA targets, so the PR carries `qa/rc-required`. The actual integration-install command was not exercised; compatibility was checked through retained wheel metadata, representative imports, and `pip check`.
