### PR TITLE
Run `lint_windows-x64` in `main` pipelines too

### DIFF
--- a/.gitlab/windows/build/lint/windows.yml
+++ b/.gitlab/windows/build/lint/windows.yml
@@ -33,6 +33,7 @@ lint_windows-x64:
   extends: .lint_windows_base
   rules:
     - !reference [.on_native_os_linters]
+    - !reference [.on_main_or_release_branch]  # lint_cross_windows-x64 missed regressions, leading to #55162 and #55210
   variables:
     ARCH: "x64"
   timeout: 1h30m


### PR DESCRIPTION
### Motivation
Nightly pipelines are about as far from Continuous Integration as it gets, with native-only regressions in `lint_windows-x64` going unnoticed for days and requiring two consecutive repair PRs:
- #55162,
- #55210.

`lint_windows-x64` indeed only runs on tagged/release/nightly-deploy pipelines (`.on_native_os_linters`), not on regular pushes to `main`, on the assumption that `lint_cross_windows-x64` gives equivalent coverage there at a fraction of the cost.

It does not because `lint_cross_windows-x64` only runs the Go linter cross-compiled for `GOOS=windows`, while the native job also runs `rtloader.format`, a second Go-lint pass with:
- `--build system-probe-unit-tests`,
- `dotnet format --verify-no-changes`.

### What does this PR do?
Add `.on_main_or_release_branch` as an extra rule for `lint_windows-x64`, so it also runs on every push to `main`, alongside its existing nightly/tag/release coverage.

This mirrors `tests_macos_gitlab_amd64`, which already runs a comparably expensive native macOS job on every main push.

Only `lint_windows-x64` is touched; the shared `.on_native_os_linters` anchor and the macOS lint job are left as-is, since no equivalent gap has been reported there (yet).

### Describe how you validated your changes
`dda inv linter.gitlab-ci` passes against the repo's 9 standard CI contexts, including a `main`-branch push without `DEPLOY_AGENT` set.