### PR TITLE
Make agent-security the code owner of the SBOM collector

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -802,6 +802,8 @@
 /comp/core/workloadmeta/collectors/internal/nvml                      @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent
 /comp/core/workloadmeta/collectors/internal/podman                    @DataDog/container-platform @DataDog/container-integrations
 /comp/core/workloadmeta/collectors/internal/process                   @DataDog/container-experiences @DataDog/container-platform
+/comp/core/workloadmeta/collectors/internal/remote/sbomcollector      @DataDog/agent-security
+/comp/core/workloadmeta/collectors/sbomutil                           @DataDog/agent-security
 /comp/core/tagger/collectors                                          @DataDog/container-platform @DataDog/container-integrations
 /comp/core/tagger/types/entity_id.go                                  @DataDog/container-platform @DataDog/agent-data-plane
 /pkg/sbom/                                                            @DataDog/agent-security @DataDog/container-integrations


### PR DESCRIPTION
The collector and sbomutil sit under /comp/core/workloadmeta, so ownership
falls to container-platform. agent-security writes and reviews them.

