### PR TITLE
e2e-framework fixes, log errors, override docker registry, openshift config

### DIFF
--- a/tasks/e2e_framework/aws/deploy.py
+++ b/tasks/e2e_framework/aws/deploy.py
@@ -45,7 +45,7 @@ def deploy(
     try:
         cfg = config.get_local_config(config_path)
     except ValidationError as e:
-        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}") from e
+        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}:{e}") from e
 
     # Keep ~/.aws/config in sync: add the SSO profile if it's missing (e.g. after a role
     # rename like account-admin -> account-admin-8h). No-op if already present.

--- a/tasks/e2e_framework/azure/vm.py
+++ b/tasks/e2e_framework/azure/vm.py
@@ -73,7 +73,7 @@ def create_vm(
     try:
         cfg = config.get_local_config(config_path)
     except ValidationError as e:
-        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}") from e
+        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}:{e}") from e
 
     if not cfg.get_azure().publicKeyPath:
         raise Exit("The field `azure.publicKeyPath` is required in the config file")

--- a/tasks/e2e_framework/deploy.py
+++ b/tasks/e2e_framework/deploy.py
@@ -74,7 +74,7 @@ def deploy(
     try:
         cfg = config.get_local_config(config_path)
     except ValidationError as e:
-        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}") from e
+        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}:{e}") from e
 
     flags["scenario"] = scenario_name
     flags["ddagent:version"] = agent_version

--- a/tasks/e2e_framework/gcp/gke.py
+++ b/tasks/e2e_framework/gcp/gke.py
@@ -65,7 +65,7 @@ def create_gke(
     try:
         cfg = config.get_local_config(config_path)
     except ValidationError as e:
-        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}") from e
+        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}:{e}") from e
 
     extra_flags = {
         "ddinfra:env": f"gcp/{account if account else cfg.get_gcp().account}",

--- a/tasks/e2e_framework/gcp/openshift.py
+++ b/tasks/e2e_framework/gcp/openshift.py
@@ -54,7 +54,7 @@ def create_openshift(
     try:
         cfg = config.get_local_config(config_path)
     except ValidationError as e:
-        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}") from e
+        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}:{e}") from e
 
     # Use parameter if provided during invoke setup, otherwise use config
     if not pull_secret_path:

--- a/tasks/e2e_framework/gcp/vm.py
+++ b/tasks/e2e_framework/gcp/vm.py
@@ -80,7 +80,7 @@ def create_vm(
     try:
         cfg = config.get_local_config(config_path)
     except ValidationError as e:
-        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}") from e
+        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}:{e}") from e
 
     if not cfg.get_gcp().publicKeyPath:
         raise Exit("The field `gcp.publicKeyPath` is required in the config file")

--- a/tasks/e2e_framework/localpodman/vm.py
+++ b/tasks/e2e_framework/localpodman/vm.py
@@ -52,7 +52,7 @@ def create_vm(
     try:
         cfg = config.get_local_config(config_path)
     except ValidationError as e:
-        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}") from e
+        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}:{e}") from e
 
     if not cfg.get_local().publicKeyPath:
         raise Exit("The field `local.publicKeyPath` is required in the config file")

--- a/test/e2e-framework/components/datadog/agent/docker_image.go
+++ b/test/e2e-framework/components/datadog/agent/docker_image.go
@@ -54,6 +54,15 @@ func dockerAgentFullImagePath(e config.Env, repositoryPath, imageTag string, ote
 		return e.AgentFullImagePath()
 	}
 
+	if repositoryPath == "" {
+		// If the image pull registry is set use it instead of the default dev repository
+		if e.ImagePullRegistry() != "" {
+			repositoryPath = e.ImagePullRegistry() + "/agent"
+		} else {
+			repositoryPath = defaultDevAgentImageRepo
+		}
+	}
+
 	useOtel := otel
 	useFIPS := fips || e.AgentFIPS()
 	useJMX := jmx
@@ -94,9 +103,6 @@ func dockerAgentFullImagePath(e config.Env, repositoryPath, imageTag string, ote
 	}
 
 	if useOtel {
-		if repositoryPath == "" {
-			repositoryPath = defaultDevAgentImageRepo
-		}
 		if imageTag == "" {
 			imageTag = defaultOTAgentImageTag
 		}
@@ -106,9 +112,6 @@ func dockerAgentFullImagePath(e config.Env, repositoryPath, imageTag string, ote
 	}
 
 	if useFIPS {
-		if repositoryPath == "" {
-			repositoryPath = defaultDevAgentImageRepo
-		}
 		if imageTag == "" {
 			if useJMX {
 				imageTag = "main" + fipsSuffix + jmxSuffix
@@ -118,10 +121,6 @@ func dockerAgentFullImagePath(e config.Env, repositoryPath, imageTag string, ote
 		}
 		e.Ctx().Log.Info("The following image will be used in your test: "+fmt.Sprintf("%s:%s", repositoryPath, imageTag), nil)
 		return utils.BuildDockerImagePath(repositoryPath, imageTag)
-	}
-
-	if repositoryPath == "" {
-		repositoryPath = defaultAgentImageRepo
 	}
 
 	if imageTag == "" {
@@ -145,6 +144,15 @@ func dockerClusterAgentFullImagePath(e config.Env, repositoryPath, imageTag stri
 		return e.ClusterAgentFullImagePath()
 	}
 
+	if repositoryPath == "" {
+		// If the image pull registry is set use it instead of the default dev repository
+		if e.ImagePullRegistry() != "" {
+			repositoryPath = e.ImagePullRegistry() + "/cluster-agent"
+		} else {
+			repositoryPath = defaultClusterAgentImageRepo
+		}
+	}
+
 	useFips := fips || e.AgentFIPS()
 
 	// if agent pipeline id and commit sha are defined, use the image from the pipeline pushed on agent QA registry
@@ -163,18 +171,11 @@ func dockerClusterAgentFullImagePath(e config.Env, repositoryPath, imageTag stri
 	}
 
 	if useFips {
-		if repositoryPath == "" {
-			repositoryPath = defaultDevAgentImageRepo
-		}
 		if imageTag == "" {
 			imageTag = "main" + fipsSuffix
 		}
 		e.Ctx().Log.Info("The following image will be used for dca in your test: "+fmt.Sprintf("%s:%s", repositoryPath, imageTag), nil)
 		return utils.BuildDockerImagePath(repositoryPath, imageTag)
-	}
-
-	if repositoryPath == "" {
-		repositoryPath = defaultClusterAgentImageRepo
 	}
 
 	if imageTag == "" {

--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -884,6 +884,24 @@ func BuildOpenShiftHelmValues() HelmValues {
 				},
 			},
 		},
+		"clusterChecksRunner": pulumi.Map{
+			"enabled": pulumi.Bool(true),
+			"podSecurity": pulumi.Map{
+				"securityContextConstraints": pulumi.Map{
+					"create": pulumi.Bool(true),
+				},
+			},
+			"resources": pulumi.StringMapMap{
+				"limits": pulumi.StringMap{
+					"cpu":    pulumi.String("300m"),
+					"memory": pulumi.String("400Mi"),
+				},
+				"requests": pulumi.StringMap{
+					"cpu":    pulumi.String("150m"),
+					"memory": pulumi.String("300Mi"),
+				},
+			},
+		},
 	}
 }
 

--- a/test/e2e-framework/components/docker/component.go
+++ b/test/e2e-framework/components/docker/component.go
@@ -315,8 +315,8 @@ func (d *Manager) assertCompose() (command.Command, error) {
 	// AMI pre-bakes docker-compose. RHEL family has no -e2e AMI yet (introduced by
 	// the SBOM/RHEL10 work in #51486); migrated OSes assume docker-compose is
 	// pre-baked and hard-fail below if it is missing.
-	switch d.Host.OS.Descriptor().Flavor {
-	case os.RedHat, os.CentOS, os.RockyLinux, os.AlmaLinux, os.AmazonLinux:
+	switch d.Host.OS.Descriptor().Family() {
+	case os.LinuxFamily:
 		return InstallCompose(d.Host, opts...)
 	}
 

--- a/test/e2e-framework/components/docker/ecr.go
+++ b/test/e2e-framework/components/docker/ecr.go
@@ -34,8 +34,8 @@ const ecrCredentialHelperVersion = "0.12.0"
 // OSes assume both are pre-baked. Remove the RHEL-family install once a RHEL 10 -e2e AMI bakes
 // them.
 func SetupECRDockerAuth(n namer.Namer, host *remoteComp.Host, opts ...pulumi.ResourceOption) (command.Command, error) {
-	switch host.OS.Descriptor().Flavor {
-	case os.RedHat, os.CentOS, os.RockyLinux, os.AlmaLinux, os.AmazonLinux:
+	switch host.OS.Descriptor().Family() {
+	case os.LinuxFamily:
 		ecrCredsHelperInstall, err := ensureECRCredentialHelper(n, host, opts...)
 		if err != nil {
 			return nil, err

--- a/test/e2e-framework/scenarios/aws/ec2docker/run.go
+++ b/test/e2e-framework/scenarios/aws/ec2docker/run.go
@@ -84,6 +84,9 @@ func Run(ctx *pulumi.Context, awsEnv aws.Environment, env outputs.DockerHostOutp
 			params.agentOptions = append(params.agentOptions, dockeragentparams.WithExtraComposeManifest(dogstatsd.DockerComposeManifest.Name, dogstatsd.DockerComposeManifest.Content))
 			params.agentOptions = append(params.agentOptions, dockeragentparams.WithEnvironmentVariables(pulumi.StringMap{"HOST_IP": host.Address}))
 		}
+		if awsEnv.ImagePullRegistry() != "" {
+			params.agentOptions = append(params.agentOptions, dockeragentparams.WithRepository(awsEnv.ImagePullRegistry()))
+		}
 		agent, err := agent.NewDockerAgent(&awsEnv, host, manager, params.agentOptions...)
 		if err != nil {
 			return err


### PR DESCRIPTION

<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Initial fix:

Add missing security constraint creation flag for the cluster agent too.

leads to:

When deploying the agent, in some scenarios like gcp, ecs etc we want to force the registry being used. In other scenario allow the user to provide the config flag with a custom registry to pull the image. So any user deploying a local openshift can use some public registry to pull custom image.

leads to:

Testing the changes to validate them, deploy aws-kind + gcp-gke, found out some error logs where missing in parsing the e2e-framework config file.

Found out that the check to install `jq` and `docker-compose` where wrong by listing all linux OS instead of just checking for the OS family.

### Motivation

auto-configure SCC on openshift local deploy for QA testing. 

### Describe how you validated your changes

deployed aws-kind + gcp-gke scenarios

### Additional Notes

Have you see Malcolm in the middle when the dad changes a light bulb ?