### PR TITLE
[WP] Add scope in kill action precheck

### DIFF
--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -296,6 +296,13 @@ func (k *KillDefinition) PreCheck(opts PolicyLoaderOpts) error {
 	if k.Signal == "" {
 		return errors.New("a valid signal has to be specified to the 'kill' action")
 	}
+	// default scope to process
+	if k.Scope == "" {
+		k.Scope = "process"
+	}
+	if k.Scope != "process" && k.Scope != "cgroup" && k.Scope != "container" {
+		return fmt.Errorf("invalid scope '%s'", k.Scope)
+	}
 
 	if _, found := model.SignalConstants[k.Signal]; !found {
 		return fmt.Errorf("unsupported signal '%s'", k.Signal)

--- a/pkg/security/secl/rules/model_test.go
+++ b/pkg/security/secl/rules/model_test.go
@@ -236,3 +236,23 @@ func TestNetworkFilterDefinitionEmptyScopeDefaultOnRuleLoad(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "process", actionDef.NetworkFilter.Scope)
 }
+
+func TestKillDefinitionEmptyScopeDefault(t *testing.T) {
+	k := &KillDefinition{
+		Signal: "SIGKILL",
+	}
+	err := k.PreCheck(PolicyLoaderOpts{})
+	assert.NoError(t, err)
+	assert.Equal(t, "process", k.Scope)
+}
+
+func TestKillDefinitionEmptyScopeDefaultOnRuleLoad(t *testing.T) {
+	actionDef := &ActionDefinition{
+		Kill: &KillDefinition{
+			Signal: "SIGKILL",
+		},
+	}
+	err := actionDef.PreCheck(PolicyLoaderOpts{})
+	assert.NoError(t, err)
+	assert.Equal(t, "process", actionDef.Kill.Scope)
+}

--- a/pkg/security/secl/rules/policy_loader_test.go
+++ b/pkg/security/secl/rules/policy_loader_test.go
@@ -1775,6 +1775,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									{
 										Kill: &KillDefinition{
 											Signal: "SIGUSR2",
+											Scope: "process",
 										},
 									},
 								},
@@ -1870,11 +1871,13 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									{
 										Kill: &KillDefinition{
 											Signal: "SIGUSR1",
+											Scope: "process",
 										},
 									},
 									{
 										Kill: &KillDefinition{
 											Signal: "SIGUSR2",
+											Scope: "process",
 										},
 									},
 								},
@@ -1962,6 +1965,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									{
 										Kill: &KillDefinition{
 											Signal: "SIGUSR1",
+											Scope: "process",
 										},
 									},
 								},
@@ -2049,6 +2053,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									{
 										Kill: &KillDefinition{
 											Signal: "SIGUSR1",
+											Scope: "process",
 										},
 									},
 								},
@@ -2245,6 +2250,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									{
 										Kill: &KillDefinition{
 											Signal: "SIGUSR1",
+											Scope: "process",
 										},
 									},
 								},
@@ -2340,11 +2346,13 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									{
 										Kill: &KillDefinition{
 											Signal: "SIGUSR1",
+											Scope: "process",
 										},
 									},
 									{
 										Kill: &KillDefinition{
 											Signal: "SIGUSR2",
+											Scope: "process",
 										},
 									},
 								},


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
This PR add some verification on the scope of the kill action in the Pre check. 
In addition, it makes sure there is no empty scope by overwriting the empty scope with process, the scope by default.

### Motivation
Empty scope could create some confusion and a valid scope was not verified in the pre checks.
