### PR TITLE
Add otlpreceiver metric origin for Agent OTLP ingest

### DIFF
--- a/comp/otelcol/otlp/components/exporter/serializerexporter/consumer.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/consumer.go
@@ -54,6 +54,7 @@ var metricOriginsMappings = map[otlpmetrics.OriginProductDetail]metrics.MetricSo
 	otlpmetrics.OriginProductDetailNginxReceiver:             metrics.MetricSourceOpenTelemetryCollectorNginxReceiver,
 	otlpmetrics.OriginProductDetailNSXTReceiver:              metrics.MetricSourceOpenTelemetryCollectorNsxtReceiver,
 	otlpmetrics.OriginProductDetailOracleDBReceiver:          metrics.MetricSourceOpenTelemetryCollectorOracledbReceiver,
+	otlpmetrics.OriginProductDetailOTLPReceiver:              metrics.MetricSourceOpenTelemetryCollectorOtlpReceiver,
 	otlpmetrics.OriginProductDetailPodmanReceiver:            metrics.MetricSourceOpenTelemetryCollectorPodmanReceiver,
 	otlpmetrics.OriginProductDetailPostgreSQLReceiver:        metrics.MetricSourceOpenTelemetryCollectorPostgresqlReceiver,
 	otlpmetrics.OriginProductDetailPrometheusReceiver:        metrics.MetricSourceOpenTelemetryCollectorPrometheusReceiver,
@@ -129,6 +130,27 @@ func (c *serializerConsumer) ConsumeAPMStats(ss *pb.ClientStatsPayload) {
 	c.apmstats = append(c.apmstats, body)
 }
 
+// metricSource resolves the MetricSource for a data point from the contrib receiver
+// the translator identified via the instrumentation scope name.
+//
+// Points that carry no contrib receiver scope cannot be attributed by the translator:
+// the OTLP receiver lives in collector core and stamps no scope of its own, so the
+// scope on the data is whatever the upstream producer set. In Agent OTLP ingest the
+// pipeline is a fixed otlpreceiver -> serializer exporter one, so such points are
+// known to have arrived over OTLP. DDOT and the OSS collector run user-defined
+// pipelines with an arbitrary receiver set, so there they stay unknown rather than
+// risk attributing another receiver's data to the OTLP receiver.
+func (c *serializerConsumer) metricSource(dimensions *otlpmetrics.Dimensions) metrics.MetricSource {
+	detail := dimensions.OriginProductDetail()
+	if detail == otlpmetrics.OriginProductDetailUnknown && c.ipath == agentOTLPIngest {
+		return metrics.MetricSourceOpenTelemetryCollectorOtlpReceiver
+	}
+	if msrc, ok := metricOriginsMappings[detail]; ok {
+		return msrc
+	}
+	return metrics.MetricSourceOpenTelemetryCollectorUnknown
+}
+
 func enrichTags(extraTags []string, dimensions *otlpmetrics.Dimensions) []string {
 	enrichedTags := make([]string, 0, len(extraTags)+len(dimensions.Tags()))
 	enrichedTags = append(enrichedTags, extraTags...)
@@ -137,10 +159,7 @@ func enrichTags(extraTags []string, dimensions *otlpmetrics.Dimensions) []string
 }
 
 func (c *serializerConsumer) ConsumeSketch(_ context.Context, dimensions *otlpmetrics.Dimensions, ts uint64, interval int64, qsketch *quantile.Sketch) {
-	msrc, ok := metricOriginsMappings[dimensions.OriginProductDetail()]
-	if !ok {
-		msrc = metrics.MetricSourceOpenTelemetryCollectorUnknown
-	}
+	msrc := c.metricSource(dimensions)
 	c.sketches = append(c.sketches, &metrics.SketchSeries{
 		DistributionMetadata: metrics.DistributionMetadata{
 			Name:     dimensions.Name(),
@@ -169,10 +188,7 @@ func apiTypeFromTranslatorType(typ otlpmetrics.DataType) metrics.APIMetricType {
 }
 
 func (c *serializerConsumer) ConsumeTimeSeries(_ context.Context, dimensions *otlpmetrics.Dimensions, typ otlpmetrics.DataType, ts uint64, interval int64, value float64) {
-	msrc, ok := metricOriginsMappings[dimensions.OriginProductDetail()]
-	if !ok {
-		msrc = metrics.MetricSourceOpenTelemetryCollectorUnknown
-	}
+	msrc := c.metricSource(dimensions)
 	c.series = append(c.series,
 		&metrics.Serie{
 			Name:     dimensions.Name(),

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumererror"
+	exp "go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -402,6 +403,70 @@ func Test_ConsumeMetrics_MetricOrigins(t *testing.T) {
 				}
 				assert.Equal(t, sketch.Source, tt.msrc)
 			}
+		})
+	}
+}
+
+// Test_ConsumeMetrics_UnattributedOrigin covers points whose instrumentation scope does
+// not name a contrib receiver -- an SDK reporting straight over OTLP. The OTLP receiver
+// stamps no scope, so these can only be attributed to it where the pipeline is known to
+// be an OTLP one: Agent OTLP ingest, but not DDOT.
+func Test_ConsumeMetrics_UnattributedOrigin(t *testing.T) {
+	genMetrics := func() pmetric.Metrics {
+		md := pmetric.NewMetrics()
+		ilm := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+		ilm.Scope().SetName("go.opentelemetry.io/otel/metric/example")
+		met := ilm.Metrics().AppendEmpty()
+		met.SetName(numberMetricName)
+		met.SetEmptyGauge()
+		met.Gauge().DataPoints().AppendEmpty().SetIntValue(100)
+		return md
+	}
+
+	tests := []struct {
+		name    string
+		typeStr string
+		factory func(s serializer.MetricSerializer) exp.Factory
+		msrc    metrics.MetricSource
+	}{
+		{
+			name:    "agent otlp ingest",
+			typeStr: TypeStr,
+			factory: func(s serializer.MetricSerializer) exp.Factory {
+				return NewFactoryForAgent(s, func(context.Context) (string, error) { return "", nil }, TelemetryStore{})
+			},
+			msrc: metrics.MetricSourceOpenTelemetryCollectorOtlpReceiver,
+		},
+		{
+			name:    "ddot",
+			typeStr: "datadog",
+			factory: func(s serializer.MetricSerializer) exp.Factory {
+				return NewFactoryForOTelAgent(s, func(context.Context) (string, error) { return "", nil }, nil, otel.NewDisabledGatewayUsage(), TelemetryStore{}, nil)
+			},
+			msrc: metrics.MetricSourceOpenTelemetryCollectorUnknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &metricRecorder{}
+			ctx := context.Background()
+			f := tt.factory(rec)
+			cfg := f.CreateDefaultConfig().(*ExporterConfig)
+			exp, err := f.CreateMetrics(ctx, exportertest.NewNopSettings(component.MustNewType(tt.typeStr)), cfg)
+			require.NoError(t, err)
+			require.NoError(t, exp.Start(ctx, componenttest.NewNopHost()))
+			require.NoError(t, exp.ConsumeMetrics(ctx, genMetrics()))
+			require.NoError(t, exp.Shutdown(ctx))
+
+			var found bool
+			for _, serie := range rec.series {
+				if serie.Name != numberMetricName {
+					continue
+				}
+				found = true
+				assert.Equal(t, tt.msrc, serie.Source)
+			}
+			assert.True(t, found, "expected the gauge to reach the serializer")
 		})
 	}
 }

--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -370,6 +370,7 @@ const (
 	MetricSourceOpenTelemetryCollectorNginxReceiver
 	MetricSourceOpenTelemetryCollectorNsxtReceiver
 	MetricSourceOpenTelemetryCollectorOracledbReceiver
+	MetricSourceOpenTelemetryCollectorOtlpReceiver
 	MetricSourceOpenTelemetryCollectorPodmanReceiver
 	MetricSourceOpenTelemetryCollectorPostgresqlReceiver
 	MetricSourceOpenTelemetryCollectorPrometheusReceiver
@@ -1072,6 +1073,8 @@ func (ms MetricSource) String() string {
 		return "opentelemetry_collector_nsxtreceiver"
 	case MetricSourceOpenTelemetryCollectorOracledbReceiver:
 		return "opentelemetry_collector_oracledbreceiver"
+	case MetricSourceOpenTelemetryCollectorOtlpReceiver:
+		return "opentelemetry_collector_otlpreceiver"
 	case MetricSourceOpenTelemetryCollectorPodmanReceiver:
 		return "opentelemetry_collector_podmanreceiver"
 	case MetricSourceOpenTelemetryCollectorPostgresqlReceiver:
@@ -1794,6 +1797,8 @@ func CheckNameToMetricSource(name string) MetricSource {
 		return MetricSourceOpenTelemetryCollectorNsxtReceiver
 	case "opentelemetry_collector_oracledbreceiver":
 		return MetricSourceOpenTelemetryCollectorOracledbReceiver
+	case "opentelemetry_collector_otlpreceiver":
+		return MetricSourceOpenTelemetryCollectorOtlpReceiver
 	case "opentelemetry_collector_podmanreceiver":
 		return MetricSourceOpenTelemetryCollectorPodmanReceiver
 	case "opentelemetry_collector_postgresqlreceiver":

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/origin.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/origin.go
@@ -94,6 +94,7 @@ const (
 	OriginProductDetailNginxReceiver             OriginProductDetail = 234
 	OriginProductDetailNSXTReceiver              OriginProductDetail = 235
 	OriginProductDetailOracleDBReceiver          OriginProductDetail = 236
+	OriginProductDetailOTLPReceiver              OriginProductDetail = 529
 	OriginProductDetailPodmanReceiver            OriginProductDetail = 521
 	OriginProductDetailPostgreSQLReceiver        OriginProductDetail = 237
 	OriginProductDetailPrometheusReceiver        OriginProductDetail = 238

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -841,6 +841,8 @@ func metricSourceToOriginService(ms metrics.MetricSource) int32 {
 		return 235
 	case metrics.MetricSourceOpenTelemetryCollectorOracledbReceiver:
 		return 236
+	case metrics.MetricSourceOpenTelemetryCollectorOtlpReceiver:
+		return 529
 	case metrics.MetricSourceOpenTelemetryCollectorPodmanReceiver:
 		return 521
 	case metrics.MetricSourceOpenTelemetryCollectorPostgresqlReceiver:

--- a/releasenotes/notes/add-otlpreceiver-origin-mapping-1a5c3f9e2b7d4068.yaml
+++ b/releasenotes/notes/add-otlpreceiver-origin-mapping-1a5c3f9e2b7d4068.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Metrics received through Agent OTLP ingest that cannot be attributed to a specific
+    OpenTelemetry Collector receiver -- for example points reported directly by an OpenTelemetry
+    SDK -- are now classified with origin ``opentelemetry_collector_otlpreceiver`` instead of
+    ``opentelemetry_collector_unknown``, so OTLP ingest traffic can be accounted for separately.


### PR DESCRIPTION
### What does this PR do?

Adds the `opentelemetry_collector_otlpreceiver` metric origin (product detail `529`) and applies it
to metrics arriving through Agent OTLP ingest that the translator cannot attribute to a specific
OpenTelemetry Collector receiver.

### Motivation

Origin product detail for OTLP metrics is derived entirely from the instrumentation scope name: the
translator matches `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/<name>` and
returns `unknown` for everything else. That leaves the single largest slice of OTLP traffic — points
produced by an OpenTelemetry SDK and sent straight over the wire — indistinguishable from genuinely
unclassifiable data, so we can't tell "arrived via the OTLP receiver" from "we don't know".

`otlpreceiver` can't be handled like the other receivers in this mapping, because it lives in
collector **core** and core stamps no instrumentation scope — the scope on the data is whatever the
upstream producer set. So it is resolved from the ingestion path instead of from the scope name:
Agent OTLP ingest is a fixed `otlpreceiver` → serializer exporter pipeline, so an unattributed point
there is known to have come in over OTLP.

DDOT and the OSS `datadogexporter` deliberately keep reporting `unknown` for those points. The
tempting generalisation — treat *any* scope lacking the contrib prefix as the OTLP receiver — was
tried and rejected: those two run user-defined pipelines with an arbitrary receiver set, so it would
mislabel data from any receiver that passes an upstream scope through (`prometheusreceiver`
preserving target metadata, a nested collector forwarding on) and would reclassify existing series
rather than fill in a blank. Covering them properly needs a signal from the receiver itself.

### Describe how you validated your changes

- [ ] CI passes
- New `Test_ConsumeMetrics_UnattributedOrigin` in `serializerexporter/exporter_test.go` pushes an
  SDK-scoped gauge through both factories and asserts it reaches the serializer as
  `MetricSourceOpenTelemetryCollectorOtlpReceiver` on the Agent OTLP ingest path and stays
  `MetricSourceOpenTelemetryCollectorUnknown` on DDOT.
- Existing `Test_ConsumeMetrics_MetricOrigins` and the `pkg/opentelemetry-mapping-go/otlp/metrics`
  golden tests are unchanged, confirming contrib-receiver attribution is untouched.

### Additional Notes

Companion dd-source PR adding the enum value to `origin.proto`: DDSOURCE_PR_URL. Follows the shape of
the podman addition ([dd-source#462622](https://github.com/DataDog/dd-source/pull/462622) /
[#52594](https://github.com/DataDog/datadog-agent/pull/52594)).

Opened as a draft pending the dd-source enum landing, and so the metrics-origins owners can confirm
the sub-product/pricing classification chosen there.
