### PR TITLE
[CWS] Wait for the ssh auth log line, but only briefly

### DIFF
--- a/comp/api/grpcserver/impl-agent/BUILD.bazel
+++ b/comp/api/grpcserver/impl-agent/BUILD.bazel
@@ -67,6 +67,7 @@ dd_agent_go_test(
         "//comp/core/telemetry/mock",
         "//comp/healthplatform/store/def",
         "//comp/healthplatform/store/mock",
+        "//google/protobuf:wrapperspb",
         "//pkg/proto/pbgo/core",
         "@com_github_datadog_agent_payload_v5//healthplatform",
         "@com_github_stretchr_testify//assert",
@@ -75,6 +76,5 @@ dd_agent_go_test(
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//proto",
-        "@org_golang_google_protobuf//types/known/wrapperspb",
     ],
 )

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -155,6 +155,7 @@ use_repo(
     "com_github_go_jose_go_jose_v4",
     "com_github_go_json_experiment_json",
     "com_github_go_ole_go_ole",
+    "com_github_go_openapi_testify_v2",
     "com_github_go_sql_driver_mysql",
     "com_github_go_viper_mapstructure_v2",
     "com_github_go_zookeeper_zk",

--- a/go.mod
+++ b/go.mod
@@ -277,6 +277,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-json-experiment/json v0.0.0-20250517221953-25912455fbc8
 	github.com/go-ole/go-ole v1.3.0
+	github.com/go-openapi/testify/v2 v2.6.0
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/go-zookeeper/zk v1.0.4

--- a/pkg/security/module/BUILD.bazel
+++ b/pkg/security/module/BUILD.bazel
@@ -91,11 +91,30 @@ go_library(
 
 dd_agent_go_test(
     name = "module_test",
-    srcs = ["server_test.go"],
+    srcs = [
+        "server_linux_test.go",
+        "server_test.go",
+    ],
     embed = [":module"],
     deps = [
         "//pkg/security/config",
         "//pkg/security/secl/compiler/eval",
         "//pkg/security/secl/model",
-    ],
+    ] + select({
+        "@rules_go//go/platform:android": [
+            "//pkg/security/probe",
+            "//pkg/security/resolvers/usersessions",
+            "//pkg/security/serializers",
+            "@com_github_go_openapi_testify_v2//require",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/security/probe",
+            "//pkg/security/resolvers/usersessions",
+            "//pkg/security/serializers",
+            "@com_github_go_openapi_testify_v2//require",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -80,9 +80,6 @@ func (p *pendingMsg) getMaxRetry() int {
 	for _, report := range p.actionReports {
 		maxRetry = max(maxRetry, report.MaxRetry())
 	}
-	if p.sshSessionPatcher != nil {
-		maxRetry = max(maxRetry, p.sshSessionPatcher.MaxRetry())
-	}
 	return maxRetry
 }
 
@@ -142,13 +139,22 @@ func (p *pendingMsg) isResolved() bool {
 		}
 	}
 
-	// TODO: for now skip the retry mechanism and always send the event
-	// if p.sshSessionPatcher != nil {
-	// 	if err := p.sshSessionPatcher.IsResolved(); err != nil {
-	// 		seclog.Tracef("ssh session not resolved: %v", err)
-	// 		return false
-	// 	}
-	// }
+	// The SSH session patcher has its own, much smaller, retry budget: the auth log line of a
+	// session is expected within a few hundreds of milliseconds, and the retry queue is ordered so
+	// waiting longer would delay all the following events.
+	if p.sshSessionPatcher != nil {
+		if err := p.sshSessionPatcher.IsResolved(); err != nil {
+			if p.retry < p.sshSessionPatcher.MaxRetry() {
+				seclog.Tracef("ssh session not resolved: %v", err)
+				return false
+			}
+			// give up on this session, the auth log line will most likely never show up (session
+			// established before the agent started tailing the log). Flag it so that its next
+			// events are sent right away instead of being delayed too.
+			seclog.Debugf("giving up on ssh session resolution: %v", err)
+			p.sshSessionPatcher.MarkUnresolved()
+		}
+	}
 	return true
 }
 

--- a/pkg/security/module/server_linux.go
+++ b/pkg/security/module/server_linux.go
@@ -292,6 +292,12 @@ func createSSHSessionPatcher(ev *model.Event, p *probe.Probe) sshSessionPatcher 
 	if ev.ProcessContext.UserSession.SSHSessionID != 0 {
 		// Access the EBPFProbe to get the UserSessionsResolver
 		if ebpfProbe, ok := p.PlatformProbe.(*probe.EBPFProbe); ok {
+			// without the auth log tailer nothing will ever resolve the session, don't make the
+			// event wait for it
+			if !ebpfProbe.Resolvers.UserSessionsResolver.SSHSessionsResolvable() {
+				return nil
+			}
+
 			// Create the user session context serializer
 			userSessionCtx := &serializers.SSHSessionContextSerializer{
 				SSHSessionID:  strconv.FormatUint(uint64(ev.ProcessContext.UserSession.SSHSessionID), 16),

--- a/pkg/security/module/server_linux_test.go
+++ b/pkg/security/module/server_linux_test.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package module
+
+import (
+	"testing"
+
+	"github.com/go-openapi/testify/v2/require"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/usersessions"
+	"github.com/DataDog/datadog-agent/pkg/security/serializers"
+)
+
+// TestPendingMsgIsResolvedSSHSession makes sure that an event of an SSH session waits for its
+// authentication log line to be tailed, but only for a bounded number of retries, and only once per
+// session: the retry queue is ordered, so waiting longer would delay all the following events.
+func TestPendingMsgIsResolvedSSHSession(t *testing.T) {
+	resolver, err := usersessions.NewResolver(64, true)
+	require.NoError(t, err)
+
+	newPatcher := func() sshSessionPatcher {
+		return probe.NewSSHUserSessionPatcher(
+			&serializers.SSHSessionContextSerializer{
+				SSHClientIP:   "127.0.0.1",
+				SSHClientPort: 38835,
+			},
+			resolver,
+			4242,
+		)
+	}
+	newMsg := func(retry int) *pendingMsg {
+		return &pendingMsg{
+			ruleID:            "test-rule",
+			retry:             retry,
+			sshSessionPatcher: newPatcher(),
+		}
+	}
+	maxRetry := newPatcher().MaxRetry()
+
+	// the auth log line has not been tailed yet, the event must be held back
+	assert.False(t, newMsg(0).isResolved(), "event must wait for the ssh session to be resolved")
+	assert.False(t, newMsg(maxRetry-1).isResolved(), "event must wait until its retry budget is exhausted")
+
+	// budget exhausted: the event is sent as is, and the session is flagged so that the next events
+	// of the same session are not delayed anymore
+	key := usersessions.SSHSessionKey{SSHDPid: "4242", IP: "127.0.0.1", Port: "38835"}
+	assert.False(t, resolver.IsSSHSessionUnresolved(key))
+	assert.True(t, newMsg(maxRetry).isResolved(), "event must be sent once the retry budget is exhausted")
+	assert.True(t, resolver.IsSSHSessionUnresolved(key), "the ssh session must be flagged as unresolved")
+
+	// following events of that session must not be delayed
+	assert.True(t, newMsg(0).isResolved(), "events of an unresolved session must not be delayed")
+}

--- a/pkg/security/module/server_other.go
+++ b/pkg/security/module/server_other.go
@@ -18,6 +18,7 @@ type sshSessionPatcher interface {
 	IsResolved() error
 	PatchEvent(_ interface{})
 	MaxRetry() int
+	MarkUnresolved()
 }
 
 // createSSHSessionPatcher creates a no-op patcher for other platforms

--- a/pkg/security/module/server_windows.go
+++ b/pkg/security/module/server_windows.go
@@ -19,6 +19,7 @@ type sshSessionPatcher interface {
 	IsResolved() error
 	PatchEvent(_ interface{})
 	MaxRetry() int
+	MarkUnresolved()
 }
 
 // createSSHSessionPatcher creates a no-op patcher for Windows

--- a/pkg/security/probe/ssh_user_session.go
+++ b/pkg/security/probe/ssh_user_session.go
@@ -19,7 +19,17 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/serializers"
 )
 
-const maxRetryForMsgWithSSHContext = 15
+// maxRetryForMsgWithSSHContext is the number of retries granted to an event to wait for the
+// authentication log line of its SSH session to be tailed from the auth log.
+//
+// sshd logs the "Accepted <method>" line right before spawning the user session, so the event of
+// the very first command of a session usually races with the auth log tailer. A couple of retries
+// (each one is `retryDelay` apart) is enough to close that gap.
+//
+// This budget must stay small: the retry queue is ordered, so an event waiting here delays all the
+// following events. Sessions that can never be resolved (typically because they were established
+// before the agent started tailing the log) pay it only once, see MarkUnresolved.
+const maxRetryForMsgWithSSHContext = 5
 
 func (p *EBPFProbe) HandleSSHUserSessionFromEvent(event *model.Event) {
 	if p.config.RuntimeSecurity.SSHUserSessionsEnabled {
@@ -45,6 +55,15 @@ func NewSSHUserSessionPatcher(userSessionCtx *serializers.SSHSessionContextSeria
 	}
 }
 
+// sessionKey returns the LRU key of the SSH session of the event
+func (p *SSHUserSessionPatcher) sessionKey() usersessions.SSHSessionKey {
+	return usersessions.SSHSessionKey{
+		SSHDPid: strconv.FormatUint(uint64(p.SSHDPid), 10),
+		IP:      p.userSessionCtx.SSHClientIP,
+		Port:    strconv.Itoa(p.userSessionCtx.SSHClientPort),
+	}
+}
+
 // IsResolved implements the EventSerializerPatcher interface for SSH user sessions
 func (p *SSHUserSessionPatcher) IsResolved() error {
 	if p.userSessionCtx == nil {
@@ -54,26 +73,34 @@ func (p *SSHUserSessionPatcher) IsResolved() error {
 		return errors.New("resolver is nil")
 	}
 
+	key := p.sessionKey()
+
 	// Check in LRU
-	key := usersessions.SSHSessionKey{
-		SSHDPid: strconv.FormatUint(uint64(p.SSHDPid), 10),
-		IP:      p.userSessionCtx.SSHClientIP,
-		Port:    strconv.Itoa(p.userSessionCtx.SSHClientPort),
+	if _, ok := p.resolver.GetSSHSession(key); ok {
+		return nil
 	}
 
-	_, ok := p.resolver.GetSSHSession(key)
-
-	if !ok {
-		return fmt.Errorf("ssh session not found in LRU for %s:%d",
-			p.userSessionCtx.SSHClientIP, p.userSessionCtx.SSHClientPort)
+	// the session was already given up on, don't delay this event
+	if p.resolver.IsSSHSessionUnresolved(key) {
+		return nil
 	}
 
-	return nil
+	return fmt.Errorf("ssh session not found in LRU for %s:%d",
+		p.userSessionCtx.SSHClientIP, p.userSessionCtx.SSHClientPort)
 }
 
 // MaxRetry implements the DelayabledEvent interface for SSH user sessions
 func (p *SSHUserSessionPatcher) MaxRetry() int {
 	return maxRetryForMsgWithSSHContext
+}
+
+// MarkUnresolved flags the SSH session of the event as unresolvable so that the next events of the
+// same session are sent without waiting for its authentication log line
+func (p *SSHUserSessionPatcher) MarkUnresolved() {
+	if p.userSessionCtx == nil || p.resolver == nil {
+		return
+	}
+	p.resolver.MarkSSHSessionUnresolved(p.sessionKey())
 }
 
 // PatchEvent implements the EventSerializerPatcher interface for SSH user sessions

--- a/pkg/security/resolvers/usersessions/BUILD.bazel
+++ b/pkg/security/resolvers/usersessions/BUILD.bazel
@@ -49,11 +49,13 @@ dd_agent_go_test(
     deps = select({
         "@rules_go//go/platform:android": [
             "//pkg/security/secl/model/usersession",
+            "@com_github_go_openapi_testify_v2//require",
             "@com_github_hashicorp_golang_lru_v2//:golang-lru",
             "@com_github_stretchr_testify//assert",
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/security/secl/model/usersession",
+            "@com_github_go_openapi_testify_v2//require",
             "@com_github_hashicorp_golang_lru_v2//:golang-lru",
             "@com_github_stretchr_testify//assert",
         ],

--- a/pkg/security/resolvers/usersessions/resolver_linux.go
+++ b/pkg/security/resolvers/usersessions/resolver_linux.go
@@ -37,7 +37,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
-const logDir = "var/log"
+const (
+	logDir = "var/log"
+
+	// sshSessionCacheSize is the size of the caches holding the SSH sessions parsed from the auth log
+	sshSessionCacheSize = 100
+)
 
 // UserSessionKey describes the key to a user session
 type UserSessionKey struct {
@@ -101,19 +106,33 @@ type Resolver struct {
 	sshEnabled       bool
 	sshLogReader     *incrementalFileReader
 	sshSessionParsed *lru.Cache[SSHSessionKey, SSHSessionValue]
+	// sshSessionUnresolved holds the sessions for which the authentication log line was never
+	// found. It is used to make sure we delay the events of a given session only once.
+	sshSessionUnresolved *lru.Cache[SSHSessionKey, struct{}]
 }
 
 // NewResolver returns a new instance of Resolver
 func NewResolver(cacheSize int, sshEnabled bool) (*Resolver, error) {
-	lru, err := simplelru.NewLRU[uint64, *model.K8SSessionContext](cacheSize, nil)
+	k8sCache, err := simplelru.NewLRU[uint64, *model.K8SSessionContext](cacheSize, nil)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create User Session resolver cache: %v", err)
 	}
 
-	return &Resolver{
-		k8suserSessions: lru,
+	resolver := &Resolver{
+		k8suserSessions: k8sCache,
 		sshEnabled:      sshEnabled,
-	}, nil
+	}
+
+	if sshEnabled {
+		if resolver.sshSessionParsed, err = lru.New[SSHSessionKey, SSHSessionValue](sshSessionCacheSize); err != nil {
+			return nil, fmt.Errorf("couldn't create SSH Session cache: %v", err)
+		}
+		if resolver.sshSessionUnresolved, err = lru.New[SSHSessionKey, struct{}](sshSessionCacheSize); err != nil {
+			return nil, fmt.Errorf("couldn't create SSH Session unresolved cache: %v", err)
+		}
+	}
+
+	return resolver, nil
 }
 
 // Start initializes the eBPF map of the resolver
@@ -195,6 +214,32 @@ func (r *Resolver) GetSSHSession(key SSHSessionKey) (SSHSessionValue, bool) {
 		return SSHSessionValue{}, false
 	}
 	return r.sshSessionParsed.Get(key)
+}
+
+// SSHSessionsResolvable returns true if the ssh auth log is being tailed. When it is not, nothing
+// will ever populate the session cache, so waiting for a session to be resolved is pointless.
+func (r *Resolver) SSHSessionsResolvable() bool {
+	r.RLock()
+	defer r.RUnlock()
+
+	return r.sshLogReader != nil
+}
+
+// MarkSSHSessionUnresolved flags a session as unresolvable, so that the events of that session are
+// not delayed anymore while waiting for its authentication log line.
+func (r *Resolver) MarkSSHSessionUnresolved(key SSHSessionKey) {
+	if r.sshSessionUnresolved == nil {
+		return
+	}
+	r.sshSessionUnresolved.Add(key, struct{}{})
+}
+
+// IsSSHSessionUnresolved returns true if the session was already flagged as unresolvable
+func (r *Resolver) IsSSHSessionUnresolved(key SSHSessionKey) bool {
+	if r.sshSessionUnresolved == nil {
+		return false
+	}
+	return r.sshSessionUnresolved.Contains(key)
 }
 
 // Init opens the file and sets the initial offset
@@ -470,21 +515,11 @@ func sshAuthLogPathCandidates() []string {
 // StartSSHUserSessionResolver initializes the ssh log reader by looking for the available file, opening it and setting up the initial offset
 // Lock must be held
 func (r *Resolver) StartSSHUserSessionResolver() error {
-	var err error
-
-	// Initialize the SSH session LRU cache (needed in all cases)
-	r.sshSessionParsed, err = lru.New[SSHSessionKey, SSHSessionValue](100)
-	if err != nil {
-		seclog.Errorf("couldn't create SSH Session LRU cache: %v", err)
-		return err
-	}
-
 	// Try to find the ssh log file (container: also under HOST_ROOT or /host/var/log)
 	// We stop on the first file found
 	path := ""
 	for _, possiblePath := range sshAuthLogPathCandidates() {
-		_, err = os.Stat(possiblePath)
-		if err == nil {
+		if _, err := os.Stat(possiblePath); err == nil {
 			path = possiblePath
 			break
 		}

--- a/pkg/security/resolvers/usersessions/resolver_linux_test.go
+++ b/pkg/security/resolvers/usersessions/resolver_linux_test.go
@@ -11,6 +11,7 @@ package usersessions
 import (
 	"testing"
 
+	"github.com/go-openapi/testify/v2/require"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/stretchr/testify/assert"
 
@@ -101,4 +102,41 @@ func Test_parseSSHLogLine(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_SSHSessionsResolvable(t *testing.T) {
+	resolver, err := NewResolver(64, true)
+	require.NoError(t, err)
+
+	// no auth log tailer started, nothing will ever populate the session cache
+	assert.False(t, resolver.SSHSessionsResolvable())
+
+	resolver.sshLogReader = &incrementalFileReader{path: "/var/log/auth.log"}
+	assert.True(t, resolver.SSHSessionsResolvable())
+}
+
+func Test_SSHSessionUnresolved(t *testing.T) {
+	key := SSHSessionKey{SSHDPid: "4242", IP: "127.0.0.1", Port: "38835"}
+
+	t.Run("ssh disabled", func(t *testing.T) {
+		resolver, err := NewResolver(64, false)
+		assert.NoError(t, err)
+
+		// must not panic nor report anything when the ssh caches are not initialized
+		resolver.MarkSSHSessionUnresolved(key)
+		assert.False(t, resolver.IsSSHSessionUnresolved(key))
+	})
+
+	t.Run("ssh enabled", func(t *testing.T) {
+		resolver, err := NewResolver(64, true)
+		assert.NoError(t, err)
+
+		assert.False(t, resolver.IsSSHSessionUnresolved(key), "session must not be flagged yet")
+
+		resolver.MarkSSHSessionUnresolved(key)
+		assert.True(t, resolver.IsSSHSessionUnresolved(key), "session must be flagged")
+
+		other := SSHSessionKey{SSHDPid: "4243", IP: "127.0.0.1", Port: "38835"}
+		assert.False(t, resolver.IsSSHSessionUnresolved(other), "other sessions must not be flagged")
+	})
 }


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Events of a new SSH session race with the auth log tailer, so the first one was often reported with ssh_auth_method `unknown`. Re-enable the patcher retry with its own small budget (5 retries), and flag sessions that can't be resolved so they only delay the ordered retry queue once. Hosts with no auth log file (journald only) get no patcher at all.

### Motivation

Fix SSH flacky tests

### Describe how you validated your changes

### Additional Notes
