### PR TITLE
[AXT] testing: add GPU burner integration coverage

### DIFF
--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -208,6 +208,7 @@ tests_gpu:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
     - dda inv -- -e gpu.download-gpu-burner --output-path "$CI_PROJECT_DIR"
+    - export GPU_BURNER_BIN="$CI_PROJECT_DIR/gpu-burner/gpu-burner"
   after_script:
     - !reference [.upload_junit_source]
     - !reference [.manage_coverage_cache]

--- a/pkg/collector/corechecks/gpu/integrationtests/BUILD.bazel
+++ b/pkg/collector/corechecks/gpu/integrationtests/BUILD.bazel
@@ -9,10 +9,17 @@ go_library(
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/integrationtests",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_stretchr_testify//assert",
-        "@com_github_stretchr_testify//require",
-    ],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 dd_agent_go_test(
@@ -39,7 +46,6 @@ dd_agent_go_test(
             "//pkg/process/util/containers/mocks",
             "//pkg/util/gpu",
             "@com_github_nvidia_go_nvml//pkg/nvml",
-            "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
             "@org_uber_go_mock//gomock",
@@ -57,7 +63,6 @@ dd_agent_go_test(
             "//pkg/process/util/containers/mocks",
             "//pkg/util/gpu",
             "@com_github_nvidia_go_nvml//pkg/nvml",
-            "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
             "@org_uber_go_mock//gomock",

--- a/pkg/collector/corechecks/gpu/integrationtests/BUILD.bazel
+++ b/pkg/collector/corechecks/gpu/integrationtests/BUILD.bazel
@@ -3,15 +3,23 @@ load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "integrationtests",
-    srcs = ["doc.go"],
+    srcs = [
+        "doc.go",
+        "gpu_burner_helper.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/integrationtests",
     visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )
 
 dd_agent_go_test(
     name = "integrationtests_test",
     srcs = [
         "check_test.go",
+        "gpu_burner_test.go",
         "nvml_test.go",
     ],
     embed = [":integrationtests"],
@@ -31,6 +39,7 @@ dd_agent_go_test(
             "//pkg/process/util/containers/mocks",
             "//pkg/util/gpu",
             "@com_github_nvidia_go_nvml//pkg/nvml",
+            "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
             "@org_uber_go_mock//gomock",
@@ -48,6 +57,7 @@ dd_agent_go_test(
             "//pkg/process/util/containers/mocks",
             "//pkg/util/gpu",
             "@com_github_nvidia_go_nvml//pkg/nvml",
+            "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
             "@com_github_stretchr_testify//suite",
             "@org_uber_go_mock//gomock",

--- a/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_helper.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_helper.go
@@ -100,6 +100,7 @@ func StartGPUBurner(t *testing.T, visibleDevices string, workers int, targetSM i
 	burner.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	burner.cmd.Env = append(os.Environ(), "CUDA_VISIBLE_DEVICES="+visibleDevices)
 	burner.cmd.Stderr = &burner.stderr
+	t.Logf("starting gpu-burner: CUDA_VISIBLE_DEVICES=%q command=%s", visibleDevices, burner.cmd.String())
 	require.NoError(t, burner.cmd.Start(), "start gpu-burner")
 
 	t.Cleanup(func() {

--- a/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_helper.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_helper.go
@@ -1,0 +1,163 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build linux && nvml && test
+
+package integrationtests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	gpuBurnerBinEnv             = "GPU_BURNER_BIN"
+	gpuBurnerStartupLimit       = 90 * time.Second
+	gpuBurnerRunTime            = 30
+	gpuBurnerCalibrationSeconds = 10
+)
+
+// GPUBurnerMetrics is the live GPU metric snapshot returned by gpu-burner.
+type GPUBurnerMetrics struct {
+	SMActive float64 `json:"sm_active"`
+}
+
+// GPUBurnerWorker describes a gpu-burner worker returned by its status API.
+type GPUBurnerWorker struct {
+	GPUUUID string            `json:"gpu_uuid"`
+	Stage   string            `json:"stage"`
+	Metrics *GPUBurnerMetrics `json:"metrics"`
+}
+
+// GPUBurnerStatus is the response returned by the gpu-burner status API.
+type GPUBurnerStatus struct {
+	Stage   string            `json:"stage"`
+	Workers []GPUBurnerWorker `json:"workers"`
+}
+
+// GPUBurner is a gpu-burner process managed by an integration test.
+type GPUBurner struct {
+	statusURL string
+	cmd       *exec.Cmd
+	stderr    bytes.Buffer
+}
+
+func requireGPUBurner(t *testing.T) string {
+	t.Helper()
+
+	bin := os.Getenv(gpuBurnerBinEnv)
+	if bin != "" {
+		return bin
+	}
+	if os.Getenv("CI") != "" {
+		t.Fatalf("%s must be set for GPU integration tests in CI", gpuBurnerBinEnv)
+	}
+	t.Skipf("%s is not set; skipping gpu-burner integration test", gpuBurnerBinEnv)
+	return ""
+}
+
+// StartGPUBurner starts gpu-burner with the requested CUDA_VISIBLE_DEVICES value and
+// waits until its status API reports running workers.
+func StartGPUBurner(t *testing.T, visibleDevices string, workers int, targetSM int) *GPUBurner {
+	t.Helper()
+	require.NotEmpty(t, visibleDevices)
+
+	command := strings.Fields(requireGPUBurner(t))
+	require.NotEmpty(t, command)
+	port := reserveLoopbackPort(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	burner := &GPUBurner{
+		statusURL: "http://127.0.0.1:" + strconv.Itoa(port) + "/status",
+	}
+	args := append(command[1:],
+		"--api-host", "127.0.0.1",
+		"--api-port", strconv.Itoa(port),
+		"--run_time", strconv.Itoa(gpuBurnerRunTime),
+		"--num_gpu_workers", strconv.Itoa(workers),
+		"auto",
+		"--target_sm", strconv.Itoa(targetSM),
+		"--calibration_seconds", strconv.Itoa(gpuBurnerCalibrationSeconds),
+		"--calibration_metric_sampling_interval", "0.2",
+		"--calibration_max_iters", "3",
+	)
+	burner.cmd = exec.CommandContext(ctx, command[0], args...)
+	burner.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	burner.cmd.Env = append(os.Environ(), "CUDA_VISIBLE_DEVICES="+visibleDevices)
+	burner.cmd.Stderr = &burner.stderr
+	require.NoError(t, burner.cmd.Start(), "start gpu-burner")
+
+	t.Cleanup(func() {
+		cancel()
+		if burner.cmd.Process != nil {
+			if err := syscall.Kill(-burner.cmd.Process.Pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+				t.Errorf("stop gpu-burner process group: %v", err)
+			}
+		}
+		err := burner.cmd.Wait()
+		if err != nil && ctx.Err() == nil {
+			t.Errorf("gpu-burner exited unexpectedly: %v\nstderr:\n%s", err, burner.stderr.String())
+		}
+	})
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		status, err := burner.Status(t.Context())
+		require.NoError(collect, err)
+		require.Equal(collect, "running", status.Stage)
+		require.Len(collect, status.Workers, workers)
+		for _, worker := range status.Workers {
+			require.Equal(collect, "running", worker.Stage)
+			require.NotEmpty(collect, worker.GPUUUID)
+			require.NotNil(collect, worker.Metrics)
+		}
+	}, gpuBurnerStartupLimit, time.Second, "gpu-burner did not become ready")
+
+	return burner
+}
+
+// Status retrieves the current gpu-burner status API response.
+func (burner *GPUBurner) Status(ctx context.Context) (GPUBurnerStatus, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, burner.statusURL, nil)
+	if err != nil {
+		return GPUBurnerStatus{}, fmt.Errorf("create status request: %w", err)
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return GPUBurnerStatus{}, fmt.Errorf("fetch gpu-burner status: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return GPUBurnerStatus{}, fmt.Errorf("gpu-burner status returned %s", response.Status)
+	}
+
+	var status GPUBurnerStatus
+	if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
+		return GPUBurnerStatus{}, fmt.Errorf("decode gpu-burner status: %w", err)
+	}
+	return status, nil
+}
+
+func reserveLoopbackPort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "reserve loopback port")
+	port := listener.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener.Close(), "release loopback port")
+	return port
+}

--- a/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_helper.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_helper.go
@@ -98,7 +98,10 @@ func StartGPUBurner(t *testing.T, visibleDevices string, workers int, targetSM i
 	)
 	burner.cmd = exec.CommandContext(ctx, command[0], args...)
 	burner.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	burner.cmd.Env = append(os.Environ(), "CUDA_VISIBLE_DEVICES="+visibleDevices)
+	burner.cmd.Env = append(os.Environ(),
+		"CUDA_DEVICE_ORDER=PCI_BUS_ID",
+		"CUDA_VISIBLE_DEVICES="+visibleDevices,
+	)
 	burner.cmd.Stderr = &burner.stderr
 	t.Logf("starting gpu-burner: CUDA_VISIBLE_DEVICES=%q command=%s", visibleDevices, burner.cmd.String())
 	require.NoError(t, burner.cmd.Start(), "start gpu-burner")

--- a/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_helper.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_helper.go
@@ -30,9 +30,12 @@ import (
 const (
 	gpuBurnerBinEnv             = "GPU_BURNER_BIN"
 	gpuBurnerStartupLimit       = 90 * time.Second
+	gpuBurnerStatusTimeout      = 5 * time.Second
 	gpuBurnerRunTime            = 30
 	gpuBurnerCalibrationSeconds = 10
 )
+
+var gpuBurnerHTTPClient = &http.Client{Timeout: gpuBurnerStatusTimeout}
 
 // GPUBurnerMetrics is the live GPU metric snapshot returned by gpu-burner.
 type GPUBurnerMetrics struct {
@@ -161,7 +164,7 @@ func (burner *GPUBurner) Status(ctx context.Context) (GPUBurnerStatus, error) {
 	if err != nil {
 		return GPUBurnerStatus{}, fmt.Errorf("create status request: %w", err)
 	}
-	response, err := http.DefaultClient.Do(request)
+	response, err := gpuBurnerHTTPClient.Do(request)
 	if err != nil {
 		return GPUBurnerStatus{}, fmt.Errorf("fetch gpu-burner status: %w", err)
 	}

--- a/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_helper.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_helper.go
@@ -56,6 +56,7 @@ type GPUBurner struct {
 	statusURL string
 	cmd       *exec.Cmd
 	stderr    bytes.Buffer
+	done      chan error
 }
 
 func requireGPUBurner(t *testing.T) string {
@@ -81,9 +82,10 @@ func StartGPUBurner(t *testing.T, visibleDevices string, workers int, targetSM i
 	command := strings.Fields(requireGPUBurner(t))
 	require.NotEmpty(t, command)
 	port := reserveLoopbackPort(t)
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	burner := &GPUBurner{
 		statusURL: "http://127.0.0.1:" + strconv.Itoa(port) + "/status",
+		done:      make(chan error, 1),
 	}
 	args := append(command[1:],
 		"--api-host", "127.0.0.1",
@@ -105,18 +107,27 @@ func StartGPUBurner(t *testing.T, visibleDevices string, workers int, targetSM i
 	burner.cmd.Stderr = &burner.stderr
 	t.Logf("starting gpu-burner: CUDA_VISIBLE_DEVICES=%q command=%s", visibleDevices, burner.cmd.String())
 	require.NoError(t, burner.cmd.Start(), "start gpu-burner")
+	go func() {
+		burner.done <- burner.cmd.Wait()
+	}()
 
 	t.Cleanup(func() {
+		select {
+		case err := <-burner.done:
+			if err != nil {
+				t.Errorf("gpu-burner exited unexpectedly: %v\nstderr:\n%s", err, burner.stderr.String())
+			}
+			return
+		default:
+		}
+
 		cancel()
 		if burner.cmd.Process != nil {
 			if err := syscall.Kill(-burner.cmd.Process.Pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
 				t.Errorf("stop gpu-burner process group: %v", err)
 			}
 		}
-		err := burner.cmd.Wait()
-		if err != nil && ctx.Err() == nil {
-			t.Errorf("gpu-burner exited unexpectedly: %v\nstderr:\n%s", err, burner.stderr.String())
-		}
+		<-burner.done
 	})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {

--- a/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_helper.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_helper.go
@@ -18,6 +18,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -57,6 +58,9 @@ type GPUBurner struct {
 	cmd       *exec.Cmd
 	stderr    bytes.Buffer
 	done      chan error
+	mu        sync.Mutex
+	exited    bool
+	exitErr   error
 }
 
 func requireGPUBurner(t *testing.T) string {
@@ -108,17 +112,23 @@ func StartGPUBurner(t *testing.T, visibleDevices string, workers int, targetSM i
 	t.Logf("starting gpu-burner: CUDA_VISIBLE_DEVICES=%q command=%s", visibleDevices, burner.cmd.String())
 	require.NoError(t, burner.cmd.Start(), "start gpu-burner")
 	go func() {
-		burner.done <- burner.cmd.Wait()
+		err := burner.cmd.Wait()
+		burner.mu.Lock()
+		burner.exited = true
+		burner.exitErr = err
+		burner.mu.Unlock()
+		burner.done <- err
 	}()
 
 	t.Cleanup(func() {
-		select {
-		case err := <-burner.done:
+		burner.mu.Lock()
+		exited, err := burner.exited, burner.exitErr
+		burner.mu.Unlock()
+		if exited {
 			if err != nil {
 				t.Errorf("gpu-burner exited unexpectedly: %v\nstderr:\n%s", err, burner.stderr.String())
 			}
 			return
-		default:
 		}
 
 		cancel()

--- a/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_test.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_test.go
@@ -30,11 +30,15 @@ import (
 )
 
 const (
-	smActiveDelta = 15.0
+	smActiveDelta               = 15.0
+	gpuBurnerCollectionPasses   = 3
+	gpuBurnerCollectionInterval = 5 * time.Second
 )
 
-func collectGPUBurnerMetrics(t *testing.T) map[string]map[string][]gpuspec.MetricObservation {
+func collectGPUBurnerMetrics(t *testing.T, passes int, interval time.Duration) map[string]map[string][]gpuspec.MetricObservation {
 	t.Helper()
+	require.Positive(t, passes)
+	require.Positive(t, interval)
 
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	wmetaMock := testutil.GetWorkloadMetaMock(t)
@@ -54,10 +58,14 @@ func collectGPUBurnerMetrics(t *testing.T) map[string]map[string][]gpuspec.Metri
 	require.NoError(t, checkInstance.Configure(senderManager, integration.FakeConfigHash, []byte{}, []byte{}, "test", "provider"))
 	t.Cleanup(checkInstance.Cancel)
 
+	// Run once to initialize rate-derived collectors, then collect multiple
+	// intervals while the burner is active. Keep every observation so callers
+	// can validate how metric values evolve across the collection window.
 	require.NoError(t, checkInstance.Run())
-	time.Sleep(time.Second)
-	mockSender.ResetCalls()
-	require.NoError(t, checkInstance.Run())
+	for range passes {
+		time.Sleep(interval)
+		require.NoError(t, checkInstance.Run())
+	}
 
 	metricsByUUID := make(map[string]map[string][]gpuspec.MetricObservation)
 	for metricName, observations := range gpu.GetEmittedGPUMetrics(mockSender) {
@@ -126,11 +134,10 @@ func TestGPUBurnerTwoGPUDeviceSelection(t *testing.T) {
 func assertBurnerDevicesActive(t *testing.T, burner *GPUBurner, expectedWorkers int, targetSM float64) {
 	t.Helper()
 
+	metricsByUUID := collectGPUBurnerMetrics(t, gpuBurnerCollectionPasses, gpuBurnerCollectionInterval)
 	status, err := burner.Status(t.Context())
 	require.NoError(t, err)
 	require.Len(t, status.Workers, expectedWorkers)
-
-	metricsByUUID := collectGPUBurnerMetrics(t)
 	for _, worker := range status.Workers {
 		deviceMetrics := metricsByUUID[strings.ToLower(worker.GPUUUID)]
 		require.NotEmpty(t, deviceMetrics, "no metrics emitted for gpu-burner worker GPU %s", worker.GPUUUID)
@@ -165,13 +172,13 @@ func assertBurnerDevicesActive(t *testing.T, burner *GPUBurner, expectedWorkers 
 func requireMetricsMatchSmi(t *testing.T, deviceMetrics map[string][]gpuspec.MetricObservation, sample *testutil.SmiSample) {
 	t.Helper()
 
-	requireMetricNearSmi(t, deviceMetrics, "sm_active", sample.SMUtilPct, 1, smActiveDelta)
-	requireMetricNearSmi(t, deviceMetrics, "temperature", sample.GPUTempC, 1, 5)
-	requireMetricNearSmi(t, deviceMetrics, "encoder_active", sample.EncoderPct, 1, 5)
-	requireMetricNearSmi(t, deviceMetrics, "decoder_active", sample.DecoderPct, 1, 5)
-	requireMetricNearSmi(t, deviceMetrics, "clock.speed.memory", sample.MemClockMHz, 1, 25)
+	requireLatestMetricNearSmi(t, deviceMetrics, "sm_active", sample.SMUtilPct, 1, smActiveDelta)
+	requireLatestMetricNearSmi(t, deviceMetrics, "temperature", sample.GPUTempC, 1, 5)
+	requireLatestMetricNearSmi(t, deviceMetrics, "encoder_active", sample.EncoderPct, 1, 5)
+	requireLatestMetricNearSmi(t, deviceMetrics, "decoder_active", sample.DecoderPct, 1, 5)
+	requireLatestMetricNearSmi(t, deviceMetrics, "clock.speed.memory", sample.MemClockMHz, 1, 25)
 	if sample.MemTempC != nil {
-		requireMetricNearSmi(t, deviceMetrics, "memory.temperature", sample.MemTempC, 1, 5)
+		requireLatestMetricNearSmi(t, deviceMetrics, "memory.temperature", sample.MemTempC, 1, 5)
 	}
 }
 
@@ -180,6 +187,18 @@ func requireMetricNearValue(t *testing.T, deviceMetrics map[string][]gpuspec.Met
 
 	observations := deviceMetrics[name]
 	require.NotEmpty(t, observations, "%s was not emitted", name)
-	require.NotNil(t, observations[0].Value, "%s was emitted without a value", name)
-	require.InDelta(t, expected, *observations[0].Value, delta, "%s differs from gpu-burner status value", name)
+	latest := observations[len(observations)-1]
+	require.NotNil(t, latest.Value, "%s was emitted without a value", name)
+	require.InDelta(t, expected, *latest.Value, delta, "%s differs from gpu-burner status value", name)
+}
+
+func requireLatestMetricNearSmi(t *testing.T, deviceMetrics map[string][]gpuspec.MetricObservation, name string, smiValue *float64, scale, delta float64) {
+	t.Helper()
+
+	observations := deviceMetrics[name]
+	require.NotEmpty(t, observations, "%s was not emitted for this device", name)
+	latest := observations[len(observations)-1]
+	require.NotNil(t, latest.Value, "%s was emitted without a value", name)
+	require.NotNil(t, smiValue, "nvidia-smi value was blank for %s", name)
+	require.InDelta(t, *smiValue*scale, *latest.Value, delta, "%s value %v differs from nvidia-smi reading %v", name, *latest.Value, *smiValue*scale)
 }

--- a/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_test.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_test.go
@@ -102,7 +102,7 @@ func TestGPUBurnerSingleGPUDeviceSelection(t *testing.T) {
 	for _, index := range indices {
 		t.Run(fmt.Sprintf("one-gpu-%d", index), func(t *testing.T) {
 			burner := StartGPUBurner(t, strconv.Itoa(index), 1, 100)
-			assertBurnerDevicesActive(t, burner, 1, 100)
+			assertBurnerDevicesActive(t, burner, gpuUUIDsForIndices(t, lib, []int{index}), 100)
 		})
 	}
 }
@@ -126,23 +126,40 @@ func TestGPUBurnerTwoGPUDeviceSelection(t *testing.T) {
 	for _, devices := range deviceSets {
 		t.Run(fmt.Sprintf("two-gpus-%d-%d", devices[0], devices[1]), func(t *testing.T) {
 			burner := StartGPUBurner(t, fmt.Sprintf("%d,%d", devices[0], devices[1]), 2, 100)
-			assertBurnerDevicesActive(t, burner, 2, 100)
+			assertBurnerDevicesActive(t, burner, gpuUUIDsForIndices(t, lib, devices), 100)
 		})
 	}
 }
 
-func assertBurnerDevicesActive(t *testing.T, burner *GPUBurner, expectedWorkers int, targetSM float64) {
+func gpuUUIDsForIndices(t *testing.T, lib safenvml.SafeNVML, indices []int) []string {
+	t.Helper()
+
+	uuids := make([]string, 0, len(indices))
+	for _, index := range indices {
+		device, err := lib.DeviceGetHandleByIndex(index)
+		require.NoError(t, err, "get NVML device handle for index %d", index)
+		uuid, err := device.GetUUID()
+		require.NoError(t, err, "get NVML device UUID for index %d", index)
+		uuids = append(uuids, strings.ToLower(uuid))
+	}
+	return uuids
+}
+
+func assertBurnerDevicesActive(t *testing.T, burner *GPUBurner, expectedUUIDs []string, targetSM float64) {
 	t.Helper()
 
 	metricsByUUID := collectGPUBurnerMetrics(t, gpuBurnerCollectionPasses, gpuBurnerCollectionInterval)
 	status, err := burner.Status(t.Context())
 	require.NoError(t, err)
-	require.Len(t, status.Workers, expectedWorkers)
+	require.Len(t, status.Workers, len(expectedUUIDs))
+	actualUUIDs := make([]string, 0, len(status.Workers))
 	for _, worker := range status.Workers {
+		actualUUIDs = append(actualUUIDs, strings.ToLower(worker.GPUUUID))
 		deviceMetrics := metricsByUUID[strings.ToLower(worker.GPUUUID)]
 		require.NotEmpty(t, deviceMetrics, "no metrics emitted for gpu-burner worker GPU %s", worker.GPUUUID)
 		require.NotEmpty(t, deviceMetrics["sm_active"], "sm_active was not emitted for gpu-burner worker GPU %s", worker.GPUUUID)
 	}
+	require.ElementsMatch(t, expectedUUIDs, actualUUIDs, "gpu-burner workers do not match the selected CUDA-visible devices")
 
 	type smiResult struct {
 		sample *testutil.SmiSample

--- a/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_test.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_test.go
@@ -1,0 +1,185 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build linux && nvml
+
+package integrationtests
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu"
+	gpuspec "github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/spec"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
+	"github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
+	mockcontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers/mocks"
+)
+
+const (
+	smActiveDelta = 15.0
+)
+
+func collectGPUBurnerMetrics(t *testing.T) map[string]map[string][]gpuspec.MetricObservation {
+	t.Helper()
+
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	wmetaMock := testutil.GetWorkloadMetaMock(t)
+	gpu.SetupWorkloadmetaGPUs(t, wmetaMock, fakeTagger, gpuspec.DeviceModePhysical, false)
+
+	senderManager := mocksender.CreateDefaultDemultiplexer(t)
+	checkInstance := gpu.NewCheck(fakeTagger, testutil.GetTelemetryMock(t), wmetaMock)
+	mockSender := mocksender.NewMockSenderWithSenderManager(checkInstance.ID(), senderManager)
+	mockSender.SetupAcceptAll()
+	gpu.WithGPUConfigEnabled(t)
+
+	checkInternal, ok := checkInstance.(*gpu.Check)
+	require.True(t, ok)
+	containerProvider := mockcontainers.NewMockContainerProvider(gomock.NewController(t))
+	containerProvider.EXPECT().GetPidToCid(gomock.Any()).Return(map[int]string{}).AnyTimes()
+	checkInternal.SetContainerProvider(containerProvider)
+	require.NoError(t, checkInstance.Configure(senderManager, integration.FakeConfigHash, []byte{}, []byte{}, "test", "provider"))
+	t.Cleanup(checkInstance.Cancel)
+
+	require.NoError(t, checkInstance.Run())
+	time.Sleep(time.Second)
+	mockSender.ResetCalls()
+	require.NoError(t, checkInstance.Run())
+
+	metricsByUUID := make(map[string]map[string][]gpuspec.MetricObservation)
+	for metricName, observations := range gpu.GetEmittedGPUMetrics(mockSender) {
+		for _, observation := range observations {
+			uuids := gpuspec.TagsToKeyValues(observation.Tags)["gpu_uuid"]
+			if len(uuids) == 0 {
+				continue
+			}
+			uuid := strings.ToLower(uuids[0])
+			if metricsByUUID[uuid] == nil {
+				metricsByUUID[uuid] = make(map[string][]gpuspec.MetricObservation)
+			}
+			metricsByUUID[uuid][metricName] = append(metricsByUUID[uuid][metricName], observation)
+		}
+	}
+	return metricsByUUID
+}
+
+func TestGPUBurnerSingleGPUDeviceSelection(t *testing.T) {
+	testutil.RequireGPU(t)
+	testutil.RequireSmi(t)
+	env.SetFeatures(t, env.KubernetesDevicePlugins, env.NVML)
+
+	lib, err := safenvml.GetSafeNvmlLib()
+	require.NoError(t, err)
+	count, err := lib.DeviceGetCount()
+	require.NoError(t, err)
+	require.Positive(t, count)
+
+	indices := []int{0}
+	if count > 1 {
+		indices = append(indices, 1)
+	}
+	for _, index := range indices {
+		t.Run(fmt.Sprintf("one-gpu-%d", index), func(t *testing.T) {
+			burner := StartGPUBurner(t, strconv.Itoa(index), 1, 100)
+			assertBurnerDevicesActive(t, burner, 1, 100)
+		})
+	}
+}
+
+func TestGPUBurnerTwoGPUDeviceSelection(t *testing.T) {
+	testutil.RequireGPU(t)
+	testutil.RequireSmi(t)
+	env.SetFeatures(t, env.KubernetesDevicePlugins, env.NVML)
+
+	lib, err := safenvml.GetSafeNvmlLib()
+	require.NoError(t, err)
+	count, err := lib.DeviceGetCount()
+	require.NoError(t, err)
+	if count < 2 {
+		t.Skip("two-GPU device-selection tests require at least two physical GPUs")
+	}
+	deviceSets := [][]int{{0, 1}}
+	if count >= 4 {
+		deviceSets = append(deviceSets, []int{2, 3})
+	}
+	for _, devices := range deviceSets {
+		t.Run(fmt.Sprintf("two-gpus-%d-%d", devices[0], devices[1]), func(t *testing.T) {
+			burner := StartGPUBurner(t, fmt.Sprintf("%d,%d", devices[0], devices[1]), 2, 100)
+			assertBurnerDevicesActive(t, burner, 2, 100)
+		})
+	}
+}
+
+func assertBurnerDevicesActive(t *testing.T, burner *GPUBurner, expectedWorkers int, targetSM float64) {
+	t.Helper()
+
+	status, err := burner.Status(t.Context())
+	require.NoError(t, err)
+	require.Len(t, status.Workers, expectedWorkers)
+
+	metricsByUUID := collectGPUBurnerMetrics(t)
+	for _, worker := range status.Workers {
+		deviceMetrics := metricsByUUID[strings.ToLower(worker.GPUUUID)]
+		require.NotEmpty(t, deviceMetrics, "no metrics emitted for gpu-burner worker GPU %s", worker.GPUUUID)
+		require.NotEmpty(t, deviceMetrics["sm_active"], "sm_active was not emitted for gpu-burner worker GPU %s", worker.GPUUUID)
+	}
+
+	type smiResult struct {
+		sample *testutil.SmiSample
+		err    error
+	}
+	smiResults := make([]smiResult, len(status.Workers))
+	var smiWG sync.WaitGroup
+	for i, worker := range status.Workers {
+		smiWG.Add(1)
+		go func(i int, uuid string) {
+			defer smiWG.Done()
+			sample, err := testutil.CollectSmiSample(uuid)
+			smiResults[i] = smiResult{sample: sample, err: err}
+		}(i, worker.GPUUUID)
+	}
+	smiWG.Wait()
+	for i, worker := range status.Workers {
+		require.NotNil(t, worker.Metrics)
+		deviceMetrics := metricsByUUID[strings.ToLower(worker.GPUUUID)]
+		require.InDelta(t, targetSM, worker.Metrics.SMActive, smActiveDelta, "gpu-burner status SM activity differs from target")
+		requireMetricNearValue(t, deviceMetrics, "sm_active", targetSM, smActiveDelta)
+		require.NoError(t, smiResults[i].err, "collect nvidia-smi sample for GPU %s", worker.GPUUUID)
+		requireMetricsMatchSmi(t, deviceMetrics, smiResults[i].sample)
+	}
+}
+
+func requireMetricsMatchSmi(t *testing.T, deviceMetrics map[string][]gpuspec.MetricObservation, sample *testutil.SmiSample) {
+	t.Helper()
+
+	requireMetricNearSmi(t, deviceMetrics, "sm_active", sample.SMUtilPct, 1, smActiveDelta)
+	requireMetricNearSmi(t, deviceMetrics, "temperature", sample.GPUTempC, 1, 5)
+	requireMetricNearSmi(t, deviceMetrics, "encoder_active", sample.EncoderPct, 1, 5)
+	requireMetricNearSmi(t, deviceMetrics, "decoder_active", sample.DecoderPct, 1, 5)
+	requireMetricNearSmi(t, deviceMetrics, "clock.speed.memory", sample.MemClockMHz, 1, 25)
+	if sample.MemTempC != nil {
+		requireMetricNearSmi(t, deviceMetrics, "memory.temperature", sample.MemTempC, 1, 5)
+	}
+}
+
+func requireMetricNearValue(t *testing.T, deviceMetrics map[string][]gpuspec.MetricObservation, name string, expected, delta float64) {
+	t.Helper()
+
+	observations := deviceMetrics[name]
+	require.NotEmpty(t, observations, "%s was not emitted", name)
+	require.NotNil(t, observations[0].Value, "%s was emitted without a value", name)
+	require.InDelta(t, expected, *observations[0].Value, delta, "%s differs from gpu-burner status value", name)
+}

--- a/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_test.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_test.go
@@ -35,7 +35,12 @@ const (
 	gpuBurnerCollectionInterval = 5 * time.Second
 )
 
-func collectGPUBurnerMetrics(t *testing.T, passes int, interval time.Duration) map[string]map[string][]gpuspec.MetricObservation {
+type smiResult struct {
+	sample *testutil.SmiSample
+	err    error
+}
+
+func collectGPUBurnerMetrics(t *testing.T, passes int, interval time.Duration, smiUUIDs []string) (map[string]map[string][]gpuspec.MetricObservation, map[string]smiResult) {
 	t.Helper()
 	require.Positive(t, passes)
 	require.Positive(t, interval)
@@ -58,14 +63,30 @@ func collectGPUBurnerMetrics(t *testing.T, passes int, interval time.Duration) m
 	require.NoError(t, checkInstance.Configure(senderManager, integration.FakeConfigHash, []byte{}, []byte{}, "test", "provider"))
 	t.Cleanup(checkInstance.Cancel)
 
+	smiResults := make([]smiResult, len(smiUUIDs))
+	var smiWG sync.WaitGroup
+
 	// Run once to initialize rate-derived collectors, then collect multiple
-	// intervals while the burner is active. Keep every observation so callers
-	// can validate how metric values evolve across the collection window.
+	// intervals while the burner is active. Start nvidia-smi dmon after the
+	// penultimate run: its three one-second samples overlap most of the final
+	// five-second Agent collection interval.
 	require.NoError(t, checkInstance.Run())
-	for range passes {
+	for pass := range passes {
 		time.Sleep(interval)
 		require.NoError(t, checkInstance.Run())
+		if pass != passes-2 {
+			continue
+		}
+		for i, uuid := range smiUUIDs {
+			smiWG.Add(1)
+			go func(i int, uuid string) {
+				defer smiWG.Done()
+				sample, err := testutil.CollectSmiSample(uuid)
+				smiResults[i] = smiResult{sample: sample, err: err}
+			}(i, uuid)
+		}
 	}
+	smiWG.Wait()
 
 	metricsByUUID := make(map[string]map[string][]gpuspec.MetricObservation)
 	for metricName, observations := range gpu.GetEmittedGPUMetrics(mockSender) {
@@ -81,7 +102,11 @@ func collectGPUBurnerMetrics(t *testing.T, passes int, interval time.Duration) m
 			metricsByUUID[uuid][metricName] = append(metricsByUUID[uuid][metricName], observation)
 		}
 	}
-	return metricsByUUID
+	samplesByUUID := make(map[string]smiResult, len(smiUUIDs))
+	for i, uuid := range smiUUIDs {
+		samplesByUUID[strings.ToLower(uuid)] = smiResults[i]
+	}
+	return metricsByUUID, samplesByUUID
 }
 
 func TestGPUBurnerSingleGPUDeviceSelection(t *testing.T) {
@@ -148,7 +173,7 @@ func gpuUUIDsForIndices(t *testing.T, lib safenvml.SafeNVML, indices []int) []st
 		require.NoError(t, err, "get NVML device handle for index %d", index)
 		uuid, err := device.GetUUID()
 		require.NoError(t, err, "get NVML device UUID for index %d", index)
-		uuids = append(uuids, strings.ToLower(uuid))
+		uuids = append(uuids, uuid)
 	}
 	return uuids
 }
@@ -156,41 +181,30 @@ func gpuUUIDsForIndices(t *testing.T, lib safenvml.SafeNVML, indices []int) []st
 func assertBurnerDevicesActive(t *testing.T, burner *GPUBurner, expectedUUIDs []string, targetSM float64) {
 	t.Helper()
 
-	metricsByUUID := collectGPUBurnerMetrics(t, gpuBurnerCollectionPasses, gpuBurnerCollectionInterval)
 	status, err := burner.Status(t.Context())
 	require.NoError(t, err)
 	require.Len(t, status.Workers, len(expectedUUIDs))
 	actualUUIDs := make([]string, 0, len(status.Workers))
 	for _, worker := range status.Workers {
 		actualUUIDs = append(actualUUIDs, strings.ToLower(worker.GPUUUID))
+	}
+	expectedUUIDKeys := make([]string, 0, len(expectedUUIDs))
+	for _, uuid := range expectedUUIDs {
+		expectedUUIDKeys = append(expectedUUIDKeys, strings.ToLower(uuid))
+	}
+	require.ElementsMatch(t, expectedUUIDKeys, actualUUIDs, "gpu-burner workers do not match the selected CUDA-visible devices")
+
+	metricsByUUID, smiResults := collectGPUBurnerMetrics(t, gpuBurnerCollectionPasses, gpuBurnerCollectionInterval, expectedUUIDs)
+	for _, worker := range status.Workers {
+		require.NotNil(t, worker.Metrics)
 		deviceMetrics := metricsByUUID[strings.ToLower(worker.GPUUUID)]
 		require.NotEmpty(t, deviceMetrics, "no metrics emitted for gpu-burner worker GPU %s", worker.GPUUUID)
 		require.NotEmpty(t, deviceMetrics["sm_active"], "sm_active was not emitted for gpu-burner worker GPU %s", worker.GPUUUID)
-	}
-	require.ElementsMatch(t, expectedUUIDs, actualUUIDs, "gpu-burner workers do not match the selected CUDA-visible devices")
-
-	type smiResult struct {
-		sample *testutil.SmiSample
-		err    error
-	}
-	smiResults := make([]smiResult, len(status.Workers))
-	var smiWG sync.WaitGroup
-	for i, worker := range status.Workers {
-		smiWG.Add(1)
-		go func(i int, uuid string) {
-			defer smiWG.Done()
-			sample, err := testutil.CollectSmiSample(uuid)
-			smiResults[i] = smiResult{sample: sample, err: err}
-		}(i, worker.GPUUUID)
-	}
-	smiWG.Wait()
-	for i, worker := range status.Workers {
-		require.NotNil(t, worker.Metrics)
-		deviceMetrics := metricsByUUID[strings.ToLower(worker.GPUUUID)]
 		require.InDelta(t, targetSM, worker.Metrics.SMActive, smActiveDelta, "gpu-burner status SM activity differs from target")
 		requireMetricNearValue(t, deviceMetrics, "sm_active", targetSM, smActiveDelta)
-		require.NoError(t, smiResults[i].err, "collect nvidia-smi sample for GPU %s", worker.GPUUUID)
-		requireMetricsMatchSmi(t, deviceMetrics, smiResults[i].sample)
+		smiResult := smiResults[strings.ToLower(worker.GPUUUID)]
+		require.NoError(t, smiResult.err, "collect nvidia-smi sample for GPU %s", worker.GPUUUID)
+		requireMetricsMatchSmi(t, deviceMetrics, smiResult.sample)
 	}
 }
 

--- a/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_test.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/gpu_burner_test.go
@@ -99,10 +99,14 @@ func TestGPUBurnerSingleGPUDeviceSelection(t *testing.T) {
 	if count > 1 {
 		indices = append(indices, 1)
 	}
+	expectedUUIDsByIndex := make(map[int][]string, len(indices))
+	for _, index := range indices {
+		expectedUUIDsByIndex[index] = gpuUUIDsForIndices(t, lib, []int{index})
+	}
 	for _, index := range indices {
 		t.Run(fmt.Sprintf("one-gpu-%d", index), func(t *testing.T) {
 			burner := StartGPUBurner(t, strconv.Itoa(index), 1, 100)
-			assertBurnerDevicesActive(t, burner, gpuUUIDsForIndices(t, lib, []int{index}), 100)
+			assertBurnerDevicesActive(t, burner, expectedUUIDsByIndex[index], 100)
 		})
 	}
 }
@@ -123,10 +127,14 @@ func TestGPUBurnerTwoGPUDeviceSelection(t *testing.T) {
 	if count >= 4 {
 		deviceSets = append(deviceSets, []int{2, 3})
 	}
-	for _, devices := range deviceSets {
+	expectedUUIDsBySet := make([][]string, len(deviceSets))
+	for i, devices := range deviceSets {
+		expectedUUIDsBySet[i] = gpuUUIDsForIndices(t, lib, devices)
+	}
+	for i, devices := range deviceSets {
 		t.Run(fmt.Sprintf("two-gpus-%d-%d", devices[0], devices[1]), func(t *testing.T) {
 			burner := StartGPUBurner(t, fmt.Sprintf("%d,%d", devices[0], devices[1]), 2, 100)
-			assertBurnerDevicesActive(t, burner, gpuUUIDsForIndices(t, lib, devices), 100)
+			assertBurnerDevicesActive(t, burner, expectedUUIDsBySet[i], 100)
 		})
 	}
 }

--- a/pkg/gpu/testutil/smi.go
+++ b/pkg/gpu/testutil/smi.go
@@ -59,12 +59,9 @@ func CollectSmiSample(deviceID string) (*SmiSample, error) {
 		args = append(args, "--gpm-metrics", strings.Join(gpmMetrics, ","))
 	}
 	cmd := exec.Command(nvidiaSmi, args...)
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("nvidia-smi failed (%w):\nstderr: %s", err, ee.Stderr)
-		}
-		return nil, fmt.Errorf("could not collect sample: %w", err)
+		return nil, fmt.Errorf("run nvidia-smi dmon: %w\noutput: %s", err, out)
 	}
 
 	// One data line per monitoring cycle (single device via --id). Read the

--- a/tasks/gpu.py
+++ b/tasks/gpu.py
@@ -28,7 +28,7 @@ VALIDATOR_PACKAGE = f"{SPEC_PACKAGE}/metrics-validator"
 VALIDATOR_BINARY = f"{VALIDATOR_PACKAGE}/gpu-metrics-validator"
 VALIDATOR_SITE = "datadoghq.com"
 GPU_BURNER_BRANCH = "main"
-GPU_BURNER_VERSION = "9ded3e87"
+GPU_BURNER_VERSION = "87719309"
 MASS_READ_URL = "https://mass-read.us1.ddbuild.io/internal/artifact"
 MASS_AUDIENCE = "rapid-dependency-management-mass"
 


### PR DESCRIPTION
### What does this PR do?

Adds GPU burner integration coverage for CUDA device selection and GPU metric activity.

### Motivation

Detect device-mapping and activity-reporting regressions under a controlled GPU workload.

### Describe how you validated your changes

`GPU_BURNER_BIN='uv run --directory /home/gjulianm/dd/gpu-burner gpu-burner' dda inv test --targets=./pkg/collector/corechecks/gpu/integrationtests --build-include=nvml,test --extra-args='-run ^TestGPUBurner'`

### Additional Notes