### PR TITLE
create dynamicTags map if nil and needed

### DIFF
--- a/pkg/network/sender/tags.go
+++ b/pkg/network/sender/tags.go
@@ -92,6 +92,9 @@ func (d *directSender) addTags(builder *model.ConnectionBuilder, nc network.Conn
 	for _, encoder := range usmEncoders {
 		encoderStaticTags, encoderDynamicTags := encoder.EncodeConnection(nc, builder)
 		staticTags |= encoderStaticTags
+		if dynamicTags == nil {
+			dynamicTags = make(map[string]struct{})
+		}
 		maps.Copy(dynamicTags, encoderDynamicTags)
 	}
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Creates the `dynamicTags` map if needed. 

### Motivation

Fixes the flaky test `TestEC2VMWKitDirectSuite/Test00FakeIntakeNPM_HostRequests` caused by the following panic:
```
panic: assignment to entry in nil map

goroutine 482 [running]:
maps.Copy[...](...)
	maps/maps.go:64
github.com/DataDog/datadog-agent/pkg/network/sender.(*directSender).addTags(_, _, {0x0, 0x0, {0x17d32560c510, 0x2, 0x2}, {0x0, 0x0}, {0x0}, ...}, ...)
	github.com/DataDog/datadog-agent/pkg/network/sender/tags.go:95 +0x196
github.com/DataDog/datadog-agent/pkg/network/sender.(*directSender).batches.func5.2(0x17d32480a858)
	github.com/DataDog/datadog-agent/pkg/network/sender/sender.go:466 +0x278
github.com/DataDog/agent-payload/v5/process.(*CollectorConnectionsBuilder).AddConnections(0x17d32480a808, 0x17d3259142d0?)
	github.com/DataDog/agent-payload/v5@v5.0.209/process/connections.proto_builder.go:60 +0xa4
github.com/DataDog/datadog-agent/pkg/network/sender.(*directSender).batches.func5-range1({0x17d32521e000, 0x9d, 0x9d})
	github.com/DataDog/datadog-agent/pkg/network/sender/sender.go:462 +0x650
github.com/DataDog/datadog-agent/pkg/network/sender.(*directSender).batches.func5.Chunk[...].5(...)
	slices/iter.go:109
github.com/DataDog/datadog-agent/pkg/network/sender.(*directSender).batches.func5(0x17d323f0d440?)
	github.com/DataDog/datadog-agent/pkg/network/sender/sender.go:431 +0x21c
github.com/DataDog/datadog-agent/pkg/network/sender.(*directSender).collect(0x17d323f0d440)
	github.com/DataDog/datadog-agent/pkg/network/sender/sender.go:336 +0x495
github.com/DataDog/datadog-agent/pkg/network/sender.(*directSender).start.func1()
	github.com/DataDog/datadog-agent/pkg/network/sender/sender.go:235 +0x72
created by github.com/DataDog/datadog-agent/pkg/network/sender.(*directSender).start in goroutine 213
	github.com/DataDog/datadog-agent/pkg/network/sender/sender.go:226 +0xf6
```

### Describe how you validated your changes

### Additional Notes
