### PR TITLE
fix(kmt): warn and tag instance-not-found before KMT test jobs fail on ssh

### DIFF
--- a/.gitlab/test/kernel_matrix_testing/common.yml
+++ b/.gitlab/test/kernel_matrix_testing/common.yml
@@ -82,11 +82,11 @@
 .collect_outcomes_kmt:
   - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
   - export MICRO_VM_IP=$(jq --exit-status --arg TAG $TAG --arg ARCH $ARCH --arg TEST_SET $TEST_SET -r '.[$ARCH].microvms | map(select(."vmset-tags"| index($TEST_SET))) | map(select(.tag==$TAG)) | .[].ip' $CI_PROJECT_DIR/stack.output)
-  # ~/.ssh/config is only written once the running-instances check in the script section passes. If it is
-  # missing, the metal instance was gone by the time this job ran (e.g. a retry of a job whose instance was
-  # already cleaned up): there is nothing to collect over ssh/scp, so skip straight to tagging.
+  # If the script section could not find the metal instance (e.g. this job is a retry of a job whose
+  # instance was already cleaned up), it leaves instance_not_found behind and never sets up ssh access.
+  # There is nothing to collect over ssh/scp in that case, so skip straight to tagging.
   - |
-    if [ -f ~/.ssh/config ]; then
+    if [ ! -f ${CI_PROJECT_DIR}/instance_not_found ]; then
       # Collect setup-ddvm systemd service logs
       mkdir -p $CI_PROJECT_DIR/logs
       ssh metal_instance "ssh ${MICRO_VM_IP} \"journalctl -u setup-ddvm.service\"" > $CI_PROJECT_DIR/logs/setup-ddvm.log || true
@@ -103,7 +103,7 @@
   # Retrieve complexity data
   - !reference [.define_if_collect_complexity]
   - |
-    if [ "${COLLECT_COMPLEXITY}" = "yes" ] && [ -f ~/.ssh/config ]; then
+    if [ "${COLLECT_COMPLEXITY}" = "yes" ] && [ ! -f ${CI_PROJECT_DIR}/instance_not_found ]; then
       ssh metal_instance "scp ${MICRO_VM_IP}:/verifier-complexity.tar.gz /home/ubuntu/verifier-complexity-${ARCH}-${TAG}-${TEST_COMPONENT}.tar.gz" || true
       scp "metal_instance:/home/ubuntu/verifier-complexity-${ARCH}-${TAG}-${TEST_COMPONENT}.tar.gz" $DD_AGENT_TESTING_DIR/ || true
     fi
@@ -295,6 +295,7 @@
       if [ $RUNNING_INSTANCES -eq "0" ]; then
         echo "WARNING: the metal instance for this job could not be found. This test job does not support being retried: it was likely retried automatically by GitLab or manually by a user after the original instance was already cleaned up."
         echo "The go tests themselves are retried a user-specified number of times automatically. To re-run the tests from scratch, trigger the pipeline again instead of retrying this job."
+        touch ${CI_PROJECT_DIR}/instance_not_found
         exit 1
       fi
     - MICRO_VM_IP=$(jq --exit-status --arg TAG $TAG --arg ARCH $ARCH --arg TEST_SET $TEST_SET -r '.[$ARCH].microvms | map(select(."vmset-tags"| index($TEST_SET))) | map(select(.tag==$TAG)) | .[].ip' $CI_PROJECT_DIR/stack.output)

--- a/.gitlab/test/kernel_matrix_testing/common.yml
+++ b/.gitlab/test/kernel_matrix_testing/common.yml
@@ -287,8 +287,10 @@
     - RUNNING_INSTANCES=$(aws ec2 describe-instances --filters $FILTER_TEAM $FILTER_MANAGED $FILTER_PIPELINE $FILTER_TEST_COMPONENT "Name=private-ip-address,Values=$INSTANCE_IP" --output text --query $QUERY_INSTANCE_IDS | wc -l )
     - |
       if [ $RUNNING_INSTANCES -eq "0" ]; then
+        echo "WARNING: the metal instance for this job could not be found, provisioning must have failed or the instance was cleaned up before the test ran."
         echo "These jobs do not permit retries. The go tests are retried a user-specified number of times automatically. In order to re-run the tests, you must trigger the pipeline again"
-        'false'
+        touch ${CI_PROJECT_DIR}/instance_not_found
+        exit 1
       fi
     - MICRO_VM_IP=$(jq --exit-status --arg TAG $TAG --arg ARCH $ARCH --arg TEST_SET $TEST_SET -r '.[$ARCH].microvms | map(select(."vmset-tags"| index($TEST_SET))) | map(select(.tag==$TAG)) | .[].ip' $CI_PROJECT_DIR/stack.output)
     - MICRO_VM_NAME=$(jq --exit-status --arg TAG $TAG --arg ARCH $ARCH --arg TEST_SET $TEST_SET -r '.[$ARCH].microvms | map(select(."vmset-tags"| index($TEST_SET))) | map(select(.tag==$TAG)) | .[].id' $CI_PROJECT_DIR/stack.output)

--- a/.gitlab/test/kernel_matrix_testing/common.yml
+++ b/.gitlab/test/kernel_matrix_testing/common.yml
@@ -82,22 +82,28 @@
 .collect_outcomes_kmt:
   - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
   - export MICRO_VM_IP=$(jq --exit-status --arg TAG $TAG --arg ARCH $ARCH --arg TEST_SET $TEST_SET -r '.[$ARCH].microvms | map(select(."vmset-tags"| index($TEST_SET))) | map(select(.tag==$TAG)) | .[].ip' $CI_PROJECT_DIR/stack.output)
-  # Collect setup-ddvm systemd service logs
-  - mkdir -p $CI_PROJECT_DIR/logs
-  - ssh metal_instance "ssh ${MICRO_VM_IP} \"journalctl -u setup-ddvm.service\"" > $CI_PROJECT_DIR/logs/setup-ddvm.log || true
-  - cat $CI_PROJECT_DIR/logs/setup-ddvm.log || true
-  - ssh metal_instance "ssh ${MICRO_VM_IP} \"systemctl is-active setup-ddvm.service\"" | tee $CI_PROJECT_DIR/logs/setup-ddvm.status || true
-  # Retrieve the junit generated
-  - ssh metal_instance "scp ${MICRO_VM_IP}:/ci-visibility/junit.tar.gz /home/ubuntu/junit-${ARCH}-${TAG}-${TEST_SET}.tar.gz" || true
-  - scp "metal_instance:/home/ubuntu/junit-${ARCH}-${TAG}-${TEST_SET}.tar.gz" $DD_AGENT_TESTING_DIR/ || true
-  - ssh metal_instance "scp ${MICRO_VM_IP}:/ci-visibility/testjson.tar.gz /home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz" || true
-  - scp "metal_instance:/home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz" $DD_AGENT_TESTING_DIR/ || true
-  - ssh metal_instance "scp -r ${MICRO_VM_IP}:/tmp/test_pcaps /home/ubuntu/test_pcaps-${ARCH}-${TAG}-${TEST_SET}" || true
-  - mkdir -p "$CI_PROJECT_DIR/pcaps" && scp -r "metal_instance:/home/ubuntu/test_pcaps-${ARCH}-${TAG}-${TEST_SET}" "$CI_PROJECT_DIR/pcaps/test_pcaps-${ARCH}-${TAG}-${TEST_SET}" || true
+  # ~/.ssh/config is only written once the running-instances check in the script section passes. If it is
+  # missing, the metal instance was gone by the time this job ran (e.g. a retry of a job whose instance was
+  # already cleaned up): there is nothing to collect over ssh/scp, so skip straight to tagging.
+  - |
+    if [ -f ~/.ssh/config ]; then
+      # Collect setup-ddvm systemd service logs
+      mkdir -p $CI_PROJECT_DIR/logs
+      ssh metal_instance "ssh ${MICRO_VM_IP} \"journalctl -u setup-ddvm.service\"" > $CI_PROJECT_DIR/logs/setup-ddvm.log || true
+      cat $CI_PROJECT_DIR/logs/setup-ddvm.log || true
+      ssh metal_instance "ssh ${MICRO_VM_IP} \"systemctl is-active setup-ddvm.service\"" | tee $CI_PROJECT_DIR/logs/setup-ddvm.status || true
+      # Retrieve the junit generated
+      ssh metal_instance "scp ${MICRO_VM_IP}:/ci-visibility/junit.tar.gz /home/ubuntu/junit-${ARCH}-${TAG}-${TEST_SET}.tar.gz" || true
+      scp "metal_instance:/home/ubuntu/junit-${ARCH}-${TAG}-${TEST_SET}.tar.gz" $DD_AGENT_TESTING_DIR/ || true
+      ssh metal_instance "scp ${MICRO_VM_IP}:/ci-visibility/testjson.tar.gz /home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz" || true
+      scp "metal_instance:/home/ubuntu/testjson-${ARCH}-${TAG}-${TEST_SET}.tar.gz" $DD_AGENT_TESTING_DIR/ || true
+      ssh metal_instance "scp -r ${MICRO_VM_IP}:/tmp/test_pcaps /home/ubuntu/test_pcaps-${ARCH}-${TAG}-${TEST_SET}" || true
+      mkdir -p "$CI_PROJECT_DIR/pcaps" && scp -r "metal_instance:/home/ubuntu/test_pcaps-${ARCH}-${TAG}-${TEST_SET}" "$CI_PROJECT_DIR/pcaps/test_pcaps-${ARCH}-${TAG}-${TEST_SET}" || true
+    fi
   # Retrieve complexity data
   - !reference [.define_if_collect_complexity]
   - |
-    if [ "${COLLECT_COMPLEXITY}" = "yes" ]; then
+    if [ "${COLLECT_COMPLEXITY}" = "yes" ] && [ -f ~/.ssh/config ]; then
       ssh metal_instance "scp ${MICRO_VM_IP}:/verifier-complexity.tar.gz /home/ubuntu/verifier-complexity-${ARCH}-${TAG}-${TEST_COMPONENT}.tar.gz" || true
       scp "metal_instance:/home/ubuntu/verifier-complexity-${ARCH}-${TAG}-${TEST_COMPONENT}.tar.gz" $DD_AGENT_TESTING_DIR/ || true
     fi
@@ -287,9 +293,8 @@
     - RUNNING_INSTANCES=$(aws ec2 describe-instances --filters $FILTER_TEAM $FILTER_MANAGED $FILTER_PIPELINE $FILTER_TEST_COMPONENT "Name=private-ip-address,Values=$INSTANCE_IP" --output text --query $QUERY_INSTANCE_IDS | wc -l )
     - |
       if [ $RUNNING_INSTANCES -eq "0" ]; then
-        echo "WARNING: the metal instance for this job could not be found, provisioning must have failed or the instance was cleaned up before the test ran."
-        echo "These jobs do not permit retries. The go tests are retried a user-specified number of times automatically. In order to re-run the tests, you must trigger the pipeline again"
-        touch ${CI_PROJECT_DIR}/instance_not_found
+        echo "WARNING: the metal instance for this job could not be found. This test job does not support being retried: it was likely retried automatically by GitLab or manually by a user after the original instance was already cleaned up."
+        echo "The go tests themselves are retried a user-specified number of times automatically. To re-run the tests from scratch, trigger the pipeline again instead of retrying this job."
         exit 1
       fi
     - MICRO_VM_IP=$(jq --exit-status --arg TAG $TAG --arg ARCH $ARCH --arg TEST_SET $TEST_SET -r '.[$ARCH].microvms | map(select(."vmset-tags"| index($TEST_SET))) | map(select(.tag==$TAG)) | .[].ip' $CI_PROJECT_DIR/stack.output)

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -2264,11 +2264,17 @@ def tag_ci_job(ctx: Context):
 
         ssh_config_path = Path.home() / ".ssh" / "config"
         setup_ddvm_status_file = ci_project_dir / "setup-ddvm.status"
+        instance_not_found_marker = ci_project_dir / "instance_not_found"
 
         if test_jobs_executed and not tests_failed:
             tags["failure_reason"] = "none"
         elif test_jobs_executed and tests_failed:  # The first condition is redundant but makes the logic clearer
             tags["failure_reason"] = "test"
+        elif instance_not_found_marker.is_file():
+            # The metal instance backing this test job was gone by the time the test job ran (e.g. provisioning
+            # failed or the instance was cleaned up early). SSH config is never set up in that case, which would
+            # otherwise be misreported as infra_ssh-config.
+            tags["failure_reason"] = "infra_instance-not-found"
         elif setup_ddvm_status_file.is_file() and "active" not in setup_ddvm_status_file.read_text():
             tags["failure_reason"] = "infra_setup-ddvm"
         elif not ssh_config_path.is_file():

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -2264,17 +2264,11 @@ def tag_ci_job(ctx: Context):
 
         ssh_config_path = Path.home() / ".ssh" / "config"
         setup_ddvm_status_file = ci_project_dir / "setup-ddvm.status"
-        instance_not_found_marker = ci_project_dir / "instance_not_found"
 
         if test_jobs_executed and not tests_failed:
             tags["failure_reason"] = "none"
         elif test_jobs_executed and tests_failed:  # The first condition is redundant but makes the logic clearer
             tags["failure_reason"] = "test"
-        elif instance_not_found_marker.is_file():
-            # The metal instance backing this test job was gone by the time the test job ran (e.g. provisioning
-            # failed or the instance was cleaned up early). SSH config is never set up in that case, which would
-            # otherwise be misreported as infra_ssh-config.
-            tags["failure_reason"] = "infra_instance-not-found"
         elif setup_ddvm_status_file.is_file() and "active" not in setup_ddvm_status_file.read_text():
             tags["failure_reason"] = "infra_setup-ddvm"
         elif not ssh_config_path.is_file():


### PR DESCRIPTION
### What does this PR do?

When the metal instance backing a KMT test job is gone before the test runs, the job now warns explicitly and gets tagged `kmt.failure_reason:infra_instance-not-found`, instead of silently failing SSH steps and being mistagged `infra_ssh-config`.

### Motivation

Security-agent KMT jobs were failing with confusing `ssh: Could not resolve hostname metal_instance` errors when the underlying instance disappeared before test execution, masking the real root cause.

### Describe how you validated your changes

`codex review` against `main`: no issues found.