### PR TITLE
Dedupe auditwheel libraries in Linux packages

### DIFF
--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -7,6 +7,12 @@ dependency 'datadog-agent-integrations-py3'
 build do
     command "bazel run #{omnibazel_flags} -- //packages/agent/dependencies:install --destdir=#{install_dir}",
         :live_stream => Omnibus.logger.live_stream(:info)
+
+    if linux_target? && !fips_mode? && !heroku_target?
+        python = "#{install_dir}/embedded/bin/python3"
+        site_packages_path = "#{install_dir}/embedded/lib/python3.13/site-packages"
+        command_on_repo_root "#{python} -B tasks/libs/package/auditwheel.py #{site_packages_path} #{install_dir}/embedded/lib"
+    end
 end
 
 build do

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -117,9 +117,5 @@ build do
         end
       end
     end
-  elsif linux_target? && !heroku_target?
-    block "Normalize auditwheel libraries" do
-      command_on_repo_root "#{python} -B tasks/libs/package/auditwheel.py #{site_packages_path} #{install_dir}/embedded/lib"
-    end
   end
 end

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -117,5 +117,9 @@ build do
         end
       end
     end
+  elsif linux_target? && !heroku_target?
+    block "Normalize auditwheel libraries" do
+      command_on_repo_root "#{python} -B tasks/libs/package/auditwheel.py #{site_packages_path} #{install_dir}/embedded/lib"
+    end
   end
 end

--- a/tasks/libs/package/auditwheel.py
+++ b/tasks/libs/package/auditwheel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import subprocess
 from collections.abc import Callable, Sequence
@@ -130,8 +131,9 @@ def normalize_auditwheel_libraries(
             runner(('--replace-needed', needed, canonical_name, consumer))
             patched_consumers.add(consumer)
 
-    embedded_lib_rpath = str(embedded_lib)
     for consumer in sorted(patched_consumers):
+        relative_embedded_lib = os.path.relpath(embedded_lib, consumer.parent)
+        embedded_lib_rpath = '$ORIGIN' if relative_embedded_lib == '.' else f'$ORIGIN/{relative_embedded_lib}'
         existing_rpath = runner(('--print-rpath', consumer))
         if embedded_lib_rpath not in existing_rpath.split(':'):
             runner(('--add-rpath', embedded_lib_rpath, consumer))

--- a/tasks/libs/package/auditwheel.py
+++ b/tasks/libs/package/auditwheel.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+PatchelfRunner = Callable[[Sequence[str | Path]], str]
+
+_LIBRARY_ABIS = (
+    ('libssl', '3'),
+    ('libcrypto', '3'),
+    ('libz', '1'),
+    ('libcurl', '4'),
+    ('libkrb5', '3'),
+    ('libk5crypto', '3'),
+    ('libkrb5support', '0'),
+    ('libcom_err', '3'),
+    ('libgssapi_krb5', '2'),
+    ('libodbc', '2'),
+)
+_AUDITWHEEL_NAME_PATTERNS = tuple(
+    (
+        re.compile(rf'^{re.escape(library)}-[0-9a-f]{{8}}\.so\.{abi}(?:\.\d+)*$'),
+        f'{library}.so.{abi}',
+    )
+    for library, abi in _LIBRARY_ABIS
+)
+
+
+@dataclass(frozen=True)
+class NormalizationResult:
+    removed_library_count: int
+    removed_logical_bytes: int
+    patched_consumer_count: int
+
+
+def canonical_library_name(filename: str) -> str | None:
+    """Return the embedded ABI SONAME for a supported auditwheel-renamed library."""
+    for pattern, canonical_name in _AUDITWHEEL_NAME_PATTERNS:
+        if pattern.fullmatch(filename):
+            return canonical_name
+    return None
+
+
+def discover_duplicate_libraries(site_packages: Path) -> tuple[Path, ...]:
+    """Find supported auditwheel library copies without matching unrelated bundled libraries."""
+    return tuple(
+        path
+        for path in sorted(site_packages.rglob('*'))
+        if (path.is_file() or path.is_symlink()) and canonical_library_name(path.name) is not None
+    )
+
+
+def _is_elf(path: Path) -> bool:
+    if not path.is_file() or path.is_symlink():
+        return False
+    with path.open('rb') as file:
+        return file.read(4) == b'\x7fELF'
+
+
+def _discover_elf_files(site_packages: Path) -> tuple[Path, ...]:
+    return tuple(path for path in sorted(site_packages.rglob('*')) if _is_elf(path))
+
+
+def _run_patchelf(arguments: Sequence[str | Path]) -> str:
+    command = ['patchelf', *(str(argument) for argument in arguments)]
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    return completed.stdout.rstrip('\n')
+
+
+def _read_needed(elf_files: Sequence[Path], runner: PatchelfRunner) -> dict[Path, tuple[str, ...]]:
+    return {
+        elf_file: tuple(needed for needed in runner(('--print-needed', elf_file)).splitlines() if needed)
+        for elf_file in elf_files
+    }
+
+
+def _format_needed_references(references: Sequence[tuple[Path, str]], site_packages: Path) -> str:
+    return ', '.join(f'{consumer.relative_to(site_packages)} -> {needed}' for consumer, needed in references)
+
+
+def normalize_auditwheel_libraries(
+    site_packages: Path,
+    embedded_lib: Path,
+    *,
+    runner: PatchelfRunner = _run_patchelf,
+) -> NormalizationResult:
+    """Retarget supported wheel libraries to embedded SONAMEs, then remove the duplicate copies."""
+    site_packages = Path(site_packages)
+    embedded_lib = Path(embedded_lib)
+    duplicate_libraries = discover_duplicate_libraries(site_packages)
+    duplicate_names = {library.name for library in duplicate_libraries}
+    removed_logical_bytes = sum(library.stat().st_size for library in duplicate_libraries if not library.is_symlink())
+
+    missing_canonical_libraries = sorted(
+        {
+            embedded_lib / canonical_name
+            for library in duplicate_libraries
+            if (canonical_name := canonical_library_name(library.name)) is not None
+            and not (embedded_lib / canonical_name).exists()
+        }
+    )
+    if missing_canonical_libraries:
+        missing = ', '.join(str(path) for path in missing_canonical_libraries)
+        raise RuntimeError(f'canonical library is missing: {missing}')
+
+    elf_files = _discover_elf_files(site_packages)
+    needed_by_file = _read_needed(elf_files, runner)
+    unmatched_references = [
+        (consumer, needed)
+        for consumer, needed_libraries in needed_by_file.items()
+        for needed in needed_libraries
+        if canonical_library_name(needed) is not None and needed not in duplicate_names
+    ]
+    if unmatched_references:
+        references = _format_needed_references(unmatched_references, site_packages)
+        raise RuntimeError(f'auditwheel DT_NEEDED has no matching bundled library: {references}')
+
+    patched_consumers: set[Path] = set()
+    for consumer, needed_libraries in needed_by_file.items():
+        for needed in needed_libraries:
+            canonical_name = canonical_library_name(needed)
+            if canonical_name is None:
+                continue
+            runner(('--replace-needed', needed, canonical_name, consumer))
+            patched_consumers.add(consumer)
+
+    embedded_lib_rpath = str(embedded_lib)
+    for consumer in sorted(patched_consumers):
+        existing_rpath = runner(('--print-rpath', consumer))
+        if embedded_lib_rpath not in existing_rpath.split(':'):
+            runner(('--add-rpath', embedded_lib_rpath, consumer))
+
+    remaining_needed = _read_needed(elf_files, runner)
+    stale_references = [
+        (consumer, needed)
+        for consumer, needed_libraries in remaining_needed.items()
+        for needed in needed_libraries
+        if canonical_library_name(needed) is not None
+    ]
+    if stale_references:
+        references = _format_needed_references(stale_references, site_packages)
+        raise RuntimeError(f'stale auditwheel DT_NEEDED after patching: {references}')
+
+    for library in duplicate_libraries:
+        library.unlink()
+
+    return NormalizationResult(
+        removed_library_count=len(duplicate_libraries),
+        removed_logical_bytes=removed_logical_bytes,
+        patched_consumer_count=len(patched_consumers),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Retarget supported auditwheel libraries to canonical embedded ABI SONAMEs.'
+    )
+    parser.add_argument('site_packages', type=Path)
+    parser.add_argument('embedded_lib', type=Path)
+    arguments = parser.parse_args()
+
+    result = normalize_auditwheel_libraries(arguments.site_packages, arguments.embedded_lib)
+    print(
+        f'Removed {result.removed_library_count} duplicate auditwheel libraries '
+        f'({result.removed_logical_bytes} logical bytes); patched {result.patched_consumer_count} ELF consumers.'
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/tasks/unit_tests/libs/package/auditwheel_tests.py
+++ b/tasks/unit_tests/libs/package/auditwheel_tests.py
@@ -1,0 +1,274 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from tasks.libs.package.auditwheel import (
+    canonical_library_name,
+    discover_duplicate_libraries,
+    normalize_auditwheel_libraries,
+)
+
+
+class FakePatchelf:
+    def __init__(self, needed_by_file, ignore_replacements=False):
+        self.needed_by_file = {str(path): list(needed) for path, needed in needed_by_file.items()}
+        self.ignore_replacements = ignore_replacements
+        self.rpaths = {}
+        self.calls = []
+        self.on_print_needed = None
+
+    def __call__(self, arguments):
+        arguments = [str(argument) for argument in arguments]
+        self.calls.append(arguments)
+        operation = arguments[0]
+        if operation == '--print-needed':
+            path = arguments[1]
+            if self.on_print_needed is not None:
+                self.on_print_needed(Path(path))
+            return '\n'.join(self.needed_by_file[path])
+        if operation == '--replace-needed':
+            old_name, new_name, path = arguments[1:]
+            if not self.ignore_replacements:
+                self.needed_by_file[path] = [
+                    new_name if needed == old_name else needed for needed in self.needed_by_file[path]
+                ]
+            return ''
+        if operation == '--print-rpath':
+            return self.rpaths.get(arguments[1], '')
+        if operation == '--add-rpath':
+            rpath, path = arguments[1:]
+            existing = self.rpaths.get(path, '')
+            self.rpaths[path] = ':'.join(part for part in (existing, rpath) if part)
+            return ''
+        raise AssertionError(f'unexpected patchelf invocation: {arguments}')
+
+
+def write_elf(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b'\x7fELFtest fixture')
+    return path
+
+
+class TestAuditwheelLibrary(unittest.TestCase):
+    def test_maps_precise_auditwheel_hashes_with_version_suffixes(self):
+        valid_names = {
+            'libssl-0123abcd.so.3': 'libssl.so.3',
+            'libcrypto-deadbeef.so.3.2.1': 'libcrypto.so.3',
+            'libz-a1b2c3d4.so.1.2.7': 'libz.so.1',
+            'libcurl-abcdef01.so.4.8.0': 'libcurl.so.4',
+            'libkrb5-04e0cbc2.so.3.3': 'libkrb5.so.3',
+            'libk5crypto-37a76880.so.3.1': 'libk5crypto.so.3',
+            'libkrb5support-c059b95f.so.0.1': 'libkrb5support.so.0',
+            'libcom_err-c2c4a5b1.so.3.0': 'libcom_err.so.3',
+            'libgssapi_krb5-8da44e5f.so.2.2': 'libgssapi_krb5.so.2',
+            'libodbc-0febc3ca.so.2.0.0': 'libodbc.so.2',
+        }
+        for name, canonical_name in valid_names.items():
+            with self.subTest(name=name):
+                self.assertEqual(canonical_library_name(name), canonical_name)
+
+        invalid_names = (
+            'libssl-1234567.so.3',
+            'libssl-0123ABCDE.so.3',
+            'libssl-notahash.so.3',
+            'libssl-0123abcd.so.1',
+            'libssl.so.3',
+            'libpq-0123abcd.so.5.17',
+        )
+        for name in invalid_names:
+            with self.subTest(name=name):
+                self.assertIsNone(canonical_library_name(name))
+
+    def test_discovers_candidates_recursively_and_preserves_unique_wheel_libraries(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            site_packages = Path(temporary_directory)
+            candidates = (
+                'cryptography.libs/libssl-0123abcd.so.3',
+                'confluent_kafka.libs/libz-a1b2c3d4.so.1.2.7',
+                'pyodbc.libs/libodbc-0febc3ca.so.2.0.0',
+                'linked.libs/libssl-0123abcd.so.3',
+            )
+            preserved = (
+                'psycopg_c.libs/libpq-0123abcd.so.5.17',
+                'confluent_kafka.libs/librdkafka-0123abcd.so.1',
+                'zstandard.libs/libzstd-0123abcd.so.1.5.7',
+                'lmdb.libs/liblmdb-0123abcd.so.0.0.0',
+            )
+            for relative_path in candidates[:-1] + preserved:
+                write_elf(site_packages / relative_path)
+            linked_library = site_packages / candidates[-1]
+            linked_library.parent.mkdir(parents=True)
+            linked_library.symlink_to('../cryptography.libs/libssl-0123abcd.so.3')
+
+            discovered = discover_duplicate_libraries(site_packages)
+
+            self.assertEqual(
+                {path.relative_to(site_packages).as_posix() for path in discovered},
+                set(candidates),
+            )
+            for relative_path in preserved:
+                self.assertTrue((site_packages / relative_path).exists())
+
+    def test_rewrites_every_elf_consumer_and_preserves_unique_libraries(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            site_packages = root / 'site-packages'
+            embedded_lib = root / 'embedded' / 'lib'
+            embedded_lib.mkdir(parents=True)
+            duplicate_names = {
+                'libssl-0123abcd.so.3': 'libssl.so.3',
+                'libcrypto-deadbeef.so.3': 'libcrypto.so.3',
+                'libcurl-abcdef01.so.4.8.0': 'libcurl.so.4',
+            }
+            for duplicate_name, canonical_name in duplicate_names.items():
+                write_elf(site_packages / 'wheel.libs' / duplicate_name)
+                write_elf(embedded_lib / canonical_name)
+
+            extension = write_elf(site_packages / 'package' / 'extension.abi3.so')
+            libpq = write_elf(site_packages / 'psycopg_c.libs' / 'libpq-0123abcd.so.5.17')
+            librdkafka = write_elf(site_packages / 'confluent_kafka.libs' / 'librdkafka-0123abcd.so.1')
+            zstd = write_elf(site_packages / 'zstandard.libs' / 'libzstd-0123abcd.so.1.5.7')
+            lmdb = write_elf(site_packages / 'lmdb.libs' / 'liblmdb-0123abcd.so.0.0.0')
+            (site_packages / 'package' / 'not-an-elf.so').write_text('not an ELF')
+            runner = FakePatchelf(
+                {
+                    extension: ['libssl-0123abcd.so.3'],
+                    libpq: ['libcrypto-deadbeef.so.3', 'libssl-0123abcd.so.3'],
+                    librdkafka: ['libcurl-abcdef01.so.4.8.0', 'libssl-0123abcd.so.3'],
+                    zstd: [],
+                    lmdb: [],
+                    **{site_packages / 'wheel.libs' / duplicate_name: [] for duplicate_name in duplicate_names},
+                }
+            )
+
+            result = normalize_auditwheel_libraries(site_packages, embedded_lib, runner=runner)
+
+            self.assertEqual(runner.needed_by_file[str(extension)], ['libssl.so.3'])
+            self.assertEqual(runner.needed_by_file[str(libpq)], ['libcrypto.so.3', 'libssl.so.3'])
+            self.assertEqual(runner.needed_by_file[str(librdkafka)], ['libcurl.so.4', 'libssl.so.3'])
+            for consumer in (extension, libpq, librdkafka):
+                self.assertIn(str(embedded_lib), runner.rpaths[str(consumer)].split(':'))
+            for duplicate_name in duplicate_names:
+                self.assertFalse((site_packages / 'wheel.libs' / duplicate_name).exists())
+            for unique_library in (libpq, librdkafka, zstd, lmdb):
+                self.assertTrue(unique_library.exists())
+            self.assertEqual(result.removed_library_count, 3)
+            self.assertEqual(result.patched_consumer_count, 3)
+
+    def test_reports_pre_patch_logical_bytes_when_patchelf_grows_a_duplicate(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            site_packages = root / 'site-packages'
+            embedded_lib = root / 'embedded' / 'lib'
+            embedded_lib.mkdir(parents=True)
+            ssl_duplicate = write_elf(site_packages / 'wheel.libs' / 'libssl-0123abcd.so.3')
+            crypto_duplicate = write_elf(site_packages / 'wheel.libs' / 'libcrypto-deadbeef.so.3')
+            write_elf(embedded_lib / 'libssl.so.3')
+            write_elf(embedded_lib / 'libcrypto.so.3')
+            fake_patchelf = FakePatchelf(
+                {
+                    ssl_duplicate: ['libcrypto-deadbeef.so.3'],
+                    crypto_duplicate: [],
+                }
+            )
+            original_size = ssl_duplicate.stat().st_size + crypto_duplicate.stat().st_size
+
+            def growing_patchelf(arguments):
+                output = fake_patchelf(arguments)
+                if str(arguments[0]) == '--replace-needed':
+                    consumer = Path(arguments[-1])
+                    consumer.write_bytes(consumer.read_bytes() + b'patchelf growth')
+                return output
+
+            result = normalize_auditwheel_libraries(site_packages, embedded_lib, runner=growing_patchelf)
+
+            self.assertEqual(result.removed_logical_bytes, original_size)
+
+    def test_verifies_all_consumers_before_deleting_duplicates(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            site_packages = root / 'site-packages'
+            embedded_lib = root / 'embedded' / 'lib'
+            embedded_lib.mkdir(parents=True)
+            duplicate = write_elf(site_packages / 'wheel.libs' / 'libssl-0123abcd.so.3')
+            write_elf(embedded_lib / 'libssl.so.3')
+            consumer = write_elf(site_packages / 'package' / 'extension.so')
+            runner = FakePatchelf({duplicate: [], consumer: ['libssl-0123abcd.so.3']})
+            print_count = 0
+
+            def assert_duplicate_still_exists(_):
+                nonlocal print_count
+                print_count += 1
+                if print_count > 2:
+                    self.assertTrue(duplicate.exists())
+
+            runner.on_print_needed = assert_duplicate_still_exists
+
+            normalize_auditwheel_libraries(site_packages, embedded_lib, runner=runner)
+
+            self.assertGreater(print_count, 2)
+            self.assertFalse(duplicate.exists())
+
+    def test_fails_before_mutation_when_a_canonical_library_is_missing(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            site_packages = root / 'site-packages'
+            embedded_lib = root / 'embedded' / 'lib'
+            embedded_lib.mkdir(parents=True)
+            duplicate = write_elf(site_packages / 'wheel.libs' / 'libssl-0123abcd.so.3')
+            consumer = write_elf(site_packages / 'package' / 'extension.so')
+            runner = FakePatchelf({duplicate: [], consumer: ['libssl-0123abcd.so.3']})
+
+            with self.assertRaisesRegex(RuntimeError, 'canonical library is missing.*libssl.so.3'):
+                normalize_auditwheel_libraries(site_packages, embedded_lib, runner=runner)
+
+            self.assertTrue(duplicate.exists())
+            self.assertFalse(any(call[0] == '--replace-needed' for call in runner.calls))
+
+    def test_keeps_duplicates_when_post_patch_verification_finds_a_stale_consumer(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            site_packages = root / 'site-packages'
+            embedded_lib = root / 'embedded' / 'lib'
+            embedded_lib.mkdir(parents=True)
+            duplicate = write_elf(site_packages / 'wheel.libs' / 'libssl-0123abcd.so.3')
+            write_elf(embedded_lib / 'libssl.so.3')
+            consumer = write_elf(site_packages / 'package' / 'extension.so')
+            runner = FakePatchelf(
+                {duplicate: [], consumer: ['libssl-0123abcd.so.3']},
+                ignore_replacements=True,
+            )
+
+            with self.assertRaisesRegex(RuntimeError, 'stale auditwheel DT_NEEDED.*extension.so'):
+                normalize_auditwheel_libraries(site_packages, embedded_lib, runner=runner)
+
+            self.assertTrue(duplicate.exists())
+
+    def test_fails_before_mutation_for_a_hashed_needed_library_that_was_not_discovered(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            site_packages = root / 'site-packages'
+            embedded_lib = root / 'embedded' / 'lib'
+            embedded_lib.mkdir(parents=True)
+            write_elf(embedded_lib / 'libssl.so.3')
+            consumer = write_elf(site_packages / 'package' / 'extension.so')
+            runner = FakePatchelf({consumer: ['libssl-0123abcd.so.3']})
+
+            with self.assertRaisesRegex(RuntimeError, 'has no matching bundled library'):
+                normalize_auditwheel_libraries(site_packages, embedded_lib, runner=runner)
+
+            self.assertFalse(any(call[0] == '--replace-needed' for call in runner.calls))
+
+
+class TestAuditwheelRecipe(unittest.TestCase):
+    def test_runs_normalization_only_for_standard_non_heroku_linux(self):
+        repository_root = Path(__file__).resolve().parents[4]
+        recipe = (repository_root / 'omnibus/config/software/datadog-agent-integrations-py3.rb').read_text()
+
+        self.assertIn("elsif linux_target? && !heroku_target?", recipe)
+        self.assertIn("tasks/libs/package/auditwheel.py", recipe)
+        self.assertLess(recipe.index("if fips_mode?"), recipe.index("elsif linux_target? && !heroku_target?"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tasks/unit_tests/libs/package/auditwheel_tests.py
+++ b/tasks/unit_tests/libs/package/auditwheel_tests.py
@@ -261,13 +261,19 @@ class TestAuditwheelLibrary(unittest.TestCase):
 
 
 class TestAuditwheelRecipe(unittest.TestCase):
-    def test_runs_normalization_only_for_standard_non_heroku_linux(self):
+    def test_runs_normalization_after_installing_canonical_dependencies_on_standard_linux(self):
         repository_root = Path(__file__).resolve().parents[4]
-        recipe = (repository_root / 'omnibus/config/software/datadog-agent-integrations-py3.rb').read_text()
+        integrations_recipe = (
+            repository_root / 'omnibus/config/software/datadog-agent-integrations-py3.rb'
+        ).read_text()
+        dependencies_recipe = (repository_root / 'omnibus/config/software/datadog-agent-dependencies.rb').read_text()
 
-        self.assertIn("elsif linux_target? && !heroku_target?", recipe)
-        self.assertIn("tasks/libs/package/auditwheel.py", recipe)
-        self.assertLess(recipe.index("if fips_mode?"), recipe.index("elsif linux_target? && !heroku_target?"))
+        self.assertNotIn("tasks/libs/package/auditwheel.py", integrations_recipe)
+        self.assertIn("if linux_target? && !fips_mode? && !heroku_target?", dependencies_recipe)
+        self.assertLess(
+            dependencies_recipe.index("//packages/agent/dependencies:install"),
+            dependencies_recipe.index("tasks/libs/package/auditwheel.py"),
+        )
 
 
 if __name__ == '__main__':

--- a/tasks/unit_tests/libs/package/auditwheel_tests.py
+++ b/tasks/unit_tests/libs/package/auditwheel_tests.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -147,7 +148,10 @@ class TestAuditwheelLibrary(unittest.TestCase):
             self.assertEqual(runner.needed_by_file[str(libpq)], ['libcrypto.so.3', 'libssl.so.3'])
             self.assertEqual(runner.needed_by_file[str(librdkafka)], ['libcurl.so.4', 'libssl.so.3'])
             for consumer in (extension, libpq, librdkafka):
-                self.assertIn(str(embedded_lib), runner.rpaths[str(consumer)].split(':'))
+                relative_embedded_lib = os.path.relpath(embedded_lib, consumer.parent)
+                expected_rpath = f'$ORIGIN/{relative_embedded_lib}'
+                self.assertIn(expected_rpath, runner.rpaths[str(consumer)].split(':'))
+                self.assertNotIn(str(embedded_lib), runner.rpaths[str(consumer)].split(':'))
             for duplicate_name in duplicate_names:
                 self.assertFalse((site_packages / 'wheel.libs' / duplicate_name).exists())
             for unique_library in (libpq, librdkafka, zstd, lmdb):


### PR DESCRIPTION
### What does this PR do?

Normalizes supported auditwheel-hashed shared libraries in the standard Linux Agent package to the canonical ABI SONAMEs already shipped in `embedded/lib`, then removes the duplicate wheel copies.

The standalone normalizer:
- discovers the approved OpenSSL, zlib, curl, Kerberos, and ODBC auditwheel names with exact hash/ABI matching;
- rewrites every ELF consumer under `site-packages`, including bundled `libpq` and `librdkafka`;
- adds a consumer-relative `$ORIGIN` RUNPATH that resolves to the canonical `embedded/lib`, preserving relocatability across versioned OCI build/install directories;
- fails closed for missing canonical libraries, unmatched hashed dependencies, or stale post-patch `DT_NEEDED` entries;
- verifies all consumers before deleting duplicates and leaves unique libpq/librdkafka/zstd/lmdb libraries intact.

Normalization runs immediately after `//packages/agent/dependencies:install`, so all canonical replacement libraries are present first.

### Motivation

Python integration wheels bundle duplicate copies of libraries already present in the Agent. Normalizing these dependencies removes 10,361,168 logical bytes (9.8812 MiB) from the audited artifact while retaining one canonical embedded implementation per ABI.

### Describe how you validated your changes

- TDD unit suite: `dda inv invoke-unit-tests.run --tests=auditwheel --directory=tasks/unit_tests/libs/package --no-buffer` — 9 tests passed, including dependency-install ordering and relocatable RUNPATH coverage.
- Python format/lint: `CI=true dda inv linter.python` — Ruff, Vulture, and Mypy passed.
- Ruby syntax and Python compilation checks passed.
- Applied the exact normalizer to a fresh copy of `/tmp/dd-agent-size-audit/root` in an amd64 Linux container:
  - removed 31 duplicate entries / 10,361,168 logical bytes;
  - patched 66 ELF consumers;
  - scanned 123 ELFs / 60 retained canonical consumers;
  - stale hashed `DT_NEEDED`: 0;
  - relative RUNPATHs that do not resolve to canonical `embedded/lib`: 0;
  - absolute build-time embedded-lib RUNPATHs: 0;
  - unresolved `ldd` dependencies without `LD_LIBRARY_PATH`: 0;
  - preserved libpq, librdkafka, libzstd, and liblmdb.
- With `LD_BIND_NOW=1` and no `LD_LIBRARY_PATH`, imports and smoke calls passed for aerospike, krb5, gssapi, pyodbc, cryptography, psycopg, and confluent_kafka.

### Additional Notes

- Guards: only non-FIPS, non-Heroku Linux runs the new normalization. Existing FIPS handling and all Heroku, Windows, and macOS behavior are unchanged.
- Network/runtime risk: consumers such as librdkafka, curl, OpenSSL, and Kerberos now resolve the Agent's embedded canonical libraries instead of wheel-private copies. No network protocol or configuration behavior changes, and eager binding/runtime smoke checks passed, but this packaging-level ABI change should receive Release Candidate validation.
- The exact smoke environment emitted an OpenSSL legacy-provider warning while all requested imports and operations succeeded.
