### PR TITLE
Bump memory for go_e2e_test_binaries

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -202,8 +202,8 @@ go_e2e_test_binaries:
     - go_e2e_deps
   variables:
     KUBERNETES_CPU_REQUEST: 4
-    KUBERNETES_MEMORY_REQUEST: 64Gi
-    KUBERNETES_MEMORY_LIMIT: 64Gi
+    KUBERNETES_MEMORY_REQUEST: 72Gi
+    KUBERNETES_MEMORY_LIMIT: 72Gi
   before_script:
     - !reference [.retrieve_linux_go_e2e_deps]
   script:


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Bump memory for go_e2e_test_binaries. With recent changes introduced in https://github.com/DataDog/datadog-agent/pull/53982 the memory are bigger and need more memory if we want to keep building them 4 at a time

### Motivation

### Describe how you validated your changes

### Additional Notes
