### PR TITLE
Deflake `TestProviderExpectedTags` with `synctest`

### DIFF
--- a/pkg/logs/internal/tag/provider_test.go
+++ b/pkg/logs/internal/tag/provider_test.go
@@ -8,6 +8,7 @@ package tag
 import (
 	"sort"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/benbjohnson/clock"
@@ -15,7 +16,6 @@ import (
 
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
-
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
@@ -46,25 +46,26 @@ func TestProviderExpectedTags(t *testing.T) {
 	pp := p.(*provider)
 
 	var tt []string
+	synctest.Test(t, func(t *testing.T) {
+		// this will block for two (mock) seconds, so do it in a goroutine
+		tagsChan := make(chan []string)
+		go func() {
+			tagsChan <- pp.GetTags()
+		}()
+		synctest.Wait() // GetTags is now sleeping for the warmup duration
 
-	// this will block for two (mock) seconds, so do it in a goroutine
-	tagsChan := make(chan []string)
-	go func() {
-		tagsChan <- pp.GetTags()
-	}()
-
-wait:
-	for {
+		// Just before the warmup duration elapses, GetTags must still be asleep.
+		clock.Add(1999 * time.Millisecond)
 		select {
 		case tt = <-tagsChan:
-			break wait
+			t.Fatal("tags arrived before warmup duration elapsed!")
 		default:
-			clock.Add(90 * time.Millisecond)
 		}
-	}
 
-	// Ensure we waited at least 2 seconds
-	require.True(t, clock.Now().After(then.Add(2*time.Second)))
+		// Once the warmup duration elapses, GetTags unblocks.
+		clock.Add(1 * time.Millisecond)
+		tt = <-tagsChan
+	})
 
 	sort.Strings(tags)
 	sort.Strings(tt)


### PR DESCRIPTION
### What does this PR do?
Wrap the goroutine/clock synchronization in `TestProviderExpectedTags` (`pkg/logs/internal/tag/provider_test.go`) in a `testing/synctest` "bubble", using `synctest.Wait` to deterministically wait for `GetTags` to register its warmup timer before advancing the mock clock.

### Motivation
Unit test jobs have been failing at times ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1984654651#L1735)) with errors like:
```
Error Trace:	pkg/logs/internal/tag/provider_test.go:71
Error:      	Not equal:
                expected: []string{"tag1:value1", "tag2", "tag3"}
                actual  : []string{}

                Diff:
                --- Expected
                +++ Actual
                @@ -1,5 +1,2 @@
                -([]string) (len=3) {
                - (string) (len=11) "tag1:value1",
                - (string) (len=4) "tag2",
                - (string) (len=4) "tag3"
                +([]string) {
                 }
Test:       	TestProviderExpectedTags
```
The test is a known active flake, tracked in [Flaky Tests Management](https://app.datadoghq.com/ci/test/flaky?query=fingerprint_fqn%3A1cf7fb021a451d23) since 2025-05-23, also observed failing the opposite assertion ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1937238482#L2436)):
```
Error Trace:	github.com/DataDog/datadog-agent/pkg/logs/internal/tag/provider_test.go:77
Error:      	Should be empty, but was [tag1:value1 tag2 tag3]
Test:       	TestProviderExpectedTags
```
This is because `clock.Mock.Add` advances the mock clock unconditionally, regardless of which timers are registered yet: the test spawned a goroutine calling `GetTags` and immediately advanced the clock in a loop, with no guarantee that goroutine had registered its 2s warmup timer yet.

Under CI scheduling delays, the loop could cross a 5s expected-tags deadline, already registered synchronously at provider construction, before that registration happened, silently clearing `expectedTags` to `nil` before `GetTags` read it.

`synctest.Wait` removes the race entirely: it blocks until `GetTags` is durably parked inside `clock.Sleep`, which the library only reaches after registering its timer, so the clock cannot advance past that point too early.

### Describe how you validated your changes
Ran `dda inv test --targets=./pkg/logs/internal/tag --race` at `-count=1`, `40`, and `200`: all pass, no races.

### Additional Notes
Only the goroutine/clock synchronization runs inside the bubble: the rest of this test's setup (hostname resolution, the fake tagger's `fx` app) isn't `synctest`-safe.