### PR TITLE
Fix VS Code `golangci-lint` integration after its bazelification

### DIFF
--- a/.vscode/settings.json.template
+++ b/.vscode/settings.json.template
@@ -1,9 +1,18 @@
 {{
     "go.buildTags": "{build_tags}",
     "go.testTags": "{build_tags}",
-    "go.lintTool": "golangci-lint",
+    "go.lintTool": "bazelisk",
     "go.buildFlags": ["-buildvcs=false"],
     "go.lintFlags": [
+        "run",
+        "//internal/tools:golangci-lint",
+        "--",
+        "run",
+        "--issues-exit-code=0",
+        "--output.text.print-issued-lines=false",
+        "--show-stats=false",
+        "--output.text.path=stdout",
+        "--path-mode=abs",
         "--build-tags",
         "{build_tags}"
     ],

--- a/internal/tools/BUILD.bazel
+++ b/internal/tools/BUILD.bazel
@@ -8,17 +8,6 @@ go_shim(
     tool = "@com_github_golangci_golangci_lint_v2//cmd/golangci-lint",
 )
 
-pkg_files(
-    name = "golangci-lint_exe",
-    srcs = ["@com_github_golangci_golangci_lint_v2//cmd/golangci-lint"],
-    attributes = pkg_attributes(mode = "0755"),
-)
-
-pkg_install(
-    name = "install_golangci-lint",
-    srcs = [":golangci-lint_exe"],
-)
-
 go_shim(
     name = "gotestsum",
     tool = "@tools_gotest_gotestsum//:gotestsum",

--- a/tasks/devcontainer.py
+++ b/tasks/devcontainer.py
@@ -127,9 +127,21 @@ def setup(
                 # they are intentionally left unset here.
                 "go.buildTags": local_build_tags,
                 "go.testTags": local_build_tags,
-                "go.lintTool": "golangci-lint-v2",  # not "golangci-lint" to bypass the v1/v2 detection heuristic
+                "go.lintTool": "bazelisk",
                 "go.lintOnSave": "package",
                 "go.lintFlags": [
+                    "run",
+                    "//internal/tools:golangci-lint",
+                    "--",
+                    # add vscode-go default args, see:
+                    # https://github.com/golang/vscode-go/blob/master/extension/src/diagnostics/goLint.ts#L122-L163
+                    "run",
+                    "--issues-exit-code=0",
+                    "--output.text.print-issued-lines=false",
+                    "--show-stats=false",
+                    "--output.text.path=stdout",
+                    "--path-mode=abs",
+                    # then our own
                     "--build-tags",
                     local_build_tags,
                 ],
@@ -153,8 +165,6 @@ def setup(
         " && git config --global --add safe.directory /workspaces/${localWorkspaceFolderBasename}"
         " && dda config set github.auth.token \"$GITHUB_TOKEN\""
         " && dda inv -- -e install-tools && dda inv -- -e deps"
-        ' && golangci_lint="$(go list -f {{.Target}} github.com/golangci/golangci-lint/v2/cmd/golangci-lint)"'
-        ' && bazel run //internal/tools:install_golangci-lint -- --destdir="$(dirname "$golangci_lint")"'
     )
 
     devcontainer["containerEnv"] = {


### PR DESCRIPTION
### What does this PR do?
Point `go.lintTool` at `bazelisk` (`bazel` bootstrapper) in both `tasks/devcontainer.py` (devcontainer) and
`.vscode/settings.json.template` (local dev), with `go.lintFlags` prefixed with `run`, `//internal/tools:golangci-lint`, `--` so VS Code lints through the same Bazel-resolved `golangci-lint` CI already uses.

Remove the now-unused `golangci-lint_exe`/`install_golangci-lint` `pkg_files`/`pkg_install` targets from `internal/tools/BUILD.bazel`.

### Motivation
After #55405 bazelified `golangci-lint`, `go install` no longer puts it onto `GOBIN`/`PATH`, so both VS Code integrations lost a working `golangci-lint` binary.

The devcontainer change in that same PR set `"go.lintTool": "golangci-lint-v2"` and extracted a ([misadvised](https://github.com/DataDog/datadog-agent/pull/55405#discussion_r3863190836)) copy to `GOBIN`, but that was broken too: VS Code resolves `go.lintTool` by searching for a binary with that exact name, and `golang/vscode-go`'s own install-tools command explicitly renames the binary to `golangci-lint-v2` after building it, which our extraction never did, so `getBinPath('golangci-lint-v2')` would never find it.

Rather than extracting and keeping a renamed copy in sync, routing lint-on-save through `bazelisk run //internal/tools:golangci-lint --` reuses Bazel's own build cache directly, and stays cheap on repeat invocations since the target is already built.

### Describe how you validated your changes
Ran `dda inv vscode.setup-settings` and confirmed the generated `.vscode/settings.json` has the expected `go.lintTool` and `go.lintFlags`.

Ran `bazelisk run //internal/tools:golangci-lint -- run --build-tags test --output.text.print-issued-lines=false --show-stats=false --output.text.path=stdout --path-mode=abs --issues-exit-code=0 ./pkg/version/...` directly, matching the exact invocation VS Code makes, and got a clean pass with correct output.

### Additional Notes
The `--issues-exit-code=0` and `--output.text.*`/`--path-mode=abs` flags are copied verbatim from `golang/vscode-go`'s own `goLint.ts`, since routing through `bazelisk` bypasses the extension's `golangci-lint`-specific flag logic entirely (its
`linter.startsWith('golangci-lint')` check is false for `"bazelisk"`). Source:
https://github.com/golang/vscode-go/blob/7618e2bdd2c17b687e09a25450f5def577c7158c/extension/src/diagnostics/goLint.ts#L144-L162