### PR TITLE
fix(anomaly-detection): Count scorer reports in emitted telemetry

### DIFF
--- a/comp/anomalydetection/reporter/impl/BUILD.bazel
+++ b/comp/anomalydetection/reporter/impl/BUILD.bazel
@@ -28,10 +28,15 @@ dd_agent_go_test(
     srcs = [
         "notify_test.go",
         "payload_test.go",
+        "reporter_test.go",
     ],
     embed = [":impl"],
     deps = [
         "//comp/anomalydetection/observer/def",
+        "//comp/anomalydetection/reporter/def",
+        "//comp/core/telemetry/def",
+        "//comp/core/telemetry/impl",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/comp/anomalydetection/reporter/impl/reporter.go
+++ b/comp/anomalydetection/reporter/impl/reporter.go
@@ -23,9 +23,22 @@ import (
 const (
 	// telemetryReportsOngoing counts advances where at least one already-seen correlation was still active.
 	telemetryReportsOngoing = "observer.reports.ongoing"
-	// telemetryReportsEmitted counts new correlation patterns seen for the first time (would-have-been event reports).
+	// telemetryReportsEmitted counts report events produced locally, partitioned by kind.
 	telemetryReportsEmitted = "observer.reports.emitted"
+
+	reportKindCorrelation    = "correlation"
+	reportKindEpisodeStarted = "episode_started"
+	reportKindEpisodeEnded   = "episode_ended"
 )
+
+func newReportsEmittedCounter(telemetry telemetryComp.Component) telemetryComp.Counter {
+	return telemetry.NewCounter(
+		"observer",
+		telemetryReportsEmitted,
+		[]string{"kind"},
+		"Number of report events produced locally, partitioned by kind",
+	)
+}
 
 // Requires defines the dependencies for the live reporter component.
 type Requires struct {
@@ -53,12 +66,7 @@ func NewComponent(req Requires) (Provides, error) {
 		nil,
 		"Number of advances with at least one ongoing (already-seen) active anomaly correlation",
 	)
-	emittedCounter := req.Telemetry.NewCounter(
-		"observer",
-		telemetryReportsEmitted,
-		nil,
-		"Number of new anomaly correlation patterns detected for the first time",
-	)
+	emittedCounter := newReportsEmittedCounter(req.Telemetry)
 
 	reporters := []reporterdef.Reporter{&stdoutReporter{
 		ongoingCounter: ongoingCounter,
@@ -112,11 +120,11 @@ func (r *stdoutReporter) Report(output reporterdef.ReportOutput) bool {
 	newlyDetected := make(map[string]struct{}, len(output.CorrelatorEvents))
 
 	// Log all correlator events at info level and drive the emitted counter.
-	// emittedCounter counts only CorrelationDetected events (new pattern first-seen
-	// or recurrence); episode events are not counted.
 	for _, ce := range output.CorrelatorEvents {
 		switch ce.Kind {
 		case observerdef.CorrelatorEventEpisodeStarted:
+			r.emittedCounter.Add(1, reportKindEpisodeStarted)
+			emitted = true
 			if r.stdoutEnabled {
 				message := formatScorerContributorMessage(ce.Contributors, r.storage)
 				if message == "" {
@@ -127,6 +135,8 @@ func (r *stdoutReporter) Report(output reporterdef.ReportOutput) bool {
 				}
 			}
 		case observerdef.CorrelatorEventEpisodeEnded:
+			r.emittedCounter.Add(1, reportKindEpisodeEnded)
+			emitted = true
 			if r.stdoutEnabled {
 				logging.Infof("reporter scorer episode ended: scorer=%s pattern=%s t=%d duration=%ds",
 					ce.CorrelatorName, ce.Correlation.Pattern, ce.Timestamp,
@@ -134,7 +144,7 @@ func (r *stdoutReporter) Report(output reporterdef.ReportOutput) bool {
 			}
 		case observerdef.CorrelatorEventCorrelationDetected:
 			newlyDetected[ce.Correlation.Pattern] = struct{}{}
-			r.emittedCounter.Add(1)
+			r.emittedCounter.Add(1, reportKindCorrelation)
 			emitted = true
 			if r.stdoutEnabled {
 				logging.Infof("reporter anomaly detection report: pattern=%s title=%q members=%d",

--- a/comp/anomalydetection/reporter/impl/reporter_test.go
+++ b/comp/anomalydetection/reporter/impl/reporter_test.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package reporterimpl
+
+import (
+	"testing"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+	reporterdef "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStdoutReporterCountsEveryReportKind(t *testing.T) {
+	tel := telemetryimpl.GetCompatComponent()
+	tel.Reset()
+	t.Cleanup(tel.Reset)
+
+	reporter := &stdoutReporter{
+		emittedCounter: newReportsEmittedCounter(tel),
+	}
+
+	for _, kind := range []observerdef.CorrelatorEventKind{
+		observerdef.CorrelatorEventEpisodeStarted,
+		observerdef.CorrelatorEventEpisodeEnded,
+		observerdef.CorrelatorEventCorrelationDetected,
+	} {
+		emitted := reporter.Report(reporterOutputWithEvent(kind))
+		require.True(t, emitted)
+	}
+
+	assert.Equal(t, 1.0, reportCounterValue(t, tel, reportKindEpisodeStarted))
+	assert.Equal(t, 1.0, reportCounterValue(t, tel, reportKindEpisodeEnded))
+	assert.Equal(t, 1.0, reportCounterValue(t, tel, reportKindCorrelation))
+}
+
+func reporterOutputWithEvent(kind observerdef.CorrelatorEventKind) reporterdef.ReportOutput {
+	return reporterdef.ReportOutput{
+		CorrelatorEvents: []observerdef.CorrelatorEvent{{
+			Kind: kind,
+			Correlation: observerdef.ActiveCorrelation{
+				Pattern: "test-pattern",
+			},
+		}},
+	}
+}
+
+func reportCounterValue(t *testing.T, tel telemetry.Component, kind string) float64 {
+	t.Helper()
+
+	metricFamilies, err := tel.Gather(false)
+	require.NoError(t, err)
+
+	for _, family := range metricFamilies {
+		if family.GetName() != "observer__"+telemetryReportsEmitted {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			labels := metric.GetLabel()
+			if len(labels) == 1 && labels[0].GetName() == "kind" && labels[0].GetValue() == kind {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+
+	t.Fatalf("counter %q with kind=%q not found", telemetryReportsEmitted, kind)
+	return 0
+}

--- a/test/new-e2e/tests/anomalydetection/helpers_test.go
+++ b/test/new-e2e/tests/anomalydetection/helpers_test.go
@@ -209,6 +209,9 @@ func waitForScorerEpisode(s observerTestSuite, expectedAnomalySource string) {
 			"journal should contain the scorer episode-started marker after anomalies")
 		assert.Contains(c, out, expectedAnomalySource,
 			"journal should contain an anomaly from the test input source")
+		tel := observerTelemetryOutput(s)
+		assert.True(c, containsMetricWithTags(tel, telemetryReportsEmitted, map[string]string{"kind": "episode_started"}),
+			"observer telemetry should count the scorer episode-started report")
 	}, 3*time.Minute, 5*time.Second)
 	s.T().Log("anomaly scorer episode detected")
 }


### PR DESCRIPTION
### What does this PR do?

Extends `observer.reports.emitted` with a bounded `kind` tag and counts every locally produced report event:

- `correlation` for TimeCluster `CorrelationDetected` events
- `episode_started` when the scorer enters its reporting threshold
- `episode_ended` when the scorer exits its reporting threshold

It also makes the stdout reporter's return value reflect episode-only report output, adds focused counter tests, and extends the existing scorer episode E2E assertion to require the new telemetry dimension.

### Motivation

Follow-up to #54755. During staging validation, scorer episode events were produced and sent while `observer.reports.emitted` remained absent because the counter only covered TimeCluster correlations. The metric title implied all locally emitted reports, so this adds equivalent visibility for scorer reports while keeping cardinality bounded to three fixed values.

This metric counts local report production; it does not indicate backend delivery success.

### Describe how you validated your changes

- `dda inv test --targets=./comp/anomalydetection/reporter/impl/`
- `bazel test //comp/anomalydetection/reporter/impl:impl_test`
- Compiled `./test/new-e2e/tests/anomalydetection/` with `-run=^$`; compilation completed, but the local command could not write its empty result JSON because the disk filled during dependency downloads.
