### PR TITLE
Quality Gate limit adjustments for ADP preflight feature

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -10,7 +10,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 30% higher than the memory_usage check value
-  memory_allotment: 232 MiB
+  memory_allotment: 233 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -38,7 +38,7 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 30% higher
-      upper_bound: "178 MiB"
+      upper_bound: "179 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -10,7 +10,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 30% higher than the memory_usage check value
-  memory_allotment: 700 MiB
+  memory_allotment: 698 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -64,7 +64,7 @@ checks:
       #
       # When updating this, update the memory_allotment in the target section to
       # 30% higher
-      upper_bound: "538 MiB"
+      upper_bound: "537 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  # Set to 20% higher than the memory_usage check value
-  memory_allotment: 275 MiB
+  # Set to 30% higher than the memory_usage check value
+  memory_allotment: 286 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -30,8 +30,8 @@ checks:
     description: "Memory usage"
     bounds:
       series: total_pss_bytes
-      # When updating this, update the memory_allotment in the target section to 20% higher
-      upper_bound: "229 MiB"
+      # When updating this, update the memory_allotment in the target section to 30% higher
+      upper_bound: "220 MiB"
 
   - name: missed_bytes
     description: "Allowable bytes not polled by log Agent"

--- a/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  # Set to 20% higher than the memory_usage check value
-  memory_allotment: 544 MiB
+  # Set to 30% higher than the memory_usage check value
+  memory_allotment: 592 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -32,8 +32,8 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total collector memory usage."
     bounds:
       series: total_pss_bytes
-      # When updating this, update the memory_allotment in the target section to 20% higher
-      upper_bound: 453 MiB
+      # When updating this, update the memory_allotment in the target section to 30% higher
+      upper_bound: 455 MiB
 
   - name: cpu_usage
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."

--- a/test/regression/cases/quality_gate_private_action_runner/experiment.yaml
+++ b/test/regression/cases/quality_gate_private_action_runner/experiment.yaml
@@ -12,8 +12,8 @@ target:
   name: datadog-agent
   command: /bin/entrypoint.sh
   cpu_allotment: 4
-  # Set to 20% higher than the memory_usage check value.
-  memory_allotment: 92 MiB
+  # Set to 30% higher than the memory_usage check value.
+  memory_allotment: 98 MiB
 
   environment:
     ENTRYPOINT: privateactionrunner
@@ -32,8 +32,8 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update
-      # memory_allotment in the target section to 20% higher.
-      upper_bound: "76 MiB"
+      # memory_allotment in the target section to 30% higher.
+      upper_bound: "75 MiB"
 
 report_links:
   - text: "bounds checks dashboard"

--- a/test/regression/cases/quality_gate_security_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_security_idle/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  # Set to 20% higher than the memory_usage check value
-  memory_allotment: 402 MiB
+  # Set to 30% higher than the memory_usage check value
+  memory_allotment: 461 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -47,8 +47,8 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total memory usage for CWS with no custom policy and no lading-generated filesystem load."
     bounds:
       series: total_pss_bytes
-      # When updating this, update the memory_allotment in the target section to 20% higher.
-      upper_bound: "335 MiB"
+      # When updating this, update the memory_allotment in the target section to 30% higher.
+      upper_bound: "355 MiB"
 
   - name: cpu_usage
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."

--- a/test/regression/cases/quality_gate_security_mean_fs_load/experiment.yaml
+++ b/test/regression/cases/quality_gate_security_mean_fs_load/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  # Set to 20% higher than the memory_usage check value
-  memory_allotment: 377 MiB
+  # Set to 30% higher than the memory_usage check value
+  memory_allotment: 436 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -47,8 +47,8 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total memory usage for CWS workloads."
     bounds:
       series: total_pss_bytes
-      # When updating this, update the memory_allotment in the target section to 20% higher.
-      upper_bound: "314 MiB"
+      # When updating this, update the memory_allotment in the target section to 30% higher.
+      upper_bound: "335 MiB"
 
   - name: cpu_usage
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."

--- a/test/regression/cases/quality_gate_security_no_fs_load/experiment.yaml
+++ b/test/regression/cases/quality_gate_security_no_fs_load/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  # Set to 20% higher than the memory_usage check value
-  memory_allotment: 412 MiB
+  # Set to 30% higher than the memory_usage check value
+  memory_allotment: 449 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -47,8 +47,8 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total memory usage for CWS with the default.policy in effect but no lading-generated filesystem load."
     bounds:
       series: total_pss_bytes
-      # When updating this, update the memory_allotment in the target section to 20% higher.
-      upper_bound: "343 MiB"
+      # When updating this, update the memory_allotment in the target section to 30% higher.
+      upper_bound: "345 MiB"
 
   - name: cpu_usage
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."


### PR DESCRIPTION
### What does this PR do?

- adjusts memory limits for all impacted gates due to the ADP preflight feature

### Motivation

When certain features get introduced, the memory (or other) profile of the Agent can change. The ADP preflight feature is one of those. It impacts quality gates memory usage. In this case, it's a known feature that leadership has accepted the memory increase for. We need to adjust the limits on the Quality Gates to reflect this.

### Describe how you validated your changes
The changes were validated by running 2 nightly sized jobs using the same agent version but with ADP preflight turned on/off. This allows us to get higher fidelity data that also isolates this feature specifically.

The notebooks below go into more detail.

tl;dr: an increase of ~25 MiB was identified and is being applied uniformally across impacted gates

### Additional Notes
ADP preflight was introduced here: https://github.com/DataDog/datadog-agent/pull/54175
ADP preflight was extended to run for full quality gate duration here: https://github.com/DataDog/datadog-agent/pull/54794

The original limit adjustments were the following:
- https://github.com/DataDog/datadog-agent/pull/54792
  - this estimate was done before preflight was extended to run for the full duration
- https://github.com/DataDog/datadog-agent/pull/55120
  - this was an additional limit adjustment done after preflight was extended to run for the full duration
  
This PR undos the previous limit adjustments in favor of the new investigation/analysis:
- [initial investigation](https://app.datadoghq.com/notebook/15356517/agent-quality-gates-%25E2%2580%2594-limit-adjustment-investigation-ir-59125)
- [analysis of the adp preflight feature's impact on memory](https://app.datadoghq.com/notebook/15379608/incident-59125-establishing-new-bounds-for-quality-gates)

One additional note: the private action runner quality gate limit adjustment was **reverted**. We identified that it is NOT impacted by the ADP preflight feature and should not have received any limit adjustments previously.