### PR TITLE
refactor(delegated-auth): prepare config writeback for dual shipping

### DIFF
--- a/comp/core/delegatedauth/impl/delegatedauth.go
+++ b/comp/core/delegatedauth/impl/delegatedauth.go
@@ -188,6 +188,9 @@ func (d *delegatedAuthComponent) initializeIfNeeded(ctx context.Context, params 
 		// Auto-detect cloud provider (network I/O happens here, outside any lock)
 		source, err := detectAWSCredentialSource(ctx)
 		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
 			// No supported cloud provider detected. Warn and record the reason for the status page.
 			disabledReason = fmt.Sprintf("no supported cloud provider detected: %v", err)
 			log.Warnf("Delegated authentication is configured but no supported cloud provider was "+

--- a/comp/core/delegatedauth/impl/delegatedauth.go
+++ b/comp/core/delegatedauth/impl/delegatedauth.go
@@ -107,6 +107,9 @@ type authInstance struct {
 // Thread-safety: This struct uses sync.RWMutex (mu) to protect concurrent access to all
 // mutable fields.
 type delegatedAuthComponent struct {
+	// addInstanceMu serializes construction and replacement without blocking status reads.
+	addInstanceMu sync.Mutex
+
 	// Mutable fields (protected by mu)
 	mu               sync.RWMutex
 	config           pkgconfigmodel.ReaderWriter
@@ -262,7 +265,12 @@ func (d *delegatedAuthComponent) AddInstance(ctx context.Context, params delegat
 		return errors.New("additional_endpoint_domain and additional_endpoints_list_config_key are mutually exclusive")
 	}
 
-	// Check for context cancellation early
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	d.addInstanceMu.Lock()
+	defer d.addInstanceMu.Unlock()
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -280,6 +288,9 @@ func (d *delegatedAuthComponent) AddInstance(ctx context.Context, params delegat
 	// now if set, so dual-shipping still works. No retry — detection only runs once.
 	if providerConfig == nil {
 		log.Warnf("Delegated auth is not available on this host, so '%s' will keep its statically configured value", params.APIKeyConfigKey)
+		if err := d.replaceInstance(ctx, params.APIKeyConfigKey, nil); err != nil {
+			return err
+		}
 		if params.FallbackAPIKey != "" {
 			d.writeAPIKeyToTarget(fallbackTargetInstance(params), params.FallbackAPIKey, true)
 		}
@@ -332,33 +343,9 @@ func (d *delegatedAuthComponent) AddInstance(ctx context.Context, params delegat
 		done:                             make(chan struct{}),
 	}
 
-	// Check if we're replacing an existing instance.
-	// This is expected behavior - callers may reconfigure delegated auth (e.g., with different org UUID
-	// or refresh interval). When this happens, we cancel the old refresh goroutine and wait for it to
-	// exit before starting a new one to prevent goroutine leaks.
-	var existingDone chan struct{}
-	d.mu.Lock()
-	if existingInstance, exists := d.instances[apiKeyConfigKey]; exists {
-		log.Infof("Replacing existing delegated auth configuration for '%s'", apiKeyConfigKey)
-		// Cancel the existing refresh goroutine
-		if existingInstance.refreshCancel != nil {
-			existingInstance.refreshCancel()
-		}
-		existingDone = existingInstance.done
-	}
-	d.instances[apiKeyConfigKey] = instance
-	d.mu.Unlock()
-
-	// Wait for the old goroutine to exit outside the lock to avoid blocking other operations
-	if existingDone != nil {
-		select {
-		case <-existingDone:
-			// Old goroutine has exited
-		case <-ctx.Done():
-			// Context was canceled while waiting - clean up and return error
-			refreshCancel()
-			return ctx.Err()
-		}
+	if err := d.replaceInstance(ctx, apiKeyConfigKey, instance); err != nil {
+		refreshCancel()
+		return err
 	}
 
 	log.Infof("Delegated authentication is enabled for '%s', fetching initial API key...", apiKeyConfigKey)
@@ -386,6 +373,46 @@ func (d *delegatedAuthComponent) AddInstance(ctx context.Context, params delegat
 	// This ensures retries will happen with exponential backoff
 	d.startBackgroundRefresh(instance)
 
+	return nil
+}
+
+// replaceInstance stops the old refresh loop before publishing its replacement.
+// A nil replacement removes the existing instance.
+func (d *delegatedAuthComponent) replaceInstance(ctx context.Context, key string, replacement *authInstance) error {
+	d.mu.RLock()
+	existing := d.instances[key]
+	d.mu.RUnlock()
+
+	if existing != nil {
+		log.Infof("Replacing existing delegated auth configuration for '%s'", key)
+		if existing.refreshCancel != nil {
+			existing.refreshCancel()
+		}
+		if existing.done != nil {
+			select {
+			case <-existing.done:
+			case <-ctx.Done():
+				if replacement != nil && replacement.refreshCancel != nil {
+					replacement.refreshCancel()
+				}
+				return ctx.Err()
+			}
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		if replacement != nil && replacement.refreshCancel != nil {
+			replacement.refreshCancel()
+		}
+		return err
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if replacement == nil {
+		delete(d.instances, key)
+	} else {
+		d.instances[key] = replacement
+	}
 	return nil
 }
 

--- a/comp/core/delegatedauth/impl/delegatedauth_test.go
+++ b/comp/core/delegatedauth/impl/delegatedauth_test.go
@@ -1635,3 +1635,34 @@ func TestInitializeIfNeeded_DetectionFailureIsRecorded(t *testing.T) {
 	assert.Nil(t, providerConfig)
 	assert.Contains(t, comp.disabledReason, "no supported cloud provider detected")
 }
+
+func TestInitializeIfNeeded_DetectionTimeoutCanRetry(t *testing.T) {
+	original := detectAWSCredentialSource
+	calls := 0
+	detectAWSCredentialSource = func(ctx context.Context) (string, error) {
+		calls++
+		if calls == 1 {
+			return "", ctx.Err()
+		}
+		return "environment", nil
+	}
+	t.Cleanup(func() { detectAWSCredentialSource = original })
+
+	mockConfig := mock.New(t)
+	mockConfig.Set("delegated_auth.aws.region", "us-east-1", pkgconfigmodel.SourceFile)
+	comp := &delegatedAuthComponent{instances: make(map[string]*authInstance)}
+	params := delegatedauth.InstanceParams{Config: mockConfig, OrgUUID: "test-org", APIKeyConfigKey: "api_key"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	providerConfig, err := comp.initializeIfNeeded(ctx, params)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, providerConfig)
+	assert.False(t, comp.initialized)
+
+	providerConfig, err = comp.initializeIfNeeded(context.Background(), params)
+	require.NoError(t, err)
+	require.NotNil(t, providerConfig)
+	assert.Equal(t, 2, calls)
+	assert.True(t, comp.initialized)
+}

--- a/comp/core/delegatedauth/impl/delegatedauth_test.go
+++ b/comp/core/delegatedauth/impl/delegatedauth_test.go
@@ -539,25 +539,54 @@ func TestAddInstanceRespectsContextCancellation(t *testing.T) {
 }
 
 func TestWaitForOldGoroutineRespectsContextCancellation(t *testing.T) {
-	// Test that when waiting for an old goroutine to exit, we respect context cancellation
-	// This prevents hanging if the old goroutine is stuck
+	existing := &authInstance{done: make(chan struct{}), refreshCancel: func() {}}
+	comp := &delegatedAuthComponent{instances: map[string]*authInstance{"api_key": existing}}
 
-	oldDone := make(chan struct{})
-	// Don't close oldDone - simulate a stuck goroutine
-
-	waitCtx, waitCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer waitCancel()
-
-	// Simulate the select pattern used in AddInstance when waiting for old goroutine
-	start := time.Now()
-	select {
-	case <-oldDone:
-		t.Fatal("Old goroutine should not have exited")
-	case <-waitCtx.Done():
-		// Expected - context timed out
-		elapsed := time.Since(start)
-		assert.Less(t, elapsed, 200*time.Millisecond, "Should have timed out quickly")
+	replacementCtx, cancelReplacement := context.WithCancel(context.Background())
+	replacement := &authInstance{
+		refreshCtx:    replacementCtx,
+		refreshCancel: cancelReplacement,
+		done:          make(chan struct{}),
 	}
+	waitCtx, cancelWait := context.WithCancel(context.Background())
+	cancelWait()
+
+	require.ErrorIs(t, comp.replaceInstance(waitCtx, "api_key", replacement), context.Canceled)
+	assert.Same(t, existing, comp.instances["api_key"])
+	assert.ErrorIs(t, replacement.refreshCtx.Err(), context.Canceled)
+}
+
+func TestClosedOldGoroutineDoesNotHideContextCancellation(t *testing.T) {
+	done := make(chan struct{})
+	close(done)
+	existing := &authInstance{done: done, refreshCancel: func() {}}
+	comp := &delegatedAuthComponent{instances: map[string]*authInstance{"api_key": existing}}
+
+	replacementCtx, cancelReplacement := context.WithCancel(context.Background())
+	replacement := &authInstance{refreshCtx: replacementCtx, refreshCancel: cancelReplacement}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorIs(t, comp.replaceInstance(ctx, "api_key", replacement), context.Canceled)
+	assert.Same(t, existing, comp.instances["api_key"])
+	assert.ErrorIs(t, replacement.refreshCtx.Err(), context.Canceled)
+}
+
+func TestRemoveInstanceWaitsForRefreshLoop(t *testing.T) {
+	refreshCtx, cancelRefresh := context.WithCancel(context.Background())
+	existing := &authInstance{
+		refreshCtx:    refreshCtx,
+		refreshCancel: cancelRefresh,
+		done:          make(chan struct{}),
+	}
+	go func() {
+		<-refreshCtx.Done()
+		close(existing.done)
+	}()
+	comp := &delegatedAuthComponent{instances: map[string]*authInstance{"api_key": existing}}
+
+	require.NoError(t, comp.replaceInstance(context.Background(), "api_key", nil))
+	assert.NotContains(t, comp.instances, "api_key")
 }
 
 // Refresh Interval Validation Tests

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -6846,6 +6846,11 @@ properties:
         node_type: setting
         type: integer
         default: 60
+      startup_timeout_secs:
+        node_type: setting
+        type: integer
+        default: 60
+        comment: Bounds provider detection and the initial credential exchange during config loading. Set to 0 to disable the deadline.
   disable_unsafe_yaml:
     node_type: setting
     type: boolean

--- a/pkg/config/setup/BUILD.bazel
+++ b/pkg/config/setup/BUILD.bazel
@@ -94,6 +94,7 @@ dd_agent_go_test(
     ],
     embed = [":setup"],
     deps = [
+        "//comp/core/delegatedauth/def",
         "//comp/core/delegatedauth/mock",
         "//comp/core/secrets/mock",
         "//pkg/config/model",

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -422,10 +422,7 @@ func LoadDatadog(config pkgconfigmodel.Config, secretResolver secrets.Component,
 		return err
 	}
 
-	// Configure delegated auth after secrets are resolved but before other components initialize
-	// Cloud provider detection happens automatically within the delegatedauth component
-	// Use a background context since LoadDatadog doesn't take a context parameter.
-	// The context is still useful for cancellation during cloud provider detection and initial API key fetch.
+	// Configure delegated auth after secrets are resolved but before other components initialize.
 	if err := configureDelegatedAuth(context.Background(), config, delegatedAuthComp); err != nil {
 		log.Errorf("Failed to configure delegated authentication: %v. Agent will continue without delegated auth.", err)
 	}
@@ -489,6 +486,13 @@ func configureDelegatedAuth(ctx context.Context, config pkgconfigmodel.Config, d
 		// region itself once detection picks AWS.
 	}
 
+	startupCtx := ctx
+	cancelStartup := func() {}
+	if timeout := config.GetInt("delegated_auth.startup_timeout_secs"); timeout > 0 {
+		startupCtx, cancelStartup = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+	}
+	defer cancelStartup()
+
 	// Scan all registered prefixes to find which ones have delegated auth enabled
 	for _, section := range delegatedAuthKeys {
 		// Check if org_uuid is set for this prefix
@@ -499,9 +503,7 @@ func configureDelegatedAuth(ctx context.Context, config pkgconfigmodel.Config, d
 
 		log.Infof("Configuring delegated authentication for '%s'", section.description)
 
-		// Call AddInstance - the component auto-initializes on the first call
-		// Config and ProviderConfig are only used on the first call
-		err := delegatedAuthComp.AddInstance(ctx, delegatedauth.InstanceParams{
+		err := addDelegatedAuthInstance(startupCtx, delegatedAuthComp, delegatedauth.InstanceParams{
 			Config:          config,
 			ProviderConfig:  providerConfig,
 			OrgUUID:         orgUUID,
@@ -513,6 +515,22 @@ func configureDelegatedAuth(ctx context.Context, config pkgconfigmodel.Config, d
 		}
 	}
 
+	return ctx.Err()
+}
+
+// addDelegatedAuthInstance lets startup continue when synchronous initialization times out.
+func addDelegatedAuthInstance(ctx context.Context, delegatedAuthComp delegatedauth.Component, params delegatedauth.InstanceParams) error {
+	err := delegatedAuthComp.AddInstance(ctx, params)
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+
+	log.Warnf("Delegated auth startup timed out for '%s'; continuing in the background", params.APIKeyConfigKey)
+	go func() {
+		if retryErr := delegatedAuthComp.AddInstance(context.Background(), params); retryErr != nil {
+			log.Errorf("Failed to configure delegated auth for '%s' in the background: %v", params.APIKeyConfigKey, retryErr)
+		}
+	}()
 	return nil
 }
 

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -6,6 +6,7 @@
 package setup
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v2"
 
+	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
 	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
@@ -25,6 +27,28 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 )
+
+func TestAddDelegatedAuthInstanceContinuesAfterDeadline(t *testing.T) {
+	backgroundCall := make(chan delegatedauth.InstanceParams, 1)
+	comp := &delegatedauthmock.Mock{AddInstanceFunc: func(ctx context.Context, params delegatedauth.InstanceParams) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		backgroundCall <- params
+		return nil
+	}}
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	params := delegatedauth.InstanceParams{APIKeyConfigKey: "api_key"}
+
+	require.NoError(t, addDelegatedAuthInstance(ctx, comp, params))
+	select {
+	case got := <-backgroundCall:
+		assert.Equal(t, params.APIKeyConfigKey, got.APIKeyConfigKey)
+	case <-time.After(time.Second):
+		t.Fatal("background registration did not run")
+	}
+}
 
 func confFromYAML(t *testing.T, yamlConfig string) pkgconfigmodel.BuildableConfig {
 	conf := newTestConf(t)


### PR DESCRIPTION
### What does this PR do?

Makes delegated-auth startup bounded and instance replacement deterministic.

```text
config load
    |
    +-- setup completes within the shared timeout --> key is available before consumers start
    |
    `-- setup times out ---------------------------> continue Agent startup
                                                        `-- retry setup in the background

AddInstance(new)
    |
    +-- stop and wait for the old refresh loop
    `-- publish the new instance
```

`delegated_auth.startup_timeout_secs` bounds the total time configuration loading spends across all delegated-auth sections. It defaults to 60 seconds; `0` disables the deadline.

The initial attempt is synchronous because some consumers read their API key during initialization. If the shared deadline expires, Agent startup continues and setup is retried asynchronously because provider, metadata, STS, network, and exchange failures can be transient.

Instance additions are serialized so an old refresh loop exits before its replacement is published. A canceled provider-detection attempt can also be retried instead of permanently disabling delegated auth.

### Known limitation

Late first-key delivery depends on the consumer reacting to configuration updates. The top-level `api_key` path updates live, but section-specific keys have gaps:

- Remote Config snapshots `remote_configuration.api_key`; its update callback watches only `api_key`.
- Logs chooses between `api_key` and `logs_config.api_key` when its endpoint is constructed, then watches only that path.
- EVP and OpenLineage snapshot `evp_proxy_config.api_key` and `ol_proxy_config.api_key` during trace-agent setup.

Those paths may not pick up a key obtained after startup or later rotations. Fixing them requires concurrency-safe dynamic key storage and is outside this foundation PR.

An initial exchange failure currently retries on the configured refresh cadence. A separate follow-up decouples failure retries from routine key refreshes.

### Motivation

Provider detection and credential exchange perform network I/O during configuration loading. They should not block Agent startup indefinitely, and reconfiguration should not leave old and new refresh loops active at the same time.

This is the foundation used by #55791 for delegated-auth config writeback. It does not add provider interfaces or import delegated auth into sender modules.

### Describe how you validated your changes

- `dda inv test --targets=./comp/core/delegatedauth/... --coverage --rerun-fails=2`
- `dda inv test --targets=./pkg/config/setup --coverage --rerun-fails=2`

WIF-48
