### PR TITLE
fix(buildimages-update): Set PR targeted branch to prevent failures when feature branch already exists

### DIFF
--- a/.github/workflows/buildimages-update.yml
+++ b/.github/workflows/buildimages-update.yml
@@ -134,6 +134,7 @@ jobs:
         with:
           token: ${{ steps.octo-sts.outputs.token }}
           commit-message: ${{ steps.update_build_images.outputs.MESSAGE }}
+          base: ${{ github.ref_name }}
           branch: ${{ inputs.branch }}
           sign-commits: true
           title: "[automated] ${{ steps.update_build_images.outputs.MESSAGE }}"


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

In the PR creation step, sets the `base` branch to the branch where the workflow is from.

### Motivation

By default, `base` is set to the current branch but if the branch passed as an input already exists, the prior step will checkout to the same branch and fail the PR creation.

### Describe how you validated your changes

Cannot really test it because the workflow cannot get the permissions when run from branches other than `main` and release branches.

### Additional Notes
