### PR TITLE
[OTAGENT-1268] Fix default DDOT core config path on Linux

### DIFF
--- a/cmd/otel-agent/subcommands/run/BUILD.bazel
+++ b/cmd/otel-agent/subcommands/run/BUILD.bazel
@@ -145,6 +145,7 @@ go_library(
 dd_agent_go_test(
     name = "run_test",
     srcs = [
+        "command_nix_test.go",
         "command_test.go",
         "fleet_policies_dir_nix_test.go",
         "fleet_policies_dir_test.go",

--- a/cmd/otel-agent/subcommands/run/command_nix.go
+++ b/cmd/otel-agent/subcommands/run/command_nix.go
@@ -34,11 +34,11 @@ func fleetPoliciesDirFromPlatform() string {
 // defaulting to an absent path would boot-loop deployments that legitimately
 // run without a core Agent.
 func defaultCoreConfPath(candidate string) string {
-	// A standalone collector has no core Agent to share IPC artifacts with. The
-	// dedicated otel-agent image bakes DD_OTEL_STANDALONE=true in and is built
-	// FROM the Agent image, so without this it could pick up a datadog.yaml the
-	// deployment opted out of. Reading the env directly is required: the config
-	// is not loaded yet.
+	// A standalone collector has no core Agent to share IPC artifacts with, so
+	// it can function normally without having to load a core config.
+	// Furthermore, the ddot-collector image contains a default core config at the
+	// default path, while the users not including `--core-config` in the CLI args
+	// do not intend for it to be loaded.
 	if standalone, err := strconv.ParseBool(os.Getenv("DD_OTEL_STANDALONE")); err == nil && standalone {
 		return ""
 	}

--- a/cmd/otel-agent/subcommands/run/command_nix.go
+++ b/cmd/otel-agent/subcommands/run/command_nix.go
@@ -9,13 +9,56 @@ package run
 
 import (
 	"context"
+	"os"
+	"strconv"
 
 	"github.com/DataDog/datadog-agent/cmd/otel-agent/subcommands"
+	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 	"github.com/spf13/cobra"
 )
 
 func fleetPoliciesDirFromPlatform() string {
 	return ""
+}
+
+// defaultCoreConfPath returns candidate when it is a usable fallback for a
+// missing --core-config, and "" otherwise.
+//
+// Without a core config the Datadog config file is never read, so the IPC cert
+// and auth token resolve against the process working directory rather than the
+// core Agent's config directory and the handshake fails with "certificate
+// signed by unknown authority". Package units and Helm pass --core-config; the
+// container entrypoints do not.
+//
+// The file must exist: LoadDatadog surfaces the ReadInConfig error, so
+// defaulting to an absent path would boot-loop deployments that legitimately
+// run without a core Agent.
+func defaultCoreConfPath(candidate string) string {
+	// A standalone collector has no core Agent to share IPC artifacts with. The
+	// dedicated otel-agent image bakes DD_OTEL_STANDALONE=true in and is built
+	// FROM the Agent image, so without this it could pick up a datadog.yaml the
+	// deployment opted out of. Reading the env directly is required: the config
+	// is not loaded yet.
+	if standalone, err := strconv.ParseBool(os.Getenv("DD_OTEL_STANDALONE")); err == nil && standalone {
+		return ""
+	}
+
+	// Stat follows symlinks, which is what the container entrypoints create.
+	fi, err := os.Stat(candidate)
+	if err != nil || fi.IsDir() {
+		return ""
+	}
+	return candidate
+}
+
+// TryToGetDefaultParamsIfMissing fills a missing core config path with the
+// default datadog.yaml location. It does not override --core-config or
+// DD_CORE_CONFIG.
+func TryToGetDefaultParamsIfMissing(p *cliParams) {
+	if p.CoreConfPath != "" {
+		return
+	}
+	p.CoreConfPath = defaultCoreConfPath(defaultpaths.GetDefaultConfFile())
 }
 
 // MakeCommand creates the `run` command
@@ -28,6 +71,7 @@ func MakeCommand(globalConfGetter func() *subcommands.GlobalParams) *cobra.Comma
 		RunE: func(_ *cobra.Command, _ []string) error {
 			globalParams := globalConfGetter()
 			params.GlobalParams = globalParams
+			TryToGetDefaultParamsIfMissing(params)
 			return runOTelAgentCommand(context.Background(), params)
 		},
 	}

--- a/cmd/otel-agent/subcommands/run/command_nix_test.go
+++ b/cmd/otel-agent/subcommands/run/command_nix_test.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows && otlp && test
+
+package run
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/cmd/otel-agent/subcommands"
+)
+
+// writeCoreConf creates a datadog.yaml in a fresh temp dir and returns its path.
+func writeCoreConf(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "datadog.yaml")
+	if err := os.WriteFile(path, []byte("api_key: 0000001\n"), 0o600); err != nil {
+		t.Fatalf("writing core config: %v", err)
+	}
+	return path
+}
+
+func TestDefaultCoreConfPath(t *testing.T) {
+	tests := []struct {
+		name string
+		// candidate is built from the temp dir when nil.
+		candidate  func(t *testing.T) string
+		standalone string
+		wantFound  bool
+	}{
+		{
+			name:      "existing file is used",
+			candidate: writeCoreConf,
+			wantFound: true,
+		},
+		{
+			name: "missing file is not used",
+			candidate: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "datadog.yaml")
+			},
+		},
+		{
+			name: "directory is not used",
+			candidate: func(t *testing.T) string {
+				return t.TempDir()
+			},
+		},
+		{
+			name:       "standalone opts out even when the file exists",
+			candidate:  writeCoreConf,
+			standalone: "true",
+		},
+		{
+			name:       "standalone=false still uses the file",
+			candidate:  writeCoreConf,
+			standalone: "false",
+			wantFound:  true,
+		},
+		{
+			name:       "unparseable standalone value is ignored",
+			candidate:  writeCoreConf,
+			standalone: "yes-please",
+			wantFound:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.standalone != "" {
+				t.Setenv("DD_OTEL_STANDALONE", tc.standalone)
+			}
+			candidate := tc.candidate(t)
+
+			got := defaultCoreConfPath(candidate)
+
+			if tc.wantFound {
+				assert.Equal(t, candidate, got)
+			} else {
+				assert.Empty(t, got)
+			}
+		})
+	}
+}
+
+// A symlinked datadog.yaml is what the container entrypoint scripts create
+// (cont-init.d/50-ecs.sh and friends symlink datadog-ecs.yaml into place).
+func TestDefaultCoreConfPathFollowsSymlink(t *testing.T) {
+	target := writeCoreConf(t)
+	link := filepath.Join(filepath.Dir(target), "datadog-link.yaml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	assert.Equal(t, link, defaultCoreConfPath(link))
+}
+
+func TestTryToGetDefaultParamsIfMissingKeepsExplicitPath(t *testing.T) {
+	// An explicit path wins even when it does not exist, so that a typo surfaces
+	// as a config load error rather than being silently swapped for the default.
+	p := &cliParams{GlobalParams: &subcommands.GlobalParams{CoreConfPath: "/custom/datadog.yaml"}}
+
+	TryToGetDefaultParamsIfMissing(p)
+
+	assert.Equal(t, "/custom/datadog.yaml", p.CoreConfPath)
+}
+
+func TestTryToGetDefaultParamsIfMissingSkipsStandalone(t *testing.T) {
+	t.Setenv("DD_OTEL_STANDALONE", "true")
+	p := &cliParams{GlobalParams: &subcommands.GlobalParams{}}
+
+	TryToGetDefaultParamsIfMissing(p)
+
+	assert.Empty(t, p.CoreConfPath)
+}

--- a/releasenotes/notes/ddot-default-core-config-059e76778b475fd8.yaml
+++ b/releasenotes/notes/ddot-default-core-config-059e76778b475fd8.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed DDOT being unable to reach the core Agent in containerized deployments that do not pass ``--core-config`` (Docker, ECS, and ECS Fargate). Without a core config path the connection failed with ``x509: certificate signed by unknown authority``.
+    The OTel Agent now falls back to the default ``datadog.yaml`` location when it exists and the collector is not running in standalone mode.


### PR DESCRIPTION
### What does this PR do?

Back-fills the otel-agent's core config path with the default `datadog.yaml` location on Linux when neither `--core-config` nor `DD_CORE_CONFIG` was supplied, mirroring what `command_windows.go` already does.

The fallback is gated twice:

- **The file must exist.** `loadCustom` propagates the `ReadInConfig` error (`pkg/config/setup/config.go:527`), so an unconditional default would turn a working collector into a boot loop for every deployment that legitimately has no core Agent (gateway mode, BYOC, standalone on a bare host).
- **`DD_OTEL_STANDALONE` opts out.** The dedicated otel-agent image bakes that var in and is built `FROM` the Agent image, so without this it could pick up a `datadog.yaml` left in place by an entrypoint script. The env var is read directly because the config is not loaded yet at this point.

### Motivation

[OTAGENT-1268](https://datadoghq.atlassian.net/browse/OTAGENT-1268). DDOT cannot reach the core Agent in Docker, ECS, and ECS Fargate:

```
grpc: addrConn.createTransport failed to connect to {Addr: "localhost:5001" ...}
tls: failed to verify certificate: x509: certificate signed by unknown authority
```

Without a core config, `NewConfigComponent` (`cmd/otel-agent/config/agent_config.go:113`) skips `LoadDatadog` entirely. The IPC cert and auth token then resolve against the process working directory instead of `/etc/datadog-agent`, so the collector mints its own CA and the handshake fails. Skipping `LoadDatadog` also skips `DetectFeatures()` and `ApplyOverrideFuncs()`, which run in its `defer`.

Only the two container entrypoints are affected. Every other launcher already passes the flag:

| Launcher | `--core-config` |
|---|---|
| `packages/ddot/{debian,redhat}/*` | yes |
| `pkg/fleet/installer/.../processes.d/datadog-agent-ddot.yaml` | yes |
| Helm / Operator | yes |
| Windows (`command_windows.go:40`) | yes, back-filled |
| `Dockerfiles/agent/s6-services/otel/run` | no |
| `Dockerfiles/agent/entrypoint.d/otel-agent` | no |
| `Dockerfiles/otel-agent/Dockerfile` (standalone) | no, intentionally |

The fix lands in the `run` command's `RunE`. Since the root command is a shallow copy of it (`cmd/otel-agent/command/command.go:70`), this covers both `otel-agent --config ...` (containers) and `otel-agent run --config ...` (packages).

### Describe how you validated your changes
Validated with unit tests and running locally in a Docker container (with and without `DD_OTEL_STANDALONE`)

### Additional Notes

- `otel_standalone` still defaults to `false` (`pkg/config/setup/all_settings.go:1004`), so this is live for all connected-mode container users today, not only those who set `DD_OTEL_STANDALONE=false` explicitly.
- I deliberately did **not** add `--core-config` to the entrypoint scripts. That is less safe than the gated Go path: if the `datadog.yaml` symlink is not in place yet the collector hard-fails, and `s6-services/otel/finish` restart-loops it every 2s.


[OTAGENT-1268]: https://datadoghq.atlassian.net/browse/OTAGENT-1268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ