### PR TITLE
[AAD-79] Resolve metrics host

### DIFF
--- a/comp/anomalydetection/observer/def/types.go
+++ b/comp/anomalydetection/observer/def/types.go
@@ -143,8 +143,7 @@ func (sd SeriesDescriptor) DisplayName() string {
 }
 
 // Key returns a stable string suitable for use as a map key.
-// Format: "namespace|name:agg|host|tag1,tag2,...". Hostless descriptors
-// retain the legacy three-part format for compatibility with existing output.
+// Format: "namespace|name:agg|host|tag1,tag2,...".
 func (sd SeriesDescriptor) Key() string {
 	aggStr := AggregateString(sd.Aggregate)
 	var tagStr string
@@ -153,9 +152,6 @@ func (sd SeriesDescriptor) Key() string {
 		copy(sorted, sd.Tags)
 		sort.Strings(sorted)
 		tagStr = strings.Join(sorted, ",")
-	}
-	if sd.Host == "" {
-		return sd.Namespace + "|" + sd.Name + ":" + aggStr + "|" + tagStr
 	}
 	return sd.Namespace + "|" + sd.Name + ":" + aggStr + "|" + sd.Host + "|" + tagStr
 }

--- a/comp/anomalydetection/observer/def/types.go
+++ b/comp/anomalydetection/observer/def/types.go
@@ -39,6 +39,8 @@ type MetricView interface {
 	GetName() string
 	GetValue() float64
 	GetRawTags() []string
+	// GetHost returns the host dimension carried separately from metric tags.
+	GetHost() string
 	// GetTimestampUnix returns the sample timestamp in Unix seconds.
 	GetTimestampUnix() int64
 	GetSampleRate() float64
@@ -84,6 +86,7 @@ type LogObserver interface {
 type MetricOutput struct {
 	Name    string
 	Value   float64
+	Host    string
 	Tags    []string
 	Context *MetricContext // optional; stored on the series for anomaly enrichment
 }
@@ -106,6 +109,8 @@ type SeriesDescriptor struct {
 	Namespace string
 	// Name is the base metric name (e.g. "log.pattern.<hash>.count", "cpu.user").
 	Name string
+	// Host is the host dimension carried separately from Tags.
+	Host string
 	// Tags are the series-level tags (e.g. ["host:web-1", "env:prod"]).
 	Tags []string
 	// Aggregate is the aggregation applied when reading the series.
@@ -127,14 +132,19 @@ func (sd SeriesDescriptor) String() string {
 // DisplayName returns a display string with tags (e.g. "cpu.user:avg{host:web-1}").
 func (sd SeriesDescriptor) DisplayName() string {
 	base := sd.String()
-	if len(sd.Tags) == 0 {
+	tags := sd.Tags
+	if sd.Host != "" && !containsTag(tags, "host:"+sd.Host) {
+		tags = append([]string{"host:" + sd.Host}, tags...)
+	}
+	if len(tags) == 0 {
 		return base
 	}
-	return base + "{" + strings.Join(sd.Tags, ",") + "}"
+	return base + "{" + strings.Join(tags, ",") + "}"
 }
 
 // Key returns a stable string suitable for use as a map key.
-// Format: "namespace|name:agg|tag1,tag2,..."
+// Format: "namespace|name:agg|host|tag1,tag2,...". Hostless descriptors
+// retain the legacy three-part format for compatibility with existing output.
 func (sd SeriesDescriptor) Key() string {
 	aggStr := AggregateString(sd.Aggregate)
 	var tagStr string
@@ -144,7 +154,19 @@ func (sd SeriesDescriptor) Key() string {
 		sort.Strings(sorted)
 		tagStr = strings.Join(sorted, ",")
 	}
-	return sd.Namespace + "|" + sd.Name + ":" + aggStr + "|" + tagStr
+	if sd.Host == "" {
+		return sd.Namespace + "|" + sd.Name + ":" + aggStr + "|" + tagStr
+	}
+	return sd.Namespace + "|" + sd.Name + ":" + aggStr + "|" + sd.Host + "|" + tagStr
+}
+
+func containsTag(tags []string, tag string) bool {
+	for _, candidate := range tags {
+		if candidate == tag {
+			return true
+		}
+	}
+	return false
 }
 
 // SeriesRef is a compact numeric handle for a stored time series.
@@ -250,6 +272,7 @@ type ReportOutput struct {
 type Series struct {
 	Namespace string
 	Name      string
+	Host      string
 	Tags      []string
 	Points    []Point
 }
@@ -451,6 +474,7 @@ const AgentNamespace = "agent"
 // SeriesFilter specifies criteria for selecting series.
 type SeriesFilter struct {
 	Namespace   string            // exact match (empty = any)
+	Host        string            // exact match (empty = any)
 	NamePattern string            // prefix match (empty = any)
 	TagMatchers map[string]string // required tag key=value pairs
 	// ExcludeNamespaces skips series whose namespace is in this list. It is only
@@ -471,6 +495,7 @@ type SeriesMeta struct {
 	Ref       SeriesRef
 	Namespace string
 	Name      string
+	Host      string
 	Tags      []string
 }
 

--- a/comp/anomalydetection/observer/impl/baseline_test.go
+++ b/comp/anomalydetection/observer/impl/baseline_test.go
@@ -416,7 +416,7 @@ func (d *storageAwareDetector) Detect(sr observerdef.StorageReader, dataTime int
 	anomalies := make([]observerdef.Anomaly, 0, len(metas))
 	for _, meta := range metas {
 		anomalies = append(anomalies, observerdef.Anomaly{
-			Source:       observerdef.SeriesDescriptor{Namespace: meta.Namespace, Name: meta.Name, Tags: meta.Tags, Aggregate: AggregateAverage},
+			Source:       observerdef.SeriesDescriptor{Namespace: meta.Namespace, Name: meta.Name, Host: meta.Host, Tags: meta.Tags, Aggregate: AggregateAverage},
 			DetectorName: "storage_aware",
 			Timestamp:    dataTime,
 			Title:        "anomaly",
@@ -448,18 +448,18 @@ func TestBaseline_VirtualMetricDroppedAfterFreeze(t *testing.T) {
 	})
 
 	// First IngestLog creates the series; Advance marks it as noisy.
-	e.IngestLog("src", &logObs{timestampMs: 100_000})
+	e.IngestLog("src", &logObs{hostname: "web-1", timestampMs: 100_000})
 	e.Advance(100)
 
 	// During the window: subsequent ingests must still reach storage.
 	countBefore := storage.TotalSeriesCount()
-	e.IngestLog("src", &logObs{timestampMs: 200_000})
+	e.IngestLog("src", &logObs{hostname: "web-1", timestampMs: 200_000})
 	assert.Equal(t, countBefore, storage.TotalSeriesCount())
 
 	e.Advance(700) // freeze: series removed from storage
 	assert.Equal(t, 0, storage.TotalSeriesCount())
 
 	// After freeze: virtual metric is dropped at ingest and not re-created.
-	e.IngestLog("src", &logObs{timestampMs: 800_000})
+	e.IngestLog("src", &logObs{hostname: "web-1", timestampMs: 800_000})
 	assert.Equal(t, 0, storage.TotalSeriesCount())
 }

--- a/comp/anomalydetection/observer/impl/engine.go
+++ b/comp/anomalydetection/observer/impl/engine.go
@@ -911,7 +911,7 @@ func (e *engine) completeBaseline(detectorName string, upToSec int64) {
 	if e.baseline.config.Verbose {
 		for _, ref := range refs {
 			if meta := e.storage.GetSeriesMeta(ref); meta != nil {
-				displayNames = append(displayNames, seriesKey(meta.Namespace, meta.Name, meta.Tags))
+				displayNames = append(displayNames, seriesKey(meta.Namespace, meta.Name, meta.Host, meta.Tags))
 			}
 		}
 		sort.Strings(displayNames)

--- a/comp/anomalydetection/observer/impl/engine.go
+++ b/comp/anomalydetection/observer/impl/engine.go
@@ -334,16 +334,16 @@ func (e *engine) IngestLog(source string, l *logObs) []advanceRequest {
 			// Always canonicalize so the hash computed here matches storage's
 			// seriesKeyHash, and storage.Add hits the tagsSorted fast path.
 			tags = canonicalizeTags(tags)
-			if e.baseline != nil && e.baseline.config.MuteNoisyMetrics && len(e.baseline.mutedHashes) > 0 {
-				if _, ok := e.baseline.mutedHashes[seriesKeyHash(extractor.Name(), m.Name, "", tags)]; ok {
-					continue
-				}
-			}
-			timestamp := l.timestampMs / 1000
 			host := m.Host
 			if host == "" {
 				host = l.hostname
 			}
+			if e.baseline != nil && e.baseline.config.MuteNoisyMetrics && len(e.baseline.mutedHashes) > 0 {
+				if _, ok := e.baseline.mutedHashes[seriesKeyHash(extractor.Name(), m.Name, host, tags)]; ok {
+					continue
+				}
+			}
+			timestamp := l.timestampMs / 1000
 			if e.logCounts != nil && e.logCounts.handlesMetric(m.Name) {
 				if !e.logCounts.observe(extractor.Name(), m, host, timestamp, tags) {
 					e.latePoints.Add(1)

--- a/comp/anomalydetection/observer/impl/engine.go
+++ b/comp/anomalydetection/observer/impl/engine.go
@@ -297,7 +297,7 @@ func (e *engine) sourceTagForIngest(source string) string {
 // to determine whether detectors should advance. Returns advance requests
 // that the caller should execute via Advance.
 func (e *engine) IngestMetric(source string, m *metricObs) []advanceRequest {
-	e.storage.Add(source, m.name, m.value, m.timestamp, m.tags)
+	e.storage.AddWithHost(source, m.name, m.host, m.value, m.timestamp, m.tags)
 	// Track points that arrive after their timestamp was already analyzed.
 	// These points are in storage but were invisible to detectors at analysis time.
 	if m.timestamp <= e.lastAnalyzedDataTime {
@@ -335,13 +335,17 @@ func (e *engine) IngestLog(source string, l *logObs) []advanceRequest {
 			// seriesKeyHash, and storage.Add hits the tagsSorted fast path.
 			tags = canonicalizeTags(tags)
 			if e.baseline != nil && e.baseline.config.MuteNoisyMetrics && len(e.baseline.mutedHashes) > 0 {
-				if _, ok := e.baseline.mutedHashes[seriesKeyHash(extractor.Name(), m.Name, tags)]; ok {
+				if _, ok := e.baseline.mutedHashes[seriesKeyHash(extractor.Name(), m.Name, "", tags)]; ok {
 					continue
 				}
 			}
 			timestamp := l.timestampMs / 1000
+			host := m.Host
+			if host == "" {
+				host = l.hostname
+			}
 			if e.logCounts != nil && e.logCounts.handlesMetric(m.Name) {
-				if !e.logCounts.observe(extractor.Name(), m, timestamp, tags) {
+				if !e.logCounts.observe(extractor.Name(), m, host, timestamp, tags) {
 					e.latePoints.Add(1)
 					if e.latePointsBySource == nil {
 						e.latePointsBySource = make(map[string]int64)
@@ -350,7 +354,7 @@ func (e *engine) IngestLog(source string, l *logObs) []advanceRequest {
 				}
 				continue
 			}
-			res := e.storage.Add(extractor.Name(), m.Name, m.Value, timestamp, tags)
+			res := e.storage.AddWithHost(extractor.Name(), m.Name, host, m.Value, timestamp, tags)
 			if m.Context != nil && res.Ref >= 0 {
 				e.storage.SetContext(res.Ref, m.Context)
 			}
@@ -644,12 +648,12 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 			// anomaly.Source.Tags are sorted (copied from storage's intern pool by seriesDetectorAdapter).
 			if e.baseline != nil && e.baseline.isAnalyzingAt(detector.Name(), upTo) {
 				if anomaly.SourceRef != nil {
-					e.baseline.mark(detector.Name(), seriesKeyHash(anomaly.Source.Namespace, anomaly.Source.Name, anomaly.Source.Tags))
+					e.baseline.mark(detector.Name(), seriesKeyHash(anomaly.Source.Namespace, anomaly.Source.Name, anomaly.Source.Host, anomaly.Source.Tags))
 				}
 				continue
 			}
 			if e.baseline != nil && e.baseline.config.MuteNoisyMetrics && len(e.baseline.mutedHashes) > 0 {
-				h := seriesKeyHash(anomaly.Source.Namespace, anomaly.Source.Name, anomaly.Source.Tags)
+				h := seriesKeyHash(anomaly.Source.Namespace, anomaly.Source.Name, anomaly.Source.Host, anomaly.Source.Tags)
 				if _, muted := e.baseline.mutedHashes[h]; muted {
 					continue
 				}

--- a/comp/anomalydetection/observer/impl/filter_rules.go
+++ b/comp/anomalydetection/observer/impl/filter_rules.go
@@ -11,10 +11,11 @@
 //           - type: exclude_at_match
 //             name: drop_dev_dogstatsd
 //             source: dogstatsd
+//             host: noisy-host
 //             tags: ["env:dev"]
 //
 //   code:
-//     if rules.isAllowed(sample.GetName(), source, sample.GetRawTags()) { ... }
+//     if rules.isAllowedWithHost(sample.GetName(), source, sample.GetHost(), sample.GetRawTags()) { ... }
 
 package observerimpl
 
@@ -44,6 +45,7 @@ type metricsProcessingRule struct {
 	NamePattern string   `mapstructure:"name_pattern"`
 	Tags        []string `mapstructure:"tags"`
 	Source      string   `mapstructure:"source"`
+	Host        string   `mapstructure:"host"`
 }
 
 // metricsFilterRules evaluates the ordered rule list against incoming metrics.
@@ -61,6 +63,7 @@ type metricsCompiledRule struct {
 	namePrefix string
 	tags       []string
 	source     string
+	host       string
 }
 
 // newMetricsFilterRules parses, validates, and compiles rules.
@@ -98,6 +101,7 @@ func newMetricsFilterRules(rules []metricsProcessingRule) (*metricsFilterRules, 
 			namePrefix: namePrefix,
 			tags:       tags,
 			source:     strings.TrimSpace(rule.Source),
+			host:       strings.TrimSpace(rule.Host),
 		})
 	}
 
@@ -184,13 +188,13 @@ type metricFilterPrecheck struct {
 // tags for the mute check and storage. If the first name/source candidate has
 // tag conditions, firstCandidate lets the tag-aware pass resume there without
 // rescanning rules that cannot match.
-func (f *metricsFilterRules) precheck(name, source string) metricFilterPrecheck {
+func (f *metricsFilterRules) precheck(name, source, host string) metricFilterPrecheck {
 	if f == nil || source == LogMetricsExtractorName {
 		return metricFilterPrecheck{}
 	}
 
 	for i, rule := range f.rules {
-		if !rule.matchesNameAndSource(name, source) {
+		if !rule.matchesNameSourceAndHost(name, source, host) {
 			continue
 		}
 		if len(rule.tags) > 0 {
@@ -205,6 +209,10 @@ func (f *metricsFilterRules) precheck(name, source string) metricFilterPrecheck 
 // isAllowed returns true if the metric should be ingested.
 // tags must be sorted so the mute hash matches seriesKeyHash in storage.
 func (f *metricsFilterRules) isAllowed(name, source string, tags []string) bool {
+	return f.isAllowedWithHost(name, source, "", tags)
+}
+
+func (f *metricsFilterRules) isAllowedWithHost(name, source, host string, tags []string) bool {
 	if f == nil {
 		return true
 	}
@@ -213,20 +221,24 @@ func (f *metricsFilterRules) isAllowed(name, source string, tags []string) bool 
 		return true
 	}
 
-	if f.isMuted(name, source, tags) {
+	if f.isMutedWithHost(name, source, host, tags) {
 		return false
 	}
 
-	return f.isAllowedByRulesFrom(name, source, tags, 0)
+	return f.isAllowedByRulesFromWithHost(name, source, host, tags, 0)
 }
 
 func (f *metricsFilterRules) isMuted(name, source string, tags []string) bool {
+	return f.isMutedWithHost(name, source, "", tags)
+}
+
+func (f *metricsFilterRules) isMutedWithHost(name, source, host string, tags []string) bool {
 	if f == nil || source == LogMetricsExtractorName {
 		return false
 	}
 
 	if m := f.muted.Load(); m != nil {
-		if _, ok := (*m)[seriesKeyHash(source, name, "", tags)]; ok {
+		if _, ok := (*m)[seriesKeyHash(source, name, host, tags)]; ok {
 			return true
 		}
 	}
@@ -234,8 +246,12 @@ func (f *metricsFilterRules) isMuted(name, source string, tags []string) bool {
 }
 
 func (f *metricsFilterRules) isAllowedByRulesFrom(name, source string, tags []string, start int) bool {
+	return f.isAllowedByRulesFromWithHost(name, source, "", tags, start)
+}
+
+func (f *metricsFilterRules) isAllowedByRulesFromWithHost(name, source, host string, tags []string, start int) bool {
 	for _, rule := range f.rules[start:] {
-		if rule.matches(name, source, tags) {
+		if rule.matchesWithHost(name, source, host, tags) {
 			return !rule.exclude
 		}
 	}
@@ -253,11 +269,22 @@ func (f *metricsFilterRules) publishMutedSnapshot(m map[uint64]struct{}) {
 // matches reports whether the rule applies to the given metric.
 // tags must be sorted in ascending order (guaranteed by canonicalizeTags in prepareMetricIngest).
 func (r metricsCompiledRule) matches(name, source string, tags []string) bool {
-	return r.matchesNameAndSource(name, source) && containsAllTagsSorted(tags, r.tags)
+	return r.matchesWithHost(name, source, "", tags)
+}
+
+func (r metricsCompiledRule) matchesWithHost(name, source, host string, tags []string) bool {
+	return r.matchesNameSourceAndHost(name, source, host) && containsAllTagsSorted(tags, r.tags)
 }
 
 func (r metricsCompiledRule) matchesNameAndSource(name, source string) bool {
+	return r.matchesNameSourceAndHost(name, source, "")
+}
+
+func (r metricsCompiledRule) matchesNameSourceAndHost(name, source, host string) bool {
 	if r.source != "" && source != r.source {
+		return false
+	}
+	if r.host != "" && host != r.host {
 		return false
 	}
 

--- a/comp/anomalydetection/observer/impl/filter_rules.go
+++ b/comp/anomalydetection/observer/impl/filter_rules.go
@@ -228,10 +228,6 @@ func (f *metricsFilterRules) isAllowedWithHost(name, source, host string, tags [
 	return f.isAllowedByRulesFromWithHost(name, source, host, tags, 0)
 }
 
-func (f *metricsFilterRules) isMuted(name, source string, tags []string) bool {
-	return f.isMutedWithHost(name, source, "", tags)
-}
-
 func (f *metricsFilterRules) isMutedWithHost(name, source, host string, tags []string) bool {
 	if f == nil || source == LogMetricsExtractorName {
 		return false
@@ -243,10 +239,6 @@ func (f *metricsFilterRules) isMutedWithHost(name, source, host string, tags []s
 		}
 	}
 	return false
-}
-
-func (f *metricsFilterRules) isAllowedByRulesFrom(name, source string, tags []string, start int) bool {
-	return f.isAllowedByRulesFromWithHost(name, source, "", tags, start)
 }
 
 func (f *metricsFilterRules) isAllowedByRulesFromWithHost(name, source, host string, tags []string, start int) bool {
@@ -266,18 +258,8 @@ func (f *metricsFilterRules) publishMutedSnapshot(m map[uint64]struct{}) {
 	f.muted.Store(&m)
 }
 
-// matches reports whether the rule applies to the given metric.
-// tags must be sorted in ascending order (guaranteed by canonicalizeTags in prepareMetricIngest).
-func (r metricsCompiledRule) matches(name, source string, tags []string) bool {
-	return r.matchesWithHost(name, source, "", tags)
-}
-
 func (r metricsCompiledRule) matchesWithHost(name, source, host string, tags []string) bool {
 	return r.matchesNameSourceAndHost(name, source, host) && containsAllTagsSorted(tags, r.tags)
-}
-
-func (r metricsCompiledRule) matchesNameAndSource(name, source string) bool {
-	return r.matchesNameSourceAndHost(name, source, "")
 }
 
 func (r metricsCompiledRule) matchesNameSourceAndHost(name, source, host string) bool {

--- a/comp/anomalydetection/observer/impl/filter_rules.go
+++ b/comp/anomalydetection/observer/impl/filter_rules.go
@@ -226,7 +226,7 @@ func (f *metricsFilterRules) isMuted(name, source string, tags []string) bool {
 	}
 
 	if m := f.muted.Load(); m != nil {
-		if _, ok := (*m)[seriesKeyHash(source, name, tags)]; ok {
+		if _, ok := (*m)[seriesKeyHash(source, name, "", tags)]; ok {
 			return true
 		}
 	}

--- a/comp/anomalydetection/observer/impl/filter_rules_test.go
+++ b/comp/anomalydetection/observer/impl/filter_rules_test.go
@@ -78,6 +78,7 @@ type rawTagsTrackingMetric struct {
 
 func (m *rawTagsTrackingMetric) GetName() string         { return m.name }
 func (m *rawTagsTrackingMetric) GetValue() float64       { return m.value }
+func (m *rawTagsTrackingMetric) GetHost() string         { return "" }
 func (m *rawTagsTrackingMetric) GetTimestampUnix() int64 { return m.timestamp }
 func (m *rawTagsTrackingMetric) GetSampleRate() float64  { return 1.0 }
 func (m *rawTagsTrackingMetric) GetRawTags() []string {
@@ -90,7 +91,7 @@ func TestMetricsFilterRulesMuteSetBlocksMatchingMetric(t *testing.T) {
 	require.NoError(t, err)
 
 	tags := []string{"env:prod"}
-	h := seriesKeyHash("check", "system.cpu.user", tags)
+	h := seriesKeyHash("check", "system.cpu.user", "", tags)
 	filter.publishMutedSnapshot(map[uint64]struct{}{h: {}})
 
 	assert.False(t, filter.isAllowed("system.cpu.user", "check", tags))
@@ -351,7 +352,7 @@ func TestPrepareMetricIngestTaglessIncludeStillHonorsMuteSet(t *testing.T) {
 
 	tags := []string{"env:prod", "service:web"}
 	filter.publishMutedSnapshot(map[uint64]struct{}{
-		seriesKeyHash("dogstatsd", "system.cpu.user", tags): {},
+		seriesKeyHash("dogstatsd", "system.cpu.user", "", tags): {},
 	})
 	sample := &rawTagsTrackingMetric{
 		name: "system.cpu.user",

--- a/comp/anomalydetection/observer/impl/filter_rules_test.go
+++ b/comp/anomalydetection/observer/impl/filter_rules_test.go
@@ -159,6 +159,19 @@ func TestMetricsFilterRulesSourceFilter(t *testing.T) {
 	assert.True(t, filter.isAllowed("system.cpu.user", "check", []string{"env:dev"}))
 }
 
+func TestMetricsFilterRulesHostFilter(t *testing.T) {
+	filter, err := newMetricsFilterRules([]metricsProcessingRule{{
+		Type: excludeAtMatch,
+		Name: "drop_noisy_host",
+		Host: "noisy-host",
+	}})
+	require.NoError(t, err)
+
+	assert.False(t, filter.isAllowedWithHost("system.cpu.user", "dogstatsd", "noisy-host", []string{"env:prod"}))
+	assert.True(t, filter.isAllowedWithHost("system.cpu.user", "dogstatsd", "other-host", []string{"env:prod"}))
+	assert.True(t, filter.isAllowed("system.cpu.user", "dogstatsd", []string{"host:noisy-host"}))
+}
+
 func TestMetricsFilterRulesOrderedEvaluationFirstMatchWins(t *testing.T) {
 	filter, err := newMetricsFilterRules([]metricsProcessingRule{
 		{

--- a/comp/anomalydetection/observer/impl/group_compression.go
+++ b/comp/anomalydetection/observer/impl/group_compression.go
@@ -42,12 +42,17 @@ type seriesCompact struct {
 }
 
 func (s seriesCompact) effectiveTags() []string {
-	if s.Host == "" || sliceContains(s.Tags, "host:"+s.Host) {
+	if s.Host == "" || (len(s.Tags) > 0 && s.Tags[0] == "host:"+s.Host) {
 		return s.Tags
 	}
 	tags := make([]string, 0, len(s.Tags)+1)
 	tags = append(tags, "host:"+s.Host)
-	return append(tags, s.Tags...)
+	for _, tag := range s.Tags {
+		if tag != "host:"+s.Host {
+			tags = append(tags, tag)
+		}
+	}
+	return tags
 }
 
 // extractCommonTags finds tags shared by all members, returning common tags as a map

--- a/comp/anomalydetection/observer/impl/group_compression.go
+++ b/comp/anomalydetection/observer/impl/group_compression.go
@@ -42,17 +42,12 @@ type seriesCompact struct {
 }
 
 func (s seriesCompact) effectiveTags() []string {
-	if s.Host == "" || (len(s.Tags) > 0 && s.Tags[0] == "host:"+s.Host) {
+	if s.Host == "" || sliceContains(s.Tags, "host:"+s.Host) {
 		return s.Tags
 	}
 	tags := make([]string, 0, len(s.Tags)+1)
 	tags = append(tags, "host:"+s.Host)
-	for _, tag := range s.Tags {
-		if tag != "host:"+s.Host {
-			tags = append(tags, tag)
-		}
-	}
-	return tags
+	return append(tags, s.Tags...)
 }
 
 // extractCommonTags finds tags shared by all members, returning common tags as a map

--- a/comp/anomalydetection/observer/impl/group_compression.go
+++ b/comp/anomalydetection/observer/impl/group_compression.go
@@ -37,7 +37,17 @@ type MetricPattern struct {
 type seriesCompact struct {
 	Namespace string
 	Name      string
+	Host      string
 	Tags      []string
+}
+
+func (s seriesCompact) effectiveTags() []string {
+	if s.Host == "" || sliceContains(s.Tags, "host:"+s.Host) {
+		return s.Tags
+	}
+	tags := make([]string, 0, len(s.Tags)+1)
+	tags = append(tags, "host:"+s.Host)
+	return append(tags, s.Tags...)
 }
 
 // extractCommonTags finds tags shared by all members, returning common tags as a map
@@ -50,7 +60,7 @@ func extractCommonTags(members []seriesCompact) (common map[string]string, resid
 
 	// Parse tags from first member as candidates
 	candidates := make(map[string]string)
-	for _, tag := range members[0].Tags {
+	for _, tag := range members[0].effectiveTags() {
 		k, v := splitTag(tag)
 		candidates[k] = v
 	}
@@ -58,7 +68,7 @@ func extractCommonTags(members []seriesCompact) (common map[string]string, resid
 	// Intersect with remaining members
 	for _, m := range members[1:] {
 		memberTags := make(map[string]string)
-		for _, tag := range m.Tags {
+		for _, tag := range m.effectiveTags() {
 			k, v := splitTag(tag)
 			memberTags[k] = v
 		}
@@ -74,7 +84,7 @@ func extractCommonTags(members []seriesCompact) (common map[string]string, resid
 	// Compute residuals
 	residuals = make([][]string, len(members))
 	for i, m := range members {
-		for _, tag := range m.Tags {
+		for _, tag := range m.effectiveTags() {
 			k, _ := splitTag(tag)
 			if _, isCommon := common[k]; !isCommon {
 				residuals[i] = append(residuals[i], tag)
@@ -267,7 +277,7 @@ func CompressGroup(correlatorName, groupID, title string, members []seriesCompac
 	for _, m := range members {
 		stripped := stripAggSuffix(m.Name)
 		memberNameSet[stripped] = struct{}{}
-		memberSources = append(memberSources, seriesKey(m.Namespace, m.Name, m.Tags))
+		memberSources = append(memberSources, seriesKey(m.Namespace, m.Name, m.Host, m.Tags))
 	}
 	memberNames := make([]string, 0, len(memberNameSet))
 	for name := range memberNameSet {

--- a/comp/anomalydetection/observer/impl/group_compression.go
+++ b/comp/anomalydetection/observer/impl/group_compression.go
@@ -41,15 +41,6 @@ type seriesCompact struct {
 	Tags      []string
 }
 
-func (s seriesCompact) effectiveTags() []string {
-	if s.Host == "" || sliceContains(s.Tags, "host:"+s.Host) {
-		return s.Tags
-	}
-	tags := make([]string, 0, len(s.Tags)+1)
-	tags = append(tags, "host:"+s.Host)
-	return append(tags, s.Tags...)
-}
-
 // extractCommonTags finds tags shared by all members, returning common tags as a map
 // and the residual per-member tags.
 func extractCommonTags(members []seriesCompact) (common map[string]string, residuals [][]string) {
@@ -60,7 +51,7 @@ func extractCommonTags(members []seriesCompact) (common map[string]string, resid
 
 	// Parse tags from first member as candidates
 	candidates := make(map[string]string)
-	for _, tag := range members[0].effectiveTags() {
+	for _, tag := range members[0].Tags {
 		k, v := splitTag(tag)
 		candidates[k] = v
 	}
@@ -68,7 +59,7 @@ func extractCommonTags(members []seriesCompact) (common map[string]string, resid
 	// Intersect with remaining members
 	for _, m := range members[1:] {
 		memberTags := make(map[string]string)
-		for _, tag := range m.effectiveTags() {
+		for _, tag := range m.Tags {
 			k, v := splitTag(tag)
 			memberTags[k] = v
 		}
@@ -84,7 +75,7 @@ func extractCommonTags(members []seriesCompact) (common map[string]string, resid
 	// Compute residuals
 	residuals = make([][]string, len(members))
 	for i, m := range members {
-		for _, tag := range m.effectiveTags() {
+		for _, tag := range m.Tags {
 			k, _ := splitTag(tag)
 			if _, isCommon := common[k]; !isCommon {
 				residuals[i] = append(residuals[i], tag)

--- a/comp/anomalydetection/observer/impl/group_compression_test.go
+++ b/comp/anomalydetection/observer/impl/group_compression_test.go
@@ -25,6 +25,17 @@ func TestExtractCommonTags_Overlapping(t *testing.T) {
 	assert.Equal(t, []string{"host:web3"}, residuals[2])
 }
 
+func TestExtractCommonTags_KeepsHostSeparate(t *testing.T) {
+	common, residuals := extractCommonTags([]seriesCompact{
+		{Host: "web-1", Tags: []string{"env:prod"}},
+		{Host: "web-2", Tags: []string{"env:prod"}},
+	})
+
+	assert.Equal(t, map[string]string{"env": "prod"}, common)
+	assert.Empty(t, residuals[0])
+	assert.Empty(t, residuals[1])
+}
+
 func TestExtractCommonTags_Disjoint(t *testing.T) {
 	members := []seriesCompact{
 		{Tags: []string{"host:web1", "env:prod"}},

--- a/comp/anomalydetection/observer/impl/log_count_bucketizer.go
+++ b/comp/anomalydetection/observer/impl/log_count_bucketizer.go
@@ -45,6 +45,7 @@ type logCountBucketInterval struct {
 type logCountBucketSeries struct {
 	namespace string
 	name      string
+	host      string
 	tags      []string
 	context   *observerdef.MetricContext
 	anchor    int64
@@ -92,10 +93,11 @@ func (b *materializedLogCountBucketizer) handlesMetric(name string) bool {
 func (b *materializedLogCountBucketizer) observe(
 	namespace string,
 	metric observerdef.MetricOutput,
+	host string,
 	timestamp int64,
 	tags []string,
 ) bool {
-	key := seriesKeyHash(namespace, metric.Name, tags)
+	key := seriesKeyHash(namespace, metric.Name, host, tags)
 	state := b.series[key]
 	if state == nil && timestamp <= b.flushedThrough {
 		return false
@@ -113,6 +115,7 @@ func (b *materializedLogCountBucketizer) observe(
 		state = &logCountBucketSeries{
 			namespace:    namespace,
 			name:         metric.Name,
+			host:         host,
 			tags:         append([]string(nil), tags...),
 			context:      metric.Context,
 			anchor:       timestamp,
@@ -153,9 +156,10 @@ func (b *materializedLogCountBucketizer) flush(storage *timeSeriesStorage, upTo 
 		for _, interval := range state.intervals {
 			nextEnd := interval.firstEnd
 			for nextEnd <= interval.lastEnd && nextEnd <= upTo {
-				result := storage.Add(
+				result := storage.AddWithHost(
 					state.namespace,
 					state.name,
+					state.host,
 					state.values[nextEnd],
 					nextEnd,
 					state.tags,

--- a/comp/anomalydetection/observer/impl/log_count_bucketizer_test.go
+++ b/comp/anomalydetection/observer/impl/log_count_bucketizer_test.go
@@ -36,8 +36,8 @@ func TestMaterializedLogCountBucketizerCountsAndZeros(t *testing.T) {
 	}
 	tags := canonicalizeTags([]string{"service:api"})
 
-	require.True(t, b.observe("logs", metric, 1, tags))
-	require.True(t, b.observe("logs", metric, 3, tags))
+	require.True(t, b.observe("logs", metric, "", 1, tags))
+	require.True(t, b.observe("logs", metric, "", 3, tags))
 	b.flush(storage, 15)
 
 	series := storage.GetSeries("logs", "log.pattern.count", tags, observerdef.AggregateAverage)
@@ -58,9 +58,9 @@ func TestMaterializedLogCountBucketizerStopsAtIdleTTLAndReactivates(t *testing.T
 	b := newMaterializedLogCountBucketizer(LogCountBucketConfig{BucketSeconds: 5, IdleTTLSeconds: 10})
 	metric := observerdef.MetricOutput{Name: "log.pattern.count", Value: 1}
 
-	require.True(t, b.observe("logs", metric, 1, nil))
+	require.True(t, b.observe("logs", metric, "", 1, nil))
 	b.flush(storage, 20)
-	require.True(t, b.observe("logs", metric, 21, nil))
+	require.True(t, b.observe("logs", metric, "", 21, nil))
 	b.flush(storage, 35)
 
 	series := storage.GetSeries("logs", "log.pattern.count", nil, observerdef.AggregateAverage)
@@ -78,9 +78,9 @@ func TestMaterializedLogCountBucketizerRejectsFlushedLateBucket(t *testing.T) {
 	b := newMaterializedLogCountBucketizer(LogCountBucketConfig{BucketSeconds: 5, IdleTTLSeconds: 0})
 	metric := observerdef.MetricOutput{Name: "log.pattern.count", Value: 1}
 
-	require.True(t, b.observe("logs", metric, 1, nil))
+	require.True(t, b.observe("logs", metric, "", 1, nil))
 	b.flush(storage, 5)
-	assert.False(t, b.observe("logs", metric, 2, nil))
+	assert.False(t, b.observe("logs", metric, "", 2, nil))
 }
 
 func TestMaterializedLogCountBucketizerAcceptsLateObservationForOpenBucket(t *testing.T) {
@@ -88,9 +88,9 @@ func TestMaterializedLogCountBucketizerAcceptsLateObservationForOpenBucket(t *te
 	b := newMaterializedLogCountBucketizer(LogCountBucketConfig{BucketSeconds: 5, IdleTTLSeconds: 0})
 	metric := observerdef.MetricOutput{Name: "log.pattern.count", Value: 1}
 
-	require.True(t, b.observe("logs", metric, 1, nil))
+	require.True(t, b.observe("logs", metric, "", 1, nil))
 	b.flush(storage, 4)
-	require.True(t, b.observe("logs", metric, 3, nil))
+	require.True(t, b.observe("logs", metric, "", 3, nil))
 	b.flush(storage, 5)
 
 	series := storage.GetSeries("logs", "log.pattern.count", nil, observerdef.AggregateAverage)
@@ -111,9 +111,9 @@ func TestMaterializedLogCountBucketizerOverridesRetentionForLogSeries(t *testing
 	})
 	metric := observerdef.MetricOutput{Name: "log.pattern.count", Value: 1}
 
-	require.True(t, b.observe("logs", metric, 1, nil))
+	require.True(t, b.observe("logs", metric, "", 1, nil))
 	b.flush(storage, 5)
-	require.True(t, b.observe("logs", metric, 21, nil))
+	require.True(t, b.observe("logs", metric, "", 21, nil))
 	b.flush(storage, 25)
 
 	series := storage.GetSeries("logs", "log.pattern.count", nil, observerdef.AggregateAverage)

--- a/comp/anomalydetection/observer/impl/metrics_detector_bocpd.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_bocpd.go
@@ -454,6 +454,7 @@ func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, s
 	source := observer.SeriesDescriptor{
 		Namespace: series.Namespace,
 		Name:      series.Name,
+		Host:      series.Host,
 		Tags:      series.Tags,
 		Aggregate: agg,
 	}

--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
@@ -509,6 +509,7 @@ func (d *HoltResidualDetector) processPoint(
 		Source: observer.SeriesDescriptor{
 			Namespace: series.Namespace,
 			Name:      series.Name,
+			Host:      series.Host,
 			Tags:      tags,
 			Aggregate: agg,
 		},

--- a/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
@@ -247,19 +247,20 @@ func (r *RRCFDetector) resolveAllKeys(storage observer.StorageReader) bool {
 		}
 	}
 
-	// Build a tag signature for each series
-	tagSig := func(tags []string) string {
+	// Build an identity signature for each series. Host is separate from metric
+	// tags, so it must participate to avoid combining different hosts.
+	tagSig := func(host string, tags []string) string {
 		sorted := make([]string, len(tags))
 		copy(sorted, tags)
 		sort.Strings(sorted)
-		return strings.Join(sorted, ",")
+		return host + "|" + strings.Join(sorted, ",")
 	}
 
 	// Group series by tag signature and find a tag set that has ALL metrics
 	tagSetMetrics := make(map[string]map[string]observer.SeriesMeta) // tagSig -> cursorKey -> SeriesMeta
 	for cursorKey, metas := range seriesByMetric {
 		for _, meta := range metas {
-			sig := tagSig(meta.Tags)
+			sig := tagSig(meta.Host, meta.Tags)
 			if tagSetMetrics[sig] == nil {
 				tagSetMetrics[sig] = make(map[string]observer.SeriesMeta)
 			}

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
@@ -332,7 +332,7 @@ func (d *ScanMWDetector) scanMW(points []observer.Point, series *observer.Series
 	seriesName := series.Name + ":" + aggSuffix(agg)
 	anomaly := observer.Anomaly{
 		Type:         observer.AnomalyTypeMetric,
-		Source:       observer.SeriesDescriptor{Namespace: series.Namespace, Name: series.Name, Tags: series.Tags, Aggregate: agg},
+		Source:       observer.SeriesDescriptor{Namespace: series.Namespace, Name: series.Name, Host: series.Host, Tags: series.Tags, Aggregate: agg},
 		DetectorName: d.Name(),
 		Title:        "ScanMW changepoint: " + seriesName,
 		Description: fmt.Sprintf("%s %s (pre_median=%.4f, post_median=%.4f, p=%.2e, effect=%.2f, %.1f MADs)",

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanwelch.go
@@ -339,7 +339,7 @@ func (d *ScanWelchDetector) scanWelch(points []observer.Point, series *observer.
 	seriesName := series.Name + ":" + aggSuffix(agg)
 	anomaly := observer.Anomaly{
 		Type:         observer.AnomalyTypeMetric,
-		Source:       observer.SeriesDescriptor{Namespace: series.Namespace, Name: series.Name, Tags: series.Tags, Aggregate: agg},
+		Source:       observer.SeriesDescriptor{Namespace: series.Namespace, Name: series.Name, Host: series.Host, Tags: series.Tags, Aggregate: agg},
 		DetectorName: d.Name(),
 		Title:        "ScanWelch changepoint: " + seriesName,
 		Description: fmt.Sprintf("%s %s (pre_median=%.4f, post_median=%.4f, t=%.2f, p=%.2e, effect=%.2f, %.1f MADs)",

--- a/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight.go
@@ -416,7 +416,7 @@ func (d *TukeyBiweightDetector) scoreBiweight(points []observer.Point, series *o
 	seriesName := series.Name + ":" + aggSuffix(agg)
 	anomaly := observer.Anomaly{
 		Type:                observer.AnomalyTypeMetric,
-		Source:              observer.SeriesDescriptor{Namespace: series.Namespace, Name: series.Name, Tags: series.Tags, Aggregate: agg},
+		Source:              observer.SeriesDescriptor{Namespace: series.Namespace, Name: series.Name, Host: series.Host, Tags: series.Tags, Aggregate: agg},
 		DetectorName:        d.Name(),
 		Title:               "Tukey biweight: " + seriesName,
 		SamplingIntervalSec: medianPointInterval(points),

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -70,6 +70,7 @@ type observation struct {
 type metricObs struct {
 	name      string
 	value     float64
+	host      string
 	tags      []string
 	timestamp int64
 }
@@ -88,6 +89,8 @@ func (m *metricObs) GetValue() float64 {
 func (m *metricObs) GetRawTags() []string {
 	return m.tags
 }
+
+func (m *metricObs) GetHost() string { return m.host }
 
 func (m *metricObs) GetTimestampUnix() int64 { return m.timestamp }
 
@@ -699,6 +702,7 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 				result.Anomalies[j].Source = observerdef.SeriesDescriptor{
 					Namespace: series.Namespace,
 					Name:      series.Name,
+					Host:      series.Host,
 					Tags:      series.Tags,
 					Aggregate: agg,
 				}
@@ -1094,6 +1098,7 @@ func prepareMetricIngest(source string, sample observerdef.MetricView, filter *m
 		metric: &metricObs{
 			name:      name,
 			value:     sample.GetValue(),
+			host:      sample.GetHost(),
 			tags:      tags,
 			timestamp: timestamp,
 		},

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -1075,8 +1075,9 @@ type metricIngestDecision struct {
 
 func prepareMetricIngest(source string, sample observerdef.MetricView, filter *metricsFilterRules) metricIngestDecision {
 	name := sample.GetName()
+	host := sample.GetHost()
 	normalizedSource := normalizeMetricSource(name, source)
-	precheck := filter.precheck(name, normalizedSource)
+	precheck := filter.precheck(name, normalizedSource, host)
 	if precheck.reject {
 		return metricIngestDecision{source: normalizedSource}
 	}
@@ -1084,8 +1085,8 @@ func prepareMetricIngest(source string, sample observerdef.MetricView, filter *m
 	// Canonicalize once so the mute hash in isMuted matches seriesKeyHash in
 	// storage, and downstream Add calls hit the tagsSorted fast path.
 	tags := canonicalizeTags(sample.GetRawTags())
-	if filter.isMuted(name, normalizedSource, tags) ||
-		(precheck.needsTags && !filter.isAllowedByRulesFrom(name, normalizedSource, tags, precheck.firstCandidate)) {
+	if filter.isMutedWithHost(name, normalizedSource, host, tags) ||
+		(precheck.needsTags && !filter.isAllowedByRulesFromWithHost(name, normalizedSource, host, tags, precheck.firstCandidate)) {
 		return metricIngestDecision{source: normalizedSource}
 	}
 
@@ -1098,7 +1099,7 @@ func prepareMetricIngest(source string, sample observerdef.MetricView, filter *m
 		metric: &metricObs{
 			name:      name,
 			value:     sample.GetValue(),
-			host:      sample.GetHost(),
+			host:      host,
 			tags:      tags,
 			timestamp: timestamp,
 		},

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -674,17 +674,11 @@ func seriesKey(namespace, name, host string, tags []string) string {
 // parseSeriesKey parses a series key back into its parts.
 func parseSeriesKey(key string) (namespace, name, host string, tags []string, ok bool) {
 	parts := strings.SplitN(key, "|", 4)
-	if len(parts) < 3 {
+	if len(parts) != 4 {
 		return "", "", "", nil, false
 	}
 	namespace = parts[0]
 	name = parts[1]
-	if len(parts) == 3 { // legacy hostless key
-		if parts[2] == "" {
-			return namespace, name, "", nil, true
-		}
-		return namespace, name, "", strings.Split(parts[2], ","), true
-	}
 	host = parts[2]
 	if parts[3] == "" {
 		return namespace, name, host, nil, true

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -892,6 +892,7 @@ type seriesMeta struct {
 	Ref        observer.SeriesRef // compact numeric ref
 	Namespace  string
 	Name       string
+	Host       string
 	Tags       []string
 	PointCount int
 }
@@ -909,6 +910,7 @@ func (s *timeSeriesStorage) ListSeriesMetadata(namespace string) []seriesMeta {
 				Ref:        stats.ref,
 				Namespace:  stats.Namespace,
 				Name:       stats.Name,
+				Host:       stats.Host,
 				Tags:       copyTags(stats.Tags),
 				PointCount: stats.pointCount(),
 			})

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -641,12 +641,15 @@ func (s *timeSeriesStorage) MaxTimestamp() int64 {
 // the hot path for log ingestion and detector loops, so we build the key with
 // a single growth via strings.Builder to avoid the chained `+` and intermediate
 // joinTags allocations that the naive form produces.
-func seriesKey(namespace, name string, tags []string) string {
+func seriesKey(namespace, name, host string, tags []string) string {
 	if len(tags) > 1 && !tagsSorted(tags) {
 		tags = canonicalizeTags(tags)
 	}
-	// Pre-compute exact length: namespace + '|' + name + '|' + joined(tags).
+	// Pre-compute exact length: namespace + '|' + name + '|' + host + '|' + joined(tags).
 	n := len(namespace) + 1 + len(name) + 1
+	if host != "" {
+		n += len(host) + 1
+	}
 	for i, t := range tags {
 		if i > 0 {
 			n++ // ',' separator
@@ -659,6 +662,10 @@ func seriesKey(namespace, name string, tags []string) string {
 	b.WriteByte('|')
 	b.WriteString(name)
 	b.WriteByte('|')
+	if host != "" {
+		b.WriteString(host)
+		b.WriteByte('|')
+	}
 	for i, t := range tags {
 		if i > 0 {
 			b.WriteByte(',')
@@ -946,6 +953,7 @@ func (s *timeSeriesStorage) ListAllSeriesCompact() []seriesCompact {
 		result = append(result, seriesCompact{
 			Namespace: st.Namespace,
 			Name:      st.Name,
+			Host:      st.Host,
 			Tags:      st.Tags,
 		})
 	}

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -146,6 +146,7 @@ type tagInternEntry struct {
 type seriesStats struct {
 	Namespace string
 	Name      string
+	Host      string
 	Tags      []string
 	tagsHash  uint64                  // fnv64a hash of Tags; 0 means not interned
 	ref       observer.SeriesRef      // compact numeric ID assigned on creation
@@ -259,6 +260,7 @@ func (s *seriesStats) toSeries(agg Aggregate) observer.Series {
 	return observer.Series{
 		Namespace: s.Namespace,
 		Name:      s.Name,
+		Host:      s.Host,
 		Tags:      s.Tags,
 		Points:    points,
 	}
@@ -303,6 +305,11 @@ type AddResult struct {
 // Timestamps are maintained in sorted order so replay and live ingestion remain
 // correct even when data arrives out of order.
 func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp int64, tags []string) AddResult {
+	return s.AddWithHost(namespace, name, "", value, timestamp, tags)
+}
+
+// AddWithHost inserts a point whose host is a separate series dimension.
+func (s *timeSeriesStorage) AddWithHost(namespace, name, host string, value float64, timestamp int64, tags []string) AddResult {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -316,7 +323,7 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		s.recordDroppedValue("extreme", namespace, name, value, timestamp, tags)
 		return AddResult{Ref: -1}
 	}
-	h := seriesKeyHash(namespace, name, tags)
+	h := seriesKeyHash(namespace, name, host, tags)
 	// Skip the alloc when tags are already sorted. Both ingest paths (real metrics
 	// via prepareMetricIngest and virtual metrics via IngestLog) canonicalize before
 	// calling Add, so this fast path is hit on every normal call.
@@ -329,13 +336,13 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 
 	stats, exists := s.series[h]
 	// Collision guard: verify full identity (namespace + name + sorted tags).
-	if exists && (stats.Namespace != namespace || stats.Name != name || !tagsEqual(stats.Tags, canonTags)) {
+	if exists && (stats.Namespace != namespace || stats.Name != name || stats.Host != host || !tagsEqual(stats.Tags, canonTags)) {
 		// Hash collision — extremely rare with FNV-64a (~10^-14 at 1000 series).
 		logging.Warnf("seriesKeyHash collision h=%d: incumbent={%s,%s} new={%s,%s}",
 			h, stats.Namespace, stats.Name, namespace, name)
 		exists = false
 		for _, st := range s.seriesIDStats {
-			if st != nil && st.Namespace == namespace && st.Name == name && tagsEqual(st.Tags, canonTags) {
+			if st != nil && st.Namespace == namespace && st.Name == name && st.Host == host && tagsEqual(st.Tags, canonTags) {
 				stats = st
 				exists = true
 				break
@@ -351,6 +358,7 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		stats = &seriesStats{
 			Namespace: namespace,
 			Name:      name,
+			Host:      host,
 			Tags:      canonical,
 			tagsHash:  th,
 			ref:       id,
@@ -478,8 +486,8 @@ func (s *timeSeriesStorage) GetSeries(namespace, name string, tags []string, agg
 
 	if tags != nil {
 		// Exact match with tags.
-		stats := s.series[seriesKeyHash(namespace, name, tags)]
-		if stats == nil || stats.Namespace != namespace || stats.Name != name {
+		stats := s.series[seriesKeyHash(namespace, name, "", tags)]
+		if stats == nil || stats.Namespace != namespace || stats.Name != name || stats.Host != "" {
 			return nil
 		}
 		series := stats.toSeries(agg)
@@ -502,8 +510,8 @@ func (s *timeSeriesStorage) GetSeriesSince(namespace, name string, tags []string
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	stats := s.series[seriesKeyHash(namespace, name, tags)]
-	if stats == nil || stats.Namespace != namespace || stats.Name != name {
+	stats := s.series[seriesKeyHash(namespace, name, "", tags)]
+	if stats == nil || stats.Namespace != namespace || stats.Name != name || stats.Host != "" {
 		return nil
 	}
 
@@ -661,18 +669,24 @@ func seriesKey(namespace, name string, tags []string) string {
 }
 
 // parseSeriesKey parses a series key back into its parts.
-func parseSeriesKey(key string) (namespace, name string, tags []string, ok bool) {
-	parts := strings.SplitN(key, "|", 3)
-	if len(parts) != 3 {
-		return "", "", nil, false
+func parseSeriesKey(key string) (namespace, name, host string, tags []string, ok bool) {
+	parts := strings.SplitN(key, "|", 4)
+	if len(parts) < 3 {
+		return "", "", "", nil, false
 	}
 	namespace = parts[0]
 	name = parts[1]
-	if parts[2] == "" {
-		return namespace, name, nil, true
+	if len(parts) == 3 { // legacy hostless key
+		if parts[2] == "" {
+			return namespace, name, "", nil, true
+		}
+		return namespace, name, "", strings.Split(parts[2], ","), true
 	}
-	tags = strings.Split(parts[2], ",")
-	return namespace, name, tags, true
+	host = parts[2]
+	if parts[3] == "" {
+		return namespace, name, host, nil, true
+	}
+	return namespace, name, host, strings.Split(parts[3], ","), true
 }
 
 // copyTags creates a copy of tags slice.
@@ -801,12 +815,13 @@ func (s *timeSeriesStorage) TagInternedCount() int {
 
 // seriesKeyHash computes FNV-1a over namespace|name|tag1,tag2,... without
 // allocating a string. Produces the same value as fnv64aString(seriesKey(...)).
-func seriesKeyHash(namespace, name string, tags []string) uint64 {
+func seriesKeyHash(namespace, name, host string, tags []string) uint64 {
 	if len(tags) > 1 && !tagsSorted(tags) {
 		tags = canonicalizeTags(tags)
 	}
 	h := fnv64aString(namespace)
 	h = fnv64aMix(h, name)
+	h = fnv64aMix(h, host)
 	h ^= uint64('|')
 	h *= fnvPrime64
 	for i, t := range tags {
@@ -859,6 +874,7 @@ func (s *timeSeriesStorage) GetSeriesMeta(ref observer.SeriesRef) *observer.Seri
 		Ref:       ref,
 		Namespace: ss.Namespace,
 		Name:      ss.Name,
+		Host:      ss.Host,
 		Tags:      ss.Tags,
 	}
 }
@@ -1089,7 +1105,7 @@ func (s *timeSeriesStorage) removeSeries(stats *seriesStats) bool {
 		return false
 	}
 	s.releaseTagIntern(stats.tagsHash)
-	h := seriesKeyHash(stats.Namespace, stats.Name, stats.Tags)
+	h := seriesKeyHash(stats.Namespace, stats.Name, stats.Host, stats.Tags)
 	if s.series[h] == stats {
 		delete(s.series, h)
 	}
@@ -1294,7 +1310,7 @@ func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	namespace, nameWithAgg, tags, ok := parseSeriesKey(fullKey)
+	namespace, nameWithAgg, host, tags, ok := parseSeriesKey(fullKey)
 	if !ok {
 		return fullKey
 	}
@@ -1308,8 +1324,8 @@ func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {
 	}
 
 	// Look up by hash; verify identity to guard against hash collisions.
-	stats := s.series[seriesKeyHash(namespace, baseName, tags)]
-	if stats == nil || stats.Namespace != namespace || stats.Name != baseName {
+	stats := s.series[seriesKeyHash(namespace, baseName, host, tags)]
+	if stats == nil || stats.Namespace != namespace || stats.Name != baseName || stats.Host != host {
 		return fullKey
 	}
 
@@ -1343,6 +1359,7 @@ func (s *timeSeriesStorage) ListSeries(filter observer.SeriesFilter) []observer.
 			Ref:       stats.ref,
 			Namespace: stats.Namespace,
 			Name:      stats.Name,
+			Host:      stats.Host,
 			Tags:      stats.Tags,
 		})
 	}
@@ -1502,6 +1519,9 @@ func matchesSeriesFilter(stats *seriesStats, filter observer.SeriesFilter) bool 
 		}
 	}
 	if filter.NamePattern != "" && !strings.HasPrefix(stats.Name, filter.NamePattern) {
+		return false
+	}
+	if filter.Host != "" && stats.Host != filter.Host {
 		return false
 	}
 	return matchTags(stats.Tags, filter.TagMatchers)

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -828,7 +828,9 @@ func seriesKeyHash(namespace, name, host string, tags []string) uint64 {
 	}
 	h := fnv64aString(namespace)
 	h = fnv64aMix(h, name)
-	h = fnv64aMix(h, host)
+	if host != "" {
+		h = fnv64aMix(h, host)
+	}
 	h ^= uint64('|')
 	h *= fnvPrime64
 	for i, t := range tags {

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -536,6 +536,7 @@ func (s *timeSeriesStorage) GetSeriesSince(namespace, name string, tags []string
 	return &observer.Series{
 		Namespace: stats.Namespace,
 		Name:      stats.Name,
+		Host:      stats.Host,
 		Tags:      stats.Tags,
 		Points:    points,
 	}
@@ -1583,6 +1584,7 @@ func (s *timeSeriesStorage) GetSeriesRange(ref observer.SeriesRef, start, end in
 	return &observer.Series{
 		Namespace: stats.Namespace,
 		Name:      stats.Name,
+		Host:      stats.Host,
 		Tags:      stats.Tags,
 		Points:    points,
 	}
@@ -1647,7 +1649,7 @@ func (s *timeSeriesStorage) ForEachLastPoints(
 	}
 	endIndex := searchAfter(stats.timestamps, end)
 	startIndex := max(0, endIndex-n)
-	series := observer.Series{Namespace: stats.Namespace, Name: stats.Name, Tags: stats.Tags}
+	series := observer.Series{Namespace: stats.Namespace, Name: stats.Name, Host: stats.Host, Tags: stats.Tags}
 	buf = snapshotPoints(stats, startIndex, endIndex, agg, buf)
 	s.mu.RUnlock()
 
@@ -1719,6 +1721,7 @@ func (s *timeSeriesStorage) snapshotRange(
 	return observer.Series{
 		Namespace: stats.Namespace,
 		Name:      stats.Name,
+		Host:      stats.Host,
 		Tags:      stats.Tags,
 	}, buf, true
 }

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -637,7 +637,7 @@ func (s *timeSeriesStorage) MaxTimestamp() int64 {
 
 // seriesKey creates a unique key for a series.
 //
-// The result has the form "namespace|name|tag1,tag2,...". This function is on
+// The result has the form "namespace|name|host|tag1,tag2,...". This function is on
 // the hot path for log ingestion and detector loops, so we build the key with
 // a single growth via strings.Builder to avoid the chained `+` and intermediate
 // joinTags allocations that the naive form produces.
@@ -646,10 +646,7 @@ func seriesKey(namespace, name, host string, tags []string) string {
 		tags = canonicalizeTags(tags)
 	}
 	// Pre-compute exact length: namespace + '|' + name + '|' + host + '|' + joined(tags).
-	n := len(namespace) + 1 + len(name) + 1
-	if host != "" {
-		n += len(host) + 1
-	}
+	n := len(namespace) + 1 + len(name) + 1 + len(host) + 1
 	for i, t := range tags {
 		if i > 0 {
 			n++ // ',' separator
@@ -662,10 +659,8 @@ func seriesKey(namespace, name, host string, tags []string) string {
 	b.WriteByte('|')
 	b.WriteString(name)
 	b.WriteByte('|')
-	if host != "" {
-		b.WriteString(host)
-		b.WriteByte('|')
-	}
+	b.WriteString(host)
+	b.WriteByte('|')
 	for i, t := range tags {
 		if i > 0 {
 			b.WriteByte(',')
@@ -820,7 +815,7 @@ func (s *timeSeriesStorage) TagInternedCount() int {
 	return len(s.tagIntern)
 }
 
-// seriesKeyHash computes FNV-1a over namespace|name|tag1,tag2,... without
+// seriesKeyHash computes FNV-1a over namespace|name|host|tag1,tag2,... without
 // allocating a string. Produces the same value as fnv64aString(seriesKey(...)).
 func seriesKeyHash(namespace, name, host string, tags []string) uint64 {
 	if len(tags) > 1 && !tagsSorted(tags) {
@@ -828,9 +823,7 @@ func seriesKeyHash(namespace, name, host string, tags []string) uint64 {
 	}
 	h := fnv64aString(namespace)
 	h = fnv64aMix(h, name)
-	if host != "" {
-		h = fnv64aMix(h, host)
-	}
+	h = fnv64aMix(h, host)
 	h ^= uint64('|')
 	h *= fnvPrime64
 	for i, t := range tags {

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -1006,6 +1006,7 @@ func (s *timeSeriesStorage) DumpToFile(path string) error {
 	type dumpSeries struct {
 		Namespace string      `json:"namespace"`
 		Name      string      `json:"name"`
+		Host      string      `json:"host,omitempty"`
 		Tags      []string    `json:"tags"`
 		Points    []dumpPoint `json:"points"`
 	}
@@ -1018,6 +1019,7 @@ func (s *timeSeriesStorage) DumpToFile(path string) error {
 		ds := dumpSeries{
 			Namespace: st.Namespace,
 			Name:      st.Name,
+			Host:      st.Host,
 			Tags:      st.Tags,
 		}
 		n := st.pointCount()

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -1304,8 +1304,8 @@ func (s *timeSeriesStorage) EvictDefault() []observer.SeriesRef {
 }
 
 // CompactSeriesID translates a full series key to its compact numeric ID string.
-// The full key format is "namespace|name:agg|tags" where the storage key is
-// "namespace|name|tags" (without the agg suffix). This method strips the agg
+// The full key format is "namespace|name:agg|host|tags" where the storage key is
+// "namespace|name|host|tags" (without the agg suffix). This method strips the agg
 // suffix, looks up the numeric ID, and returns "numericID:agg".
 // Returns the original key unchanged if no mapping exists.
 func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -1029,3 +1029,15 @@ func TestSeriesKeyHashMatchesSeriesKey(t *testing.T) {
 		)
 	}
 }
+
+func TestParseSeriesKeyRequiresHostField(t *testing.T) {
+	namespace, name, host, tags, ok := parseSeriesKey("ns|metric:avg||env:prod")
+	assert.True(t, ok)
+	assert.Equal(t, "ns", namespace)
+	assert.Equal(t, "metric:avg", name)
+	assert.Empty(t, host)
+	assert.Equal(t, []string{"env:prod"}, tags)
+
+	_, _, _, _, ok = parseSeriesKey("ns|metric:avg|env:prod")
+	assert.False(t, ok)
+}

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -33,6 +33,21 @@ func TestTimeSeriesStorage_Add(t *testing.T) {
 	assert.Equal(t, 10.0, series.Points[0].Value)
 }
 
+func TestTimeSeriesStorage_AddWithHostSeparatesIdenticalMetricAndTags(t *testing.T) {
+	s := newTimeSeriesStorage()
+	first := s.AddWithHost("test", "my.metric", "host-a", 10, 1000, []string{"env:prod"})
+	second := s.AddWithHost("test", "my.metric", "host-b", 20, 1000, []string{"env:prod"})
+
+	require.NotEqual(t, first.Ref, second.Ref)
+	firstMeta := s.GetSeriesMeta(first.Ref)
+	secondMeta := s.GetSeriesMeta(second.Ref)
+	require.NotNil(t, firstMeta)
+	require.NotNil(t, secondMeta)
+	assert.Equal(t, "host-a", firstMeta.Host)
+	assert.Equal(t, "host-b", secondMeta.Host)
+	assert.Equal(t, "test|my.metric:avg|host-a|env:prod", (observer.SeriesDescriptor{Namespace: "test", Name: "my.metric", Host: "host-a", Tags: []string{"env:prod"}, Aggregate: AggregateAverage}).Key())
+}
+
 func TestTimeSeriesStorage_ForEachLastPoints(t *testing.T) {
 	s := newTimeSeriesStorage()
 	var ref observer.SeriesRef
@@ -768,9 +783,9 @@ func TestTimeSeriesStorage_FindRefsByHashes(t *testing.T) {
 	resB := s.Add("ns", "b", 2.0, 1000, []string{"k:2"})
 	s.Add("ns", "c", 3.0, 1000, []string{"k:3"})
 
-	hA := seriesKeyHash("ns", "a", []string{"k:1"})
-	hB := seriesKeyHash("ns", "b", []string{"k:2"})
-	hMissing := seriesKeyHash("ns", "ghost", nil)
+	hA := seriesKeyHash("ns", "a", "", []string{"k:1"})
+	hB := seriesKeyHash("ns", "b", "", []string{"k:2"})
+	hMissing := seriesKeyHash("ns", "ghost", "", nil)
 
 	refs := s.FindRefsByHashes(map[uint64]struct{}{hA: {}, hB: {}, hMissing: {}})
 

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -1041,3 +1041,37 @@ func TestParseSeriesKeyRequiresHostField(t *testing.T) {
 	_, _, _, _, ok = parseSeriesKey("ns|metric:avg|env:prod")
 	assert.False(t, ok)
 }
+
+func TestCompactSeriesIDResolvesHostDimension(t *testing.T) {
+	s := newTimeSeriesStorage()
+	tags := []string{"env:prod"}
+	hostless := s.AddWithHost("ns", "metric", "", 1, 1000, tags)
+	hostA := s.AddWithHost("ns", "metric", "web-a", 1, 1000, tags)
+	hostB := s.AddWithHost("ns", "metric", "web-b", 1, 1000, tags)
+
+	for _, tc := range []struct {
+		host string
+		ref  observer.SeriesRef
+	}{
+		{host: "", ref: hostless.Ref},
+		{host: "web-a", ref: hostA.Ref},
+		{host: "web-b", ref: hostB.Ref},
+	} {
+		key := (observer.SeriesDescriptor{
+			Namespace: "ns",
+			Name:      "metric",
+			Host:      tc.host,
+			Tags:      tags,
+			Aggregate: AggregateAverage,
+		}).Key()
+		assert.Equal(t, fmt.Sprintf("%d:avg", tc.ref), s.CompactSeriesID(key))
+	}
+}
+
+func TestCompactSeriesIDRejectsLegacyHostlessKey(t *testing.T) {
+	s := newTimeSeriesStorage()
+	s.Add("ns", "metric", 1, 1000, []string{"env:prod"})
+	legacyKey := "ns|metric:avg|env:prod"
+
+	assert.Equal(t, legacyKey, s.CompactSeriesID(legacyKey))
+}

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -46,6 +46,9 @@ func TestTimeSeriesStorage_AddWithHostSeparatesIdenticalMetricAndTags(t *testing
 	require.NotNil(t, secondMeta)
 	assert.Equal(t, "host-a", firstMeta.Host)
 	assert.Equal(t, "host-b", secondMeta.Host)
+	ranged := s.GetSeriesRange(first.Ref, 0, 1000, AggregateAverage)
+	require.NotNil(t, ranged)
+	assert.Equal(t, "host-a", ranged.Host)
 	assert.Equal(t, "test|my.metric:avg|host-a|env:prod", (observer.SeriesDescriptor{Namespace: "test", Name: "my.metric", Host: "host-a", Tags: []string{"env:prod"}, Aggregate: AggregateAverage}).Key())
 	assert.Equal(t, "test|my.metric:avg||env:prod", (observer.SeriesDescriptor{Namespace: "test", Name: "my.metric", Tags: []string{"env:prod"}, Aggregate: AggregateAverage}).Key())
 }

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -8,6 +8,7 @@ package observerimpl
 import (
 	"fmt"
 	"math"
+	"os"
 	"sync"
 	"testing"
 	"unsafe"
@@ -988,4 +989,15 @@ func TestTimeSeriesStorage_TagIntern_Cap(t *testing.T) {
 
 	s.Add("ns2", "m0", 1.0, 1000, []string{"unique:tag0"})
 	assert.Equal(t, tagInternMaxSize, s.TagInternedCount(), "hit on existing entry must not grow pool")
+}
+
+func TestTimeSeriesStorage_DumpToFileIncludesHost(t *testing.T) {
+	s := newTimeSeriesStorage()
+	s.AddWithHost("ns", "metric", "web-1", 1, 1000, []string{"env:prod"})
+
+	path := t.TempDir() + "/series.json"
+	require.NoError(t, s.DumpToFile(path))
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"host": "web-1"`)
 }

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -1001,3 +1001,12 @@ func TestTimeSeriesStorage_DumpToFileIncludesHost(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(data), `"host": "web-1"`)
 }
+
+func TestTimeSeriesStorage_ListSeriesMetadataIncludesHost(t *testing.T) {
+	s := newTimeSeriesStorage()
+	s.AddWithHost("ns", "metric", "web-1", 1, 1000, nil)
+
+	metas := s.ListSeriesMetadata("ns")
+	require.Len(t, metas, 1)
+	assert.Equal(t, "web-1", metas[0].Host)
+}

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -1010,3 +1010,18 @@ func TestTimeSeriesStorage_ListSeriesMetadataIncludesHost(t *testing.T) {
 	require.Len(t, metas, 1)
 	assert.Equal(t, "web-1", metas[0].Host)
 }
+
+func TestSeriesKeyHashMatchesSeriesKey(t *testing.T) {
+	for _, tc := range []struct {
+		host string
+		tags []string
+	}{
+		{tags: []string{"env:prod", "service:api"}},
+		{host: "web-1", tags: []string{"env:prod", "service:api"}},
+	} {
+		assert.Equal(t,
+			fnv64aString(seriesKey("ns", "metric", tc.host, tc.tags)),
+			seriesKeyHash("ns", "metric", tc.host, tc.tags),
+		)
+	}
+}

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -47,6 +47,7 @@ func TestTimeSeriesStorage_AddWithHostSeparatesIdenticalMetricAndTags(t *testing
 	assert.Equal(t, "host-a", firstMeta.Host)
 	assert.Equal(t, "host-b", secondMeta.Host)
 	assert.Equal(t, "test|my.metric:avg|host-a|env:prod", (observer.SeriesDescriptor{Namespace: "test", Name: "my.metric", Host: "host-a", Tags: []string{"env:prod"}, Aggregate: AggregateAverage}).Key())
+	assert.Equal(t, "test|my.metric:avg||env:prod", (observer.SeriesDescriptor{Namespace: "test", Name: "my.metric", Tags: []string{"env:prod"}, Aggregate: AggregateAverage}).Key())
 }
 
 func TestTimeSeriesStorage_ForEachLastPoints(t *testing.T) {

--- a/comp/anomalydetection/observer/impl/test_helpers_test.go
+++ b/comp/anomalydetection/observer/impl/test_helpers_test.go
@@ -17,6 +17,7 @@ type sampleNoSource struct{ name string }
 func (s *sampleNoSource) GetName() string         { return s.name }
 func (s *sampleNoSource) GetValue() float64       { return 0 }
 func (s *sampleNoSource) GetRawTags() []string    { return nil }
+func (s *sampleNoSource) GetHost() string         { return "" }
 func (s *sampleNoSource) GetTimestampUnix() int64 { return 0 }
 func (s *sampleNoSource) GetSampleRate() float64  { return 1 }
 

--- a/comp/anomalydetection/reporter/impl/notify.go
+++ b/comp/anomalydetection/reporter/impl/notify.go
@@ -195,17 +195,34 @@ func formatScorerContributorMessage(contributors []observerdef.ScorerContributor
 // pattern when no example is available. Other metrics retain their series name.
 func scorerContributorDisplayName(meta *observerdef.SeriesMeta, context *observerdef.MetricContext, aggregate observerdef.Aggregate) string {
 	if name := logDerivedContributorName(meta.Namespace, context); name != "" {
-		if len(meta.Tags) == 0 {
+		tags := scorerContributorTags(meta)
+		if len(tags) == 0 {
 			return name
 		}
-		return name + " — {" + strings.Join(meta.Tags, ",") + "}"
+		return name + " — {" + strings.Join(tags, ",") + "}"
 	}
 	return observerdef.SeriesDescriptor{
 		Namespace: meta.Namespace,
 		Name:      meta.Name,
+		Host:      meta.Host,
 		Tags:      meta.Tags,
 		Aggregate: aggregate,
 	}.DisplayName()
+}
+
+func scorerContributorTags(meta *observerdef.SeriesMeta) []string {
+	if meta.Host == "" {
+		return meta.Tags
+	}
+	hostTag := "host:" + meta.Host
+	for _, tag := range meta.Tags {
+		if tag == hostTag {
+			return meta.Tags
+		}
+	}
+	tags := make([]string, 0, len(meta.Tags)+1)
+	tags = append(tags, hostTag)
+	return append(tags, meta.Tags...)
 }
 
 // logDerivedContributorName returns the human-readable name for a log-derived

--- a/comp/anomalydetection/reporter/impl/notify.go
+++ b/comp/anomalydetection/reporter/impl/notify.go
@@ -443,6 +443,9 @@ func BuildEventTags(c observerdef.ActiveCorrelation) []string {
 				}
 			}
 		}
+		if a.Source.Host != "" {
+			dimensionSet["host:"+a.Source.Host] = struct{}{}
+		}
 		// For log-derived anomalies, dimensional info lives in Context.SplitTags
 		// (set by the log tagged pattern clusterer).
 		if a.Context != nil {

--- a/comp/anomalydetection/reporter/impl/notify_test.go
+++ b/comp/anomalydetection/reporter/impl/notify_test.go
@@ -308,6 +308,25 @@ func TestBuildEventTags_DimensionalTagsFromSourceTags(t *testing.T) {
 	assert.NotContains(t, tags, "version:1.0") // non-dimensional tags not propagated
 }
 
+func TestBuildEventTags_DimensionalHostFromSource(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type: observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{
+					Namespace: "dogstatsd",
+					Host:      "web-1",
+					Tags:      []string{"service:web", "env:prod"},
+				},
+			},
+		},
+	}
+
+	tags := BuildEventTags(c)
+	assert.Contains(t, tags, "host:web-1")
+}
+
 func TestBuildEventTags_DimensionalTagsFromSplitTags(t *testing.T) {
 	// Log-derived anomalies carry dimensional info in Context.SplitTags.
 	c := observerdef.ActiveCorrelation{

--- a/comp/anomalydetection/reporter/impl/notify_test.go
+++ b/comp/anomalydetection/reporter/impl/notify_test.go
@@ -44,7 +44,7 @@ func (s *sumRangeStorage) GetContext(ref observerdef.SeriesRef) *observerdef.Met
 
 func TestFormatScorerContributorMessage(t *testing.T) {
 	storage := &sumRangeStorage{metas: map[observerdef.SeriesRef]observerdef.SeriesMeta{
-		42: {Ref: 42, Namespace: "dogstatsd", Name: "system.cpu.user", Tags: []string{"host:web-1", "env:prod"}},
+		42: {Ref: 42, Namespace: "dogstatsd", Name: "system.cpu.user", Host: "web-1", Tags: []string{"env:prod"}},
 		7:  {Ref: 7, Namespace: "dogstatsd", Name: "nginx.requests", Tags: []string{"service:api"}},
 	}}
 
@@ -62,7 +62,7 @@ func TestFormatScorerContributorMessage(t *testing.T) {
 func TestFormatScorerContributorMessageUsesLogDerivedDisplay(t *testing.T) {
 	storage := &sumRangeStorage{
 		metas: map[observerdef.SeriesRef]observerdef.SeriesMeta{
-			42: {Ref: 42, Namespace: logMetricsExtractorNamespace, Name: "log.pattern.abc.count", Tags: []string{"service:api"}},
+			42: {Ref: 42, Namespace: logMetricsExtractorNamespace, Name: "log.pattern.abc.count", Host: "web-1", Tags: []string{"service:api"}},
 			43: {Ref: 43, Namespace: logPatternExtractorNamespace, Name: "log.pattern.def.rate", Tags: []string{"env:prod"}},
 		},
 		contexts: map[observerdef.SeriesRef]*observerdef.MetricContext{
@@ -76,7 +76,7 @@ func TestFormatScorerContributorMessageUsesLogDerivedDisplay(t *testing.T) {
 		{Handle: observerdef.QueryHandle{Ref: 43, Aggregate: observerdef.AggregateSum}, Share: 0.25},
 	}, storage)
 
-	assert.Contains(t, message, "1. 75% — log: ERROR: connection refused to db.prod:5432 — {service:api}")
+	assert.Contains(t, message, "1. 75% — log: ERROR: connection refused to db.prod:5432 — {host:web-1,service:api}")
 	assert.Contains(t, message, "2. 25% — log: GET /checkout <*> returned 500 — {env:prod}")
 	assert.NotContains(t, message, "log.pattern.abc.count")
 	assert.NotContains(t, message, "log.pattern.def.rate")

--- a/internal/qbranch/anomalydetection-testbench/bench/api.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/api.go
@@ -419,6 +419,7 @@ func (api *BenchAPI) handleSeriesList(w http.ResponseWriter, _ *http.Request) {
 		ID         string   `json:"id"`
 		Namespace  string   `json:"namespace"`
 		Name       string   `json:"name"`
+		Host       string   `json:"host,omitempty"`
 		Tags       []string `json:"tags"`
 		PointCount int      `json:"pointCount"`
 		Virtual    bool     `json:"virtual"`
@@ -458,6 +459,7 @@ func (api *BenchAPI) handleSeriesList(w http.ResponseWriter, _ *http.Request) {
 					ID:         compactID,
 					Namespace:  m.Namespace,
 					Name:       nameWithAgg,
+					Host:       m.Host,
 					Tags:       m.Tags,
 					PointCount: pointCount,
 					Virtual:    virtual,
@@ -577,6 +579,7 @@ func (api *BenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericID ob
 		ID        string          `json:"id"`
 		Namespace string          `json:"namespace"`
 		Name      string          `json:"name"`
+		Host      string          `json:"host,omitempty"`
 		Tags      []string        `json:"tags"`
 		Points    []pointOutput   `json:"points"`
 		Anomalies []anomalyMarker `json:"anomalies"`
@@ -586,6 +589,7 @@ func (api *BenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericID ob
 		ID:        originalID,
 		Namespace: meta.Namespace,
 		Name:      nameWithAgg,
+		Host:      meta.Host,
 		Tags:      series.Tags,
 		Points:    make([]pointOutput, len(series.Points)),
 		Anomalies: markers,
@@ -719,6 +723,7 @@ func (api *BenchAPI) handleSeriesDataForSeries(w http.ResponseWriter, namespace,
 		ID        string          `json:"id"`
 		Namespace string          `json:"namespace"`
 		Name      string          `json:"name"`
+		Host      string          `json:"host,omitempty"`
 		Tags      []string        `json:"tags"`
 		Points    []pointOutput   `json:"points"`
 		Anomalies []anomalyMarker `json:"anomalies"`
@@ -728,6 +733,7 @@ func (api *BenchAPI) handleSeriesDataForSeries(w http.ResponseWriter, namespace,
 		ID:        seriesID,
 		Namespace: namespace,
 		Name:      nameWithAgg,
+		Host:      foundMeta.Host,
 		Tags:      foundMeta.Tags,
 		Points:    make([]pointOutput, len(series.Points)),
 		Anomalies: markers,
@@ -767,6 +773,7 @@ func (api *BenchAPI) handleAnomalies(w http.ResponseWriter, r *http.Request) {
 		DetectorComponent string             `json:"detectorComponent"`
 		Title             string             `json:"title"`
 		Description       string             `json:"description"`
+		Host              string             `json:"host,omitempty"`
 		Tags              []string           `json:"tags"`
 		Timestamp         int64              `json:"timestamp"`
 		DebugInfo         *debugInfoResponse `json:"debugInfo,omitempty"`
@@ -798,6 +805,7 @@ func (api *BenchAPI) handleAnomalies(w http.ResponseWriter, r *http.Request) {
 			DetectorComponent: detectorComponentMap[a.DetectorName],
 			Title:             a.Title,
 			Description:       a.Description,
+			Host:              a.Source.Host,
 			Tags:              a.Source.Tags,
 			Timestamp:         a.Timestamp,
 		}
@@ -1366,27 +1374,41 @@ func scorerReportContributorName(meta *observerdef.SeriesMeta, context *observer
 		switch meta.Namespace {
 		case "log_metrics_extractor":
 			if example := strings.TrimSpace(context.Example); example != "" {
-				return logReportContributorName(example, meta.Tags)
+				return logReportContributorName(example, meta.Host, meta.Tags)
 			}
 			if pattern := strings.TrimSpace(context.Pattern); pattern != "" {
-				return logReportContributorName(pattern, meta.Tags)
+				return logReportContributorName(pattern, meta.Host, meta.Tags)
 			}
 		case "log_pattern_extractor":
 			if pattern := strings.TrimSpace(context.Pattern); pattern != "" {
-				return logReportContributorName(pattern, meta.Tags)
+				return logReportContributorName(pattern, meta.Host, meta.Tags)
 			}
 		}
 	}
 	return observerdef.SeriesDescriptor{
 		Namespace: meta.Namespace,
 		Name:      meta.Name,
+		Host:      meta.Host,
 		Tags:      meta.Tags,
 		Aggregate: aggregate,
 	}.DisplayName()
 }
 
-func logReportContributorName(name string, tags []string) string {
+func logReportContributorName(name, host string, tags []string) string {
 	name = "log: " + name
+	if host != "" {
+		hostTag := "host:" + host
+		hasHost := false
+		for _, tag := range tags {
+			if tag == hostTag {
+				hasHost = true
+				break
+			}
+		}
+		if !hasHost {
+			tags = append([]string{hostTag}, tags...)
+		}
+	}
 	if len(tags) == 0 {
 		return name
 	}

--- a/internal/qbranch/anomalydetection-testbench/bench/api.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/api.go
@@ -492,12 +492,12 @@ func (api *BenchAPI) handleSeriesDataByID(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	namespace, nameWithAgg, tags, ok := parseSeriesKey(seriesID)
+	namespace, nameWithAgg, host, tags, ok := parseSeriesKey(seriesID)
 	if !ok {
 		api.writeError(w, http.StatusBadRequest, "invalid series id")
 		return
 	}
-	api.handleSeriesDataForSeries(w, namespace, nameWithAgg, tags, seriesID)
+	api.handleSeriesDataForSeries(w, namespace, nameWithAgg, host, tags, seriesID)
 }
 
 // handleNumericSeriesData resolves a compact numeric ID to series data.
@@ -539,6 +539,7 @@ func (api *BenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericID ob
 	sd := observerdef.SeriesDescriptor{
 		Namespace: meta.Namespace,
 		Name:      series.Name,
+		Host:      meta.Host,
 		Tags:      series.Tags,
 		Aggregate: agg,
 	}
@@ -613,10 +614,10 @@ func (api *BenchAPI) handleSeriesData(w http.ResponseWriter, r *http.Request) {
 
 	namespace := parts[0]
 	nameWithAgg := parts[1]
-	api.handleSeriesDataForSeries(w, namespace, nameWithAgg, nil, "")
+	api.handleSeriesDataForSeries(w, namespace, nameWithAgg, "", nil, "")
 }
 
-func (api *BenchAPI) handleSeriesDataForSeries(w http.ResponseWriter, namespace, nameWithAgg string, tags []string, requestedID string) {
+func (api *BenchAPI) handleSeriesDataForSeries(w http.ResponseWriter, namespace, nameWithAgg, host string, tags []string, requestedID string) {
 	seriesID := requestedID
 
 	name := nameWithAgg
@@ -655,7 +656,7 @@ func (api *BenchAPI) handleSeriesDataForSeries(w http.ResponseWriter, namespace,
 		if m.Name != name {
 			continue
 		}
-		if tags == nil || tagsMatch(m.Tags, tags) {
+		if (requestedID == "" || m.Host == host) && (tags == nil || tagsMatch(m.Tags, tags)) {
 			foundMeta = m
 			break
 		}
@@ -688,6 +689,7 @@ func (api *BenchAPI) handleSeriesDataForSeries(w http.ResponseWriter, namespace,
 	sd := observerdef.SeriesDescriptor{
 		Namespace: namespace,
 		Name:      name,
+		Host:      foundMeta.Host,
 		Tags:      foundMeta.Tags,
 		Aggregate: agg,
 	}
@@ -780,7 +782,7 @@ func (api *BenchAPI) handleAnomalies(w http.ResponseWriter, r *http.Request) {
 		if sv != nil && a.DetectorName != "" && a.Source.Name != "" {
 			storage := &stateViewStorage{sv: sv}
 			telemetryName := "telemetry." + a.DetectorName + "." + a.Source.String()
-			key := seriesKey("telemetry", telemetryName+":avg", nil)
+			key := seriesKey("telemetry", telemetryName+":avg", "", nil)
 			if compactID := storage.compactSeriesID(key); compactID != key {
 				return compactID
 			}

--- a/internal/qbranch/anomalydetection-testbench/bench/api.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/api.go
@@ -1029,6 +1029,7 @@ func (api *BenchAPI) handleCorrelations(w http.ResponseWriter, _ *http.Request) 
 		Description string   `json:"description"`
 		Timestamp   int64    `json:"timestamp"`
 		Score       *float64 `json:"score,omitempty"`
+		Host        string   `json:"host,omitempty"`
 		Tags        []string `json:"tags"`
 	}
 
@@ -1056,6 +1057,7 @@ func (api *BenchAPI) handleCorrelations(w http.ResponseWriter, _ *http.Request) 
 				Description: a.Description,
 				Timestamp:   a.Timestamp,
 				Score:       a.Score,
+				Host:        a.Source.Host,
 				Tags:        tgs,
 			}
 		}

--- a/internal/qbranch/anomalydetection-testbench/bench/bench.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/bench.go
@@ -662,6 +662,7 @@ func metricSeriesHash(name string, sortedTags []string) uint64 {
 func (m *parquetMetricView) GetName() string         { return m.name }
 func (m *parquetMetricView) GetValue() float64       { return m.value }
 func (m *parquetMetricView) GetRawTags() []string    { return m.tags }
+func (m *parquetMetricView) GetHost() string         { return "" }
 func (m *parquetMetricView) GetTimestampUnix() int64 { return m.timestamp }
 func (m *parquetMetricView) GetSampleRate() float64  { return 1.0 }
 

--- a/internal/qbranch/anomalydetection-testbench/bench/bench.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/bench.go
@@ -492,12 +492,8 @@ func (tb *Bench) loadParquetDir(dir string) error {
 				droppedCount++
 				continue
 			}
-			tb.rawMetrics = append(tb.rawMetrics, &parquetMetricView{
-				name:      m.Name,
-				value:     m.Value,
-				tags:      m.Tags,
-				timestamp: m.Timestamp,
-			})
+			view := newParquetMetricView(m.Name, m.Value, m.Tags, m.Timestamp)
+			tb.rawMetrics = append(tb.rawMetrics, &view)
 		}
 		if droppedCount > 0 {
 			fmt.Printf("  Skipped %d dropped observations from parquet\n", droppedCount)
@@ -542,17 +538,12 @@ func (tb *Bench) streamParquetObservations(dir string, format ParquetFormat) err
 				return nil
 			}
 
-			sort.Strings(metric.Tags)
-			tb.streamInputMetricSeries[metricSeriesHash(metric.Name, metric.Tags)] = struct{}{}
+			view := newParquetMetricView(metric.Name, metric.Value, metric.Tags, metric.Timestamp)
+			sort.Strings(view.tags)
+			tb.streamInputMetricSeries[metricSeriesHash(view.name, view.host, view.tags)] = struct{}{}
 			tb.streamInputMetricsCount++
 			tb.extendStreamBounds(metric.Timestamp, metric.Timestamp)
 
-			view := parquetMetricView{
-				name:      metric.Name,
-				value:     metric.Value,
-				tags:      metric.Tags,
-				timestamp: metric.Timestamp,
-			}
 			tb.debug.IngestMetricSync("parquet", &view)
 			return nil
 		}
@@ -634,11 +625,40 @@ func (tb *Bench) feedRawMetrics() {
 type parquetMetricView struct {
 	name      string
 	value     float64
+	host      string
 	tags      []string
 	timestamp int64
 }
 
-func metricSeriesHash(name string, sortedTags []string) uint64 {
+// newParquetMetricView resolves the recorder's legacy host:* tag into the
+// separate host dimension. The remaining tags stay raw for later tag resolution.
+func newParquetMetricView(name string, value float64, tags []string, timestamp int64) parquetMetricView {
+	host, metricTags := resolveParquetMetricHostAndTags(tags)
+	return parquetMetricView{name: name, value: value, host: host, tags: metricTags, timestamp: timestamp}
+}
+
+func resolveParquetMetricHostAndTags(tags []string) (string, []string) {
+	var host string
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, "host:") {
+			host = strings.TrimPrefix(tag, "host:")
+			break
+		}
+	}
+	if host == "" {
+		return "", tags
+	}
+
+	metricTags := make([]string, 0, len(tags)-1)
+	for _, tag := range tags {
+		if !strings.HasPrefix(tag, "host:") {
+			metricTags = append(metricTags, tag)
+		}
+	}
+	return host, metricTags
+}
+
+func metricSeriesHash(name, host string, sortedTags []string) uint64 {
 	const (
 		offset64 = 14695981039346656037
 		prime64  = 1099511628211
@@ -653,6 +673,7 @@ func metricSeriesHash(name string, sortedTags []string) uint64 {
 		hash *= prime64
 	}
 	add(name)
+	add(host)
 	for _, tag := range sortedTags {
 		add(tag)
 	}
@@ -662,7 +683,7 @@ func metricSeriesHash(name string, sortedTags []string) uint64 {
 func (m *parquetMetricView) GetName() string         { return m.name }
 func (m *parquetMetricView) GetValue() float64       { return m.value }
 func (m *parquetMetricView) GetRawTags() []string    { return m.tags }
-func (m *parquetMetricView) GetHost() string         { return "" }
+func (m *parquetMetricView) GetHost() string         { return m.host }
 func (m *parquetMetricView) GetTimestampUnix() int64 { return m.timestamp }
 func (m *parquetMetricView) GetSampleRate() float64  { return 1.0 }
 
@@ -897,7 +918,7 @@ func (tb *Bench) collectReplayResultsLocked() {
 	for _, metric := range tb.rawMetrics {
 		tags := append([]string(nil), metric.tags...)
 		sort.Strings(tags)
-		inputMetricSeries[metricSeriesHash(metric.name, tags)] = struct{}{}
+		inputMetricSeries[metricSeriesHash(metric.name, metric.host, tags)] = struct{}{}
 	}
 	replayStats := &ReplayStats{
 		DetectorStats:           detectorStats,
@@ -1375,12 +1396,8 @@ func (tb *Bench) loadDemoScenario() error {
 				{"connection.errors", getDemoConnectionErrorsValue(elapsed) * 0.6, []string{"service:worker"}},
 			}
 			for _, obs := range observations {
-				tb.rawMetrics = append(tb.rawMetrics, &parquetMetricView{
-					name:      obs.name,
-					value:     obs.value,
-					tags:      obs.tags,
-					timestamp: timestamp,
-				})
+				view := newParquetMetricView(obs.name, obs.value, obs.tags, timestamp)
+				tb.rawMetrics = append(tb.rawMetrics, &view)
 			}
 		}
 		fmt.Printf("  Generated %d seconds of demo data\n", totalSeconds)

--- a/internal/qbranch/anomalydetection-testbench/bench/metric_view_test.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/metric_view_test.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package bench
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewParquetMetricViewResolvesHostTag(t *testing.T) {
+	view := newParquetMetricView("system.cpu", 1, []string{"env:prod", "host:web-1", "service:api"}, 100)
+
+	assert.Equal(t, "web-1", view.GetHost())
+	assert.Equal(t, []string{"env:prod", "service:api"}, view.GetRawTags())
+}
+
+func TestSeriesKeyRoundTripsHost(t *testing.T) {
+	key := seriesKey("parquet", "system.cpu:avg", "web-1", []string{"service:api", "env:prod"})
+	namespace, name, host, tags, ok := parseSeriesKey(key)
+
+	assert.True(t, ok)
+	assert.Equal(t, "parquet", namespace)
+	assert.Equal(t, "system.cpu:avg", name)
+	assert.Equal(t, "web-1", host)
+	assert.Equal(t, []string{"env:prod", "service:api"}, tags)
+}

--- a/internal/qbranch/anomalydetection-testbench/bench/seriesutil.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/seriesutil.go
@@ -20,31 +20,29 @@ func aggSuffix(agg observerdef.Aggregate) string {
 }
 
 // seriesKey returns a canonical string key for a series:
-// "namespace|name:agg|tag1,tag2,..."
-func seriesKey(namespace, nameWithAgg string, tags []string) string {
-	if len(tags) == 0 {
-		return namespace + "|" + nameWithAgg + "|"
-	}
+// "namespace|name:agg|host|tag1,tag2,..."
+func seriesKey(namespace, nameWithAgg, host string, tags []string) string {
 	sorted := make([]string, len(tags))
 	copy(sorted, tags)
 	sort.Strings(sorted)
-	return namespace + "|" + nameWithAgg + "|" + strings.Join(sorted, ",")
+	return namespace + "|" + nameWithAgg + "|" + host + "|" + strings.Join(sorted, ",")
 }
 
 // parseSeriesKey parses a seriesKey back into its components.
 // Returns ok=false if the key doesn't have the expected format.
-func parseSeriesKey(key string) (namespace, name string, tags []string, ok bool) {
-	// Format: "namespace|name:agg|tags"
-	parts := strings.SplitN(key, "|", 3)
-	if len(parts) != 3 {
-		return "", "", nil, false
+func parseSeriesKey(key string) (namespace, name, host string, tags []string, ok bool) {
+	// Format: "namespace|name:agg|host|tags"
+	parts := strings.SplitN(key, "|", 4)
+	if len(parts) != 4 {
+		return "", "", "", nil, false
 	}
 	namespace = parts[0]
 	name = parts[1]
-	if parts[2] != "" {
-		tags = strings.Split(parts[2], ",")
+	host = parts[2]
+	if parts[3] != "" {
+		tags = strings.Split(parts[3], ",")
 	}
-	return namespace, name, tags, true
+	return namespace, name, host, tags, true
 }
 
 // stateViewStorage adapts a StateView to provide compact series ID lookups and
@@ -94,7 +92,7 @@ func (s *stateViewStorage) getSeriesMeta(ref observerdef.SeriesRef) *observerdef
 // compactSeriesID maps a full seriesKey to a compact numeric ID ("42:avg").
 // Returns the original key if not found (to match the original behavior).
 func (s *stateViewStorage) compactSeriesID(fullKey string) string {
-	namespace, nameWithAgg, tags, ok := parseSeriesKey(fullKey)
+	namespace, nameWithAgg, host, tags, ok := parseSeriesKey(fullKey)
 	if !ok {
 		return fullKey
 	}
@@ -116,7 +114,7 @@ func (s *stateViewStorage) compactSeriesID(fullKey string) string {
 	sort.Strings(sortedTags)
 
 	for _, m := range series {
-		if m.Name != name {
+		if m.Name != name || m.Host != host {
 			continue
 		}
 		// Compare tags.

--- a/internal/qbranch/anomalydetection-testbench/ui/src/api/client.ts
+++ b/internal/qbranch/anomalydetection-testbench/ui/src/api/client.ts
@@ -92,10 +92,11 @@ export interface ComponentInfo {
 }
 
 export interface SeriesInfo {
-  id: SeriesID;
-  namespace: string;
-  name: string;
-  tags: string[];
+	id: SeriesID;
+	namespace: string;
+	name: string;
+	host?: string;
+	tags: string[];
   pointCount: number;
   /** True when the series lives in an extractor storage namespace (log-derived metrics). */
   virtual?: boolean;
@@ -117,10 +118,11 @@ export interface AnomalyMarker {
 }
 
 export interface SeriesData {
-  id: SeriesID;
-  namespace: string;
-  name: string;
-  tags: string[];
+	id: SeriesID;
+	namespace: string;
+	name: string;
+	host?: string;
+	tags: string[];
   points: Point[];
   anomalies: AnomalyMarker[];
 }
@@ -143,8 +145,9 @@ export interface Anomaly {
   detectorName: string;
   detectorComponent?: string;
   title: string;
-  description: string;
-  tags: string[];
+	description: string;
+	host?: string;
+	tags: string[];
   timestamp: number;
   debugInfo?: AnomalyDebugInfo;
 }

--- a/internal/qbranch/anomalydetection-testbench/ui/src/api/client.ts
+++ b/internal/qbranch/anomalydetection-testbench/ui/src/api/client.ts
@@ -209,6 +209,7 @@ export interface Correlation {
     title: string;
     description: string;
     timestamp: number;
+    host?: string;
     tags: string[];
   }[];
   firstSeen: number;

--- a/internal/qbranch/anomalydetection-testbench/ui/src/components/CorrelatorView.tsx
+++ b/internal/qbranch/anomalydetection-testbench/ui/src/components/CorrelatorView.tsx
@@ -17,6 +17,11 @@ interface CorrelatorViewProps {
   phaseMarkers?: PhaseMarker[];
 }
 
+function effectiveAnomalyTags(tags: string[] | null | undefined, host?: string): string[] {
+  const baseTags = tags ?? [];
+  return host ? [`host:${host}`, ...baseTags] : baseTags;
+}
+
 export function CorrelatorView({ state, actions, sidebarWidth, timeRange, phaseMarkers }: CorrelatorViewProps) {
   const scenarios = state.scenarios ?? [];
   const components = state.components ?? [];
@@ -50,21 +55,21 @@ export function CorrelatorView({ state, actions, sidebarWidth, timeRange, phaseM
   );
 
   const tagGroups = useMemo(() => {
-    const all = extractTagGroups(allAnomalies.map((a) => a.tags ?? []));
+    const all = extractTagGroups(allAnomalies.map((a) => effectiveAnomalyTags(a.tags, a.host)));
     return new Map([...all.entries()].filter(([k]) => MAIN_TAG_FILTER_KEYS.has(k)));
   }, [allAnomalies]);
 
   const anomalies = useMemo(() => {
     const filter = parseTagFilter(tagFilterInput);
     if (filter.include.size === 0 && filter.exclude.size === 0) return allAnomalies;
-    return allAnomalies.filter((a) => matchesTagFilter(a.tags ?? [], filter));
+    return allAnomalies.filter((a) => matchesTagFilter(effectiveAnomalyTags(a.tags, a.host), filter));
   }, [allAnomalies, tagFilterInput]);
 
   const correlations = useMemo(() => {
     const filter = parseTagFilter(tagFilterInput);
     if (filter.include.size === 0 && filter.exclude.size === 0) return allCorrelations;
     return allCorrelations.filter((c) =>
-      c.anomalies.some((a) => matchesTagFilter(a.tags, filter))
+      c.anomalies.some((a) => matchesTagFilter(effectiveAnomalyTags(a.tags, a.host), filter))
     );
   }, [allCorrelations, tagFilterInput]);
 

--- a/internal/qbranch/anomalydetection-testbench/ui/src/components/MetricsView.tsx
+++ b/internal/qbranch/anomalydetection-testbench/ui/src/components/MetricsView.tsx
@@ -32,11 +32,12 @@ function getDetectorComponent(anomaly: { detectorName: string; detectorComponent
   return anomaly.detectorComponent ?? anomaly.detectorName;
 }
 
-function effectiveSeriesTags(tags: string[], host?: string): string[] {
-	return host ? [`host:${host}`, ...tags] : tags;
+function effectiveSeriesTags(tags: string[] | null | undefined, host?: string): string[] {
+	const baseTags = tags ?? [];
+	return host ? [`host:${host}`, ...baseTags] : baseTags;
 }
 
-function formatSeriesLabel(tags: string[], host?: string): string {
+function formatSeriesLabel(tags: string[] | null | undefined, host?: string): string {
 	const displayTags = effectiveSeriesTags(tags, host);
 	if (displayTags.length === 0) return 'untagged';
 	return displayTags.join(', ');

--- a/internal/qbranch/anomalydetection-testbench/ui/src/components/MetricsView.tsx
+++ b/internal/qbranch/anomalydetection-testbench/ui/src/components/MetricsView.tsx
@@ -32,9 +32,14 @@ function getDetectorComponent(anomaly: { detectorName: string; detectorComponent
   return anomaly.detectorComponent ?? anomaly.detectorName;
 }
 
-function formatSeriesLabel(tags: string[]): string {
-  if (!tags || tags.length === 0) return 'untagged';
-  return tags.join(', ');
+function effectiveSeriesTags(tags: string[], host?: string): string[] {
+	return host ? [`host:${host}`, ...tags] : tags;
+}
+
+function formatSeriesLabel(tags: string[], host?: string): string {
+	const displayTags = effectiveSeriesTags(tags, host);
+	if (displayTags.length === 0) return 'untagged';
+	return displayTags.join(', ');
 }
 
 /** Prefix sum of per-bucket deltas (time-ordered) — total from scenario start. */
@@ -214,7 +219,7 @@ export function MetricsView({
   }, [allAnomalies]);
 
   const tagGroups = useMemo(() => {
-    const all = extractTagGroups(allSeries.map((s) => s.tags));
+	const all = extractTagGroups(allSeries.map((s) => effectiveSeriesTags(s.tags, s.host)));
     return new Map([...all.entries()].filter(([k]) => MAIN_TAG_FILTER_KEYS.has(k)));
   }, [allSeries]);
 
@@ -724,7 +729,7 @@ export function MetricsView({
                       const dataList = groupSeriesData.get(groupKey) ?? [];
                       if (dataList.length === 0) return null;
                       const tagFiltered = (tagFilter.include.size > 0 || tagFilter.exclude.size > 0)
-                        ? dataList.filter((d) => matchesTagFilter(d.tags ?? [], tagFilter))
+						? dataList.filter((d) => matchesTagFilter(effectiveSeriesTags(d.tags ?? [], d.host), tagFilter))
                         : dataList;
                       const chartSeries = showAnomalyOnlySeriesLines
                         ? tagFiltered.filter((d) => (anomalyCountBySeriesID.get(d.id) ?? 0) > 0)
@@ -734,7 +739,7 @@ export function MetricsView({
                       const seriesAnomalies = anomalies.filter((a) => a.sourceSeriesId && seriesIDs.has(a.sourceSeriesId));
                       const anomalyMarkers = chartSeries.flatMap((d) => d.anomalies);
                       const seriesVariants: SeriesVariant[] = chartSeries.map((d) => ({
-                        label: formatSeriesLabel(d.tags),
+							label: formatSeriesLabel(d.tags, d.host),
                         points: d.points,
                         seriesId: d.id,
                       }));
@@ -797,7 +802,7 @@ export function MetricsView({
                             viewMode === 'rate-min' ? toRatePerMinSeries :
                             (pts: Point[]) => pts;
                           const seriesVariants: SeriesVariant[] = chartSeries.map((d) => ({
-                            label: formatSeriesLabel(d.tags),
+								label: formatSeriesLabel(d.tags, d.host),
                             points: transformPoints(d.points),
                             seriesId: d.id,
                           }));
@@ -909,7 +914,7 @@ export function MetricsView({
                           const mapPoints = (pts: Point[]) =>
                             isCounterTelemetry ? cumulativeFromStart(pts) : pts;
                           const seriesVariants: SeriesVariant[] = chartSeries.map((d) => ({
-                            label: formatSeriesLabel(d.tags),
+								label: formatSeriesLabel(d.tags, d.host),
                             points: mapPoints(d.points),
                             seriesId: d.id,
                           }));


### PR DESCRIPTION
### What does this PR do?

> [!NOTE]
> [Document](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/7111573562/Optimizing+anomaly+detection+by+relying+on+the+metrics+pipeline#Implementation-plan).

This is the first PR to unify our anomaly detection pipeline with the metrics pipeline. The goal is to use Host not as a tag but like we do in the metrics pipeline, as a separate field.

It adds `host` check in the metrics filter that is separate from tags.

This adds some extra checks but it will be cleaned up when tags will be refactored as well (to use resolved tags instead of raw tags that could contain host).

### Motivation

We want to have resolved host + tags in our pipeline, not raw tags. This way it matches the metrics pipeline + the metrics filter will behave correctly.

Resolved hosts + tags are used to compute the `contextKey` which will be the new identity of a metric sample in few PRs.

### Describe how you validated your changes

1. Run the agent with anomaly detection and anomaly detection debug dump
2. Now we have `host` field correctly resolved in the dump

### Additional Notes
