### PR TITLE
Add dd-agent identity marker to agent image

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -198,6 +198,7 @@ COPY --from=extract /output/ /
 # - Remove the /var/run -> /run symlink and create a legit /var/run folder
 # as some docker versions re-create /run from zero at container start
 RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agent \
+  && install -o dd-agent -g root -m 0440 /dev/null /opt/datadog-agent/.dd-agent-identity \
   && addgroup --system secret-manager \
   && usermod -a -G secret-manager dd-agent \
   && rm /var/run && mkdir -p /var/run/s6 && mkdir -p /var/run/datadog && mkdir -p /opt/datadog-agent/run \

--- a/Dockerfiles/agent/test_image_contents.py
+++ b/Dockerfiles/agent/test_image_contents.py
@@ -48,6 +48,15 @@ class TestFiles(unittest.TestCase):
                     sha.update(chunk)
             self.assertEqual(sha.hexdigest(), digest, file + " checksum mismatch")
 
+    def test_dd_agent_identity_marker(self):
+        marker = "/opt/datadog-agent/.dd-agent-identity"
+        marker_stat = os.stat(marker)
+        dd_agent = pwd.getpwnam("dd-agent")
+
+        self.assertEqual(marker_stat.st_uid, dd_agent.pw_uid)
+        self.assertEqual(marker_stat.st_gid, dd_agent.pw_gid)
+        self.assertEqual(stat.S_IMODE(marker_stat.st_mode), 0o440)
+
     def test_files_permissions(self):
         for root, dirs, files in os.walk("/"):
             dirs[:] = filter(

--- a/pkg/util/filesystem/permission_nix.go
+++ b/pkg/util/filesystem/permission_nix.go
@@ -145,8 +145,10 @@ const agentIdentityMarker = "/opt/datadog-agent/.dd-agent-identity"
 // GetAgentUserGroupIDs returns the UID and primary GID of the agent service
 // account ("dd-agent" on Linux, "_dd-agent" on macOS). The GID is the
 // user's primary group (e.g. "root" in the standard container, where no
-// same-named group exists), not a separately-named group. ok is false if the
-// user does not exist on the system.
+// same-named group exists), not a separately-named group. If looking up the
+// service user fails, the identity marker is consulted as a fallback. ok is
+// false if neither the service user nor a valid identity marker can provide
+// the UID and GID.
 func GetAgentUserGroupIDs() (uid, gid int, ok bool) {
 	u, err := user.Lookup(agentUsername())
 	if err != nil {

--- a/pkg/util/filesystem/permission_nix.go
+++ b/pkg/util/filesystem/permission_nix.go
@@ -140,6 +140,8 @@ func getDatadogUserUID() (uint32, error) {
 	return uint32(os.Getuid()), nil
 }
 
+const agentIdentityMarker = "/opt/datadog-agent/.dd-agent-identity"
+
 // GetAgentUserGroupIDs returns the UID and primary GID of the agent service
 // account ("dd-agent" on Linux, "_dd-agent" on macOS). The GID is the
 // user's primary group (e.g. "root" in the standard container, where no
@@ -148,7 +150,7 @@ func getDatadogUserUID() (uint32, error) {
 func GetAgentUserGroupIDs() (uid, gid int, ok bool) {
 	u, err := user.Lookup(agentUsername())
 	if err != nil {
-		return 0, 0, false
+		return getAgentUserGroupIDsFromMarker()
 	}
 	uid, err = strconv.Atoi(u.Uid)
 	if err != nil {
@@ -159,6 +161,18 @@ func GetAgentUserGroupIDs() (uid, gid int, ok bool) {
 		return 0, 0, false
 	}
 	return uid, gid, true
+}
+
+func getAgentUserGroupIDsFromMarker() (uid, gid int, ok bool) {
+	info, err := os.Lstat(agentIdentityMarker)
+	if err != nil || !info.Mode().IsRegular() {
+		return 0, 0, false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, false
+	}
+	return int(stat.Uid), int(stat.Gid), true
 }
 
 // isRootOrAgentUID reports whether uid is root (0) or the dd-agent service account.


### PR DESCRIPTION
### What does this PR do?

- Adds `/opt/datadog-agent/.dd-agent-identity` file created by the user `dd-agent` so `stat` operations 
- Makes `GetAgentUserGroupIDs` fallback on the marker if `dd-agent` doesn't exist

### Motivation

In current agent deployments, the image `/etc/passwd` is overwritten by the node's for process checks.
the `dd-agent` disappears and cannot be found by `user.Lookup` calls.

The marker is a temporary solution while operator/process discovery can mount `/etc/passwd` somewhere without masking image users


### Describe how you validated your changes

### Additional Notes
