### PR TITLE
[CONTP-2036] Include libjemalloc in Agent builds

### DIFF
--- a/deps/.renovate-untracked.json
+++ b/deps/.renovate-untracked.json
@@ -4,6 +4,7 @@
     "xz": "Pending tracking in Phase 2a (github-releases batch).",
     "zlib": "Pending tracking in Phase 2a (github-releases batch).",
     "openssl": "Pending tracking in Phase 2a (github-releases batch). Blocked by openssl drift cleanup (AIX 3.5.5, MSI 3.5).",
+    "jemalloc": "Pending tracking in Phase 2a (github-releases batch).",
     "libffi": "Pending tracking in Phase 2a (github-releases batch).",
     "pcre2": "Pending tracking in Phase 2a (github-releases batch).",
     "util-linux": "Pending tracking in Phase 2a (github-releases batch).",

--- a/deps/jemalloc.BUILD.bazel
+++ b/deps/jemalloc.BUILD.bazel
@@ -1,0 +1,51 @@
+"""BUILD file for jemalloc."""
+
+load("@@//bazel/rules:foreign_cc_shared_wrapper.bzl", "foreign_cc_shared_wrapper")
+load("@@//bazel/rules/dd_packaging:dd_cc_packaged.bzl", "dd_cc_packaged")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_package_metadata = [":license"],
+    default_visibility = ["//visibility:public"],
+)
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:BSD-2-Clause"],
+    license_text = "COPYING",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+)
+
+configure_make(
+    name = "jemalloc",
+    autoconf = True,
+    configure_in_place = True,
+    configure_options = [
+        "--disable-debug",
+        "--disable-stats",
+        "--disable-fill",
+        "--disable-prof",
+        "--disable-static",
+    ],
+    lib_source = ":all_srcs",
+    out_shared_libs = ["libjemalloc.so"],
+)
+
+foreign_cc_shared_wrapper(
+    name = "jemalloc_shared",
+    input = ":jemalloc",
+    lib_filter = "libjemalloc",
+)
+
+dd_cc_packaged(
+    name = "jemalloc_pkg",
+    input = ":jemalloc_shared",
+    libname = "libjemalloc",
+    version = "2",
+)

--- a/deps/jemalloc.BUILD.bazel
+++ b/deps/jemalloc.BUILD.bazel
@@ -19,7 +19,37 @@ license(
 
 filegroup(
     name = "all_srcs",
-    srcs = glob(["**"]),
+    srcs = glob([
+        "*",
+        "bin/*",
+        "build-aux/*",
+        "doc/*",
+        "doc_internal/*",
+        "include/jemalloc/*",
+        "include/jemalloc/internal/*",
+        "include/msvc_compat/*",
+        "include/msvc_compat/C99/*",
+        "m4/*",
+        "msvc/*",
+        "msvc/projects/vc2015/jemalloc/*",
+        "msvc/projects/vc2015/test_threads/*",
+        "msvc/projects/vc2017/jemalloc/*",
+        "msvc/projects/vc2017/test_threads/*",
+        "msvc/test_threads/*",
+        "scripts/*",
+        "scripts/freebsd/*",
+        "scripts/linux/*",
+        "scripts/windows/*",
+        "src/*",
+        "test/*",
+        "test/analyze/*",
+        "test/include/test/*",
+        "test/integration/*",
+        "test/integration/cpp/*",
+        "test/src/*",
+        "test/stress/*",
+        "test/unit/*",
+    ]),
 )
 
 configure_make(

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -386,6 +386,16 @@ http_archive(
 )
 
 http_archive(
+    name = "jemalloc",
+    build_file = "//deps:jemalloc.BUILD.bazel",
+    sha256 = "ef6f74fd45e95ee4ef7f9e19ebe5b075ca6b7fbe0140612b2a161abafb7ee179",
+    strip_prefix = "jemalloc-5.3.0",
+    urls = [
+        "https://github.com/jemalloc/jemalloc/archive/refs/tags/5.3.0.tar.gz",
+    ],
+)
+
+http_archive(
     name = "openssl",
     build_file = "//deps:openssl.BUILD.bazel",
     patch_strip = 1,

--- a/packages/agent/dependencies/BUILD.bazel
+++ b/packages/agent/dependencies/BUILD.bazel
@@ -74,6 +74,7 @@ dd_collect_dependencies(
             "//deps/msodbcsql18:installed_libs",
             "@curl//:curl_pkg",
             "@freetds//:tdsodbc_pkg",
+            "@jemalloc//:jemalloc_pkg",
             "@krb5//:installed_libs",
             "@openscap//:openscap_pkg",
             "@openscap//:openscap_sce_pkg",
@@ -82,6 +83,7 @@ dd_collect_dependencies(
             "//deps/msodbcsql18:installed_libs",
             "@curl//:curl_pkg",
             "@freetds//:tdsodbc_pkg",
+            "@jemalloc//:jemalloc_pkg",
             "@krb5//:installed_libs",
             "@openscap//:openscap_pkg",
             "@openscap//:openscap_sce_pkg",
@@ -89,6 +91,7 @@ dd_collect_dependencies(
         "//packages/agent:linux_heroku": [
             "@curl//:curl_pkg",
             "@freetds//:tdsodbc_pkg",
+            "@jemalloc//:jemalloc_pkg",
         ],
         "//conditions:default": [],
     }),

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,51 +1,51 @@
 static_quality_gate_agent_deb_amd64:
-  max_on_disk_size: 764.84 MiB
-  max_on_wire_size: 182.99 MiB
+  max_on_disk_size: 765.3 MiB
+  max_on_wire_size: 183.14 MiB
 static_quality_gate_agent_deb_amd64_fips:
-  max_on_disk_size: 716.08 MiB
-  max_on_wire_size: 177.2 MiB
+  max_on_disk_size: 716.54 MiB
+  max_on_wire_size: 177.39 MiB
 static_quality_gate_agent_heroku_amd64:
-  max_on_disk_size: 319.08 MiB
-  max_on_wire_size: 81.51 MiB
+  max_on_disk_size: 319.54 MiB
+  max_on_wire_size: 81.66 MiB
 static_quality_gate_agent_msi:
   max_on_disk_size: 661.05 MiB
   max_on_wire_size: 159.14 MiB
 static_quality_gate_agent_rpm_amd64:
-  max_on_disk_size: 764.81 MiB
-  max_on_wire_size: 186.6 MiB
+  max_on_disk_size: 765.27 MiB
+  max_on_wire_size: 186.67 MiB
 static_quality_gate_agent_rpm_amd64_fips:
-  max_on_disk_size: 716.08 MiB
-  max_on_wire_size: 177.98 MiB
+  max_on_disk_size: 716.54 MiB
+  max_on_wire_size: 178.06 MiB
 static_quality_gate_agent_rpm_arm64:
-  max_on_disk_size: 738.31 MiB
-  max_on_wire_size: 167.21 MiB
+  max_on_disk_size: 738.95 MiB
+  max_on_wire_size: 167.22 MiB
 static_quality_gate_agent_rpm_arm64_fips:
-  max_on_disk_size: 694.35 MiB
-  max_on_wire_size: 159.59 MiB
+  max_on_disk_size: 694.79 MiB
+  max_on_wire_size: 159.72 MiB
 static_quality_gate_agent_suse_amd64:
-  max_on_disk_size: 764.81 MiB
-  max_on_wire_size: 186.62 MiB
+  max_on_disk_size: 765.27 MiB
+  max_on_wire_size: 186.66 MiB
 static_quality_gate_agent_suse_amd64_fips:
-  max_on_disk_size: 716.08 MiB
-  max_on_wire_size: 177.99 MiB
+  max_on_disk_size: 716.54 MiB
+  max_on_wire_size: 178.08 MiB
 static_quality_gate_agent_suse_arm64:
-  max_on_disk_size: 738.31 MiB
-  max_on_wire_size: 167.19 MiB
+  max_on_disk_size: 738.95 MiB
+  max_on_wire_size: 167.14 MiB
 static_quality_gate_agent_suse_arm64_fips:
-  max_on_disk_size: 694.35 MiB
-  max_on_wire_size: 159.49 MiB
+  max_on_disk_size: 694.79 MiB
+  max_on_wire_size: 159.58 MiB
 static_quality_gate_docker_agent_amd64:
-  max_on_disk_size: 821.0 MiB
-  max_on_wire_size: 278.14 MiB
+  max_on_disk_size: 822.1 MiB
+  max_on_wire_size: 278.34 MiB
 static_quality_gate_docker_agent_arm64:
-  max_on_disk_size: 821.98 MiB
-  max_on_wire_size: 266.07 MiB
+  max_on_disk_size: 823.02 MiB
+  max_on_wire_size: 266.27 MiB
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_disk_size: 1011.91 MiB
-  max_on_wire_size: 346.79 MiB
+  max_on_disk_size: 1013.02 MiB
+  max_on_wire_size: 347.0 MiB
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_disk_size: 1001.68 MiB
-  max_on_wire_size: 330.75 MiB
+  max_on_disk_size: 1002.71 MiB
+  max_on_wire_size: 330.94 MiB
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_disk_size: 212.13 MiB
   max_on_wire_size: 74.52 MiB


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Adds jemalloc 5.3.0 as a Bazel-managed dependency and includes `libjemalloc.so.2` in Linux Agent packages for the base, FIPS, and Heroku flavors. This only includes jemalloc in the package but does not preload it automatically.

### Motivation

After reviewing internal production test results, the team agreed to restore jemalloc, which was previously shipped in Agent packages.

### Describe how you validated your changes

- Built the jemalloc library and its packaging target with Bazel.
- Verified the packaged ELF has the `libjemalloc.so.2` SONAME and the Agent embedded-library RPATH.
- Verified base, FIPS, and Heroku dependency graphs include jemalloc.
- Built the Agent dependency license bundle and confirmed it includes jemalloc's BSD-2-Clause license.
- Ran Buildifier and `git diff --check`.

### Additional Notes

This bumps the size of all packages. Decision record: https://datadoghq.atlassian.net/wiki/spaces/ABLD/pages/7133430399/Jemalloc+built+into+Agent+-+Quality+Gates+Decision+Records