### PR TITLE
security_profile: stop gating v2 anomaly detection on the first profi…

### DIFF
--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -509,10 +509,6 @@ func (m *ManagerV2) persistProfile(p *profile.Profile) {
 			m.persistProfileToStorage(p, request, data)
 		}
 	}
-
-	if enabled {
-		p.SetHasAlreadyBeenSent()
-	}
 }
 
 // persistProfileToStorage persists profile data to a specific storage backend
@@ -697,7 +693,7 @@ func (m *ManagerV2) queueEventForTagResolution(event *model.Event, em *perEventT
 // onEventTagsResolved is called when an event has its tags resolved and is ready to be inserted into a profile
 func (m *ManagerV2) onEventTagsResolved(event *model.Event) {
 	profile, inserted := m.insertEventIntoProfile(event)
-	if !inserted || profile == nil || !profile.HasAlreadyBeenSent() {
+	if !inserted || profile == nil {
 		return
 	}
 

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -87,9 +87,7 @@ type Profile struct {
 	Instances     []*tags.Workload
 
 	// V2
-	// First has been sent
-	hasAlreadyBeenSent *atomic.Bool
-	isEnabled          bool
+	isEnabled bool
 }
 
 // IsEnabled returns true if the profile is enabled
@@ -116,16 +114,6 @@ func (p *Profile) resetActivityTreeLocked() {
 	if p.treeOpts.differentiateArgs {
 		p.ActivityTree.DifferentiateArgs()
 	}
-}
-
-// HasAlreadyBeenSent returns true if the profile has already been sent
-func (p *Profile) HasAlreadyBeenSent() bool {
-	return p.hasAlreadyBeenSent.Load()
-}
-
-// SetHasAlreadyBeenSent sets the hasAlreadyBeenSent flag to true
-func (p *Profile) SetHasAlreadyBeenSent() {
-	p.hasAlreadyBeenSent.Store(true)
 }
 
 // Opts defines the options to create a new profile
@@ -172,12 +160,11 @@ func New(opts ...Opts) *Profile {
 		Header: ActivityDumpHeader{
 			DNSNames: utils.NewStringKeys(nil),
 		},
-		LoadedInKernel:     atomic.NewBool(false),
-		LoadedNano:         atomic.NewUint64(0),
-		hasAlreadyBeenSent: atomic.NewBool(false),
-		versionContexts:    make(map[string]*VersionContext),
-		profileCookie:      utils.RandNonZeroUint64(),
-		isEnabled:          true,
+		LoadedInKernel:  atomic.NewBool(false),
+		LoadedNano:      atomic.NewUint64(0),
+		versionContexts: make(map[string]*VersionContext),
+		profileCookie:   utils.RandNonZeroUint64(),
+		isEnabled:       true,
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
…le send

In the v2 manager, anomaly detection events were only emitted once the profile had been persisted at least once, using the profile-level hasAlreadyBeenSent flag as the end of the learning phase. That tied detection latency to the global persistence ticker (activity_dump.dump_duration, 900s by default), so a workload's learning window was really "time until the next tick" — anywhere from zero to the full period — and a new image tag joining an already-persisted profile inherited the flag and got no learning window at all.

Emit anomalies as soon as an event adds new data to a profile, and drop the now-unused flag. The stabilization window will be reintroduced as its own configurable period, independent of the send cadence.

<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
