### PR TITLE
use serverless-azure-and-gcp team as owners instead of serverless-azure-gcp

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -286,7 +286,7 @@
 /cmd/otel-agent/                                    @DataDog/opentelemetry-agent
 /cmd/privateactionrunner                            @DataDog/action-platform
 /cmd/process-agent/                                 @DataDog/container-experiences
-/cmd/serverless-init/                               @DataDog/serverless-azure-gcp
+/cmd/serverless-init/                               @DataDog/serverless-azure-and-gcp
 /cmd/sbomgen/                                       @DataDog/agent-security
 /cmd/system-probe/                                  @DataDog/ebpf-platform
 /cmd/system-probe/modules/usm*                      @DataDog/universal-service-monitoring
@@ -524,7 +524,7 @@
 /pkg/notableevents/                                                   @DataDog/windows-products
 /pkg/serializer/                                                      @DataDog/agent-metric-pipelines
 /pkg/serializer/internal/metrics/origin_mapping.go                    @DataDog/agent-metric-pipelines @DataDog/agent-integrations
-/pkg/serverless/                                                      @DataDog/serverless-azure-gcp
+/pkg/serverless/                                                      @DataDog/serverless-azure-and-gcp
 /pkg/status/                                                          @DataDog/fleet-remediation
 /pkg/status/health                                                    @DataDog/agent-runtimes
 /pkg/status/collector                                                 @DataDog/agent-runtimes
@@ -917,7 +917,7 @@
 /test/                                                          @DataDog/agent-devx
 /test/benchmarks/                                               @DataDog/agent-metric-pipelines
 /test/benchmarks/kubernetes_state/                              @DataDog/container-integrations
-/test/integration/                                              @DataDog/serverless-azure-gcp
+/test/integration/                                              @DataDog/serverless-azure-and-gcp
 /test/integration/docker/                                       @DataDog/opentelemetry-agent
 /test/e2e-framework/AGENTS.md                                   @DataDog/agent-devx
 /test/e2e-framework/CLAUDE.md                                   @DataDog/agent-devx

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -31,7 +31,7 @@ tests_windows_secagent*                 @DataDog/windows-products @DataDog/agent
 tests_flavor_*                          @DataDog/agent-runtimes
 tests_flavor_dogstatsd*                 @DataDog/agent-metric-pipelines
 tests_rtloader*                         @DataDog/agent-runtimes
-tests_serverless-init*                  @DataDog/serverless-azure-gcp
+tests_serverless-init*                  @DataDog/serverless-azure-and-gcp
 security_go_generate_check              @DataDog/agent-security
 prepare_sysprobe_ebpf_functional_tests* @DataDog/ebpf-platform
 prepare_secagent_ebpf_functional_tests* @DataDog/agent-security

--- a/tasks/libs/pipeline/github_jira_map.yaml
+++ b/tasks/libs/pipeline/github_jira_map.yaml
@@ -25,7 +25,7 @@
 '@datadog/kubernetes-experiences': CAP
 '@datadog/metrics-aggregation': AGGR
 '@datadog/serverless': SVLS
-'@datadog/serverless-azure-gcp': SVLS
+'@datadog/serverless-azure-and-gcp': SVLS
 '@datadog/remote-config': RC
 '@datadog/fleet': FA
 '@datadog/fleet-automation': FA

--- a/tasks/libs/pipeline/github_slack_map.yaml
+++ b/tasks/libs/pipeline/github_slack_map.yaml
@@ -398,7 +398,7 @@
   review:
     name: '#serverless-agent'
     id: 'C017ES2MY05'
-'@datadog/serverless-azure-gcp':
+'@datadog/serverless-azure-and-gcp':
   notification:
     name: '#serverless-azure-gcp-team'
     id: 'C06P8R33PD3'

--- a/tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS
+++ b/tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS
@@ -53,9 +53,9 @@
 /.github/CODEOWNERS                                  # do not notify anyone
 /.github/*_TEMPLATE.md                               @DataDog/agent-devx
 /.github/dependabot.yaml                             @DataDog/agent-devx
-/.github/workflows/serverless-benchmarks.yml         @DataDog/serverless @Datadog/serverless-azure-gcp
-/.github/workflows/serverless-binary-size.yml        @DataDog/serverless @Datadog/serverless-azure-gcp
-/.github/workflows/serverless-integration.yml        @DataDog/serverless @Datadog/serverless-azure-gcp
+/.github/workflows/serverless-benchmarks.yml         @DataDog/serverless @Datadog/serverless-azure-and-gcp
+/.github/workflows/serverless-binary-size.yml        @DataDog/serverless @Datadog/serverless-azure-and-gcp
+/.github/workflows/serverless-integration.yml        @DataDog/serverless @Datadog/serverless-azure-and-gcp
 /.github/workflows/cws-btfhub-sync.yml               @DataDog/agent-security
 /.github/workflows/gohai.yml                         @DataDog/agent-configuration
 /.github/workflows/go-update-commenter.yml           @DataDog/agent-runtimes
@@ -123,7 +123,7 @@
 /.gitlab/binary_build/cluster_agent_cloudfoundry.yml @DataDog/agent-integrations @DataDog/agent-build
 /.gitlab/binary_build/cluster_agent.yml              @DataDog/container-integrations @DataDog/agent-build
 /.gitlab/binary_build/fakeintake.yml                 @DataDog/agent-devx
-/.gitlab/binary_build/serverless.yml                 @DataDog/serverless @Datadog/serverless-azure-gcp @DataDog/agent-build
+/.gitlab/binary_build/serverless.yml                 @DataDog/serverless @Datadog/serverless-azure-and-gcp @DataDog/agent-build
 /.gitlab/binary_build/otel_agent.yml                 @DataDog/opentelemetry-agent @DataDog/agent-build
 /.gitlab/binary_build/system_probe.yml               @DataDog/ebpf-platform @DataDog/agent-build
 /.gitlab/binary_build/windows.yml                    @DataDog/agent-build @DataDog/windows-products
@@ -234,7 +234,7 @@
 /cmd/dogstatsd/                         @DataDog/agent-metric-pipelines
 /cmd/otel-agent/                        @DataDog/opentelemetry-agent
 /cmd/process-agent/                     @DataDog/container-experiences
-/cmd/serverless/                        @DataDog/serverless @Datadog/serverless-azure-gcp
+/cmd/serverless/                        @DataDog/serverless @Datadog/serverless-azure-and-gcp
 /cmd/serverless-init/                   @DataDog/serverless
 /cmd/sbomgen/                           @DataDog/agent-security
 /cmd/system-probe/                      @DataDog/ebpf-platform
@@ -387,7 +387,7 @@
 /pkg/metrics/metricsource.go            @DataDog/agent-metric-pipelines @DataDog/agent-integrations
 /pkg/serializer/                        @DataDog/agent-metric-pipelines
 /pkg/serializer/internal/metrics/origin_mapping.go  @DataDog/agent-metric-pipelines @DataDog/agent-integrations
-/pkg/serverless/                        @DataDog/serverless @Datadog/serverless-azure-gcp
+/pkg/serverless/                        @DataDog/serverless @Datadog/serverless-azure-and-gcp
 /pkg/serverless/appsec/                 @DataDog/asm-go
 /pkg/status/                            @DataDog/agent-configuration
 /pkg/status/health                      @DataDog/agent-runtimes
@@ -667,7 +667,7 @@
 /test/                                  @DataDog/agent-devx
 /test/benchmarks/                       @DataDog/agent-metric-pipelines
 /test/benchmarks/kubernetes_state/      @DataDog/container-integrations
-/test/integration/                      @DataDog/serverless @Datadog/serverless-azure-gcp
+/test/integration/                      @DataDog/serverless @Datadog/serverless-azure-and-gcp
 /test/integration/docker/               @DataDog/opentelemetry-agent
 /test/fakeintake/                             @DataDog/agent-e2e-testing @DataDog/agent-devx
 /test/fakeintake/aggregator/ndmAggregator.go @DataDog/network-device-monitoring-core


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Use `serverless-azure-and-gcp` team instead of `serverless-azure-gcp` as owners.

### Motivation

`serverless-azure-and-gcp` is an automatically managed, up to date team while `serverless-azure-gcp` is deprecated.

### Describe how you validated your changes

### Additional Notes
