### PR TITLE
test(e2e): isolate Operator image pull Secret

### DIFF
--- a/test/e2e-framework/AGENTS.md
+++ b/test/e2e-framework/AGENTS.md
@@ -75,6 +75,14 @@ awshost.Provisioner(
 )
 ```
 
+### Kubernetes resource ownership
+
+Pulumi resource names and component parents only make Pulumi URNs unique. Kubernetes
+resource identity is still the combination of kind, namespace, and metadata name. When
+components can be installed together, give independently owned resources distinct
+Kubernetes names or make one component the explicit owner; do not create the same
+Kubernetes object under multiple Pulumi parents.
+
 ### BaseSuite
 
 All E2E tests embed `e2e.BaseSuite[Env]` and use `e2e.Run()`:

--- a/test/e2e-framework/common/utils/BUILD.bazel
+++ b/test/e2e-framework/common/utils/BUILD.bazel
@@ -35,6 +35,7 @@ dd_agent_go_test(
     name = "utils_test",
     srcs = [
         "docker_test.go",
+        "kubernetes_test.go",
         "version_test.go",
         "yaml_test.go",
     ],
@@ -45,6 +46,9 @@ dd_agent_go_test(
         "fixtures/tags_b.yaml",
     ],
     deps = [
+        "//test/e2e-framework/common/config",
+        "@com_github_pulumi_pulumi_sdk_v3//go/common/resource",
+        "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@in_yaml_go_yaml_v3//:yaml",

--- a/test/e2e-framework/common/utils/kubernetes.go
+++ b/test/e2e-framework/common/utils/kubernetes.go
@@ -19,7 +19,8 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
 )
 
-const imagePullSecretName = "registry-credentials"
+// DefaultImagePullSecretName is the Kubernetes name used by NewImagePullSecret.
+const DefaultImagePullSecretName = "registry-credentials"
 
 // KubeConfigYAMLToJSON safely converts a yaml kubeconfig to a json string.
 func KubeConfigYAMLToJSON(kubeConfig pulumi.StringOutput) pulumi.StringInput {
@@ -40,6 +41,11 @@ func KubeConfigYAMLToJSON(kubeConfig pulumi.StringOutput) pulumi.StringInput {
 
 // NewImagePullSecret creates an image pull secret based on environment
 func NewImagePullSecret(e config.Env, namespace string, opts ...pulumi.ResourceOption) (*corev1.Secret, error) {
+	return NewImagePullSecretWithName(e, namespace, DefaultImagePullSecretName, opts...)
+}
+
+// NewImagePullSecretWithName creates a named image pull secret based on environment.
+func NewImagePullSecretWithName(e config.Env, namespace, name string, opts ...pulumi.ResourceOption) (*corev1.Secret, error) {
 	registries := strings.Split(e.ImagePullRegistry(), ",")
 	usernames := strings.Split(e.ImagePullUsername(), ",")
 
@@ -72,14 +78,14 @@ func NewImagePullSecret(e config.Env, namespace string, opts ...pulumi.ResourceO
 	}).(pulumi.StringOutput)
 
 	// Pulumi resource name must be unique per namespace to avoid duplicate URNs.
-	pulumiName := fmt.Sprintf("%s-%s", imagePullSecretName, namespace)
+	pulumiName := fmt.Sprintf("%s-%s", name, namespace)
 	return corev1.NewSecret(
 		e.Ctx(),
 		pulumiName,
 		&corev1.SecretArgs{
 			Metadata: metav1.ObjectMetaArgs{
 				Namespace: pulumi.StringPtr(namespace),
-				Name:      pulumi.StringPtr(imagePullSecretName),
+				Name:      pulumi.StringPtr(name),
 			},
 			StringData: pulumi.StringMap{
 				".dockerconfigjson": dockerConfigJSON,

--- a/test/e2e-framework/common/utils/kubernetes_test.go
+++ b/test/e2e-framework/common/utils/kubernetes_test.go
@@ -1,0 +1,120 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package utils
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
+)
+
+type imagePullSecretTestEnv struct {
+	config.Env
+	ctx *pulumi.Context
+}
+
+func (e *imagePullSecretTestEnv) Ctx() *pulumi.Context {
+	return e.ctx
+}
+
+func (e *imagePullSecretTestEnv) ImagePullRegistry() string {
+	return "registry.example.com"
+}
+
+func (e *imagePullSecretTestEnv) ImagePullUsername() string {
+	return "username"
+}
+
+func (e *imagePullSecretTestEnv) ImagePullPassword() pulumi.StringOutput {
+	return pulumi.String("password").ToStringOutput()
+}
+
+type imagePullSecretMocks struct {
+	mu        sync.Mutex
+	resources []pulumi.MockResourceArgs
+}
+
+func (m *imagePullSecretMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
+}
+
+func (m *imagePullSecretMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.resources = append(m.resources, args)
+	return args.Name + "-id", args.Inputs, nil
+}
+
+func (m *imagePullSecretMocks) secretResource() (pulumi.MockResourceArgs, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, registeredResource := range m.resources {
+		if registeredResource.TypeToken == "kubernetes:core/v1:Secret" {
+			return registeredResource, nil
+		}
+	}
+	return pulumi.MockResourceArgs{}, fmt.Errorf("image pull Secret was not registered")
+}
+
+func TestNewImagePullSecretNames(t *testing.T) {
+	tests := []struct {
+		name               string
+		secretName         string
+		expectedPulumiName string
+		useDefault         bool
+	}{
+		{
+			name:               "default",
+			secretName:         DefaultImagePullSecretName,
+			expectedPulumiName: "registry-credentials-e2e-operator",
+			useDefault:         true,
+		},
+		{
+			name:               "component scoped",
+			secretName:         "operator-registry-credentials",
+			expectedPulumiName: "operator-registry-credentials-e2e-operator",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mocks := &imagePullSecretMocks{}
+			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+				env := &imagePullSecretTestEnv{ctx: ctx}
+				if tt.useDefault {
+					_, err := NewImagePullSecret(env, "e2e-operator")
+					return err
+				}
+				_, err := NewImagePullSecretWithName(env, "e2e-operator", tt.secretName)
+				return err
+			}, pulumi.WithMocks("project", "stack", mocks))
+			if err != nil {
+				t.Fatalf("NewImagePullSecretWithName() error = %v", err)
+			}
+
+			secret, err := mocks.secretResource()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if secret.Name != tt.expectedPulumiName {
+				t.Errorf("Pulumi resource name = %q, want %q", secret.Name, tt.expectedPulumiName)
+			}
+
+			metadata := secret.Inputs["metadata"].ObjectValue()
+			if got := metadata["namespace"].StringValue(); got != "e2e-operator" {
+				t.Errorf("Kubernetes namespace = %q, want %q", got, "e2e-operator")
+			}
+			if got := metadata["name"].StringValue(); got != tt.secretName {
+				t.Errorf("Kubernetes name = %q, want %q", got, tt.secretName)
+			}
+		})
+	}
+}

--- a/test/e2e-framework/components/datadog/operator/BUILD.bazel
+++ b/test/e2e-framework/components/datadog/operator/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "operator",
@@ -24,5 +25,20 @@ go_library(
         "@com_github_pulumi_pulumi_kubernetes_sdk_v4//go/kubernetes/meta/v1:meta",
         "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
         "@in_yaml_go_yaml_v3//:yaml",
+    ],
+)
+
+dd_agent_go_test(
+    name = "operator_test",
+    srcs = ["helm_test.go"],
+    embed = [":operator"],
+    deps = [
+        "//test/e2e-framework/common/config",
+        "//test/e2e-framework/common/utils",
+        "//test/e2e-framework/components/datadog/agentwithoperatorparams",
+        "//test/e2e-framework/components/datadog/apps/dda",
+        "@com_github_pulumi_pulumi_kubernetes_sdk_v4//go/kubernetes",
+        "@com_github_pulumi_pulumi_sdk_v3//go/common/resource",
+        "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
     ],
 )

--- a/test/e2e-framework/components/datadog/operator/helm.go
+++ b/test/e2e-framework/components/datadog/operator/helm.go
@@ -17,9 +17,12 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-// Keep the Operator credentials separate from the DDA component credentials because both
-// components are installed in the same namespace and independently own their Secrets.
-const operatorCredentialsSecretName = "operator-datadog-credentials"
+// Keep the Operator Secrets separate from Agent components because they can be installed in
+// the same namespace and are independently owned Pulumi resources.
+const (
+	operatorCredentialsSecretName = "operator-datadog-credentials"
+	operatorImagePullSecretName   = "operator-registry-credentials"
+)
 
 // HelmInstallationArgs is the set of arguments for creating a new HelmInstallation component
 type HelmInstallationArgs struct {
@@ -88,7 +91,7 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 	// Create image pull secret if necessary
 	var imgPullSecret *corev1.Secret
 	if e.ImagePullRegistry() != "" {
-		imgPullSecret, err = utils.NewImagePullSecret(e, args.Namespace, opts...)
+		imgPullSecret, err = utils.NewImagePullSecretWithName(e, args.Namespace, operatorImagePullSecretName, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/test/e2e-framework/components/datadog/operator/helm_test.go
+++ b/test/e2e-framework/components/datadog/operator/helm_test.go
@@ -1,0 +1,163 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package operator
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentwithoperatorparams"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/dda"
+)
+
+type operatorTestEnv struct {
+	config.Env
+	ctx *pulumi.Context
+}
+
+func (e *operatorTestEnv) Ctx() *pulumi.Context {
+	return e.ctx
+}
+
+func (e *operatorTestEnv) WithProviders(...config.ProviderID) pulumi.ResourceOption {
+	return pulumi.Providers()
+}
+
+func (e *operatorTestEnv) AgentAPIKey() pulumi.StringOutput {
+	return pulumi.String("api-key").ToStringOutput()
+}
+
+func (e *operatorTestEnv) AgentAPPKey() pulumi.StringOutput {
+	return pulumi.String("app-key").ToStringOutput()
+}
+
+func (e *operatorTestEnv) ImagePullRegistry() string {
+	return "registry.example.com"
+}
+
+func (e *operatorTestEnv) ImagePullUsername() string {
+	return "username"
+}
+
+func (e *operatorTestEnv) ImagePullPassword() pulumi.StringOutput {
+	return pulumi.String("password").ToStringOutput()
+}
+
+func (e *operatorTestEnv) OperatorFullImagePath() string {
+	return "registry.example.com/operator:latest"
+}
+
+type operatorMocks struct {
+	mu        sync.Mutex
+	resources []pulumi.MockResourceArgs
+}
+
+func (m *operatorMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
+}
+
+func (m *operatorMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.resources = append(m.resources, args)
+	return args.Name + "-id", args.Inputs, nil
+}
+
+func (m *operatorMocks) kubernetesResourceIdentities() ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var identities []string
+	for _, registeredResource := range m.resources {
+		resourceType := string(registeredResource.TypeToken)
+		if !strings.HasPrefix(resourceType, "kubernetes:") {
+			continue
+		}
+
+		metadata, ok := registeredResource.Inputs["metadata"]
+		if !ok || !metadata.IsObject() {
+			continue
+		}
+		metadataObject := metadata.ObjectValue()
+		name, ok := metadataObject["name"]
+		if !ok || !name.IsString() {
+			return nil, fmt.Errorf("Kubernetes resource %q has no concrete metadata name", registeredResource.Name)
+		}
+		namespace := ""
+		if namespaceValue, ok := metadataObject["namespace"]; ok && namespaceValue.IsString() {
+			namespace = namespaceValue.StringValue()
+		}
+
+		// Patch resources address the same Kubernetes kind as their non-patch counterparts.
+		resourceType = strings.TrimSuffix(resourceType, "Patch")
+		identities = append(identities, fmt.Sprintf("%s/%s/%s", resourceType, namespace, name.StringValue()))
+	}
+	return identities, nil
+}
+
+func TestOperatorAndDDAResourcesHaveDistinctKubernetesIdentities(t *testing.T) {
+	mocks := &operatorMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		env := &operatorTestEnv{ctx: ctx}
+		kubeProvider, err := kubernetes.NewProvider(ctx, "kubernetes", nil)
+		if err != nil {
+			return err
+		}
+
+		_, err = NewHelmInstallation(env, HelmInstallationArgs{
+			KubeProvider:          kubeProvider,
+			Namespace:             "e2e-operator",
+			OperatorFullImagePath: "registry.example.com/operator:latest",
+			ChartPath:             "datadog-operator",
+			RepoURL:               "https://helm.datadoghq.com",
+		})
+		if err != nil {
+			return err
+		}
+
+		params, err := agentwithoperatorparams.NewParams(agentwithoperatorparams.WithNamespace("e2e-operator"))
+		if err != nil {
+			return err
+		}
+		_, err = dda.K8sAppDefinition(env, kubeProvider, params)
+		return err
+	}, pulumi.WithMocks("project", "stack", mocks))
+	if err != nil {
+		t.Fatalf("installing Operator and DDA components: %v", err)
+	}
+
+	identities, err := mocks.kubernetesResourceIdentities()
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := make(map[string]struct{}, len(identities))
+	for _, identity := range identities {
+		if _, exists := seen[identity]; exists {
+			t.Errorf("Kubernetes resource %q is independently owned more than once", identity)
+		}
+		seen[identity] = struct{}{}
+	}
+
+	for _, secretName := range []string{
+		operatorCredentialsSecretName,
+		operatorImagePullSecretName,
+		"dda-datadog-credentials",
+		utils.DefaultImagePullSecretName,
+	} {
+		identity := fmt.Sprintf("kubernetes:core/v1:Secret/e2e-operator/%s", secretName)
+		if _, exists := seen[identity]; !exists {
+			t.Errorf("expected Kubernetes resource %q was not registered", identity)
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds a named image pull Secret helper while preserving `NewImagePullSecret` and its `registry-credentials` default. The Operator component now owns `operator-registry-credentials`, while the DDA component continues to own `registry-credentials`.

It also adds a Pulumi-mock composition test that installs the Operator and DDA components together and rejects duplicate Kubernetes `(kind, namespace, metadata.name)` identities.

### Motivation

Operator e2e updates failed because the Operator and DDA Pulumi components independently created the same `e2e-operator/registry-credentials` Secret. Pulumi therefore attempted to create an object already owned by the other component.

Keeping the names component-scoped makes lifecycle ownership explicit without changing global provider behavior or affecting other e2e suites that use the shared default.

The surrounding Operator path was audited as well: credentials already use distinct names; the namespace uses patch semantics; and Operator CRDs, RBAC, and service-account creation are disabled when the external Kustomize resources are used. No other duplicate Kubernetes identity exists in the Operator+DDA composition.

### Describe how you validated your changes

- `dda inv test --module=test/e2e-framework --targets=./common/utils,./components/datadog/operator`
- `dda inv linter.go --module=test/e2e-framework --targets=./common/utils,./components/datadog/operator`
- `bazel test //test/e2e-framework/common/utils:utils_test //test/e2e-framework/components/datadog/operator:operator_test`
- Commit and pre-push hooks, including Go module checks, tests, and lint

All passed. Per request, the full e2e suite was not run locally.

### Additional Notes

No global Pulumi upsert or shared-resource behavior is introduced. No Reno note is included because this only changes internal e2e infrastructure.