### PR TITLE
Expose DPA mode and resource metrics

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/metrics/BUILD.bazel
+++ b/pkg/clusteragent/autoscaling/workload/metrics/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/metrics",
     visibility = ["//visibility:public"],
     deps = [
+        "//comp/core/tagger/tags",
         "//pkg/clusteragent/autoscaling/workload/model",
         "//pkg/clusteragent/metricsstore",
         "//pkg/util/kubernetes",

--- a/pkg/clusteragent/autoscaling/workload/metrics/BUILD.bazel
+++ b/pkg/clusteragent/autoscaling/workload/metrics/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/util/kubernetes/apiserver/leaderelection/metrics",
         "//pkg/util/log",
         "@com_github_datadog_datadog_operator_api//datadoghq/common",
+        "@com_github_datadog_datadog_operator_api//datadoghq/v1alpha2",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/util/errors",
     ],

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	taggerTags "github.com/DataDog/datadog-agent/comp/core/tagger/tags"
 	corev1 "k8s.io/api/core/v1"
 
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
@@ -27,6 +28,10 @@ const (
 	metricPrefix = "datadog.cluster_agent.autoscaling.workload"
 
 	allContainersTagValue = "all"
+
+	dpaModeTagKey      = "dpa_mode"
+	dpaDimensionTagKey = "dpa_dimension"
+	resourceNameTagKey = "resource_name"
 
 	dpaDimensionHorizontal = "horizontal"
 	dpaDimensionVertical   = "vertical"
@@ -63,8 +68,8 @@ func baseAutoscalerTags(internal *model.PodAutoscalerInternal) []string {
 
 func resourceTags(containerName, resourceName string) []string {
 	return []string{
-		"resource_name:" + resourceName,
-		"kube_container_name:" + containerName,
+		resourceNameTagKey + ":" + resourceName,
+		taggerTags.KubeContainerName + ":" + containerName,
 	}
 }
 
@@ -74,14 +79,14 @@ func conditionTags(baseTags []string, conditionType string) []string {
 }
 
 func applyModeTags(baseTags []string, applyMode, dimension string) []string {
-	return append(baseTags, "dpa_mode:"+applyMode, "dpa_dimension:"+dimension)
+	return append(baseTags, dpaModeTagKey+":"+applyMode, dpaDimensionTagKey+":"+dimension)
 }
 
 func controlledResourceTags(baseTags []string, containerName string, resource corev1.ResourceName) []string {
 	if containerName == "*" {
 		containerName = allContainersTagValue
 	}
-	return append(baseTags, "kube_container_name:"+containerName, "resource_name:"+string(resource), "dpa_dimension:"+dpaDimensionVertical)
+	return append(baseTags, taggerTags.KubeContainerName+":"+containerName, resourceNameTagKey+":"+string(resource), dpaDimensionTagKey+":"+dpaDimensionVertical)
 }
 
 func applyModeTagValue(spec *datadoghq.DatadogPodAutoscalerSpec) string {
@@ -130,10 +135,10 @@ func appendApplyModeMetrics(metrics metricsstore.StructuredMetrics, internal *mo
 func objectiveTags(baseTags []string, objectiveType, valueType, resourceName, containerName string, index int) []string {
 	tags := append(baseTags, "objective_type:"+objectiveType, "value_type:"+valueType, "objective_index:"+strconv.Itoa(index))
 	if resourceName != "" {
-		tags = append(tags, "resource_name:"+resourceName)
+		tags = append(tags, resourceNameTagKey+":"+resourceName)
 	}
 	if containerName != "" {
-		tags = append(tags, "kube_container_name:"+containerName)
+		tags = append(tags, taggerTags.KubeContainerName+":"+containerName)
 	}
 	return tags
 }
@@ -426,7 +431,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		// Mirror the resolveMinMaxBounds fallback from controller_vertical_helpers.go:
 		// prefer top-level MinAllowed/MaxAllowed; fall back to deprecated Requests field.
 		for _, container := range spec.Constraints.Containers {
-			containerTags := append(baseTags, "kube_container_name:"+container.Name)
+			containerTags := append(baseTags, taggerTags.KubeContainerName+":"+container.Name)
 
 			if container.Enabled == nil || *container.Enabled {
 				seenResources := make(map[corev1.ResourceName]struct{})
@@ -547,7 +552,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		// 14b. Vertical desired resources from status (per container, CPU in millicores, memory in bytes)
 		if vertical := podAutoscaler.Status.Vertical; vertical != nil && vertical.Target != nil {
 			for _, container := range vertical.Target.DesiredResources {
-				containerTags := append(baseTags, "kube_container_name:"+container.Name)
+				containerTags := append(baseTags, taggerTags.KubeContainerName+":"+container.Name)
 				if cpuReq, ok := container.Requests[corev1.ResourceCPU]; ok {
 					metrics = append(metrics, metricsstore.StructuredMetric{
 						Name:  metricPrefix + ".status.vertical.desired.container.cpu.request",

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator.go
@@ -86,7 +86,7 @@ func controlledResourceTags(baseTags []string, containerName string, resource co
 	if containerName == "*" {
 		containerName = allContainersTagValue
 	}
-	return append(baseTags, taggerTags.KubeContainerName+":"+containerName, resourceNameTagKey+":"+string(resource), dpaDimensionTagKey+":"+dpaDimensionVertical)
+	return append(baseTags, taggerTags.KubeContainerName+":"+containerName, resourceNameTagKey+":"+string(resource))
 }
 
 func applyModeTagValue(spec *datadoghq.DatadogPodAutoscalerSpec) string {

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator.go
@@ -125,6 +125,43 @@ func appendApplyModeMetrics(metrics metricsstore.StructuredMetrics, internal *mo
 	return metrics
 }
 
+func appendControlledResourcesMetrics(metrics metricsstore.StructuredMetrics, internal *model.PodAutoscalerInternal, baseTags []string) metricsstore.StructuredMetrics {
+	if internal == nil || !internal.IsVerticalScalingEnabled() {
+		return metrics
+	}
+
+	spec := internal.Spec()
+	if spec == nil {
+		return metrics
+	}
+
+	containers := []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{{Name: "*"}}
+	if spec.Constraints != nil && len(spec.Constraints.Containers) > 0 {
+		containers = spec.Constraints.Containers
+	}
+
+	for _, container := range containers {
+		if container.Enabled != nil && !*container.Enabled {
+			continue
+		}
+		seenResources := make(map[corev1.ResourceName]struct{})
+		for _, resource := range controlledResourcesForMetrics(container.ControlledResources) {
+			if _, seen := seenResources[resource]; seen {
+				continue
+			}
+			seenResources[resource] = struct{}{}
+			metrics = append(metrics, metricsstore.StructuredMetric{
+				Name:  metricPrefix + ".vertical_scaling.controlled_resources",
+				Type:  metricsstore.MetricTypeGauge,
+				Value: 1.0,
+				Tags:  controlledResourceTags(baseTags, container.Name, resource),
+			})
+		}
+	}
+
+	return metrics
+}
+
 // objectiveTags generates tags for autoscaler objective (target) metrics.
 // index is the 0-based position of the objective in spec.objectives[]; it guarantees a unique
 // tag-set per objective (so multiple objectives never collapse into the same timeseries), which
@@ -433,22 +470,6 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		for _, container := range spec.Constraints.Containers {
 			containerTags := append(baseTags, taggerTags.KubeContainerName+":"+container.Name)
 
-			if container.Enabled == nil || *container.Enabled {
-				seenResources := make(map[corev1.ResourceName]struct{})
-				for _, resource := range controlledResourcesForMetrics(container.ControlledResources) {
-					if _, seen := seenResources[resource]; seen {
-						continue
-					}
-					seenResources[resource] = struct{}{}
-					metrics = append(metrics, metricsstore.StructuredMetric{
-						Name:  metricPrefix + ".vertical_scaling.controlled_resources",
-						Type:  metricsstore.MetricTypeGauge,
-						Value: 1.0,
-						Tags:  controlledResourceTags(baseTags, container.Name, resource),
-					})
-				}
-			}
-
 			effectiveMin := container.MinAllowed
 			if len(effectiveMin) == 0 && container.Requests != nil {
 				effectiveMin = container.Requests.MinAllowed
@@ -493,7 +514,10 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		}
 	}
 
-	// 13. Autoscaling objectives (target values from spec)
+	// 13. Vertical controlled resources
+	metrics = appendControlledResourcesMetrics(metrics, internal, baseTags)
+
+	// 14. Autoscaling objectives (target values from spec)
 	if spec := internal.Spec(); spec != nil {
 		for idx, objective := range spec.Objectives {
 			switch objective.Type {
@@ -537,9 +561,9 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		}
 	}
 
-	// 14. Status metrics and autoscaler conditions (from upstream CR)
+	// 15. Status metrics and autoscaler conditions (from upstream CR)
 	if podAutoscaler := internal.UpstreamCR(); podAutoscaler != nil {
-		// 14a. Horizontal desired replicas from status
+		// 15a. Horizontal desired replicas from status
 		if horizontal := podAutoscaler.Status.Horizontal; horizontal != nil && horizontal.Target != nil {
 			metrics = append(metrics, metricsstore.StructuredMetric{
 				Name:  metricPrefix + ".status.desired.replicas",
@@ -549,7 +573,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 			})
 		}
 
-		// 14b. Vertical desired resources from status (per container, CPU in millicores, memory in bytes)
+		// 15b. Vertical desired resources from status (per container, CPU in millicores, memory in bytes)
 		if vertical := podAutoscaler.Status.Vertical; vertical != nil && vertical.Target != nil {
 			for _, container := range vertical.Target.DesiredResources {
 				containerTags := append(baseTags, taggerTags.KubeContainerName+":"+container.Name)
@@ -588,7 +612,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 			}
 		}
 
-		// 14c. Autoscaler conditions
+		// 15c. Autoscaler conditions
 		for _, condition := range podAutoscaler.Status.Conditions {
 			value := 0.0
 			if condition.Status == corev1.ConditionTrue {

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/metricsstore"
@@ -24,6 +25,11 @@ import (
 
 const (
 	metricPrefix = "datadog.cluster_agent.autoscaling.workload"
+
+	allContainersTagValue = "all"
+
+	dpaDimensionHorizontal = "horizontal"
+	dpaDimensionVertical   = "vertical"
 )
 
 // Tag generation helper functions
@@ -65,6 +71,53 @@ func resourceTags(containerName, resourceName string) []string {
 // conditionTags generates tags for autoscaler condition metrics
 func conditionTags(baseTags []string, conditionType string) []string {
 	return append(baseTags, "type:"+conditionType)
+}
+
+func applyModeTags(baseTags []string, applyMode, dimension string) []string {
+	return append(baseTags, "dpa_mode:"+applyMode, "dpa_dimension:"+dimension)
+}
+
+func controlledResourceTags(baseTags []string, containerName string, resource corev1.ResourceName) []string {
+	if containerName == "*" {
+		containerName = allContainersTagValue
+	}
+	return append(baseTags, "kube_container_name:"+containerName, "resource_name:"+string(resource), "dpa_dimension:"+dpaDimensionVertical)
+}
+
+func applyModeTagValue(spec *datadoghq.DatadogPodAutoscalerSpec) string {
+	mode := datadoghq.DatadogPodAutoscalerApplyModeApply
+	if spec != nil && spec.ApplyPolicy != nil && spec.ApplyPolicy.Mode != "" {
+		mode = spec.ApplyPolicy.Mode
+	}
+	return strings.ToLower(string(mode))
+}
+
+func controlledResourcesForMetrics(resources []corev1.ResourceName) []corev1.ResourceName {
+	if resources == nil {
+		return []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory}
+	}
+	return resources
+}
+
+func appendApplyModeMetrics(metrics metricsstore.StructuredMetrics, internal *model.PodAutoscalerInternal, baseTags []string) metricsstore.StructuredMetrics {
+	applyMode := applyModeTagValue(internal.Spec())
+	if internal.IsHorizontalScalingEnabled() {
+		metrics = append(metrics, metricsstore.StructuredMetric{
+			Name:  metricPrefix + ".apply_mode",
+			Type:  metricsstore.MetricTypeGauge,
+			Value: 1.0,
+			Tags:  applyModeTags(baseTags, applyMode, dpaDimensionHorizontal),
+		})
+	}
+	if internal.IsVerticalScalingEnabled() {
+		metrics = append(metrics, metricsstore.StructuredMetric{
+			Name:  metricPrefix + ".apply_mode",
+			Type:  metricsstore.MetricTypeGauge,
+			Value: 1.0,
+			Tags:  applyModeTags(baseTags, applyMode, dpaDimensionVertical),
+		})
+	}
+	return metrics
 }
 
 // objectiveTags generates tags for autoscaler objective (target) metrics.
@@ -171,7 +224,10 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		Tags:  baseTags,
 	})
 
-	// 3. Horizontal scaling received replicas
+	// 3. DPA apply mode
+	metrics = appendApplyModeMetrics(metrics, internal, baseTags)
+
+	// 4. Horizontal scaling received replicas
 	if scalingValues.Horizontal != nil {
 		metrics = append(metrics, metricsstore.StructuredMetric{
 			Name:  metricPrefix + ".horizontal_scaling_received_replicas",
@@ -181,7 +237,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		})
 	}
 
-	// 4. Vertical scaling received requests and limits
+	// 5. Vertical scaling received requests and limits
 	if scalingValues.Vertical != nil {
 		for _, containerResources := range scalingValues.Vertical.ContainerResources {
 			// Requests
@@ -206,7 +262,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		}
 	}
 
-	// 5. Horizontal scaling last action metrics
+	// 6. Horizontal scaling last action metrics
 	lastHorizontalActions := internal.HorizontalLastActions()
 	actionSource := ""
 	if sv := internal.ScalingValues(); sv.Horizontal != nil {
@@ -240,7 +296,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		Tags:  append(horizontalTags, "status:ok"),
 	})
 
-	// 6. Vertical scaling last action metrics
+	// 7. Vertical scaling last action metrics
 	metrics = append(metrics, metricsstore.StructuredMetric{
 		Name:  metricPrefix + ".vertical_rollout_triggered",
 		Type:  metricsstore.MetricTypeMonotonicCount,
@@ -255,7 +311,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		Tags:  append(baseWithVerticalSourceTags, "status:ok"),
 	})
 
-	// 7. In-place vertical scaling action metrics
+	// 8. In-place vertical scaling action metrics
 	metrics = append(metrics, metricsstore.StructuredMetric{
 		Name:  metricPrefix + ".vertical_inplace.patch",
 		Type:  metricsstore.MetricTypeMonotonicCount,
@@ -310,7 +366,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		Tags:  baseWithVerticalSourceTags,
 	})
 
-	// 8. Vertical scaled/evicted replica gauges
+	// 9. Vertical scaled/evicted replica gauges
 	if scaledReplicas := internal.ScaledReplicas(); scaledReplicas != nil {
 		metrics = append(metrics, metricsstore.StructuredMetric{
 			Name:  metricPrefix + ".status.vertical.scaled_replicas",
@@ -328,7 +384,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		})
 	}
 
-	// 9. Local recommender horizontal metrics
+	// 10. Local recommender horizontal metrics
 	if fallbackHorizontal := internal.FallbackScalingValues().Horizontal; fallbackHorizontal != nil {
 		localSourceTags := append(baseTags, "source:"+string(fallbackHorizontal.Source))
 		metrics = append(metrics, metricsstore.StructuredMetric{
@@ -347,7 +403,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		}
 	}
 
-	// 10. Horizontal scaling constraints
+	// 11. Horizontal scaling constraints
 	if spec := internal.Spec(); spec != nil && spec.Constraints != nil {
 		if spec.Constraints.MaxReplicas != nil {
 			metrics = append(metrics, metricsstore.StructuredMetric{
@@ -366,11 +422,27 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 			})
 		}
 
-		// 11. Vertical scaling container constraints (per container, CPU in millicores, memory in bytes)
+		// 12. Vertical scaling container constraints (per container, CPU in millicores, memory in bytes)
 		// Mirror the resolveMinMaxBounds fallback from controller_vertical_helpers.go:
 		// prefer top-level MinAllowed/MaxAllowed; fall back to deprecated Requests field.
 		for _, container := range spec.Constraints.Containers {
 			containerTags := append(baseTags, "kube_container_name:"+container.Name)
+
+			if container.Enabled == nil || *container.Enabled {
+				seenResources := make(map[corev1.ResourceName]struct{})
+				for _, resource := range controlledResourcesForMetrics(container.ControlledResources) {
+					if _, seen := seenResources[resource]; seen {
+						continue
+					}
+					seenResources[resource] = struct{}{}
+					metrics = append(metrics, metricsstore.StructuredMetric{
+						Name:  metricPrefix + ".vertical_scaling.controlled_resources",
+						Type:  metricsstore.MetricTypeGauge,
+						Value: 1.0,
+						Tags:  controlledResourceTags(baseTags, container.Name, resource),
+					})
+				}
+			}
 
 			effectiveMin := container.MinAllowed
 			if len(effectiveMin) == 0 && container.Requests != nil {
@@ -416,7 +488,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		}
 	}
 
-	// 12. Autoscaling objectives (target values from spec)
+	// 13. Autoscaling objectives (target values from spec)
 	if spec := internal.Spec(); spec != nil {
 		for idx, objective := range spec.Objectives {
 			switch objective.Type {
@@ -460,9 +532,9 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		}
 	}
 
-	// 13. Status metrics and autoscaler conditions (from upstream CR)
+	// 14. Status metrics and autoscaler conditions (from upstream CR)
 	if podAutoscaler := internal.UpstreamCR(); podAutoscaler != nil {
-		// 13a. Horizontal desired replicas from status
+		// 14a. Horizontal desired replicas from status
 		if horizontal := podAutoscaler.Status.Horizontal; horizontal != nil && horizontal.Target != nil {
 			metrics = append(metrics, metricsstore.StructuredMetric{
 				Name:  metricPrefix + ".status.desired.replicas",
@@ -472,7 +544,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 			})
 		}
 
-		// 13b. Vertical desired resources from status (per container, CPU in millicores, memory in bytes)
+		// 14b. Vertical desired resources from status (per container, CPU in millicores, memory in bytes)
 		if vertical := podAutoscaler.Status.Vertical; vertical != nil && vertical.Target != nil {
 			for _, container := range vertical.Target.DesiredResources {
 				containerTags := append(baseTags, "kube_container_name:"+container.Name)
@@ -511,7 +583,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 			}
 		}
 
-		// 13c. Autoscaler conditions
+		// 14c. Autoscaler conditions
 		for _, condition := range podAutoscaler.Status.Conditions {
 			value := 0.0
 			if condition.Status == corev1.ConditionTrue {

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
@@ -77,6 +77,60 @@ func TestConditionTags(t *testing.T) {
 	assert.Contains(t, tags, le.IsLeaderLabel+":"+le.JoinLeaderValue)
 }
 
+func expectedAdditionalMetricsCount(internal *model.PodAutoscalerInternal) int {
+	return expectedApplyModeMetricsCount(internal) + expectedControlledResourcesMetricsCount(internal)
+}
+
+func expectedApplyModeMetricsCount(internal *model.PodAutoscalerInternal) int {
+	if internal == nil {
+		return 0
+	}
+	count := 0
+	if internal.IsHorizontalScalingEnabled() {
+		count++
+	}
+	if internal.IsVerticalScalingEnabled() {
+		count++
+	}
+	return count
+}
+
+func expectedControlledResourcesMetricsCount(internal *model.PodAutoscalerInternal) int {
+	if internal == nil || internal.Spec() == nil || internal.Spec().Constraints == nil {
+		return 0
+	}
+
+	count := 0
+	for _, container := range internal.Spec().Constraints.Containers {
+		if container.Enabled != nil && !*container.Enabled {
+			continue
+		}
+		resources := container.ControlledResources
+		if resources == nil {
+			resources = []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory}
+		}
+		seenResources := make(map[corev1.ResourceName]struct{})
+		for _, resource := range resources {
+			if _, seen := seenResources[resource]; seen {
+				continue
+			}
+			seenResources[resource] = struct{}{}
+			count++
+		}
+	}
+	return count
+}
+
+func tagValue(tags []string, key string) string {
+	prefix := key + ":"
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, prefix) {
+			return strings.TrimPrefix(tag, prefix)
+		}
+	}
+	return ""
+}
+
 func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -580,6 +634,72 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 			},
 		},
 		{
+			name: "apply mode defaults to apply for enabled dimensions",
+			setupFunc: func() *model.PodAutoscalerInternal {
+				internal := model.FakePodAutoscalerInternal{
+					Namespace: "test-ns",
+					Name:      "test-dpa",
+					Spec: &datadoghq.DatadogPodAutoscalerSpec{
+						TargetRef: v2.CrossVersionObjectReference{
+							Name: "test-deployment",
+						},
+					},
+				}.Build()
+				return &internal
+			},
+			expectedCount: 13, // baseline only; apply_mode count is added by expectedAdditionalMetricsCount
+			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
+				dimensions := map[string]bool{}
+				for _, m := range metrics {
+					if m.Name != metricPrefix+".apply_mode" {
+						continue
+					}
+					assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+					assert.Equal(t, 1.0, m.Value)
+					assert.Contains(t, m.Tags, "dpa_mode:apply")
+					dimensions[tagValue(m.Tags, "dpa_dimension")] = true
+				}
+				assert.Equal(t, map[string]bool{
+					"horizontal": true,
+					"vertical":   true,
+				}, dimensions)
+			},
+		},
+		{
+			name: "apply mode preview omits disabled vertical dimension",
+			setupFunc: func() *model.PodAutoscalerInternal {
+				internal := model.FakePodAutoscalerInternal{
+					Namespace: "test-ns",
+					Name:      "test-dpa",
+					Spec: &datadoghq.DatadogPodAutoscalerSpec{
+						TargetRef: v2.CrossVersionObjectReference{
+							Name: "test-deployment",
+						},
+						ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+							Mode: datadoghq.DatadogPodAutoscalerApplyModePreview,
+							Update: &datadoghqcommon.DatadogPodAutoscalerUpdatePolicy{
+								Strategy: datadoghqcommon.DatadogPodAutoscalerDisabledUpdateStrategy,
+							},
+						},
+					},
+				}.Build()
+				return &internal
+			},
+			expectedCount: 13, // baseline only; apply_mode count is added by expectedAdditionalMetricsCount
+			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
+				var applyModeMetrics []metricsstore.StructuredMetric
+				for _, m := range metrics {
+					if m.Name == metricPrefix+".apply_mode" {
+						applyModeMetrics = append(applyModeMetrics, m)
+					}
+				}
+				require.Len(t, applyModeMetrics, 1)
+				assert.Equal(t, 1.0, applyModeMetrics[0].Value)
+				assert.Contains(t, applyModeMetrics[0].Tags, "dpa_mode:preview")
+				assert.Contains(t, applyModeMetrics[0].Tags, "dpa_dimension:horizontal")
+			},
+		},
+		{
 			name: "horizontal scaling constraints both min and max",
 			setupFunc: func() *model.PodAutoscalerInternal {
 				internal := model.FakePodAutoscalerInternal{
@@ -705,6 +825,60 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				assert.True(t, memMinFound, "memory.request_min metric not found")
 				assert.True(t, cpuMaxFound, "cpu.request_max metric not found")
 				assert.True(t, memMaxFound, "memory.request_max metric not found")
+			},
+		},
+		{
+			name: "vertical controlled resources metrics",
+			setupFunc: func() *model.PodAutoscalerInternal {
+				internal := model.FakePodAutoscalerInternal{
+					Namespace: "test-ns",
+					Name:      "test-dpa",
+					Spec: &datadoghq.DatadogPodAutoscalerSpec{
+						TargetRef: v2.CrossVersionObjectReference{
+							Name: "test-deployment",
+						},
+						Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+							Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+								{
+									Name:                "app",
+									ControlledResources: []corev1.ResourceName{corev1.ResourceCPU},
+								},
+								{
+									Name: "*",
+								},
+								{
+									Name:                "empty",
+									ControlledResources: []corev1.ResourceName{},
+								},
+								{
+									Name:                "disabled",
+									Enabled:             pointer.Ptr(false),
+									ControlledResources: []corev1.ResourceName{corev1.ResourceMemory},
+								},
+							},
+						},
+					},
+				}.Build()
+				return &internal
+			},
+			expectedCount: 13, // baseline only; controlled_resources count is added by expectedAdditionalMetricsCount
+			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
+				actual := map[string]float64{}
+				for _, m := range metrics {
+					if m.Name != metricPrefix+".vertical_scaling.controlled_resources" {
+						continue
+					}
+					assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+					assert.Contains(t, m.Tags, "dpa_dimension:vertical")
+					container := tagValue(m.Tags, "kube_container_name")
+					resourceName := tagValue(m.Tags, "resource_name")
+					actual[container+"/"+resourceName] = m.Value
+				}
+				assert.Equal(t, map[string]float64{
+					"app/cpu":    1.0,
+					"all/cpu":    1.0,
+					"all/memory": 1.0,
+				}, actual)
 			},
 		},
 		{
@@ -1486,7 +1660,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 			metrics := GeneratePodAutoscalerMetrics(obj)
 
 			require.NotNil(t, metrics)
-			assert.Equal(t, tt.expectedCount, len(metrics), "unexpected number of metrics")
+			assert.Equal(t, tt.expectedCount+expectedAdditionalMetricsCount(obj), len(metrics), "unexpected number of metrics")
 
 			if tt.validateMetric != nil {
 				tt.validateMetric(t, metrics)

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
@@ -96,21 +96,22 @@ func expectedApplyModeMetricsCount(internal *model.PodAutoscalerInternal) int {
 }
 
 func expectedControlledResourcesMetricsCount(internal *model.PodAutoscalerInternal) int {
-	if internal == nil || internal.Spec() == nil || internal.Spec().Constraints == nil {
+	if internal == nil || internal.Spec() == nil || !internal.IsVerticalScalingEnabled() {
 		return 0
 	}
 
+	containers := []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{{Name: "*"}}
+	if internal.Spec().Constraints != nil && len(internal.Spec().Constraints.Containers) > 0 {
+		containers = internal.Spec().Constraints.Containers
+	}
+
 	count := 0
-	for _, container := range internal.Spec().Constraints.Containers {
+	for _, container := range containers {
 		if container.Enabled != nil && !*container.Enabled {
 			continue
 		}
-		resources := container.ControlledResources
-		if resources == nil {
-			resources = []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory}
-		}
 		seenResources := make(map[corev1.ResourceName]struct{})
-		for _, resource := range resources {
+		for _, resource := range controlledResourcesForMetrics(container.ControlledResources) {
 			if _, seen := seenResources[resource]; seen {
 				continue
 			}
@@ -129,6 +130,24 @@ func tagValue(tags []string, key string) string {
 		}
 	}
 	return ""
+}
+
+func assertControlledResourcesMetrics(t *testing.T, metrics metricsstore.StructuredMetrics, expected map[string]float64) {
+	t.Helper()
+
+	actual := map[string]float64{}
+	for _, m := range metrics {
+		if m.Name != metricPrefix+".vertical_scaling.controlled_resources" {
+			continue
+		}
+		assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+		assert.Contains(t, m.Tags, dpaDimensionTagKey+":"+dpaDimensionVertical)
+		container := tagValue(m.Tags, "kube_container_name")
+		resourceName := tagValue(m.Tags, resourceNameTagKey)
+		actual[container+"/"+resourceName] = m.Value
+	}
+
+	assert.Equal(t, expected, actual)
 }
 
 func TestGeneratePodAutoscalerMetrics(t *testing.T) {
@@ -666,6 +685,51 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 			},
 		},
 		{
+			name: "vertical controlled resources default without constraints",
+			setupFunc: func() *model.PodAutoscalerInternal {
+				internal := model.FakePodAutoscalerInternal{
+					Namespace: "test-ns",
+					Name:      "test-dpa",
+					Spec: &datadoghq.DatadogPodAutoscalerSpec{
+						TargetRef: v2.CrossVersionObjectReference{
+							Name: "test-deployment",
+						},
+					},
+				}.Build()
+				return &internal
+			},
+			expectedCount: 13, // baseline only; controlled_resources count is added by expectedAdditionalMetricsCount
+			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
+				assertControlledResourcesMetrics(t, metrics, map[string]float64{
+					"all/cpu":    1.0,
+					"all/memory": 1.0,
+				})
+			},
+		},
+		{
+			name: "vertical controlled resources default with empty container constraints",
+			setupFunc: func() *model.PodAutoscalerInternal {
+				internal := model.FakePodAutoscalerInternal{
+					Namespace: "test-ns",
+					Name:      "test-dpa",
+					Spec: &datadoghq.DatadogPodAutoscalerSpec{
+						TargetRef: v2.CrossVersionObjectReference{
+							Name: "test-deployment",
+						},
+						Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{},
+					},
+				}.Build()
+				return &internal
+			},
+			expectedCount: 13, // baseline only; controlled_resources count is added by expectedAdditionalMetricsCount
+			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
+				assertControlledResourcesMetrics(t, metrics, map[string]float64{
+					"all/cpu":    1.0,
+					"all/memory": 1.0,
+				})
+			},
+		},
+		{
 			name: "apply mode preview omits disabled vertical dimension",
 			setupFunc: func() *model.PodAutoscalerInternal {
 				internal := model.FakePodAutoscalerInternal{
@@ -863,22 +927,11 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 			},
 			expectedCount: 13, // baseline only; controlled_resources count is added by expectedAdditionalMetricsCount
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
-				actual := map[string]float64{}
-				for _, m := range metrics {
-					if m.Name != metricPrefix+".vertical_scaling.controlled_resources" {
-						continue
-					}
-					assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
-					assert.Contains(t, m.Tags, "dpa_dimension:vertical")
-					container := tagValue(m.Tags, "kube_container_name")
-					resourceName := tagValue(m.Tags, "resource_name")
-					actual[container+"/"+resourceName] = m.Value
-				}
-				assert.Equal(t, map[string]float64{
+				assertControlledResourcesMetrics(t, metrics, map[string]float64{
 					"app/cpu":    1.0,
 					"all/cpu":    1.0,
 					"all/memory": 1.0,
-				}, actual)
+				})
 			},
 		},
 		{

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
@@ -141,7 +141,7 @@ func assertControlledResourcesMetrics(t *testing.T, metrics metricsstore.Structu
 			continue
 		}
 		assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
-		assert.Contains(t, m.Tags, dpaDimensionTagKey+":"+dpaDimensionVertical)
+		assert.Empty(t, tagValue(m.Tags, dpaDimensionTagKey))
 		container := tagValue(m.Tags, "kube_container_name")
 		resourceName := tagValue(m.Tags, resourceNameTagKey)
 		actual[container+"/"+resourceName] = m.Value

--- a/pkg/clusteragent/autoscaling/workload/metrics/metrics.md
+++ b/pkg/clusteragent/autoscaling/workload/metrics/metrics.md
@@ -44,6 +44,21 @@ Every metric carries the following base tags.
 
 ---
 
+### Apply mode
+
+#### `datadog.cluster_agent.autoscaling.workload.apply_mode`
+- **Type:** Gauge
+- **Tags:** base tags + `dpa_mode` + `dpa_dimension`
+- **Description:** Info-style metric that exposes the DPA apply mode for each enabled
+  autoscaling dimension. Value is always `1`. The `dpa_mode` tag is `apply` when
+  `spec.applyPolicy.mode` is unset, empty, or `Apply`; it is `preview` when the mode is
+  `Preview`. The `dpa_dimension` tag is `horizontal` or `vertical`; disabled dimensions are not
+  emitted. Use this metric when you need to count or filter DPAs by preview/apply mode. This is
+  separate from `autoscaler_conditions{type:Active}`, which reflects DPA activity state, not
+  preview/apply mode.
+
+---
+
 ### Horizontal scaling — received recommendations
 
 #### `datadog.cluster_agent.autoscaling.workload.horizontal_scaling_received_replicas`
@@ -177,6 +192,18 @@ memory values are in **bytes**.
 - **Description:** Maximum memory request (in bytes) allowed for the container, as configured
   in `spec.constraints.containers[*].maxAllowed` (or the deprecated
   `spec.constraints.containers[*].requests.maxAllowed`).
+
+#### `datadog.cluster_agent.autoscaling.workload.vertical_scaling.controlled_resources`
+- **Type:** Gauge
+- **Tags:** base tags + `kube_container_name` + `resource_name` + `dpa_dimension`
+- **Description:** Info-style metric that exposes which container resources are controlled by
+  vertical autoscaling. Value is always `1`. One point is emitted per controlled resource, so the
+  same DPA/container can emit multiple `resource_name` tag values, such as `cpu` and `memory`.
+  If `spec.constraints.containers[*].controlledResources` is omitted, the metric emits both
+  `resource_name:cpu` and `resource_name:memory`, matching the controller default. If
+  `controlledResources` is an empty list or the container constraint has `enabled: false`, no
+  point is emitted for that container constraint. A wildcard container constraint named `*` is
+  emitted as `kube_container_name:all`. The `dpa_dimension` tag is always `vertical`.
 
 ---
 

--- a/pkg/clusteragent/autoscaling/workload/metrics/metrics.md
+++ b/pkg/clusteragent/autoscaling/workload/metrics/metrics.md
@@ -52,8 +52,9 @@ Every metric carries the following base tags.
 - **Description:** Info-style metric that exposes the DPA apply mode for each enabled
   autoscaling dimension. Value is always `1`. The `dpa_mode` tag is `apply` when
   `spec.applyPolicy.mode` is unset, empty, or `Apply`; it is `preview` when the mode is
-  `Preview`. The `dpa_dimension` tag is `horizontal` or `vertical`; disabled dimensions are not
-  emitted. Use this metric when you need to count or filter DPAs by preview/apply mode.
+  `Preview`. The `dpa_dimension` tag is emitted for each enabled dimension (`horizontal`,
+  `vertical`, or both); disabled dimensions are not emitted. Use this metric when you need to count
+  or filter DPAs by preview/apply mode.
 
 ---
 
@@ -193,7 +194,7 @@ memory values are in **bytes**.
 
 #### `datadog.cluster_agent.autoscaling.workload.vertical_scaling.controlled_resources`
 - **Type:** Gauge
-- **Tags:** base tags + `kube_container_name` + `resource_name` + `dpa_dimension`
+- **Tags:** base tags + `kube_container_name` + `resource_name`
 - **Description:** Info-style metric that exposes which container resources are controlled by
   vertical autoscaling. Value is always `1`. One point is emitted per controlled resource, so the
   same DPA/container can emit multiple `resource_name` tag values, such as `cpu` and `memory`.
@@ -204,7 +205,7 @@ memory values are in **bytes**.
   emits both `resource_name:cpu` and `resource_name:memory` for that container constraint. If
   `controlledResources` is an empty list or the container constraint has `enabled: false`, no point
   is emitted for that container constraint. A wildcard container constraint named `*` is emitted as
-  `kube_container_name:all`. The `dpa_dimension` tag is always `vertical`.
+  `kube_container_name:all`.
 
 ---
 

--- a/pkg/clusteragent/autoscaling/workload/metrics/metrics.md
+++ b/pkg/clusteragent/autoscaling/workload/metrics/metrics.md
@@ -53,9 +53,7 @@ Every metric carries the following base tags.
   autoscaling dimension. Value is always `1`. The `dpa_mode` tag is `apply` when
   `spec.applyPolicy.mode` is unset, empty, or `Apply`; it is `preview` when the mode is
   `Preview`. The `dpa_dimension` tag is `horizontal` or `vertical`; disabled dimensions are not
-  emitted. Use this metric when you need to count or filter DPAs by preview/apply mode. This is
-  separate from `autoscaler_conditions{type:Active}`, which reflects DPA activity state, not
-  preview/apply mode.
+  emitted. Use this metric when you need to count or filter DPAs by preview/apply mode.
 
 ---
 
@@ -199,11 +197,14 @@ memory values are in **bytes**.
 - **Description:** Info-style metric that exposes which container resources are controlled by
   vertical autoscaling. Value is always `1`. One point is emitted per controlled resource, so the
   same DPA/container can emit multiple `resource_name` tag values, such as `cpu` and `memory`.
-  If `spec.constraints.containers[*].controlledResources` is omitted, the metric emits both
-  `resource_name:cpu` and `resource_name:memory`, matching the controller default. If
-  `controlledResources` is an empty list or the container constraint has `enabled: false`, no
-  point is emitted for that container constraint. A wildcard container constraint named `*` is
-  emitted as `kube_container_name:all`. The `dpa_dimension` tag is always `vertical`.
+  Emitted only when vertical autoscaling is enabled for the DPA.
+  If `spec.constraints` is omitted, or `spec.constraints.containers` is empty, the metric emits
+  `kube_container_name:all` with both `resource_name:cpu` and `resource_name:memory`, matching the
+  controller default. If `spec.constraints.containers[*].controlledResources` is omitted, the metric
+  emits both `resource_name:cpu` and `resource_name:memory` for that container constraint. If
+  `controlledResources` is an empty list or the container constraint has `enabled: false`, no point
+  is emitted for that container constraint. A wildcard container constraint named `*` is emitted as
+  `kube_container_name:all`. The `dpa_dimension` tag is always `vertical`.
 
 ---
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"00000000-0000-0000-0000-000000000000","source":"chat","resourceId":"0a0a94e2-629f-4089-af07-4fe2b56d2cac","workflowId":"34dc8af7-75b1-4963-b7c0-d2ba9c669466","codeChangeId":"34dc8af7-75b1-4963-b7c0-d2ba9c669466","sourceType":"chat"} -->
<!-- dd-meta {"pullId":"00000000-0000-0000-0000-000000000000","source":"chat","resourceId":"0a0a94e2-629f-4089-af07-4fe2b56d2cac","workflowId":"5401d9c3-d2ff-4558-a3d2-271824d69bec","codeChangeId":"5401d9c3-d2ff-4558-a3d2-271824d69bec","sourceType":"chat"} -->
<!-- dd-meta {"pullId":"00000000-0000-0000-0000-000000000000","source":"chat","resourceId":"0a0a94e2-629f-4089-af07-4fe2b56d2cac","workflowId":"8b1cecad-4134-4363-89f4-d1a8386ef3d9","codeChangeId":"8b1cecad-4134-4363-89f4-d1a8386ef3d9","sourceType":"chat"} -->
<!-- dd-meta {"pullId":"cb162b79-9dd9-4f9e-ae1a-6b2c7d054c6e","source":"chat","resourceId":"0a0a94e2-629f-4089-af07-4fe2b56d2cac","workflowId":"1903632d-7078-440a-aeb1-873bd8a2d2a8","codeChangeId":"1903632d-7078-440a-aeb1-873bd8a2d2a8","sourceType":"chat"} -->
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Adds two Cluster Agent workload autoscaling metrics for DatadogPodAutoscaler visibility.

- `datadog.cluster_agent.autoscaling.workload.apply_mode`
  - Value: `1`
  - Tags: base tags, `dpa_mode`, `dpa_dimension`
  - `dpa_mode` is `apply` or `preview`
  - `dpa_dimension` is emitted for each enabled autoscaling dimension: `horizontal`, `vertical`, or both

- `datadog.cluster_agent.autoscaling.workload.vertical_scaling.controlled_resources`
  - Value: `1`
  - Tags: base tags, `kube_container_name`, `resource_name`
  - Emits one point per resource controlled by vertical autoscaling for a container
  - Uses `kube_container_name:all` for wildcard or default container constraints
  - Defaults to `resource_name:cpu` and `resource_name:memory` when `controlledResources` is omitted, including unconstrained vertical DPAs

### Motivation

Dashboards need to identify DPA preview/apply mode by autoscaling dimension and show which container resources are vertically autoscaled for one container or all containers.

### Describe how you validated your changes

- Ran `GOENV_VERSION=1.26.3 gofmt -w pkg/clusteragent/autoscaling/workload/metrics/generator.go pkg/clusteragent/autoscaling/workload/metrics/generator_test.go` because the repo-pinned Go `1.26.6` is not installed in this environment.
- Ran `git diff --check`.
- Local `bazel run //:gazelle -- -mode=diff` and `dda inv test --targets=./pkg/clusteragent/autoscaling/workload/metrics` could not complete because Bazel failed fetching the external GCC toolchain through the proxy (`502 Bad Gateway`).

### Additional Notes

N/A

---

PR by Bits - View session in Datadog: https://app.datadoghq.com/code/0a0a94e2-629f-4089-af07-4fe2b56d2cac

Comment @datadog to request changes