### PR TITLE
fix(ci): pin container image media types

### DIFF
--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -82,7 +82,10 @@
       fi
     # Build image, use target none label to avoid replication
     - |-
-      docker buildx build --push --pull --platform linux/$ARCH \
+      # BuildKit v0.31 changed the default image media type to OCI. Keep the
+      # output format explicit so amd64 and arm64 images remain compatible
+      # when dd-pkg combines them into a manifest list.
+      docker buildx build --output type=image,push=true,oci-mediatypes=false --pull --platform linux/$ARCH \
         ${CACHE_SOURCE} \
         ${DOCKER_NO_CACHE} \
         --build-arg AGENT_BASE_IMAGE_TAG=${AGENT_BASE_IMAGE_TAG} \


### PR DESCRIPTION
## Summary

- Explicitly configure the BuildKit image exporter to use Docker media types.
- Keep amd64 and arm64 cluster-agent outputs compatible when combined into a manifest list.

## Context

BuildKit v0.31 changed the default image media type to OCI. During the staged BuildKit rollout, cluster-agent images were observed with mixed OCI and Docker v2s2 media types, causing kubelet to reject the manifest.

## Validation

- `git diff --check`
- The change is in the shared template inherited by both cluster-agent architecture jobs.

Incident: #59848