### PR TITLE
test(e2e): avoid Operator credentials Secret conflict

### DIFF
--- a/test/e2e-framework/components/datadog/operator/helm.go
+++ b/test/e2e-framework/components/datadog/operator/helm.go
@@ -17,6 +17,10 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
+// Keep the Operator credentials separate from the DDA component credentials because both
+// components are installed in the same namespace and independently own their Secrets.
+const operatorCredentialsSecretName = "operator-datadog-credentials"
+
 // HelmInstallationArgs is the set of arguments for creating a new HelmInstallation component
 type HelmInstallationArgs struct {
 	// KubeProvider is the Kubernetes provider to use
@@ -69,7 +73,7 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 	secret, err := corev1.NewSecret(e.Ctx(), "datadog-credentials", &corev1.SecretArgs{
 		Metadata: metav1.ObjectMetaArgs{
 			Namespace: ns.Metadata.Name(),
-			Name:      pulumi.String("dda-datadog-credentials"),
+			Name:      pulumi.String(operatorCredentialsSecretName),
 		},
 		StringData: pulumi.StringMap{
 			"api-key": apiKey,
@@ -140,8 +144,8 @@ type HelmValues pulumi.Map
 
 func buildLinuxHelmValues(operatorImagePath string, operatorImageTag string) HelmValues {
 	return HelmValues{
-		"apiKeyExistingSecret": pulumi.String("dda-datadog-credentials"),
-		"appKeyExistingSecret": pulumi.String("dda-datadog-credentials"),
+		"apiKeyExistingSecret": pulumi.String(operatorCredentialsSecretName),
+		"appKeyExistingSecret": pulumi.String(operatorCredentialsSecretName),
 		"image": pulumi.Map{
 			"repository":    pulumi.String(operatorImagePath),
 			"tag":           pulumi.String(operatorImageTag),


### PR DESCRIPTION
### What does this PR do?

Gives the Datadog Operator e2e component its own `operator-datadog-credentials` Secret and configures the Operator Helm release to use it.

The DDA component continues to own `dda-datadog-credentials`, so the two Pulumi components no longer target the same Kubernetes object.

### Motivation

The Operator and DDA components coexist in the same namespace during Operator e2e tests. Both previously registered distinct Pulumi resources backed by the same `dda-datadog-credentials` Secret.

Pulumi Kubernetes v4.29 and later use client-side create for new resources and return `AlreadyExists` instead of silently upserting an object owned by another resource. After updating the Operator e2e framework dependency for [DataDog/datadog-operator#3387](https://github.com/DataDog/datadog-operator/pull/3387), every Kubernetes matrix job failed on its first DDA environment update.

Using separate names keeps lifecycle ownership explicit without enabling the global `upsertExistingObjects` compatibility behavior or coupling the two components through a shared resource.

### Describe how you validated your changes

- `dda inv test --module=test/e2e-framework --targets=./components/datadog/operator` — passed; the package currently contains no unit-test files.
- `dda inv linter.go --module=test/e2e-framework --targets=./components/datadog/operator` — passed with zero issues.
- Repository commit and pre-push hooks passed, including formatting, module tidiness, Go tests, and Go linting.

The full e2e suite was not run locally.

### Additional Notes

No Reno note is included because this only changes internal e2e infrastructure and does not affect the Agent binary.