### PR TITLE
Bump workspaces base feature in agent-security devcontainer

### DIFF
--- a/.devcontainer/datadog/agent-security/devcontainer.json
+++ b/.devcontainer/datadog/agent-security/devcontainer.json
@@ -5,7 +5,7 @@
       "registry.ddbuild.io/workspaces/features/claude-code:0.1.122114922": {},
       "registry.ddbuild.io/workspaces/features/trajectory:0.1.121704661": {},
       "registry.ddbuild.io/workspaces/features/codex:0.1.116595837": {},
-      "registry.ddbuild.io/workspaces/features/base:0.4.116964598": {},
+      "registry.ddbuild.io/workspaces/features/base:0.4.132266657": {},
       "../default/features/datadog-agent": {}
   },
   "forwardPorts": [


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Bumps the `workspaces/features/base` pin in
`.devcontainer/datadog/agent-security/devcontainer.json` from `0.4.116964598`
to `0.4.132266657`.

### Motivation

`workspaces create --devcontainer-config .devcontainer/datadog/agent-security/devcontainer.json`
currently fails for everyone with an opaque wrapped error:

```
failed to build devcontainer: error building image for platform &{linux amd64},
got: error running docker buildx build, got: exit status 1
```

The real failure, from `service:workspaces-imagebuilder` build logs, is in the
`base` feature's install script:

```
+ dogbrew install mosaic
INFO   Fetching latest version for mosaic from channel dev
ERROR  failed to install CLI: failed to get CLI metadata:
       API error (status 400): platform query parameter is required
There was an error installing this feature.
#22 ERROR: process "/bin/sh -c cp -ar /tmp/features-src/feature-2a24aa8b... ./feature.install ..."
       did not complete successfully: exit code: 1
```

`base:0.4.116964598` ships dogbrew v1.2.1, which does not send the now-required
`platform` query parameter to the dogbrew CLI-metadata API, so `dogbrew install
mosaic` gets a 400 and the feature install exits 1.

The default devcontainer is unaffected because it consumes a pinned prebuilt
image and never runs the features. The `agent-security` config keeps its own
copy of the feature list, so it builds from scratch and hits the broken pin.

`0.4.132266657` is the version already in use by `ddoghq/web-ui` and
`ddoghq/dd-source`, whose prebuilds are green.

### Describe how you validated your changes

Verified the failure mode from prod `workspaces-imagebuilder` build logs (every
build using `0.4.116964598` fails at the same step; the error is deterministic,
not a flake), and confirmed `0.4.132266657` is the pin used by other repos whose
prebuilds currently succeed. The real test is a `workspaces create` against this
branch.

### Additional Notes

Overlaps with two existing PRs — happy to close this in favour of either:

- #55201 (automated base-feature bump) makes this exact change in both
  `agent-security/devcontainer.json` and `default/prebuild-devcontainer.json`,
  plus a prebuilt image digest bump. It has been open since 2026-08-21 and is
  unmerged, which is why the breakage persists.
- #55364 bumps the base feature in `default/prebuild-devcontainer.json` only, so
  it does not fix the `agent-security` config.

This PR deliberately touches only `agent-security/devcontainer.json` so it does
not conflict with #55364.

Longer term, the duplicated feature list between `agent-security/devcontainer.json`
and `default/prebuild-devcontainer.json` means every feature bump has to be made
twice and one copy silently rots. Worth consolidating.
