### PR TITLE
fix(api): replace hardcoded IPC port 56789 with OS-assigned port in test

### DIFF
--- a/comp/api/api/apiimpl/api_test.go
+++ b/comp/api/api/apiimpl/api_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"slices"
 	"strconv"
@@ -114,9 +115,14 @@ func hasLabelValue(labels []*dto.LabelPair, name string, value string) bool {
 }
 
 func TestStartBothServersWithObservability(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+
 	deps := getAPIServer(t, map[string]interface{}{
 		"cmd_port":       0,
-		"agent_ipc.port": 56789,
+		"agent_ipc.port": port,
 	})
 
 	registry := deps.Telemetry.GetRegistry()


### PR DESCRIPTION
## What does this PR do?
Replace hardcoded port `56789` with an OS-assigned port in `TestStartBothServersWithObservability`.

## Motivation
Port 56789 is hardcoded because [GetIPCServerPath](https://github.com/DataDog/datadog-agent/blob/main/comp/api/api/apiimpl/listener/common.go#L73) treats `agent_ipc.port = 0` as "IPC server disabled", so a non-zero value is required to start the IPC server. On a loaded CI runner, another process can hold 56789, causing: `listen tcp 127.0.0.1:56789: bind: address already in use`.

```
[Info] Started HTTP server 'CMD API Server' on 127.0.0.1:56789
[Info] Stopped HTTP server 'CMD API Server'
    app.go:61: application didn't start cleanly: unable to start IPC API server: listen tcp 127.0.0.1:56789: bind: address already in use
```

`net.Listen("tcp", "127.0.0.1:0")` asks the OS for a free port, we read the assigned number, close the listener, and pass it to the config. This has a small TOCTOU window between close and bind. Eliminating it entirely requires `startIPCServer` to accept a `net.Listener` directly instead of a port number which is production code change out of scope here.

https://datadoghq.atlassian.net/browse/AGENTRUN-1468

## Describe how you validated your changes
CI and ran `TestStartBothServersWithObservability` locally under `-race`: passed. 

## Additional Notes
Because `agent_ipc.port` is a user-facing config key, changing its zero-value semantics would be a breaking change for existing users. ([ipcServerPort := pkgconfigsetup.Datadog().GetInt("agent_ipc.port")](https://github.com/DataDog/datadog-agent/blob/main/comp/api/api/apiimpl/listener/common.go#L72))