### PR TITLE
[AXT] fix(collectors): batch NVLink field requests

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
@@ -10,7 +10,7 @@ package nvidia
 import (
 	"errors"
 	"fmt"
-	"slices"
+	"maps"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
@@ -35,68 +35,90 @@ type nvlinkFieldValueMetric struct {
 	forceScopeIDValue                *uint32
 }
 
+func (m *nvlinkFieldValueMetric) scopeForPort(port int) uint32 {
+	if m.forceScopeIDValue != nil {
+		return *m.forceScopeIDValue
+	}
+
+	return uint32(port - 1)
+}
+
 func intToPointer(i uint32) *uint32 {
 	return &i
 }
 
-var nvlinkFieldsMetrics = []nvlinkFieldValueMetric{
+var nvlinkFieldsMetrics = map[uint32]nvlinkFieldValueMetric{
 	// -- NVLink throughput --
 	// Despite NVIDIA calling these "throughput", they report cumulative bytes transferred,
 	// so we compute the rate ourselves.
-	{name: "nvlink.throughput.data.rx", fieldValueID: nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX, addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
-	{name: "nvlink.throughput.data.tx", fieldValueID: nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_TX, addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
-	{name: "nvlink.throughput.raw.rx", fieldValueID: nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_RX, addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
-	{name: "nvlink.throughput.raw.tx", fieldValueID: nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX, addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
+	nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX: {name: "nvlink.throughput.data.rx", fieldValueID: nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX, addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
+	nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_TX: {name: "nvlink.throughput.data.tx", fieldValueID: nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_TX, addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
+	nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_RX:  {name: "nvlink.throughput.raw.rx", fieldValueID: nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_RX, addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
+	nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX:  {name: "nvlink.throughput.raw.tx", fieldValueID: nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX, addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
 
 	// Alternative throughput fields
-	{name: "nvlink.throughput.data.rx", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_BYTES, addTotalMetric: true, metricType: metrics.GaugeType, priority: Medium, rateCalculationMode: PerSecondRateCalculation},
-	{name: "nvlink.throughput.data.tx", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_BYTES, addTotalMetric: true, metricType: metrics.GaugeType, priority: Medium, rateCalculationMode: PerSecondRateCalculation},
+	nvml.FI_DEV_NVLINK_COUNT_RCV_BYTES:  {name: "nvlink.throughput.data.rx", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_BYTES, addTotalMetric: true, metricType: metrics.GaugeType, priority: Medium, rateCalculationMode: PerSecondRateCalculation},
+	nvml.FI_DEV_NVLINK_COUNT_XMIT_BYTES: {name: "nvlink.throughput.data.tx", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_BYTES, addTotalMetric: true, metricType: metrics.GaugeType, priority: Medium, rateCalculationMode: PerSecondRateCalculation},
 
 	// -- NVLink speed --
 	// MediumLow: newer field (164), uses per-link speeds. Older field return the same per-link speed for all links, lower priority (default).
-	{name: "nvlink.speed", fieldValueID: nvml.FI_DEV_NVLINK_GET_SPEED, priority: MediumLow, metricType: metrics.GaugeType},
-	{name: "nvlink.speed", fieldValueID: nvml.FI_DEV_NVLINK_SPEED_MBPS_COMMON, metricType: metrics.GaugeType, forceScopeIDValue: intToPointer(0)},
+	nvml.FI_DEV_NVLINK_GET_SPEED:         {name: "nvlink.speed", fieldValueID: nvml.FI_DEV_NVLINK_GET_SPEED, priority: MediumLow, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_SPEED_MBPS_COMMON: {name: "nvlink.speed", fieldValueID: nvml.FI_DEV_NVLINK_SPEED_MBPS_COMMON, metricType: metrics.GaugeType, forceScopeIDValue: intToPointer(0)},
 
 	// -- NVLink error counters --
-	{name: "nvlink.errors.crc.data", fieldValueID: nvml.FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.crc.flit", fieldValueID: nvml.FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.ecc", fieldValueID: nvml.FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.recovery", fieldValueID: nvml.FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.replay", fieldValueID: nvml.FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL, metricType: metrics.GaugeType},
-	{name: "nvlink.rx.packets", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_PACKETS, metricType: metrics.GaugeType},
-	{name: "nvlink.tx.packets", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_PACKETS, metricType: metrics.GaugeType},
-	{name: "nvlink.tx.discards", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.malformed.packet", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_MALFORMED_PACKET_ERRORS, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.buffer.overrun", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_BUFFER_OVERRUN_ERRORS, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.rx", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_ERRORS, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.rx.remote", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_REMOTE_ERRORS, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.rx.general", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_GENERAL_ERRORS, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.local.link.integrity", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS, metricType: metrics.GaugeType},
-	{name: "nvlink.recovery.events.successful", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS, metricType: metrics.GaugeType},
-	{name: "nvlink.recovery.events.failed", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.effective", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS, markUnsupportedOnInvalidArgument: true, metricType: metrics.GaugeType},
-	{name: "nvlink.ber.effective", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_EFFECTIVE_BER, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.symbol", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS, metricType: metrics.GaugeType},
-	{name: "nvlink.ber.symbol", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_SYMBOL_BER, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL:            {name: "nvlink.errors.crc.data", fieldValueID: nvml.FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL:            {name: "nvlink.errors.crc.flit", fieldValueID: nvml.FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL:            {name: "nvlink.errors.ecc", fieldValueID: nvml.FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL:            {name: "nvlink.errors.recovery", fieldValueID: nvml.FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL:              {name: "nvlink.errors.replay", fieldValueID: nvml.FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_RCV_PACKETS:                     {name: "nvlink.rx.packets", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_PACKETS, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_XMIT_PACKETS:                    {name: "nvlink.tx.packets", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_PACKETS, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS:                   {name: "nvlink.tx.discards", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_MALFORMED_PACKET_ERRORS:         {name: "nvlink.errors.malformed.packet", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_MALFORMED_PACKET_ERRORS, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_BUFFER_OVERRUN_ERRORS:           {name: "nvlink.errors.buffer.overrun", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_BUFFER_OVERRUN_ERRORS, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_RCV_ERRORS:                      {name: "nvlink.errors.rx", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_ERRORS, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_RCV_REMOTE_ERRORS:               {name: "nvlink.errors.rx.remote", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_REMOTE_ERRORS, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_RCV_GENERAL_ERRORS:              {name: "nvlink.errors.rx.general", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_GENERAL_ERRORS, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS:     {name: "nvlink.errors.local.link.integrity", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS: {name: "nvlink.recovery.events.successful", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS:     {name: "nvlink.recovery.events.failed", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS:                {name: "nvlink.errors.effective", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS, markUnsupportedOnInvalidArgument: true, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_EFFECTIVE_BER:                   {name: "nvlink.ber.effective", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_EFFECTIVE_BER, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS:                   {name: "nvlink.errors.symbol", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_SYMBOL_BER:                      {name: "nvlink.ber.symbol", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_SYMBOL_BER, metricType: metrics.GaugeType},
 }
 
 type nvlinkFieldsCollector struct {
-	device  ddnvml.Device
-	metrics []nvlinkFieldValueMetric
-	ports   []int
-	totals  map[uint32]float64
+	device ddnvml.Device
+	// metrics maps field value ID to the metric to generate for it. It is used
+	// only during collector initialization to discover and remove unsupported
+	// field IDs. Collect uses requests instead.
+	metrics map[uint32]nvlinkFieldValueMetric
+	// requests maps a port to the requests for that port.
+	requests []nvlinkFieldValueRequest
+}
+
+// nvlinkFieldValueRequest associates one NVML field-value query with its metric
+// definition. Port needs to be stored separately as the scope might
+type nvlinkFieldValueRequest struct {
+	field  nvml.FieldValue
+	metric nvlinkFieldValueMetric
+	// ports is the list of port numbers for the request, for tagging
+	ports []int
 }
 
 func newNVLinkFieldsCollector(device ddnvml.Device, _ *CollectorDependencies) (Collector, error) {
+	return newNVLinkFieldsCollectorWithMetrics(device, nvlinkFieldsMetrics)
+}
+
+func newNVLinkFieldsCollectorWithMetrics(device ddnvml.Device, metrics map[uint32]nvlinkFieldValueMetric) (*nvlinkFieldsCollector, error) {
 	c := &nvlinkFieldsCollector{
 		device: device,
-		totals: make(map[uint32]float64),
 	}
 
-	c.metrics = append(c.metrics, nvlinkFieldsMetrics...) // copy all metrics to avoid modifying the original slice
+	c.metrics = maps.Clone(metrics)
 
-	var err error
-	c.ports, err = getSupportedNvlinkPorts(device, c.getPortMetrics)
+	_, err := getSupportedNvlinkPorts(device, c.discoverPortMetrics)
 	if err != nil {
 		return nil, fmt.Errorf("get supported NVLink ports: %w", err)
 	}
@@ -113,21 +135,54 @@ func (c *nvlinkFieldsCollector) Name() CollectorName {
 }
 
 func (c *nvlinkFieldsCollector) Collect() ([]*Metric, error) {
-	var metrics []*Metric
-	var errs []error
+	if len(c.requests) == 0 {
+		return nil, fmt.Errorf("%w: no metrics to collect", errUnsupportedDevice)
+	}
 
 	// Prepare the totals map with the field value IDs of the metrics that require a total calculation.
 	// We need to do this with the field value IDs to avoid issues with duplicates (different fields providing the same metric)
-	c.totals = make(map[uint32]float64)
+	totals := make(map[uint32]float64)
 
-	for _, port := range c.ports {
-		portMetrics, err := c.getPortMetrics(port)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to get port %d metrics: %w", port, err))
+	fields := make([]nvml.FieldValue, len(c.requests))
+	for i, request := range c.requests {
+		fields[i] = request.field
+	}
+
+	if err := c.device.GetFieldValues(fields); err != nil {
+		return nil, err
+	}
+
+	var metrics []*Metric
+	var errs []error
+	for i, val := range fields {
+		request := c.requests[i]
+		fieldValueMetric := request.metric
+
+		if val.NvmlReturn != uint32(nvml.SUCCESS) {
+			errs = append(errs, fmt.Errorf("failed to get field value %s for ports %v: %s", fieldValueMetric.name, request.ports, nvml.ErrorString(nvml.Return(val.NvmlReturn))))
 			continue
 		}
 
-		metrics = append(metrics, portMetrics...)
+		value, convErr := fieldValueToNumber[float64](nvml.ValueType(val.ValueType), val.Value)
+		if convErr != nil {
+			errs = append(errs, fmt.Errorf("failed to convert field value %s: %w", fieldValueMetric.name, convErr))
+			continue
+		}
+
+		for _, port := range request.ports {
+			metrics = append(metrics, &Metric{
+				Name:                fieldValueMetric.name,
+				Value:               value,
+				Type:                fieldValueMetric.metricType,
+				Priority:            fieldValueMetric.priority,
+				RateCalculationMode: fieldValueMetric.rateCalculationMode,
+				Tags:                []string{nvlinkPortTag(port)},
+			})
+		}
+
+		if fieldValueMetric.addTotalMetric {
+			totals[fieldValueMetric.fieldValueID] += value
+		}
 	}
 
 	for _, metric := range c.metrics {
@@ -135,7 +190,7 @@ func (c *nvlinkFieldsCollector) Collect() ([]*Metric, error) {
 			continue
 		}
 
-		total, ok := c.totals[metric.fieldValueID]
+		total, ok := totals[metric.fieldValueID]
 		if !ok {
 			// No value got added to this metric, so we skip it for consistency. That way,
 			// we only emit the total metric if there's any value. If there was a temporary
@@ -157,40 +212,31 @@ func (c *nvlinkFieldsCollector) Collect() ([]*Metric, error) {
 	return metrics, errors.Join(errs...)
 }
 
-func (c *nvlinkFieldsCollector) getPortMetrics(port int) ([]*Metric, error) {
-	// Metrics might have been removed in the previous run, so we check if there are any metrics to collect.
+func (c *nvlinkFieldsCollector) discoverPortMetrics(port int) ([]*Metric, error) {
 	if len(c.metrics) == 0 {
 		return nil, fmt.Errorf("%w: no metrics to collect", errUnsupportedDevice)
 	}
 
-	fields := make([]nvml.FieldValue, len(c.metrics))
-	for i, metric := range c.metrics {
-		fields[i].FieldId = metric.fieldValueID
-
-		if metric.forceScopeIDValue != nil {
-			fields[i].ScopeId = *metric.forceScopeIDValue
-		} else {
-			fields[i].ScopeId = uint32(port - 1)
-		}
+	var fields []nvml.FieldValue
+	for fieldValueID, metric := range c.metrics {
+		fields = append(fields, nvml.FieldValue{
+			FieldId: fieldValueID,
+			ScopeId: metric.scopeForPort(port),
+		})
 	}
 
 	if err := c.device.GetFieldValues(fields); err != nil {
 		return nil, err
 	}
 
-	portTag := nvlinkPortTag(port)
-	var metrics []*Metric
 	var errs []error
+	addedRequests := 0
 	for _, val := range fields {
-		metricIdx := slices.IndexFunc(c.metrics, func(m nvlinkFieldValueMetric) bool {
-			return m.fieldValueID == val.FieldId
-		})
-		if metricIdx == -1 {
+		fieldValueMetric, ok := c.metrics[val.FieldId]
+		if !ok {
 			errs = append(errs, fmt.Errorf("unexpected field value ID %d", val.FieldId))
 			continue
 		}
-
-		fieldValueMetric := c.metrics[metricIdx]
 
 		// Check first if the field returned unsupported. If it's not supported, we remove
 		// this metric from the collector, even if it's after a later run. The assumption here
@@ -198,7 +244,6 @@ func (c *nvlinkFieldsCollector) getPortMetrics(port int) ([]*Metric, error) {
 		// This way, we avoid having different functions to collect metrics and to check for support.
 		// We also assume that if a field is not supported for a port, it's not supported for any other port.
 		if val.NvmlReturn == uint32(nvml.ERROR_NOT_SUPPORTED) || (val.NvmlReturn == uint32(nvml.ERROR_INVALID_ARGUMENT) && fieldValueMetric.markUnsupportedOnInvalidArgument) {
-			c.metrics = slices.Delete(c.metrics, metricIdx, metricIdx+1)
 			log.Warnf("nvlink: fields collector removing metric %s for port %d because it's not supported, error: %s", fieldValueMetric.name, port, nvml.ErrorString(nvml.Return(val.NvmlReturn)))
 			continue
 		} else if val.NvmlReturn != uint32(nvml.SUCCESS) {
@@ -206,30 +251,31 @@ func (c *nvlinkFieldsCollector) getPortMetrics(port int) ([]*Metric, error) {
 			continue
 		}
 
-		value, convErr := fieldValueToNumber[float64](nvml.ValueType(val.ValueType), val.Value)
-		if convErr != nil {
-			errs = append(errs, fmt.Errorf("failed to convert field value %s: %w", fieldValueMetric.name, convErr))
-			continue
-		}
-
-		metrics = append(metrics, &Metric{
-			Name:                fieldValueMetric.name,
-			Value:               value,
-			Type:                fieldValueMetric.metricType,
-			Priority:            fieldValueMetric.priority,
-			RateCalculationMode: fieldValueMetric.rateCalculationMode,
-			Tags:                []string{portTag},
-		})
-
-		if fieldValueMetric.addTotalMetric {
-			c.totals[fieldValueMetric.fieldValueID] += value
-		}
+		c.addRequest(fieldValueMetric, port)
+		addedRequests++
 	}
 
-	if len(c.metrics) == 0 {
+	if addedRequests == 0 {
 		// All metrics were removed, so we return an error to indicate that the device is unsupported.
 		return nil, fmt.Errorf("%w: no metrics to collect", errUnsupportedDevice)
 	}
 
-	return metrics, errors.Join(errs...)
+	return nil, errors.Join(errs...)
+}
+
+// addRequest adds a request for a metric to the collector. If the request already exists, it adds the port to the existing request.
+func (c *nvlinkFieldsCollector) addRequest(metric nvlinkFieldValueMetric, port int) {
+	fieldValue := nvml.FieldValue{FieldId: metric.fieldValueID, ScopeId: metric.scopeForPort(port)}
+	for _, request := range c.requests {
+		if request.field.FieldId == fieldValue.FieldId && request.field.ScopeId == fieldValue.ScopeId {
+			request.ports = append(request.ports, port)
+			return
+		}
+	}
+
+	c.requests = append(c.requests, nvlinkFieldValueRequest{
+		field:  fieldValue,
+		metric: metric,
+		ports:  []int{port},
+	})
 }

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
@@ -245,6 +245,7 @@ func (c *nvlinkFieldsCollector) discoverPortMetrics(port int) ([]*Metric, error)
 		// We also assume that if a field is not supported for a port, it's not supported for any other port.
 		if val.NvmlReturn == uint32(nvml.ERROR_NOT_SUPPORTED) || (val.NvmlReturn == uint32(nvml.ERROR_INVALID_ARGUMENT) && fieldValueMetric.markUnsupportedOnInvalidArgument) {
 			log.Warnf("nvlink: fields collector removing metric %s for port %d because it's not supported, error: %s", fieldValueMetric.name, port, nvml.ErrorString(nvml.Return(val.NvmlReturn)))
+			delete(c.metrics, val.FieldId)
 			continue
 		} else if val.NvmlReturn != uint32(nvml.SUCCESS) {
 			errs = append(errs, fmt.Errorf("failed to get field value %s for port %d: %s", fieldValueMetric.name, port, nvml.ErrorString(nvml.Return(val.NvmlReturn))))
@@ -266,9 +267,9 @@ func (c *nvlinkFieldsCollector) discoverPortMetrics(port int) ([]*Metric, error)
 // addRequest adds a request for a metric to the collector. If the request already exists, it adds the port to the existing request.
 func (c *nvlinkFieldsCollector) addRequest(metric nvlinkFieldValueMetric, port int) {
 	fieldValue := nvml.FieldValue{FieldId: metric.fieldValueID, ScopeId: metric.scopeForPort(port)}
-	for _, request := range c.requests {
-		if request.field.FieldId == fieldValue.FieldId && request.field.ScopeId == fieldValue.ScopeId {
-			request.ports = append(request.ports, port)
+	for i := range c.requests {
+		if c.requests[i].field.FieldId == fieldValue.FieldId && c.requests[i].field.ScopeId == fieldValue.ScopeId {
+			c.requests[i].ports = append(c.requests[i].ports, port)
 			return
 		}
 	}

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
@@ -43,19 +43,29 @@ func TestNVLinkFieldsCollectorQueriesAllConfiguredPorts(t *testing.T) {
 			fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS,
 			metricType:   metrics.GaugeType,
 		},
+		nvml.FI_DEV_NVLINK_COUNT_RCV_ERRORS: {
+			name:         "nvlink.errors.rx",
+			fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_ERRORS,
+			metricType:   metrics.GaugeType,
+		},
 	})
 	require.NoError(t, err)
 	_, err = collector.Collect()
 	require.NoError(t, err)
 
 	require.Len(t, requests, 4, "one initialization request per port plus one batched collection request")
-	var requestedScopes []uint32
+	var requestedFieldsAndScopes [][2]uint32
 	for _, request := range requests[3] {
-		if request.FieldId == nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS {
-			requestedScopes = append(requestedScopes, request.ScopeId)
-		}
+		requestedFieldsAndScopes = append(requestedFieldsAndScopes, [2]uint32{request.FieldId, request.ScopeId})
 	}
-	require.Equal(t, []uint32{0, 1, 2}, requestedScopes)
+	require.ElementsMatch(t, [][2]uint32{
+		{nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS, 0},
+		{nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS, 1},
+		{nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS, 2},
+		{nvml.FI_DEV_NVLINK_COUNT_RCV_ERRORS, 0},
+		{nvml.FI_DEV_NVLINK_COUNT_RCV_ERRORS, 1},
+		{nvml.FI_DEV_NVLINK_COUNT_RCV_ERRORS, 2},
+	}, requestedFieldsAndScopes)
 }
 
 func TestNVLinkFieldsCollectorQueriesForcedScopeForEachPort(t *testing.T) {
@@ -168,6 +178,8 @@ func TestNVLinkFieldsCollectorAddsTotals(t *testing.T) {
 	var dataRXValues []float64
 	var rawTXValues []float64
 	var discardValues []float64
+	var dataRXTotalCount int
+	var rawTXTotalCount int
 	for _, metric := range collected {
 		switch metric.Name {
 		case "nvlink.throughput.data.rx":
@@ -177,10 +189,12 @@ func TestNVLinkFieldsCollectorAddsTotals(t *testing.T) {
 		case "nvlink.tx.discards":
 			discardValues = append(discardValues, metric.Value)
 		case "nvlink.throughput.data.rx.total":
+			dataRXTotalCount++
 			require.Equal(t, 60.0, metric.Value)
 			require.Equal(t, metrics.GaugeType, metric.Type)
 			require.Equal(t, PerSecondRateCalculation, metric.RateCalculationMode)
 		case "nvlink.throughput.raw.tx.total":
+			rawTXTotalCount++
 			require.Equal(t, 6.0, metric.Value)
 			require.Equal(t, metrics.GaugeType, metric.Type)
 			require.Equal(t, PerSecondRateCalculation, metric.RateCalculationMode)
@@ -192,6 +206,8 @@ func TestNVLinkFieldsCollectorAddsTotals(t *testing.T) {
 	require.ElementsMatch(t, []float64{10, 20, 30}, dataRXValues)
 	require.ElementsMatch(t, []float64{1, 2, 3}, rawTXValues)
 	require.ElementsMatch(t, []float64{100, 200, 300}, discardValues)
+	require.Equal(t, 1, dataRXTotalCount, "expected exactly one data RX total metric")
+	require.Equal(t, 1, rawTXTotalCount, "expected exactly one raw TX total metric")
 }
 
 func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
@@ -242,19 +258,18 @@ func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
 }
 
 func TestNVLinkFieldsCollectorReturnsErrorsForUnsupportedCollectedFields(t *testing.T) {
-	var calls int
+	collecting := false
 	device := setupMockDevice(t, testutil.WithCustomHook(func(d *mock.Device) {
 		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
 			if len(fv) == 0 {
 				panic("GetFieldValues called with empty fields")
 			}
-			calls++
 			for i := range fv {
 				if fv[i].FieldId == nvml.FI_DEV_NVLINK_LINK_COUNT {
 					testutil.ApplyMockFieldValue(&fv[i], testutil.NewFieldValue(2))
 					continue
 				}
-				if calls > 3 {
+				if collecting {
 					fv[i].NvmlReturn = uint32(nvml.ERROR_NOT_SUPPORTED)
 					continue
 				}
@@ -272,11 +287,16 @@ func TestNVLinkFieldsCollectorReturnsErrorsForUnsupportedCollectedFields(t *test
 		},
 	})
 	require.NoError(t, err)
+	collecting = true
+
+	var collected []*Metric
 	var collectErr error
 	require.NotPanics(t, func() {
-		_, collectErr = collector.Collect()
+		collected, collectErr = collector.Collect()
 	})
-	require.ErrorContains(t, collectErr, "failed to get field value nvlink.tx.discards for port")
+	require.Empty(t, collected)
+	require.ErrorContains(t, collectErr, "failed to get field value nvlink.tx.discards for ports [1]")
+	require.ErrorContains(t, collectErr, "failed to get field value nvlink.tx.discards for ports [2]")
 }
 
 func TestFieldsCollector_NvlinkSpeedPriority(t *testing.T) {

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
@@ -25,6 +25,10 @@ func TestNVLinkFieldsCollectorQueriesAllConfiguredPorts(t *testing.T) {
 			require.NotEmpty(t, fv)
 			requests = append(requests, append([]nvml.FieldValue(nil), fv...))
 			for i := range fv {
+				if fv[i].FieldId == nvml.FI_DEV_NVLINK_LINK_COUNT {
+					testutil.ApplyMockFieldValue(&fv[i], testutil.NewFieldValue(3))
+					continue
+				}
 				testutil.ApplyMockFieldValue(&fv[i], testutil.DefaultFieldValues[fv[i].FieldId])
 			}
 			return nvml.SUCCESS
@@ -58,6 +62,10 @@ func TestNVLinkFieldsCollectorQueriesForcedScopeForEachPort(t *testing.T) {
 		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
 			requests = append(requests, append([]nvml.FieldValue(nil), fv...))
 			for i := range fv {
+				if fv[i].FieldId == nvml.FI_DEV_NVLINK_LINK_COUNT {
+					testutil.ApplyMockFieldValue(&fv[i], testutil.NewFieldValue(3))
+					continue
+				}
 				testutil.ApplyMockFieldValue(&fv[i], testutil.DefaultFieldValues[fv[i].FieldId])
 			}
 			return nvml.SUCCESS
@@ -179,6 +187,10 @@ func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
 		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
 			for i := range fv {
 				requestedFieldsByScope[fv[i].ScopeId] = append(requestedFieldsByScope[fv[i].ScopeId], fv[i].FieldId)
+				if fv[i].FieldId == nvml.FI_DEV_NVLINK_LINK_COUNT {
+					testutil.ApplyMockFieldValue(&fv[i], testutil.NewFieldValue(2))
+					continue
+				}
 				if fv[i].FieldId == nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS {
 					fv[i].NvmlReturn = uint32(nvml.ERROR_NOT_SUPPORTED)
 					continue
@@ -225,6 +237,10 @@ func TestNVLinkFieldsCollectorCollectDoesNotPanicWhenMetricsBecomeEmpty(t *testi
 			}
 			calls++
 			for i := range fv {
+				if fv[i].FieldId == nvml.FI_DEV_NVLINK_LINK_COUNT {
+					testutil.ApplyMockFieldValue(&fv[i], testutil.NewFieldValue(2))
+					continue
+				}
 				if calls > 2 {
 					fv[i].NvmlReturn = uint32(nvml.ERROR_NOT_SUPPORTED)
 					continue

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
@@ -19,41 +19,83 @@ import (
 )
 
 func TestNVLinkFieldsCollectorQueriesAllConfiguredPorts(t *testing.T) {
-	var requestedScopes []uint32
+	var requests [][]nvml.FieldValue
 	device := setupMockDevice(t, testutil.WithCustomHook(func(d *mock.Device) {
 		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
 			require.NotEmpty(t, fv)
+			requests = append(requests, append([]nvml.FieldValue(nil), fv...))
 			for i := range fv {
-				if fv[i].FieldId == nvml.FI_DEV_NVLINK_LINK_COUNT {
-					testutil.ApplyMockFieldValue(&fv[i], testutil.DefaultFieldValues[fv[i].FieldId])
-					continue
-				}
-				if i == 0 {
-					requestedScopes = append(requestedScopes, fv[0].ScopeId)
-				}
-				require.Equal(t, fv[0].ScopeId, fv[i].ScopeId, "all fields in a call should target the same NVLink port")
 				testutil.ApplyMockFieldValue(&fv[i], testutil.DefaultFieldValues[fv[i].FieldId])
 			}
 			return nvml.SUCCESS
 		}
-	}))
+	}), testutil.WithNVLinkLinkCount(3))
 
-	collector := &nvlinkFieldsCollector{
-		device: device,
-		ports:  []int{1, 2, 3},
-		metrics: []nvlinkFieldValueMetric{
-			{
-				name:         "nvlink.tx.discards",
-				fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS,
-				metricType:   metrics.GaugeType,
-			},
+	collector, err := newNVLinkFieldsCollectorWithMetrics(device, map[uint32]nvlinkFieldValueMetric{
+		nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
+			name:         "nvlink.tx.discards",
+			fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS,
+			metricType:   metrics.GaugeType,
 		},
-	}
-
-	_, err := collector.Collect()
+	})
+	require.NoError(t, err)
+	_, err = collector.Collect()
 	require.NoError(t, err)
 
+	require.Len(t, requests, 4, "one initialization request per port plus one batched collection request")
+	var requestedScopes []uint32
+	for _, request := range requests[3] {
+		if request.FieldId == nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS {
+			requestedScopes = append(requestedScopes, request.ScopeId)
+		}
+	}
 	require.Equal(t, []uint32{0, 1, 2}, requestedScopes)
+}
+
+func TestNVLinkFieldsCollectorQueriesForcedScopeForEachPort(t *testing.T) {
+	var requests [][]nvml.FieldValue
+	device := setupMockDevice(t, testutil.WithCustomHook(func(d *mock.Device) {
+		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
+			requests = append(requests, append([]nvml.FieldValue(nil), fv...))
+			for i := range fv {
+				testutil.ApplyMockFieldValue(&fv[i], testutil.DefaultFieldValues[fv[i].FieldId])
+			}
+			return nvml.SUCCESS
+		}
+	}), testutil.WithNVLinkLinkCount(3))
+
+	scopeID := uint32(0)
+	collector, err := newNVLinkFieldsCollectorWithMetrics(device, map[uint32]nvlinkFieldValueMetric{
+		nvml.FI_DEV_NVLINK_SPEED_MBPS_COMMON: {
+			name:              "nvlink.speed",
+			fieldValueID:      nvml.FI_DEV_NVLINK_SPEED_MBPS_COMMON,
+			forceScopeIDValue: &scopeID,
+			metricType:        metrics.GaugeType,
+		},
+	})
+	require.NoError(t, err)
+	collected, err := collector.Collect()
+	require.NoError(t, err)
+	require.Len(t, requests, 4)
+
+	var commonSpeedRequests []nvml.FieldValue
+	for _, request := range requests[3] {
+		if request.FieldId == nvml.FI_DEV_NVLINK_SPEED_MBPS_COMMON {
+			commonSpeedRequests = append(commonSpeedRequests, request)
+		}
+	}
+	require.Len(t, commonSpeedRequests, 3)
+	for _, request := range commonSpeedRequests {
+		require.Equal(t, uint32(0), request.ScopeId)
+	}
+
+	var speeds []*Metric
+	for _, metric := range collected {
+		if metric.Name == "nvlink.speed" {
+			speeds = append(speeds, metric)
+		}
+	}
+	require.Len(t, speeds, 3)
 }
 
 func TestNVLinkFieldsCollectorAddsTotals(t *testing.T) {
@@ -75,34 +117,30 @@ func TestNVLinkFieldsCollectorAddsTotals(t *testing.T) {
 		},
 	}
 
-	device := setupMockDevice(t, testutil.WithScopedFieldValues(values))
+	device := setupMockDevice(t, testutil.WithScopedFieldValues(values), testutil.WithNVLinkLinkCount(3))
 
-	collector := &nvlinkFieldsCollector{
-		device: device,
-		ports:  []int{1, 2, 3},
-		metrics: []nvlinkFieldValueMetric{
-			{
-				name:                "nvlink.throughput.data.rx",
-				fieldValueID:        nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX,
-				addTotalMetric:      true,
-				metricType:          metrics.GaugeType,
-				rateCalculationMode: PerSecondRateCalculation,
-			},
-			{
-				name:                "nvlink.throughput.raw.tx",
-				fieldValueID:        nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX,
-				addTotalMetric:      true,
-				metricType:          metrics.GaugeType,
-				rateCalculationMode: PerSecondRateCalculation,
-			},
-			{
-				name:         "nvlink.tx.discards",
-				fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS,
-				metricType:   metrics.GaugeType,
-			},
+	collector, err := newNVLinkFieldsCollectorWithMetrics(device, map[uint32]nvlinkFieldValueMetric{
+		nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX: {
+			name:                "nvlink.throughput.data.rx",
+			fieldValueID:        nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX,
+			addTotalMetric:      true,
+			metricType:          metrics.GaugeType,
+			rateCalculationMode: PerSecondRateCalculation,
 		},
-	}
-
+		nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX: {
+			name:                "nvlink.throughput.raw.tx",
+			fieldValueID:        nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX,
+			addTotalMetric:      true,
+			metricType:          metrics.GaugeType,
+			rateCalculationMode: PerSecondRateCalculation,
+		},
+		nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
+			name:         "nvlink.tx.discards",
+			fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS,
+			metricType:   metrics.GaugeType,
+		},
+	})
+	require.NoError(t, err)
 	collected, err := collector.Collect()
 	require.NoError(t, err)
 
@@ -150,27 +188,23 @@ func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
 			}
 			return nvml.SUCCESS
 		}
-	}))
+	}), testutil.WithNVLinkLinkCount(2))
 
-	collector := &nvlinkFieldsCollector{
-		device: device,
-		ports:  []int{1, 2},
-		metrics: []nvlinkFieldValueMetric{
-			{
-				name:                "nvlink.throughput.data.rx",
-				fieldValueID:        nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX,
-				addTotalMetric:      true,
-				metricType:          metrics.GaugeType,
-				rateCalculationMode: PerSecondRateCalculation,
-			},
-			{
-				name:         "nvlink.tx.discards",
-				fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS,
-				metricType:   metrics.GaugeType,
-			},
+	collector, err := newNVLinkFieldsCollectorWithMetrics(device, map[uint32]nvlinkFieldValueMetric{
+		nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX: {
+			name:                "nvlink.throughput.data.rx",
+			fieldValueID:        nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX,
+			addTotalMetric:      true,
+			metricType:          metrics.GaugeType,
+			rateCalculationMode: PerSecondRateCalculation,
 		},
-	}
-
+		nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
+			name:         "nvlink.tx.discards",
+			fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS,
+			metricType:   metrics.GaugeType,
+		},
+	})
+	require.NoError(t, err)
 	collected, err := collector.Collect()
 	require.NoError(t, err)
 
@@ -178,43 +212,43 @@ func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
 		require.NotEqual(t, "nvlink.tx.discards", metric.Name)
 	}
 
-	require.Len(t, collector.metrics, 1)
-	require.Equal(t, uint32(nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX), collector.metrics[0].fieldValueID)
 	require.Contains(t, requestedFieldsByScope[0], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
 	require.NotContains(t, requestedFieldsByScope[1], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
 }
 
 func TestNVLinkFieldsCollectorCollectDoesNotPanicWhenMetricsBecomeEmpty(t *testing.T) {
+	var calls int
 	device := setupMockDevice(t, testutil.WithCustomHook(func(d *mock.Device) {
 		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
 			if len(fv) == 0 {
 				panic("GetFieldValues called with empty fields")
 			}
+			calls++
 			for i := range fv {
-				fv[i].NvmlReturn = uint32(nvml.ERROR_NOT_SUPPORTED)
+				if calls > 2 {
+					fv[i].NvmlReturn = uint32(nvml.ERROR_NOT_SUPPORTED)
+					continue
+				}
+				testutil.ApplyMockFieldValue(&fv[i], testutil.DefaultFieldValues[fv[i].FieldId])
 			}
 			return nvml.SUCCESS
 		}
-	}))
+	}), testutil.WithNVLinkLinkCount(2))
 
-	collector := &nvlinkFieldsCollector{
-		device: device,
-		ports:  []int{1, 2},
-		metrics: []nvlinkFieldValueMetric{
-			{
-				name:         "nvlink.tx.discards",
-				fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS,
-				metricType:   metrics.GaugeType,
-			},
+	collector, err := newNVLinkFieldsCollectorWithMetrics(device, map[uint32]nvlinkFieldValueMetric{
+		nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
+			name:         "nvlink.tx.discards",
+			fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS,
+			metricType:   metrics.GaugeType,
 		},
-	}
-
-	var err error
-	require.NotPanics(t, func() {
-		_, err = collector.Collect()
 	})
-	require.ErrorIs(t, err, errUnsupportedDevice)
-	require.ErrorContains(t, err, "no metrics to collect")
+	require.NoError(t, err)
+	var collectErr error
+	require.NotPanics(t, func() {
+		_, collectErr = collector.Collect()
+	})
+	require.ErrorIs(t, collectErr, errUnsupportedDevice)
+	require.ErrorContains(t, collectErr, "no metrics to collect")
 }
 
 func TestFieldsCollector_NvlinkSpeedPriority(t *testing.T) {

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
@@ -23,13 +23,15 @@ func TestNVLinkFieldsCollectorQueriesAllConfiguredPorts(t *testing.T) {
 	device := setupMockDevice(t, testutil.WithCustomHook(func(d *mock.Device) {
 		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
 			require.NotEmpty(t, fv)
-			requests = append(requests, append([]nvml.FieldValue(nil), fv...))
 			for i := range fv {
 				if fv[i].FieldId == nvml.FI_DEV_NVLINK_LINK_COUNT {
 					testutil.ApplyMockFieldValue(&fv[i], testutil.NewFieldValue(3))
 					continue
 				}
 				testutil.ApplyMockFieldValue(&fv[i], testutil.DefaultFieldValues[fv[i].FieldId])
+			}
+			if fv[0].FieldId != nvml.FI_DEV_NVLINK_LINK_COUNT {
+				requests = append(requests, append([]nvml.FieldValue(nil), fv...))
 			}
 			return nvml.SUCCESS
 		}
@@ -60,13 +62,15 @@ func TestNVLinkFieldsCollectorQueriesForcedScopeForEachPort(t *testing.T) {
 	var requests [][]nvml.FieldValue
 	device := setupMockDevice(t, testutil.WithCustomHook(func(d *mock.Device) {
 		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
-			requests = append(requests, append([]nvml.FieldValue(nil), fv...))
 			for i := range fv {
 				if fv[i].FieldId == nvml.FI_DEV_NVLINK_LINK_COUNT {
 					testutil.ApplyMockFieldValue(&fv[i], testutil.NewFieldValue(3))
 					continue
 				}
 				testutil.ApplyMockFieldValue(&fv[i], testutil.DefaultFieldValues[fv[i].FieldId])
+			}
+			if fv[0].FieldId != nvml.FI_DEV_NVLINK_LINK_COUNT {
+				requests = append(requests, append([]nvml.FieldValue(nil), fv...))
 			}
 			return nvml.SUCCESS
 		}
@@ -225,10 +229,10 @@ func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
 	}
 
 	require.Contains(t, requestedFieldsByScope[0], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
-	require.NotContains(t, requestedFieldsByScope[1], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
+	require.Contains(t, requestedFieldsByScope[1], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
 }
 
-func TestNVLinkFieldsCollectorCollectDoesNotPanicWhenMetricsBecomeEmpty(t *testing.T) {
+func TestNVLinkFieldsCollectorReturnsErrorsForUnsupportedCollectedFields(t *testing.T) {
 	var calls int
 	device := setupMockDevice(t, testutil.WithCustomHook(func(d *mock.Device) {
 		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
@@ -241,7 +245,7 @@ func TestNVLinkFieldsCollectorCollectDoesNotPanicWhenMetricsBecomeEmpty(t *testi
 					testutil.ApplyMockFieldValue(&fv[i], testutil.NewFieldValue(2))
 					continue
 				}
-				if calls > 2 {
+				if calls > 3 {
 					fv[i].NvmlReturn = uint32(nvml.ERROR_NOT_SUPPORTED)
 					continue
 				}
@@ -263,8 +267,7 @@ func TestNVLinkFieldsCollectorCollectDoesNotPanicWhenMetricsBecomeEmpty(t *testi
 	require.NotPanics(t, func() {
 		_, collectErr = collector.Collect()
 	})
-	require.ErrorIs(t, collectErr, errUnsupportedDevice)
-	require.ErrorContains(t, collectErr, "no metrics to collect")
+	require.ErrorContains(t, collectErr, "failed to get field value nvlink.tx.discards for port")
 }
 
 func TestFieldsCollector_NvlinkSpeedPriority(t *testing.T) {
@@ -335,13 +338,9 @@ func TestNVlinkFieldsCollectorTreatsInvalidArgumentAsUnsupportedOnlyWhenConfigur
 	fc, ok := collector.(*nvlinkFieldsCollector)
 	require.True(t, ok, "expected *nvlinkFieldsCollector")
 
-	foundNvlinkEffective := false
-	for _, metric := range fc.metrics {
-		switch metric.name {
-		case "nvlink.errors.effective":
-			foundNvlinkEffective = true
+	for _, request := range fc.requests {
+		if request.field.FieldId == nvml.FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS {
+			t.Fatal("nvlink.errors.effective should not be collected when INVALID_ARGUMENT is mapped to unsupported")
 		}
 	}
-
-	require.False(t, foundNvlinkEffective, "nvlink.errors.effective should be removed when INVALID_ARGUMENT is explicitly mapped to unsupported")
 }

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
@@ -96,7 +96,7 @@ func TestNVLinkFieldsCollectorQueriesForcedScopeForEachPort(t *testing.T) {
 			commonSpeedRequests = append(commonSpeedRequests, request)
 		}
 	}
-	require.Len(t, commonSpeedRequests, 3)
+	require.Len(t, commonSpeedRequests, 1)
 	for _, request := range commonSpeedRequests {
 		require.Equal(t, uint32(0), request.ScopeId)
 	}
@@ -108,6 +108,15 @@ func TestNVLinkFieldsCollectorQueriesForcedScopeForEachPort(t *testing.T) {
 		}
 	}
 	require.Len(t, speeds, 3)
+	require.ElementsMatch(t, []string{
+		nvlinkPortTag(1),
+		nvlinkPortTag(2),
+		nvlinkPortTag(3),
+	}, []string{
+		speeds[0].Tags[0],
+		speeds[1].Tags[0],
+		speeds[2].Tags[0],
+	})
 }
 
 func TestNVLinkFieldsCollectorAddsTotals(t *testing.T) {
@@ -229,7 +238,7 @@ func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
 	}
 
 	require.Contains(t, requestedFieldsByScope[0], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
-	require.Contains(t, requestedFieldsByScope[1], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
+	require.NotContains(t, requestedFieldsByScope[1], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
 }
 
 func TestNVLinkFieldsCollectorReturnsErrorsForUnsupportedCollectedFields(t *testing.T) {
@@ -338,9 +347,12 @@ func TestNVlinkFieldsCollectorTreatsInvalidArgumentAsUnsupportedOnlyWhenConfigur
 	fc, ok := collector.(*nvlinkFieldsCollector)
 	require.True(t, ok, "expected *nvlinkFieldsCollector")
 
-	for _, request := range fc.requests {
-		if request.field.FieldId == nvml.FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS {
-			t.Fatal("nvlink.errors.effective should not be collected when INVALID_ARGUMENT is mapped to unsupported")
+	foundNvlinkEffective := false
+	for _, metric := range fc.metrics {
+		if metric.name == "nvlink.errors.effective" {
+			foundNvlinkEffective = true
 		}
 	}
+
+	require.False(t, foundNvlinkEffective, "nvlink.errors.effective should be removed when INVALID_ARGUMENT is explicitly mapped to unsupported")
 }


### PR DESCRIPTION
### What does this PR do?
Batches NVLink field-value queries into one NVML call per GPU collection.

### Motivation
Reduce serialized NVML calls on GPUs with many NVLink ports.
#incident-59233

### Describe how you validated your changes

Tests run in NVLink enabled instance.

### Additional Notes