### PR TITLE
CONTINT-5566 fix clc init volume with correct access right

### DIFF
--- a/Dockerfiles/agent-ddot/Dockerfile
+++ b/Dockerfiles/agent-ddot/Dockerfile
@@ -17,5 +17,7 @@ RUN chmod 755 -R /opt/entrypoints \
   && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
   && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run
 
-# Set owner-only (0500) perms on built-in Rust shared-library checks (no-op when none are present).
-RUN find /etc/datadog-agent/checks.d -name 'libdatadog-agent-*.so' -exec chmod 0500 {} \;
+# Restrict built-in Rust shared-library checks to root and the root group (no-op when none are present).
+# Group-readable so init containers can copy them on OpenShift, where containers run with a
+# random UID in the root group (same reasoning as the private-action-runner config in the base image).
+RUN find /etc/datadog-agent/checks.d -name 'libdatadog-agent-*.so' -exec chmod 0550 {} \;

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -210,8 +210,10 @@ RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agen
   # copy it on OpenShift where containers run with a random UID in the root group.
   && chmod u=r,g=r,o= /etc/datadog-agent/private-action-runner/*
 
-# Set owner-only (0500) perms on built-in Rust shared-library checks (no-op when none are present).
-RUN find /etc/datadog-agent/checks.d -name 'libdatadog-agent-*.so' -exec chmod 0500 {} \;
+# Restrict built-in Rust shared-library checks to root and the root group (no-op when none are present).
+# Group-readable so init containers can copy them on OpenShift, where containers run with a
+# random UID in the root group (same reasoning as the private-action-runner config above).
+RUN find /etc/datadog-agent/checks.d -name 'libdatadog-agent-*.so' -exec chmod 0550 {} \;
 
 # Check that the UID of dd-agent is still 100.
 #

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -93,12 +93,14 @@ build do
             mkdir "/var/log/datadog"
 
             # Move the built-in shared-library checks into the package's checks.d,
-            # strip them to reduce size, then re-assert owner-only (0500) perms.
+            # strip them to reduce size, then re-assert root/root-group-only (0550)
+            # perms. Group-readable so init containers can copy them on OpenShift,
+            # where containers run with a random UID in the root group.
             Dir.glob("#{install_dir}/etc/datadog-agent/checks.d/libdatadog-agent-*.so").each do |lib|
               dest = "#{output_config_dir}/etc/datadog-agent/checks.d/#{File.basename(lib)}"
               move lib, dest, :force => true
               command "strip --strip-unneeded #{dest}"
-              command "chmod 0500 #{dest}"
+              command "chmod 0550 #{dest}"
             end
 
             # Process manager config directory (read-only, under install dir)

--- a/pkg/collector/sharedlibrary/rustchecks/BUILD.bazel
+++ b/pkg/collector/sharedlibrary/rustchecks/BUILD.bazel
@@ -11,11 +11,13 @@ ENABLED_CHECKS = {
 }
 
 # Stage every enabled cdylib into checks.d with the loader naming convention
-# (libdatadog-agent-<check_name>.so) and owner-only perms.
+# (libdatadog-agent-<check_name>.so). Root + root-group read/exec, no "other" —
+# group-readable so init containers can copy them on OpenShift, where
+# containers run with a random UID in the root group.
 pkg_files(
     name = "enabled_checks",
     srcs = ENABLED_CHECKS.values(),
-    attributes = pkg_attributes(mode = "0500"),
+    attributes = pkg_attributes(mode = "0550"),
     prefix = "checks.d",
     renames = {target: "libdatadog-agent-" + check_name + ".so" for check_name, target in ENABLED_CHECKS.items()},
     target_compatible_with = _LINUX,
@@ -23,7 +25,7 @@ pkg_files(
 )
 
 # `bazel run //pkg/collector/sharedlibrary/rustchecks:install -- --destdir=<dir>`
-# stages every enabled check into <dir>/checks.d with owner-only (0500) perms.
+# stages every enabled check into <dir>/checks.d with root/root-group-only (0550) perms.
 pkg_install(
     name = "install",
     srcs = [":enabled_checks"],

--- a/pkg/collector/sharedlibrary/rustchecks/README.md
+++ b/pkg/collector/sharedlibrary/rustchecks/README.md
@@ -41,7 +41,7 @@ The shared library will be created in `target/release` under the name `lib<check
 Checks are built and staged into `checks.d` with Bazel (Linux only). Each check
 provides a `BUILD.bazel` with a `rust_shared_library` (the cdylib) and a
 `pkg_files` target named `checks_d_files` (renames the cdylib to
-`libdatadog-agent-<check>.so` and sets owner-only `0500` perms).
+`libdatadog-agent-<check>.so` and sets root/root-group-only `0550` perms).
 
 To ship a check with the Agent, add its `checks_d_files` target to
 `ENABLED_CHECKS` in this folder's `BUILD.bazel`. The `:install` target


### PR DESCRIPTION

<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

In order for the init-volume to copy the files at init we must allow the group to read the files.

When deploying on openshift we need the group access as openshift creates a user mapping but runs with the group ID for root.

### Motivation

deploy on openshift using cluster check runners

### Describe how you validated your changes

deployed on openshift using cluster check runners

### Additional Notes
