### PR TITLE
Post performance PR comment for trace-agent benchmarks

### DIFF
--- a/.gitlab/.ci-linters.yml
+++ b/.gitlab/.ci-linters.yml
@@ -61,6 +61,7 @@ job-owners:
   allowed-jobs:
     - index-consolidation
     - benchmark
+    - benchmark_commenter
     - build_dogstatsd-binary_arm64
     - build_dogstatsd-binary_x64
     - build_dogstatsd_static-binary_arm64

--- a/.gitlab/test/benchmarks/benchmarks.yml
+++ b/.gitlab/test/benchmarks/benchmarks.yml
@@ -34,12 +34,16 @@ benchmark:
     expire_in: 3 months
 
 # Same pattern as golang_deps_commenter: post on the standard linux image, not the bench runner.
+# Automatic (not .on_trace_agent_changes_or_manual): a manual play of `benchmark` must still
+# start this job. Sharing the parent's when: manual fallback would require a second play button.
 benchmark_commenter:
   stage: benchmarks
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   extends: .dd_octo_sts
-  rules: !reference [.on_trace_agent_changes_or_manual]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
   interruptible: true
   needs: ["benchmark"]
   before_script:

--- a/.gitlab/test/benchmarks/benchmarks.yml
+++ b/.gitlab/test/benchmarks/benchmarks.yml
@@ -26,10 +26,27 @@ benchmark:
     - ./test/benchmarks/apm_scripts/run-benchmarks.sh
     - ./test/benchmarks/apm_scripts/analyze-results.sh
     - "./test/benchmarks/apm_scripts/upload-results-to-s3.sh || :"
-    - "./test/benchmarks/apm_scripts/post-pr-comment.sh || :"
   artifacts:
     name: "artifacts"
     when: always
     paths:
       - artifacts/
     expire_in: 3 months
+
+# Same pattern as golang_deps_commenter: post on the standard linux image, not the bench runner.
+benchmark_commenter:
+  stage: benchmarks
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  tags: ["arch:amd64", "specific:true"]
+  extends: .dd_octo_sts
+  rules: !reference [.on_trace_agent_changes_or_manual]
+  interruptible: true
+  needs: ["benchmark"]
+  before_script:
+    - !reference [.setup_github_token_comment_pr]
+  script:
+    - if [ ! -s artifacts/report.md ]; then
+        dda inv -- -e github.pr-commenter --title="Benchmarks" --force-delete ;
+      else
+        dda inv -- -e github.pr-commenter --title="Benchmarks" --body-file=artifacts/report.md ;
+      fi

--- a/.gitlab/test/benchmarks/benchmarks.yml
+++ b/.gitlab/test/benchmarks/benchmarks.yml
@@ -34,8 +34,6 @@ benchmark:
     expire_in: 3 months
 
 # Same pattern as golang_deps_commenter: post on the standard linux image, not the bench runner.
-# Automatic (not .on_trace_agent_changes_or_manual): a manual play of `benchmark` must still
-# start this job. Sharing the parent's when: manual fallback would require a second play button.
 benchmark_commenter:
   stage: benchmarks
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX

--- a/test/benchmarks/apm_scripts/post-pr-comment.sh
+++ b/test/benchmarks/apm_scripts/post-pr-comment.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-cat "$ARTIFACTS_DIR/report.md" | pr-commenter --for-repo="$CI_PROJECT_NAME" --for-pr="$CI_COMMIT_REF_NAME" --header="Benchmarks"


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Post performance PR comment for trace-agent benchmarks.

### Motivation

pr-commenter from BP no longer works in dd-agent repo after removal of PR Commenter Datadog App. This PR fixes PR commenting.

### Describe how you validated your changes

PR comment is present on PR that runs trace-agent benchmarks.

