### PR TITLE
comp/core/workloadmeta: fix SBOM merge mutating the input BOM

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"go.uber.org/fx"
@@ -248,7 +249,8 @@ func mergeRuntimeProperties(existingBom, newBom *cyclonedx_v1_4.Bom) *cyclonedx_
 		}
 		seen[key] = struct{}{}
 
-		// Copy all fields so we do not mutate the original BOM.
+		// Copy all fields so we do not mutate the original BOM. The property
+		// slice is cloned because updateProperty replaces entries in place.
 		mergedComp := &cyclonedx_v1_4.Component{
 			Type:               existingComp.Type,
 			MimeType:           existingComp.MimeType,
@@ -271,7 +273,7 @@ func mergeRuntimeProperties(existingBom, newBom *cyclonedx_v1_4.Bom) *cyclonedx_
 			Pedigree:           existingComp.Pedigree,
 			ExternalReferences: existingComp.ExternalReferences,
 			Components:         existingComp.Components,
-			Properties:         existingComp.Properties,
+			Properties:         slices.Clone(existingComp.Properties),
 			Evidence:           existingComp.Evidence,
 			ReleaseNotes:       existingComp.ReleaseNotes,
 		}

--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector_test.go
@@ -567,6 +567,44 @@ func TestMergeRuntimeProperties_DoesNotMutateInput(t *testing.T) {
 	assert.False(t, hasLastSeen, "original component must not be enriched in place")
 }
 
+// A component that already carries the runtime properties, as it does on every
+// merge round after the first, takes the in-place update path of updateProperty.
+func TestMergeRuntimeProperties_DoesNotMutateEnrichedInput(t *testing.T) {
+	original := component("openssl", "1.1.1k",
+		prop("trivy.layer", "sha256:abc"),
+		prop(LastAccessProperty, "1700000000"),
+		prop(HasSetSuidBitProperty, "true"),
+	)
+	existing := &cyclonedx_v1_4.Bom{
+		Components: []*cyclonedx_v1_4.Component{original},
+	}
+	newBom := &cyclonedx_v1_4.Bom{
+		Components: []*cyclonedx_v1_4.Component{
+			component("openssl", "1.1.1k",
+				prop(LastAccessProperty, "1800000000"),
+				prop(HasSetSuidBitProperty, "false"),
+			),
+		},
+	}
+
+	mergedBom := mergeRuntimeProperties(existing, newBom)
+
+	got, ok := findProp(original, LastAccessProperty)
+	require.True(t, ok)
+	assert.Equal(t, "1700000000", got, "merge overwrote LastSeenRunning on the input BOM")
+	got, ok = findProp(original, HasSetSuidBitProperty)
+	require.True(t, ok)
+	assert.Equal(t, "true", got, "merge overwrote HasSetSuidBit on the input BOM")
+
+	// The merged copy carries the new values.
+	got, ok = findProp(mergedBom.Components[0], LastAccessProperty)
+	require.True(t, ok)
+	assert.Equal(t, "1800000000", got)
+	got, ok = findProp(mergedBom.Components[0], HasSetSuidBitProperty)
+	require.True(t, ok)
+	assert.Equal(t, "false", got)
+}
+
 // ---------------------------------------------------------------------------
 // workloadmetaEventFromSBOMEventSet
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
mergeRuntimeProperties copies each component of the existing BOM before
enriching it, but the copy shared the Properties slice backing array. When
the component already carried a runtime property, which is the case on
every merge round after the first, updateProperty replaced the entry in
place and the write landed in the caller's BOM.

The only caller passes a BOM freshly decompressed from the image entity, so
the payloads the Agent sends today are correct. Cloning the slice keeps
that true for the next caller.
