### PR TITLE
fix trace agent microbenchmark, no polluting debug logs

### DIFF
--- a/.gitlab/test/benchmarks/benchmarks.yml
+++ b/.gitlab/test/benchmarks/benchmarks.yml
@@ -10,6 +10,10 @@ benchmark:
   tags: ["team:apm-k8s-tweaked-metal-datadog-agent", "specific:true"]
   variables:
     GIT_DEPTH: 0  # Full history: run-benchmarks.sh / analyze-results.sh check out BASE_BRANCH
+    # `go test -tags=test` sends pkg/util/log output to stdout at debug level, which corrupts
+    # the GoBench output the analyzer parses. Set here rather than only in tasks/trace_agent.py
+    # so it also applies to the baseline run, which is executed from a BASE_BRANCH checkout.
+    DD_LOG_LEVEL: "off"
   script:
     - export ARTIFACTS_DIR="$(pwd)/artifacts" && mkdir -p $ARTIFACTS_DIR
     - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"

--- a/.gitlab/test/benchmarks/benchmarks.yml
+++ b/.gitlab/test/benchmarks/benchmarks.yml
@@ -3,10 +3,7 @@ benchmark:
   # This base image is created here: https://gitlab.ddbuild.io/DataDog/apm-reliability/benchmarking-platform
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:trace-agent_microbenchmarks
   timeout: 1h
-  # TODO(andrew.glaude): temporarily disabled, causing flaky failures. Re-enable by
-  # restoring `rules: !reference [.on_trace_agent_changes_or_manual]`.
-  rules:
-    - when: never
+  rules: !reference [.on_trace_agent_changes_or_manual]
   interruptible: true
   needs: ["setup_agent_version"]
   retry: !reference [.retry_only_infra_failure, retry]

--- a/pkg/trace/agent/BUILD.bazel
+++ b/pkg/trace/agent/BUILD.bazel
@@ -71,6 +71,7 @@ dd_agent_go_test(
         "//pkg/trace/traceutil",
         "//pkg/trace/traceutil/normalize",
         "//pkg/trace/writer",
+        "//pkg/util/log",
         "@com_github_datadog_datadog_go_v5//statsd",
         "@com_github_datadog_datadog_go_v5//statsd/mocks",
         "@com_github_go_viper_mapstructure_v2//:mapstructure",

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -2992,6 +2992,9 @@ func BenchmarkAgentTraceProcessingWithWorstCaseFiltering(b *testing.B) {
 }
 
 func runTraceProcessingBenchmark(b *testing.B, c *config.AgentConfig) {
+	// Disable the HTTP server to avoid colliding with a real agent on dev/CI machines.
+	c.ReceiverPort = 0
+
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	wg := sync.WaitGroup{}
 	defer wg.Wait()

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/timing"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/writer"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 	mockStatsd "github.com/DataDog/datadog-go/v5/statsd/mocks"
 
 	"github.com/stretchr/testify/assert"
@@ -2992,6 +2993,12 @@ func BenchmarkAgentTraceProcessingWithWorstCaseFiltering(b *testing.B) {
 }
 
 func runTraceProcessingBenchmark(b *testing.B, c *config.AgentConfig) {
+	// The `test` build tag makes pkg/util/log write debug output to *stdout* (see
+	// pkg/util/log/log_test_init.go). That interleaves with the `go test -bench`
+	// result lines and makes the output unparseable by the benchmarking platform's
+	// GoBench parser, so silence it for the duration of the benchmark.
+	pkglog.SetupLogger(pkglog.Default(), "off")
+
 	// Disable the HTTP server to avoid colliding with a real agent on dev/CI machines.
 	c.ReceiverPort = 0
 

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -98,5 +98,11 @@ def benchmarks(ctx, bench, output="./trace-agent.benchmarks.out"):
     # TODO: remove once Bazel is used to build the Agent
     schema_codegen(ctx)
 
+    env = os.environ.copy()
+    env["DD_LOG_LEVEL"] = "info"
+
     with ctx.cd("./pkg/trace"):
-        ctx.run(f"go test -tags=test -run=XXX -bench \"{bench}\" -benchmem -count 1 -benchtime 2s ./... | tee {output}")
+        ctx.run(
+            f"go test -tags=test -run=XXX -bench \"{bench}\" -benchmem -count 1 -benchtime 2s ./... | tee {output}",
+            env=env,
+        )

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -98,8 +98,12 @@ def benchmarks(ctx, bench, output="./trace-agent.benchmarks.out"):
     # TODO: remove once Bazel is used to build the Agent
     schema_codegen(ctx)
 
+    # The `test` build tag wires pkg/util/log to write to stdout (pkg/util/log/log_test_init.go),
+    # defaulting to the `debug` level. Those lines interleave with the `go test -bench` result
+    # lines and make the output unparseable by benchmark tooling, so silence the logger unless
+    # the caller explicitly asked for a level.
     env = os.environ.copy()
-    env["DD_LOG_LEVEL"] = "info"
+    env.setdefault("DD_LOG_LEVEL", "off")
 
     with ctx.cd("./pkg/trace"):
         ctx.run(

--- a/test/benchmarks/apm_scripts/analyze-results.sh
+++ b/test/benchmarks/apm_scripts/analyze-results.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Without this, a failing `benchmark_analyzer convert` leaves base.json/pr.json missing and the
+# job still reports success (the remaining steps are guarded with `|| :`), silently producing
+# no report at all.
+set -e
+
 export UNCONFIDENCE_THRESHOLD=2.0
 
 CI_JOB_DATE=$(date +%s)


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Remove the extraneous debug logs in the benchmarking job, these break the parser we use to analyze bench results.
Reenable the benchmarking job now that it's been regenerated and properly signed

### Motivation

### Describe how you validated your changes
Ran the jobs and validated with APM benchmarking platform team

### Additional Notes
