### PR TITLE
[procmgr] Run dd-procmgr-service as LocalSystem

### DIFF
--- a/.gitlab/windows/test/e2e_install_packages/windows.yml
+++ b/.gitlab/windows/test/e2e_install_packages/windows.yml
@@ -40,6 +40,7 @@
   parallel:
     matrix:
       - E2E_MSI_TEST: TestInstall
+      - E2E_MSI_TEST: TestProcmgrLocalSystem
       - E2E_MSI_TEST: TestRepair
       - E2E_MSI_TEST: TestUpgrade
       - E2E_MSI_TEST: TestUpgradeFromLatest

--- a/releasenotes/notes/procmgr-localsystem-service-account-a3f8c2d91e047b61.yaml
+++ b/releasenotes/notes/procmgr-localsystem-service-account-a3f8c2d91e047b61.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    On Windows, ``dd-procmgr-service`` is now installed and configured to run as
+    ``LocalSystem`` instead of the Agent user account. The installer no longer
+    disables the service when ``DDAGENTUSER_PASSWORD`` is omitted on upgrade.

--- a/test/new-e2e/tests/windows/domain-test/domain_test.go
+++ b/test/new-e2e/tests/windows/domain-test/domain_test.go
@@ -158,11 +158,12 @@ type testUpgradeWithoutStoredPasswordSuite struct {
 	windows.BaseAgentInstallerSuite[environments.WindowsHost]
 }
 
-// TestUpgradeWithoutPasswordDisablesProcessManager covers the regression where upgrading a host first
-// installed with Agent 7.65 or earlier, without providing DDAGENTUSER_PASSWORD, left dd-procmgr-service
-// failing to log on until the domain account locked out. It must now be disabled instead, and re-enabled
-// once a password is provided again.
-func (suite *testUpgradeWithoutStoredPasswordSuite) TestUpgradeWithoutPasswordDisablesProcessManager() {
+// TestUpgradeWithoutPasswordKeepsProcessManagerEnabled covers upgrading a host first
+// installed with Agent 7.65 or earlier without providing DDAGENTUSER_PASSWORD. Before
+// dd-procmgr-service moved to LocalSystem (#54731), that upgrade disabled the service to
+// avoid domain account lockout (#55130). With LocalSystem procmgr, the service stays enabled
+// because it no longer logs on as the Agent user.
+func (suite *testUpgradeWithoutStoredPasswordSuite) TestUpgradeWithoutPasswordKeepsProcessManagerEnabled() {
 	host := suite.Env().RemoteHost
 	username := fmt.Sprintf("%s\\%s", TestDomain, TestUser)
 
@@ -189,11 +190,19 @@ func (suite *testUpgradeWithoutStoredPasswordSuite) TestUpgradeWithoutPasswordDi
 		windowsAgent.WithInstallLogFile(filepath.Join(suite.SessionOutputDir(), "upgrade_without_password.log")))
 	suite.Require().NoError(err, "should succeed to upgrade the Agent without providing the password")
 
-	suite.Run("process manager is disabled", func() {
+	suite.Run("process manager stays enabled as LocalSystem", func() {
 		config, err := windowsCommon.GetServiceConfig(host, procmgrServiceName)
 		suite.Require().NoError(err)
-		suite.Assert().Equal(windowsCommon.SERVICE_DISABLED, config.StartType,
-			"%s must be disabled when the Agent user password is not available", procmgrServiceName)
+		suite.Assert().Equal(windowsCommon.SERVICE_DEMAND_START, config.StartType,
+			"%s must stay enabled when it runs as LocalSystem", procmgrServiceName)
+
+		account, err := windowsCommon.GetServiceAccountName(host, procmgrServiceName)
+		suite.Require().NoError(err)
+		suite.Assert().Equal("LocalSystem", account,
+			"%s must run as LocalSystem after upgrade", procmgrServiceName)
+
+		suite.Assert().NoError(windowsCommon.StartService(host, procmgrServiceName),
+			"%s should start without the Agent user password once it runs as LocalSystem", procmgrServiceName)
 	})
 
 	suite.Run("core Agent is unaffected", func() {
@@ -207,7 +216,7 @@ func (suite *testUpgradeWithoutStoredPasswordSuite) TestUpgradeWithoutPasswordDi
 		}, 5*time.Minute, 10*time.Second)
 	})
 
-	suite.Run("providing the password re-enables the process manager", func() {
+	suite.Run("providing the password keeps process manager healthy", func() {
 		_, err := suite.InstallAgent(host,
 			windowsAgent.WithPackage(suite.AgentPackage),
 			windowsAgent.WithAgentUser(username),
@@ -218,7 +227,7 @@ func (suite *testUpgradeWithoutStoredPasswordSuite) TestUpgradeWithoutPasswordDi
 		config, err := windowsCommon.GetServiceConfig(host, procmgrServiceName)
 		suite.Require().NoError(err)
 		suite.Assert().Equal(windowsCommon.SERVICE_DEMAND_START, config.StartType,
-			"%s must be enabled again once the Agent user password is available", procmgrServiceName)
+			"%s must stay enabled after reinstall with the Agent user password", procmgrServiceName)
 		suite.Assert().NoError(windowsCommon.StartService(host, procmgrServiceName),
 			"%s should start once the Agent user password is available", procmgrServiceName)
 	})

--- a/test/new-e2e/tests/windows/domain-test/domain_test.go
+++ b/test/new-e2e/tests/windows/domain-test/domain_test.go
@@ -160,7 +160,7 @@ type testUpgradeWithoutStoredPasswordSuite struct {
 
 // TestUpgradeWithoutPasswordKeepsProcessManagerEnabled covers upgrading a host first
 // installed with Agent 7.65 or earlier without providing DDAGENTUSER_PASSWORD. Before
-// dd-procmgr-service moved to LocalSystem (#54731), that upgrade disabled the service to
+// dd-procmgr-service moved to LocalSystem (#55529), that upgrade disabled the service to
 // avoid domain account lockout (#55130). With LocalSystem procmgr, the service stays enabled
 // because it no longer logs on as the Agent user.
 func (suite *testUpgradeWithoutStoredPasswordSuite) TestUpgradeWithoutPasswordKeepsProcessManagerEnabled() {

--- a/test/new-e2e/tests/windows/install-test/BUILD.bazel
+++ b/test/new-e2e/tests/windows/install-test/BUILD.bazel
@@ -47,6 +47,7 @@ dd_agent_go_test(
         "install_test.go",
         "npm_test.go",
         "persisting_integrations_test.go",
+        "procmgr_localsystem_test.go",
         "upgrade_test.go",
     ],
     embed = [":install-test"],

--- a/test/new-e2e/tests/windows/install-test/procmgr_localsystem_test.go
+++ b/test/new-e2e/tests/windows/install-test/procmgr_localsystem_test.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package installtest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/components"
+	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const procmgrServiceName = "dd-procmgr-service"
+
+func TestProcmgrLocalSystem(t *testing.T) {
+	suite.Run(t, new(procmgrLocalSystemSuite))
+}
+
+type procmgrLocalSystemSuite struct {
+	baseAgentMSISuite
+}
+
+func (s *procmgrLocalSystemSuite) TestProcmgrServiceRunsAsLocalSystem() {
+	host := s.Env().RemoteHost
+
+	account, err := windowsCommon.GetServiceAccountName(host, procmgrServiceName)
+	s.Require().NoError(err)
+	s.Assert().Equal("LocalSystem", account, "%s SCM account", procmgrServiceName)
+
+	s.Require().NoError(windowsCommon.StartService(host, procmgrServiceName))
+
+	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
+		owner, err := windowsProcessOwnerByName(host, "dd-procmgrd.exe")
+		assert.NoError(ct, err)
+		assert.Contains(ct, owner, "NT AUTHORITY/SYSTEM")
+	}, 60*time.Second, 2*time.Second)
+}
+
+func windowsProcessOwnerByName(host *components.RemoteHost, name string) (string, error) {
+	script := fmt.Sprintf(
+		`$p = Get-CimInstance Win32_Process -Filter "Name='%s'" | Select-Object -First 1; if ($null -eq $p) { exit 1 }; $o = Invoke-CimMethod -InputObject $p -MethodName GetOwner; if ($o.ReturnValue -ne 0) { exit $o.ReturnValue }; "$($o.Domain)/$($o.User)"`,
+		name,
+	)
+	out, err := host.Execute(script)
+	return strings.TrimSpace(out), err
+}

--- a/test/new-e2e/tests/windows/install-test/procmgr_localsystem_test.go
+++ b/test/new-e2e/tests/windows/install-test/procmgr_localsystem_test.go
@@ -16,13 +16,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 const procmgrServiceName = "dd-procmgr-service"
 
 func TestProcmgrLocalSystem(t *testing.T) {
-	suite.Run(t, new(procmgrLocalSystemSuite))
+	s := &procmgrLocalSystemSuite{}
+	Run(t, s)
 }
 
 type procmgrLocalSystemSuite struct {
@@ -31,6 +31,7 @@ type procmgrLocalSystemSuite struct {
 
 func (s *procmgrLocalSystemSuite) TestProcmgrServiceRunsAsLocalSystem() {
 	host := s.Env().RemoteHost
+	_ = s.installAgentPackage(host, s.AgentPackage)
 
 	account, err := windowsCommon.GetServiceAccountName(host, procmgrServiceName)
 	s.Require().NoError(err)

--- a/test/new-e2e/tests/windows/install-test/upgrade_test.go
+++ b/test/new-e2e/tests/windows/install-test/upgrade_test.go
@@ -64,10 +64,9 @@ func (s *testUpgradeSuite) TestUpgrade() {
 		s.T().FailNow()
 	}
 
-	// The installer only disables dd-procmgr-service when the Agent user password is unavailable,
-	// which can only happen for domain accounts. This host uses the default local ddagentuser, whose
-	// password the installer always generates, so the service must stay enabled even though the
-	// upgrade above did not provide a password.
+	// dd-procmgr-service runs as LocalSystem (#54731), so it stays enabled even when the
+	// upgrade does not provide DDAGENTUSER_PASSWORD. Local accounts already behaved this way
+	// because the installer generates a password for the default ddagentuser.
 	s.Run("process manager stays enabled for a local account", func() {
 		config, err := windowsCommon.GetServiceConfig(vm, "dd-procmgr-service")
 		s.Require().NoError(err)

--- a/test/new-e2e/tests/windows/install-test/upgrade_test.go
+++ b/test/new-e2e/tests/windows/install-test/upgrade_test.go
@@ -64,7 +64,7 @@ func (s *testUpgradeSuite) TestUpgrade() {
 		s.T().FailNow()
 	}
 
-	// dd-procmgr-service runs as LocalSystem (#54731), so it stays enabled even when the
+	// dd-procmgr-service runs as LocalSystem (#55529), so it stays enabled even when the
 	// upgrade does not provide DDAGENTUSER_PASSWORD. Local accounts already behaved this way
 	// because the installer generates a password for the default ddagentuser.
 	s.Run("process manager stays enabled for a local account", func() {

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Service/ProcmgrStartTypeTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Service/ProcmgrStartTypeTests.cs
@@ -10,10 +10,6 @@ using Xunit;
 
 namespace CustomActions.Tests.Service
 {
-    /// <summary>
-    /// Unit tests for the dd-procmgr-service start type handling in ConfigureServiceUsers, which must
-    /// disable the service when the Agent user password is unavailable, and only then.
-    /// </summary>
     public class ProcmgrStartTypeTests
     {
         private const string DomainUserName = "TESTDOMAIN\\ddagentuser";
@@ -50,17 +46,16 @@ namespace CustomActions.Tests.Service
         }
 
         [Fact]
-        public void ConfigureServiceUsers_DisablesProcmgr_ForDomainAccountWithoutPassword()
+        public void ConfigureServiceUsers_EnablesProcmgr_ForDomainAccountWithoutPassword()
         {
             GivenServiceAccount(false);
             GivenAgentUserPassword(null);
 
             Test.Create().ConfigureServiceUsers(DomainUserName, DomainUserSid);
 
-            VerifyProcmgrStartType(ServiceStartMode.Disabled);
-            // the empty password stored by InstallServices is left alone
+            VerifyProcmgrStartType(ServiceStartMode.Manual);
             Test.ServiceController.Verify(
-                c => c.SetCredentials(ProcmgrServiceName, DomainUserName, null), Times.Once);
+                c => c.SetCredentials(ProcmgrServiceName, "LocalSystem", ""), Times.Once);
         }
 
         [Fact]
@@ -72,18 +67,21 @@ namespace CustomActions.Tests.Service
             Test.Create().ConfigureServiceUsers(DomainUserName, DomainUserSid);
 
             VerifyProcmgrStartType(ServiceStartMode.Manual);
+            Test.ServiceController.Verify(
+                c => c.SetCredentials(ProcmgrServiceName, "LocalSystem", ""), Times.Once);
         }
 
         [Fact]
         public void ConfigureServiceUsers_EnablesProcmgr_ForServiceAccount()
         {
-            // gMSA: no password is needed or expected
             GivenServiceAccount(true);
             GivenAgentUserPassword(null);
 
             Test.Create().ConfigureServiceUsers("TESTDOMAIN\\ddagentuser$", DomainUserSid);
 
             VerifyProcmgrStartType(ServiceStartMode.Manual);
+            Test.ServiceController.Verify(
+                c => c.SetCredentials(ProcmgrServiceName, "LocalSystem", ""), Times.Once);
         }
 
         [Fact]
@@ -114,10 +112,6 @@ namespace CustomActions.Tests.Service
                 .Should().NotThrow();
         }
 
-        /// <summary>
-        /// Other failures must propagate so the install fails. A failed upgrade leaves the customer on a
-        /// working version, which beats proceeding and locking out the account.
-        /// </summary>
         [Fact]
         public void ConfigureServiceUsers_PropagatesOtherStartTypeFailures()
         {

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
@@ -217,53 +217,28 @@ namespace Datadog.CustomActions
             {
                 _serviceController.SetCredentials(Constants.PrivateActionRunnerServiceName, ddAgentUserName, ddAgentUserPassword);
             }
-            _serviceController.SetCredentials(Constants.ProcmgrServiceName, ddAgentUserName, ddAgentUserPassword);
-            // When procmgr moves back to LocalSystem, replace this with an unconditional enable rather
-            // than deleting it. passwordNotProvided describes the Agent user, and a disabled start type
-            // survives an upgrade, so hosts disabled here would otherwise stay disabled forever.
-            ConfigureProcmgrStartType(passwordNotProvided);
-
             // SYSTEM
             // LocalSystem is a SCM specific shorthand that doesn't need to be localized
             _serviceController.SetCredentials(Constants.SystemProbeServiceName, "LocalSystem", "");
             _serviceController.SetCredentials(Constants.ProcessAgentServiceName, "LocalSystem", "");
+            _serviceController.SetCredentials(Constants.ProcmgrServiceName, "LocalSystem", "");
+            EnableProcmgrService();
             _serviceController.SetCredentials(Constants.InstallerServiceName, "LocalSystem", "");
 
             _serviceController.SetCredentials(Constants.SecurityAgentServiceName, ddAgentUserName, ddAgentUserPassword);
         }
 
-        /// <summary>
-        /// dd-procmgr-service runs as ddagentuser and is a new service. If we do not have the password
-        /// and it is not in the LSA store, the service cannot log on, and the SCM retries the failing
-        /// logon until the account is locked out. Disable the service in that case so that it is never
-        /// started, and set it back to demand start once a password is available again.
-        /// </summary>
-        private void ConfigureProcmgrStartType(bool passwordNotProvided)
+        private void EnableProcmgrService()
         {
-            ServiceStartMode startType;
-            if (passwordNotProvided)
-            {
-                startType = ServiceStartMode.Disabled;
-                _session.Log(
-                    $"The Agent user password is not available, setting {Constants.ProcmgrServiceName} start type to " +
-                    "disabled so that it does not repeatedly fail to log on, which can lock out the account. " +
-                    "Reinstall the Agent with the DDAGENTUSER_NAME and DDAGENTUSER_PASSWORD options provided " +
-                    "to enable the Datadog Process Manager service.");
-            }
-            else
-            {
-                startType = ServiceStartMode.Manual;
-                _session.Log($"Setting {Constants.ProcmgrServiceName} start type to {startType}");
-            }
-
             try
             {
-                _serviceController.SetStartType(Constants.ProcmgrServiceName, startType);
+                _session.Log($"Setting {Constants.ProcmgrServiceName} start type to {ServiceStartMode.Manual}");
+                _serviceController.SetStartType(Constants.ProcmgrServiceName, ServiceStartMode.Manual);
             }
             catch (Exception e) when (IsServiceDoesNotExistError(e))
             {
-                // If the service does not exist there is nothing that can fail to log on.
-                _session.Log($"Service {Constants.ProcmgrServiceName} not found, not changing its start type");
+                _session.Log(
+                    $"Service {Constants.ProcmgrServiceName} not found, not changing its start type: {e}");
             }
         }
 

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
@@ -692,8 +692,8 @@ namespace WixSetup.Datadog_Agent
                 Constants.ProcmgrServiceName,
                 "Datadog Process Manager",
                 "Manage Datadog agent processes",
-                "[DDAGENTUSER_PROCESSED_FQ_NAME]",
-                "[DDAGENTUSER_PROCESSED_PASSWORD]");
+                "LocalSystem",
+                null);
             agentBinDir.AddFile(new WixSharp.File(_agentBinaries.ProcmgrService, procmgrService));
             agentBinDir.Add(new EventSource
             {


### PR DESCRIPTION
### What does this PR do?

Configure **dd-procmgr-service** to run as **LocalSystem** on Windows install and upgrade. Domain upgrades without `DDAGENTUSER_PASSWORD` no longer disable the service.

Stack base: **this PR** → [#54731](https://github.com/DataDog/datadog-agent/pull/54731) → … → [#55080](https://github.com/DataDog/datadog-agent/pull/55080). Parallel: [#55531](https://github.com/DataDog/datadog-agent/pull/55531).

### Motivation

The spawn-profiles work in #54731 needs a LocalSystem process manager to supervise Agent-user children. This PR carries the installer changes so #54731 can stay focused on runtime behavior.

### Describe how you validated your changes

- Windows installer unit tests
- Windows install and domain upgrade E2E coverage for LocalSystem procmgr and no-password upgrade behavior