### PR TITLE
Run macos job on main as allow to fail to stress test macos pools

### DIFF
--- a/.gitlab/test/e2e_install_packages/macos.yml
+++ b/.gitlab/test/e2e_install_packages/macos.yml
@@ -4,6 +4,13 @@ new-e2e-agent-platform-install-script-macos-x64:
   before_script:
     - !reference [.new_e2e_template, before_script]
     - export E2E_MACOS_POOL_ENABLED=$(dda self feature ci-datadog-agent-e2e-macos-pools --default false)
+  script:
+    - |
+      if [ "$NOT_NIGHTLY" = "true" ] && [ "$E2E_MACOS_POOL_ENABLED" = "false" ]; then
+        echo "⚠️  Skipping macOS e2e install job: NOT_NIGHTLY is set and E2E_MACOS_POOL_ENABLED is false"
+        exit 0
+      fi
+    - !reference [.new_e2e_template, script]
   stage: e2e_install_packages
   needs:
     - !reference [.needs_new_e2e_template]
@@ -11,6 +18,10 @@ new-e2e-agent-platform-install-script-macos-x64:
   rules:
     - !reference [.except_disable_e2e_tests]
     - !reference [.on_deploy]
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH  # Temporary execution + allow failure for main branch, to stress test the system. NOT_NIGHTLY is used to skip all the main run if we need to disable with the feature flag. It would not handle the load
+      allow_failure: true
+      variables:
+        NOT_NIGHTLY: true
     - !reference [.manual]
   retry: !reference [.retry_only_infra_failure, retry]
   variables:


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Update Gitlab config to run as allowed to fail the MacOS job on main. Just to stress test the system.
There is also a small trick to make sure we skip the main runs if we disable the MacOS pooling through the feature flag. Otherwise we're going to consume all the MacOS pool very fast

### Motivation

EUDM folks want to start running MacOS job on all the branches containing `macos` in the name. Before doing we'd rather stress test it a bit.

### Describe how you validated your changes

### Additional Notes
