### PR TITLE
security_profile: stop gating v2 anomaly detection on the first profile send

### DIFF
--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -509,10 +509,6 @@ func (m *ManagerV2) persistProfile(p *profile.Profile) {
 			m.persistProfileToStorage(p, request, data)
 		}
 	}
-
-	if enabled {
-		p.SetHasAlreadyBeenSent()
-	}
 }
 
 // persistProfileToStorage persists profile data to a specific storage backend
@@ -697,7 +693,7 @@ func (m *ManagerV2) queueEventForTagResolution(event *model.Event, em *perEventT
 // onEventTagsResolved is called when an event has its tags resolved and is ready to be inserted into a profile
 func (m *ManagerV2) onEventTagsResolved(event *model.Event) {
 	profile, inserted := m.insertEventIntoProfile(event)
-	if !inserted || profile == nil || !profile.HasAlreadyBeenSent() {
+	if !inserted || profile == nil {
 		return
 	}
 

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -87,9 +87,7 @@ type Profile struct {
 	Instances     []*tags.Workload
 
 	// V2
-	// First has been sent
-	hasAlreadyBeenSent *atomic.Bool
-	isEnabled          bool
+	isEnabled bool
 }
 
 // IsEnabled returns true if the profile is enabled
@@ -116,16 +114,6 @@ func (p *Profile) resetActivityTreeLocked() {
 	if p.treeOpts.differentiateArgs {
 		p.ActivityTree.DifferentiateArgs()
 	}
-}
-
-// HasAlreadyBeenSent returns true if the profile has already been sent
-func (p *Profile) HasAlreadyBeenSent() bool {
-	return p.hasAlreadyBeenSent.Load()
-}
-
-// SetHasAlreadyBeenSent sets the hasAlreadyBeenSent flag to true
-func (p *Profile) SetHasAlreadyBeenSent() {
-	p.hasAlreadyBeenSent.Store(true)
 }
 
 // Opts defines the options to create a new profile
@@ -172,12 +160,11 @@ func New(opts ...Opts) *Profile {
 		Header: ActivityDumpHeader{
 			DNSNames: utils.NewStringKeys(nil),
 		},
-		LoadedInKernel:     atomic.NewBool(false),
-		LoadedNano:         atomic.NewUint64(0),
-		hasAlreadyBeenSent: atomic.NewBool(false),
-		versionContexts:    make(map[string]*VersionContext),
-		profileCookie:      utils.RandNonZeroUint64(),
-		isEnabled:          true,
+		LoadedInKernel:  atomic.NewBool(false),
+		LoadedNano:      atomic.NewUint64(0),
+		versionContexts: make(map[string]*VersionContext),
+		profileCookie:   utils.RandNonZeroUint64(),
+		isEnabled:       true,
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
### What does this PR do?

Emits anomaly detection events from the v2 security profile manager as soon as an event adds new data to a profile, instead of waiting for the profile to be persisted at least once.

Concretely, `onEventTagsResolved` no longer checks `Profile.HasAlreadyBeenSent()`, and the now-unused `hasAlreadyBeenSent` flag, its accessors, and the `SetHasAlreadyBeenSent()` call in `persistProfile` are removed.

### Motivation

`hasAlreadyBeenSent` was doing double duty: it tracked whether a profile had been shipped, and it was also the only thing marking the end of a workload's learning phase. That coupled anomaly detection latency to the persistence cadence (`activity_dump.dump_duration`, 900s by default) in two undesirable ways:

- The learning window was not a duration at all, but "time until the next global tick". Since the ticker is shared by every profile, a profile created just before a tick learned for a couple of seconds while one created just after learned for the full period.
- The flag lives on the `Profile`, and v2 keys profiles by image name with a `*` tag, so a new image tag rolling into an already-persisted profile inherited the flag and received no learning window whatsoever.

Removing the gate decouples the two concerns. The learning window is intentionally left out here rather than being retuned in place: it should be its own configurable period, anchored per profile version rather than on a global ticker, and that is a larger change than this one.

### Describe how you validated your changes

Not yet validated — opening as a draft to discuss the intermediate state before adding tests.

Worth calling out that this deliberately trades one rough edge for another: with no learning window at all, a freshly created profile treats essentially every event as new, so newly discovered workloads will emit a burst of anomalies until their tree fills in. That is the reason for the draft. The follow-up that introduces a dedicated stabilization period is what makes this behavior acceptable in isolation.

### Additional Notes

- v2 is behind `runtime_security_config.security_profile.v2.enabled` and is not the default, so this does not affect the v1 manager or default deployments.
- No release note yet, pending the decision on whether this ships on its own or together with the stabilization period follow-up.

Made with [Cursor](https://cursor.com)