### PR TITLE
[incident-59848] pin `buildx` output media type to avoid mixed OCI/Docker manifests

### DIFF
--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -81,8 +81,9 @@
         DOCKER_NO_CACHE=""
       fi
     # Build image, use target none label to avoid replication
+    # Force Docker media types to prevent buildx from switching to OCI manifests (#incident-59848)
     - |-
-      docker buildx build --push --pull --platform linux/$ARCH \
+      docker buildx build --output=type=image,push=true,oci-mediatypes=false --pull --platform linux/$ARCH \
         ${CACHE_SOURCE} \
         ${DOCKER_NO_CACHE} \
         --build-arg AGENT_BASE_IMAGE_TAG=${AGENT_BASE_IMAGE_TAG} \

--- a/.gitlab/deploy/container_build/fakeintake.yml
+++ b/.gitlab/deploy/container_build/fakeintake.yml
@@ -48,7 +48,8 @@ docker_build_fakeintake:
     - !reference [.login_to_docker_readonly]
     - |
       echo "Building with GO_BASE_IMAGE_REGISTRY=${GO_REGISTRY} ALPINE_BASE_IMAGE_REGISTRY=${ALPINE_REGISTRY}"
-      docker buildx build --push --pull --platform ${PLATFORMS} \
+      # Force Docker media types to prevent buildx from switching to OCI manifests (#incident-59848)
+      docker buildx build --output=type=image,push=true,oci-mediatypes=false --pull --platform ${PLATFORMS} \
         --build-arg=CI \
         --build-arg=GO_BASE_IMAGE_REGISTRY=${GO_REGISTRY} \
         --build-arg=ALPINE_BASE_IMAGE_REGISTRY=${ALPINE_REGISTRY} \


### PR DESCRIPTION
### What does this PR do?
Add `--output=type=image,push=true,oci-mediatypes=false` to the `docker buildx build` invocation in `.docker_build_job_definition` and in `docker_build_fakeintake`, replacing the bare `--push` flag.

### Motivation
`cluster-agent-qa` images intermittently fail to pull in `containerd`-based clusters with:
```
Failed to pull image "….com/cluster-agent-qa:123456789-fedcba98":
 copying system image from manifest list:
  parsing image configuration:
   invalid mixed OCI image with Docker v2s2 config
    ("application/vnd.docker.container.image.v1+json")
```

2 builds of the same commit and script produced manifests with different media types:
- one entirely `application/vnd.oci.image.manifest.v1+json`,
- the other entirely `application/vnd.docker.distribution.manifest.v2+json`,
- both wrapped in the same `application/vnd.docker.distribution.manifest.list.v2+json` list!

A BuildKit upgrade is in progress fleet-wide (CIEXE-1659, v0.25.2 to v0.30.0), which is a suspected contributing factor per team discussion, though **not confirmed**.

Pinning the media type explicitly removes the dependency on whichever BuildKit version happens to run a given job.

### Additional Notes
Investigated in [#incident-59848](https://dd.enterprise.slack.com/archives/C0BT4FEH85Q), alongside @KevinFairise2.