### PR TITLE
WIF-48: credential providers for trace proxy paths

### DIFF
--- a/cmd/otel-agent/subcommands/run/BUILD.bazel
+++ b/cmd/otel-agent/subcommands/run/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//comp/core/config",
         "//comp/core/configsync/def",
         "//comp/core/configsync/fx",
+        "//comp/core/delegatedauth/def",
         "//comp/core/delegatedauth/fx-noop",
         "//comp/core/fxinstrumentation/fx",
         "//comp/core/hostname/hostnameimpl",

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -24,6 +24,7 @@ import (
 	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	configsync "github.com/DataDog/datadog-agent/comp/core/configsync/def"
 	configsyncfx "github.com/DataDog/datadog-agent/comp/core/configsync/fx"
+	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	delegatedauthnoopfx "github.com/DataDog/datadog-agent/comp/core/delegatedauth/fx-noop"
 	fxinstrumentation "github.com/DataDog/datadog-agent/comp/core/fxinstrumentation/fx"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
@@ -243,7 +244,7 @@ func commonAgentFxOptions(ctx context.Context, params *cliParams, acfg coreconfi
 
 		pidfx.Module(),
 		fx.Supply(pidimpl.NewParams(params.pidfilePath)),
-		fx.Provide(func(c defaultforwarder.Component, cfg coreconfig.Component, l log.Component, sec secrets.Component) (defaultforwarder.Forwarder, error) {
+		fx.Provide(func(c defaultforwarder.Component, cfg coreconfig.Component, l log.Component, sec secrets.Component, delegatedAuth delegatedauth.Component) (defaultforwarder.Forwarder, error) {
 			if serializerexporter.IsSyncForwarderEnabled() {
 				eds, err := configutils.GetMultipleEndpoints(cfg)
 				if err != nil {
@@ -256,7 +257,7 @@ func commonAgentFxOptions(ctx context.Context, params *cliParams, acfg coreconfi
 				return defaultforwarderimpl.NewOTelSyncForwarder(cfg, l, sec, eds, &http.Client{
 					Timeout:   timeout,
 					Transport: utilhttp.CreateHTTPTransport(cfg),
-				})
+				}, delegatedAuth)
 			}
 			return defaultforwarder.Forwarder(c), nil
 		}),

--- a/comp/core/delegatedauth/mock/BUILD.bazel
+++ b/comp/core/delegatedauth/mock/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "mock",
@@ -9,4 +10,10 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock",
     visibility = ["//visibility:public"],
     deps = ["//comp/core/delegatedauth/def"],
+)
+
+dd_agent_go_test(
+    name = "mock_test",
+    srcs = ["stub_provider_test.go"],
+    embed = [":mock"],
 )

--- a/comp/core/delegatedauth/mock/BUILD.bazel
+++ b/comp/core/delegatedauth/mock/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@rules_go//go:def.bzl", "go_library")
-load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "mock",
@@ -10,10 +9,4 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock",
     visibility = ["//visibility:public"],
     deps = ["//comp/core/delegatedauth/def"],
-)
-
-dd_agent_go_test(
-    name = "mock_test",
-    srcs = ["stub_provider_test.go"],
-    embed = [":mock"],
 )

--- a/comp/forwarder/defaultforwarder/go.mod
+++ b/comp/forwarder/defaultforwarder/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/datadog-agent/pkg/config/setup/constants v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.61.0
+	github.com/DataDog/datadog-agent/pkg/credential v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.59.0
 	github.com/DataDog/datadog-agent/pkg/status/health v0.61.0
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0
@@ -48,7 +49,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/helper v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
-	github.com/DataDog/datadog-agent/pkg/credential v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.83.0-devel.0.20260729075015-99ed037f1c29 // indirect
 	github.com/DataDog/datadog-agent/pkg/template v0.65.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths v0.64.0-devel // indirect

--- a/comp/forwarder/defaultforwarder/go.mod
+++ b/comp/forwarder/defaultforwarder/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel
+	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.64.0-devel
 	github.com/DataDog/datadog-agent/comp/core/log/mock v0.64.0-devel
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1
@@ -38,7 +39,6 @@ require (
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/configstreamconsumer/def v0.0.0-00010101000000-000000000000 // indirect
-	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.72.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect

--- a/comp/forwarder/defaultforwarder/go.mod
+++ b/comp/forwarder/defaultforwarder/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/datadog-agent/pkg/config/setup/constants v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.61.0
-	github.com/DataDog/datadog-agent/pkg/credential v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.59.0
 	github.com/DataDog/datadog-agent/pkg/status/health v0.61.0
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0
@@ -49,6 +48,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/helper v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
+	github.com/DataDog/datadog-agent/pkg/credential v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.83.0-devel.0.20260729075015-99ed037f1c29 // indirect
 	github.com/DataDog/datadog-agent/pkg/template v0.65.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths v0.64.0-devel // indirect

--- a/comp/forwarder/defaultforwarder/impl/BUILD.bazel
+++ b/comp/forwarder/defaultforwarder/impl/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/config",
+        "//comp/core/delegatedauth/def",
         "//comp/core/log/def",
         "//comp/core/secrets/def",
         "//comp/core/secrets/noop-impl/types",
@@ -59,6 +60,7 @@ dd_agent_go_test(
     name = "impl_test",
     srcs = [
         "blocked_endpoints_test.go",
+        "credential_backpressure_test.go",
         "default_forwarder_test.go",
         "domain_forwarder_test.go",
         "forwarder_health_test.go",
@@ -70,6 +72,8 @@ dd_agent_go_test(
     embed = [":impl"],
     deps = [
         "//comp/core/config",
+        "//comp/core/delegatedauth/def",
+        "//comp/core/delegatedauth/mock",
         "//comp/core/log/def",
         "//comp/core/log/mock",
         "//comp/core/secrets/mock",

--- a/comp/forwarder/defaultforwarder/impl/credential_backpressure_test.go
+++ b/comp/forwarder/defaultforwarder/impl/credential_backpressure_test.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package defaultforwarderimpl
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
+	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/endpoints"
+	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
+	mock "github.com/DataDog/datadog-agent/pkg/config/mock"
+)
+
+// notReadyResolver stands in for an authorization slot whose credential has not arrived.
+type notReadyResolver struct{}
+
+func (notReadyResolver) Authorize(_ uint, _ http.Header, _ log.Component) error {
+	return transaction.ErrCredentialNotReady
+}
+
+func newWorkerForBreakerTest(t *testing.T) (*Worker, chan transaction.Transaction) {
+	t.Helper()
+	cfg := mock.New(t)
+	logger := logmock.New(t)
+	requeue := make(chan transaction.Transaction, 1)
+	w := NewWorker(
+		cfg, logger, secretsmock.New(t),
+		make(chan transaction.Transaction), make(chan transaction.Transaction), requeue,
+		newBlockedEndpoints(cfg, logger), &PointSuccessfullySentMock{},
+		NewSharedConnection(logger, false, 1, cfg, nil),
+	)
+	return w, requeue
+}
+
+func newTransactionTo(domain string) *transaction.HTTPTransaction {
+	txn := transaction.NewHTTPTransaction()
+	txn.Domain = domain
+	txn.Endpoint = endpoints.SeriesEndpoint
+	txn.Payload = transaction.NewBytesPayloadWithoutMetaData([]byte("payload"))
+	return txn
+}
+
+// The circuit breaker keys on domain+route, which every authorization slot on that domain shares.
+// A slot still waiting for its delegated-auth credential must not close it: the endpoint is
+// unprovisioned, not unhealthy, and blocking it throttles the slots that do have a credential. In
+// practice that means one org still resolving would degrade metrics delivery for the primary org.
+func TestMissingCredentialDoesNotBlockTheDomainForOtherSlots(t *testing.T) {
+	w, requeue := newWorkerForBreakerTest(t)
+
+	txn := newTransactionTo("https://app.datadoghq.com")
+	txn.Resolver = notReadyResolver{}
+
+	w.process(context.Background(), txn)
+
+	assert.False(t, w.blockedList.isBlockForSend(txn.GetTarget(), time.Now()),
+		"waiting on a credential must leave the domain open for the slots that have one")
+
+	select {
+	case <-requeue:
+	default:
+		t.Fatal("the transaction must be requeued so it is still there when the credential lands")
+	}
+}
+
+// The guard above must not swallow real errors on the way past: a genuine delivery failure still
+// has to trip the breaker, or the forwarder loses its backoff entirely.
+func TestRealFailureStillBlocksTheDomain(t *testing.T) {
+	w, _ := newWorkerForBreakerTest(t)
+
+	// Nothing is listening on this port, so Process fails to connect.
+	txn := newTransactionTo("http://127.0.0.1:1")
+
+	w.process(context.Background(), txn)
+
+	assert.True(t, w.blockedList.isBlockForSend(txn.GetTarget(), time.Now()),
+		"a connection failure is an endpoint failure and must still close the breaker")
+}
+
+// Process must preserve the sentinel through its error wrapping, since that is the only thing the
+// two circuit-breaker call sites can key on. Wrapping with %s instead of %w would silently restore
+// the old behaviour with every test above still passing at the unit level.
+func TestProcessPreservesTheCredentialSentinel(t *testing.T) {
+	txn := newTransactionTo("https://app.datadoghq.com")
+	txn.Resolver = notReadyResolver{}
+
+	err := txn.Process(context.Background(), mock.New(t), logmock.New(t), secretsmock.New(t), &http.Client{}, &PointSuccessfullySentMock{})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transaction.ErrCredentialNotReady)
+}

--- a/comp/forwarder/defaultforwarder/impl/domain_forwarder.go
+++ b/comp/forwarder/defaultforwarder/impl/domain_forwarder.go
@@ -375,7 +375,10 @@ func (f *domainForwarder) sendHTTPTransactionDirect(ctx context.Context, t *tran
 	}
 
 	if err := t.Process(ctx, f.config, f.log, f.secrets, f.Client.GetClient(), f.pointCountTelemetry); err != nil {
-		f.blockedList.close(target, time.Now())
+		// A missing credential is not an endpoint failure; see Worker.process.
+		if !errors.Is(err, transaction.ErrCredentialNotReady) {
+			f.blockedList.close(target, time.Now())
+		}
 		return err
 	}
 	if completionErr != nil {

--- a/comp/forwarder/defaultforwarder/impl/forwarder.go
+++ b/comp/forwarder/defaultforwarder/impl/forwarder.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	"github.com/DataDog/datadog-agent/comp/core/status"
@@ -23,11 +24,12 @@ import (
 )
 
 type dependencies struct {
-	Config  config.Component
-	Log     log.Component
-	Lc      compdef.Lifecycle
-	Params  defaultforwarderdef.Params
-	Secrets secrets.Component
+	Config        config.Component
+	Log           log.Component
+	Lc            compdef.Lifecycle
+	Params        defaultforwarderdef.Params
+	Secrets       secrets.Component
+	DelegatedAuth delegatedauth.Component
 }
 
 type provides struct {
@@ -36,7 +38,7 @@ type provides struct {
 }
 
 func newForwarder(dep dependencies) (provides, error) {
-	options, err := createOptions(dep.Params, dep.Config, dep.Log, dep.Secrets)
+	options, err := createOptions(dep.Params, dep.Config, dep.Log, dep.Secrets, dep.DelegatedAuth)
 	if err != nil {
 		return provides{}, err
 	}
@@ -44,7 +46,7 @@ func newForwarder(dep dependencies) (provides, error) {
 	return NewForwarder(dep.Config, dep.Log, dep.Lc, true, options), nil
 }
 
-func createOptions(params defaultforwarderdef.Params, config config.Component, log log.Component, secrets secrets.Component) (*Options, error) {
+func createOptions(params defaultforwarderdef.Params, config config.Component, log log.Component, secrets secrets.Component, delegatedAuth delegatedauth.Component) (*Options, error) {
 	var options *Options
 	endpoints, err := utils.GetMultipleEndpoints(config)
 	if err != nil {
@@ -66,6 +68,12 @@ func createOptions(params defaultforwarderdef.Params, config config.Component, l
 		}
 		options = NewOptionsWithResolvers(config, log, r)
 	}
+	// Attach after both branches, on the resolvers that were actually kept. NewOptionsWithOPW
+	// builds its own set and can swap the infra resolver for a vector-diverted one, so attaching
+	// inside the else branch alone left every binary that does not pass WithResolvers - the core
+	// Agent, dogstatsd, serverless-init, otel-agent - with no providers at all, and a delegated
+	// auth endpoint there produced no transactions and shipped nothing.
+	attachCredentialProviders(options.DomainResolvers, endpoints, delegatedAuth, log)
 	// Override the DisableAPIKeyChecking only if WithFeatures was called
 	disableOverride := params.APIKeyCheckingDisabledOverride()
 	if disableAPIKeyChecking, ok := disableOverride.Get(); ok {
@@ -84,6 +92,34 @@ func createOptions(params defaultforwarderdef.Params, config config.Component, l
 		log.Infof("domain '%s' has %d keys: %s", resolver.GetBaseDomain(), len(scrubbedKeys), strings.Join(scrubbedKeys, ", "))
 	}
 	return options, nil
+}
+
+// attachCredentialProviders gives each resolver the delegated-auth providers registered for its
+// destination, so a credential that resolves after startup reaches the send path with no rebuild
+// and without the key ever entering the config tree.
+//
+// Each provider becomes its own authorization slot, which means a transaction is created for it
+// even before it has a credential. That is deliberate: the transaction is then rescheduled by the
+// retry queue until the credential lands, rather than the payload being dropped at creation.
+func attachCredentialProviders(resolvers map[string]resolver.DomainResolver, endpoints utils.EndpointDescriptorSet, delegatedAuth delegatedauth.Component, log log.Component) {
+	if delegatedAuth == nil {
+		return
+	}
+	for _, ed := range endpoints {
+		r, ok := resolvers[ed.BaseURL]
+		if !ok {
+			continue
+		}
+		var providers []resolver.CredentialProvider
+		for _, keys := range ed.APIKeySet {
+			providers = append(providers, delegatedAuth.ProvidersFor(keys.ConfigSettingPath, ed.BaseURL)...)
+		}
+		if len(providers) == 0 {
+			continue
+		}
+		r.SetCredentialProviders(providers)
+		log.Infof("domain '%s' has %d delegated-auth credential provider(s)", ed.BaseURL, len(providers))
+	}
 }
 
 // NewForwarder returns a new forwarder component.

--- a/comp/forwarder/defaultforwarder/impl/forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/impl/forwarder_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
+	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
+	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
@@ -938,7 +940,7 @@ func TestCreateTransactionsWithLocal(t *testing.T) {
 	mockConfig.SetInTest("cluster_agent.url", "https://cluster.agent.svc")
 	mockConfig.SetInTest("cluster_agent.auth_token", "01234567890123456789012345678901")
 
-	opts, err := createOptions(defaultforwarderdef.NewParams(), mockConfig, log, secrets)
+	opts, err := createOptions(defaultforwarderdef.NewParams(), mockConfig, log, secrets, nil)
 	require.NoError(t, err)
 	f := NewDefaultForwarder(mockConfig, log, opts)
 
@@ -973,4 +975,48 @@ func TestCreateTransactionsWithLocal(t *testing.T) {
 
 	require.Len(t, txn, 1)
 	assert.Equal(t, "https://example.test", txn[0].Domain)
+}
+
+// Credential providers must be attached whichever way the options are built. Only the cluster
+// agents pass WithResolvers; the core Agent, dogstatsd, serverless-init and otel-agent all take
+// the NewOptionsWithOPW path, which builds its own resolver set. Attaching in only one branch left
+// a delegated-auth endpoint in those binaries with no static key and no provider, so the forwarder
+// created zero transactions for it and shipped nothing - silently, with no error.
+func TestCredentialProvidersAreAttachedOnBothOptionPaths(t *testing.T) {
+	const domain = "https://pending-org.datadoghq.com"
+
+	for _, tc := range []struct {
+		name   string
+		params defaultforwarderdef.Params
+	}{
+		{"without WithResolvers", defaultforwarderdef.NewParams()},
+		{"with WithResolvers", defaultforwarderdef.NewParams(defaultforwarderdef.WithResolvers())},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := mock.New(t)
+			cfg.SetInTest("api_key", "primary-key")
+			cfg.SetInTest("additional_endpoints", map[string][]string{
+				domain: {"DELA(org-uuid-1, aws)"},
+			})
+
+			auth := &delegatedauthmock.Mock{}
+			_, err := auth.AddInstance(context.Background(), delegatedauth.InstanceParams{
+				ConfigKey:   "additional_endpoints",
+				Destination: domain,
+				Directive:   "DELA(org-uuid-1, aws)",
+			})
+			require.NoError(t, err)
+
+			options, err := createOptions(tc.params, cfg, logmock.New(t), secretsmock.New(t), auth)
+			require.NoError(t, err)
+
+			r, ok := options.DomainResolvers[domain]
+			require.True(t, ok, "the delegated-auth domain must survive into the resolvers")
+			require.Len(t, r.GetCredentialProviders(), 1,
+				"the provider must be attached, or this endpoint gets no transactions at all")
+
+			// The slot is what makes a transaction get created for this endpoint.
+			assert.Len(t, r.GetAuthorizers(), 1)
+		})
+	}
 }

--- a/comp/forwarder/defaultforwarder/impl/otel_sync_forwarder.go
+++ b/comp/forwarder/defaultforwarder/impl/otel_sync_forwarder.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/multierr"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	defaultforwarderdef "github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/def"
@@ -67,11 +68,17 @@ var _ defaultforwarderdef.Forwarder = &OTelSyncForwarder{}
 // NewOTelSyncForwarder returns a new synchronous, error-propagating forwarder.
 // The caller supplies the *http.Client (typically built from confighttp.ClientConfig
 // via ToClient so OTel-native HTTP settings are honored).
-func NewOTelSyncForwarder(config config.Component, log log.Component, secrets secrets.Component, endpoints utils.EndpointDescriptorSet, client *http.Client) (*OTelSyncForwarder, error) {
+//
+// delegatedAuth supplies the delegated-auth component for credential provider lookup. It may be
+// nil in builds that wire the noop component (e.g. the standalone OTel agent), in which case no
+// providers are attached and delegated-auth endpoints produce no transactions — the same behavior
+// as the core Agent before attachCredentialProviders was called there.
+func NewOTelSyncForwarder(config config.Component, log log.Component, secrets secrets.Component, endpoints utils.EndpointDescriptorSet, client *http.Client, delegatedAuth delegatedauth.Component) (*OTelSyncForwarder, error) {
 	options, err := NewOptionsWithOPW(config, log, endpoints)
 	if err != nil {
 		return nil, err
 	}
+	attachCredentialProviders(options.DomainResolvers, endpoints, delegatedAuth, log)
 	options.Secrets = secrets
 	return &OTelSyncForwarder{
 		config:           config,

--- a/comp/forwarder/defaultforwarder/impl/otel_sync_forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/impl/otel_sync_forwarder_test.go
@@ -44,7 +44,7 @@ func newTestOTelSyncForwarder(t *testing.T, client *http.Client, extraSetup ...f
 			APIKeySet: []utils.APIKeys{utils.NewAPIKeys("api_key", "testapikey0000000000000000000000000")},
 		},
 	}
-	f, err := NewOTelSyncForwarder(cfg, log, sec, eds, client)
+	f, err := NewOTelSyncForwarder(cfg, log, sec, eds, client, nil)
 	require.NoError(t, err)
 	return f
 }
@@ -275,7 +275,7 @@ func newTestOTelSyncForwarderWithMRF(t *testing.T, client *http.Client, mrfEnabl
 			IsMRF:     true,
 		},
 	}
-	f, err := NewOTelSyncForwarder(cfg, log, sec, eds, client)
+	f, err := NewOTelSyncForwarder(cfg, log, sec, eds, client, nil)
 	require.NoError(t, err)
 	return f
 }

--- a/comp/forwarder/defaultforwarder/impl/test_common.go
+++ b/comp/forwarder/defaultforwarder/impl/test_common.go
@@ -250,8 +250,9 @@ func (tr handlerTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 }
 
 // NewTestForwarder creates an instance of the component based on config, but without using fx or starting it.
+// It wires no delegated-auth component, so resolvers get static keys only.
 func NewTestForwarder(params defaultforwarderdef.Params, config config.Component, log log.Component, secrets secrets.Component) (Forwarder, error) {
-	opts, err := createOptions(params, config, log, secrets)
+	opts, err := createOptions(params, config, log, secrets, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/forwarder/defaultforwarder/impl/worker.go
+++ b/comp/forwarder/defaultforwarder/impl/worker.go
@@ -7,6 +7,7 @@ package defaultforwarderimpl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http/httptrace"
 	"sync"
@@ -270,6 +271,14 @@ func (w *Worker) process(ctx context.Context, t transaction.Transaction) {
 		return
 	}
 	if err := t.Process(ctx, w.config, w.log, w.secrets, w.Client.GetClient(), w.pointCountTelemetry); err != nil {
+		if errors.Is(err, transaction.ErrCredentialNotReady) {
+			// Requeue without touching the circuit breaker. The target is domain+route, shared
+			// with every other authorization slot on that domain, so counting this as a failure
+			// would throttle endpoints that have a perfectly good credential.
+			w.requeue(t)
+			w.log.Debugf("Waiting for a delegated auth credential for endpoint '%s'; retrying later", target)
+			return
+		}
 		w.blockedList.close(target, time.Now())
 		w.requeue(t)
 		w.log.Errorf("Error while processing transaction: %v", err)

--- a/comp/forwarder/defaultforwarder/internal/retry/http_transactions_serializer.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/http_transactions_serializer.go
@@ -24,7 +24,11 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const transactionsSerializerVersion = 3
+// transactionsSerializerVersion is bumped when the meaning of APIKeyIndex changes. Version 4 is
+// required because provider slots are now prepended before static-key slots in GetAuthorizers,
+// so an index stored under version 3 may point at a different credential after restart. Old
+// collections are discarded by the version check in Deserialize.
+const transactionsSerializerVersion = 4
 
 // Use a non US ASCII char as a separator (Should neither appear in an HTTP header value nor in a URL).
 // Note: This is not valid UTF-8, but the proto fields using it are defined as `bytes` to avoid UTF-8 validation.
@@ -150,6 +154,13 @@ func (s *HTTPTransactionsSerializer) Deserialize(bytes []byte) ([]transaction.Tr
 
 	if err := proto.Unmarshal(bytes, &collection); err != nil {
 		return nil, 0, err
+	}
+
+	// Version 4 changes the meaning of APIKeyIndex: provider slots are now prepended before
+	// static-key slots in GetAuthorizers, so an index from an older version may point at a
+	// different credential. Discard old collections rather than reinterpreting their indices.
+	if collection.Version < transactionsSerializerVersion {
+		return nil, 0, fmt.Errorf("discarding %d transactions serialized with version %d (current version %d): authorizer index mapping has changed", len(collection.Values), collection.Version, transactionsSerializerVersion)
 	}
 
 	s.checkAPIKeyUpdate()

--- a/comp/forwarder/defaultforwarder/internal/retry/http_transactions_serializer_test.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/http_transactions_serializer_test.go
@@ -406,25 +406,12 @@ func TestDeserializeV2BackwardCompat(t *testing.T) {
 		0x1, 0x30, 0xae, 0xcc, 0xc3, 0xcb, 0x6, 0x38, 0x1, 0x40, 0x1, 0x48, 0xa, 0x50, 0x1,
 	}
 
-	txns, errorCount, err := serializer.Deserialize(bytes)
-	r.NoError(err)
-	r.Equal(0, errorCount)
-	r.Len(txns, 1)
-
-	deserialized := txns[0].(*transaction.HTTPTransaction)
-
-	// The placeholder index 0 is extracted and written to APIKeyIndex; Resolver is set so
-	// Authorize() can apply the key at send time.
-	r.NotNil(deserialized.Resolver, "V2 transactions should have Resolver set so Authorize() works")
-	r.Equal(uint(0), deserialized.APIKeyIndex, "placeholder index 0 maps to APIKeyIndex 0 for V2")
-
-	// The placeholder has been stripped from the headers; the raw key is not present.
-	r.Empty(deserialized.Headers.Get("Key"), "Headers must not contain the API key value")
-
-	// Authorize() applies the key at index 0 (apiKey1).
-	r.NotPanics(func() {
-		r.Equal(apiKey1, resolveKey(deserialized, log))
-	})
+	// V2 collections are discarded: the serializer version was bumped to 4 because
+	// provider slots are now prepended before static-key slots in GetAuthorizers,
+	// changing the meaning of APIKeyIndex.
+	txns, _, err := serializer.Deserialize(bytes)
+	r.Error(err, "V2 collections must be discarded due to version mismatch")
+	r.Empty(txns)
 }
 
 // TestDeserializeV2MissingAPIKey verifies that a V2 transaction whose placeholder index
@@ -439,9 +426,7 @@ func TestDeserializeV2MissingAPIKey(t *testing.T) {
 	r := require.New(t)
 	log := logmock.New(t)
 
-	// Binary blob of a V2 collection with placeholder index 1 (\xfeAPI_KEY\xfe1\xfe)
-	// embedded in both the route and the "Key" header — identical to the blob in
-	// TestDeserializeV2BackwardCompat but with 0x30 → 0x31 at the two index positions.
+	// Binary blob of a V2 collection with placeholder index 1.
 	var v2Bytes = []byte{
 		0x8, 0x2, 0x12, 0x45, 0x12, 0x18, 0xa, 0x10, 0x72, 0x6f, 0x75, 0x74, 0x65, 0xfe, 0x41, 0x50, 0x49, 0x5f, 0x4b,
 		0x45, 0x59, 0xfe, 0x31, 0xfe, 0x12, 0x4, 0x6e, 0x61, 0x6d, 0x65, 0x1a, 0x14, 0xa, 0x3, 0x4b, 0x65, 0x79, 0x12,
@@ -449,22 +434,19 @@ func TestDeserializeV2MissingAPIKey(t *testing.T) {
 		0x1, 0x30, 0xae, 0xcc, 0xc3, 0xcb, 0x6, 0x38, 0x1, 0x40, 0x1, 0x48, 0xa, 0x50, 0x1,
 	}
 
-	// Two-key resolver: the blob is valid (index 1 → apiKey2).
+	// V2 collections are discarded due to serializer version bump.
 	res2, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", apiKey1, apiKey2)})
 	r.NoError(err)
 	serializerFull := NewHTTPTransactionsSerializer(log, res2)
-	txns, errorCount, err := serializerFull.Deserialize(v2Bytes)
-	r.NoError(err)
-	r.Equal(0, errorCount)
-	r.Len(txns, 1)
+	txns, _, err := serializerFull.Deserialize(v2Bytes)
+	r.Error(err, "V2 collections must be discarded")
+	r.Empty(txns)
 
-	// One-key resolver: index 1 is out of range — transaction must be dropped.
 	res1, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", apiKey1)})
 	r.NoError(err)
 	serializerSmaller := NewHTTPTransactionsSerializer(log, res1)
-	txns, errorCount, err = serializerSmaller.Deserialize(v2Bytes)
-	r.NoError(err)
-	r.Equal(1, errorCount, "V2 transaction referencing a missing key must be dropped")
+	txns, _, err = serializerSmaller.Deserialize(v2Bytes)
+	r.Error(err, "V2 collections must be discarded")
 	r.Empty(txns)
 }
 
@@ -517,13 +499,9 @@ func TestV2IndexExtraction(t *testing.T) {
 	}
 }
 
-// TestV1IndexExtraction verifies that a V1-format transaction (sorted key order) is mapped
-// to the correct APIKeyIndex in the current (unsorted) resolver key list.
+// TestV1IndexExtraction verifies that V1 collections are discarded by the version check.
 func TestV1IndexExtraction(t *testing.T) {
 	log := logmock.New(t)
-	// Keys are deliberately out of alphabetical order so sorted order differs from config order.
-	// Config order (deduped): [apiKey3, apiKey1, apiKey2]
-	// Sorted order:           [apiKey1, apiKey2, apiKey3]
 	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{
 		utils.NewAPIKeys("path", apiKey3, apiKey1, apiKey2),
 	})
@@ -531,53 +509,32 @@ func TestV1IndexExtraction(t *testing.T) {
 
 	serializer := NewHTTPTransactionsSerializer(log, res)
 
-	// Build a minimal V1 proto blob by hand: version=1, one transaction whose route
-	// contains placeholder index N (sorted order).
 	buildV1Blob := func(sortedIdx int) []byte {
 		ph := fmt.Sprintf(placeHolderFormat, sortedIdx)
 		col := HttpTransactionProtoCollection{
 			Version: 1,
-			Values: []*HttpTransactionProto{
-				{
-					Endpoint:    &EndpointProto{Route: []byte("route" + ph), Name: "name"},
-					Headers:     map[string]*HeaderValuesProto{},
-					Payload:     []byte{1, 2, 3},
-					PointCount:  10,
-					Retryable:   true,
-					Destination: TransactionDestinationProto_PRIMARY_ONLY,
-				},
-			},
+			Values: []*HttpTransactionProto{{
+				Endpoint:    &EndpointProto{Route: []byte("route" + ph), Name: "name"},
+				Headers:     map[string]*HeaderValuesProto{},
+				Payload:     []byte{1, 2, 3},
+				PointCount:  10,
+				Retryable:   true,
+				Destination: TransactionDestinationProto_PRIMARY_ONLY,
+			}},
 		}
 		b, _ := proto.Marshal(&col)
 		return b
 	}
 
-	// sorted index 0 = apiKey1; apiKey1 is at position 1 in the config list.
-	// sorted index 1 = apiKey2; apiKey2 is at position 2 in the config list.
-	// sorted index 2 = apiKey3; apiKey3 is at position 0 in the config list.
-	wantCurrentIdx := []uint{1, 2, 0}
-
-	for sortedIdx, wantIdx := range wantCurrentIdx {
+	for sortedIdx := 0; sortedIdx < 3; sortedIdx++ {
 		data := buildV1Blob(sortedIdx)
-		txns, errorCount, err := serializer.Deserialize(data)
-		require.NoError(t, err, "sorted index %d", sortedIdx)
-		require.Equal(t, 0, errorCount)
-		require.Len(t, txns, 1)
-
-		deserialized := txns[0].(*transaction.HTTPTransaction)
-		assert.Equal(t, wantIdx, deserialized.APIKeyIndex,
-			"V1 sorted index %d should map to current index %d", sortedIdx, wantIdx)
-		assert.NotNil(t, deserialized.Resolver)
-
-		// Authorize() should apply the correct key.
-		dedupedKeys := res.GetAPIKeys() // [apiKey3, apiKey1, apiKey2]
-		assert.Equal(t, dedupedKeys[wantIdx], resolveKey(deserialized, log),
-			"Authorize() key at current index %d", wantIdx)
+		txns, _, err := serializer.Deserialize(data)
+		require.Error(t, err, "V1 collections must be discarded (sorted index %d)", sortedIdx)
+		require.Empty(t, txns)
 	}
 }
 
-// TestV2IndexFromHeaderPlaceholder verifies that when the route has no placeholder but a
-// header value does, the index is still extracted correctly (V2 format).
+// TestV2IndexFromHeaderPlaceholder verifies that V2 collections are discarded by the version check.
 func TestV2IndexFromHeaderPlaceholder(t *testing.T) {
 	log := logmock.New(t)
 	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", apiKey1, apiKey2)})
@@ -585,39 +542,28 @@ func TestV2IndexFromHeaderPlaceholder(t *testing.T) {
 
 	serializer := NewHTTPTransactionsSerializer(log, res)
 
-	ph1 := fmt.Sprintf(placeHolderFormat, 1) // points to apiKey2
+	ph1 := fmt.Sprintf(placeHolderFormat, 1)
 	col := HttpTransactionProtoCollection{
 		Version: 2,
-		Values: []*HttpTransactionProto{
-			{
-				// Route has no placeholder; placeholder is only in a header value.
-				Endpoint: &EndpointProto{Route: []byte("route"), Name: "name"},
-				Headers: map[string]*HeaderValuesProto{
-					"X-Custom": {Values: [][]byte{[]byte(ph1)}},
-				},
-				Payload:     []byte{1},
-				Retryable:   true,
-				Destination: TransactionDestinationProto_ALL_REGIONS,
+		Values: []*HttpTransactionProto{{
+			Endpoint: &EndpointProto{Route: []byte("route"), Name: "name"},
+			Headers: map[string]*HeaderValuesProto{
+				"X-Custom": {Values: [][]byte{[]byte(ph1)}},
 			},
-		},
+			Payload:     []byte{1},
+			Retryable:   true,
+			Destination: TransactionDestinationProto_ALL_REGIONS,
+		}},
 	}
 	data, err := proto.Marshal(&col)
 	require.NoError(t, err)
 
-	txns, errorCount, err := serializer.Deserialize(data)
-	require.NoError(t, err)
-	require.Equal(t, 0, errorCount)
-	require.Len(t, txns, 1)
-
-	deserialized := txns[0].(*transaction.HTTPTransaction)
-	assert.Equal(t, uint(1), deserialized.APIKeyIndex)
-	assert.NotNil(t, deserialized.Resolver)
-	assert.Empty(t, deserialized.Headers.Get("X-Custom"), "placeholder must be stripped from header")
+	txns, _, err := serializer.Deserialize(data)
+	require.Error(t, err, "V2 collections must be discarded")
+	require.Empty(t, txns)
 }
 
-// TestDeserializeV2 ensures that newer agent versions can read files created by old agent
-// versions (V2 format). The placeholder index is extracted from the stored data, written to
-// APIKeyIndex, and Authorize() applies the correct key.
+// TestDeserializeV2 verifies that V2 collections are discarded by the version check.
 func TestDeserializeV2(t *testing.T) {
 	r := require.New(t)
 	log := logmock.New(t)
@@ -625,7 +571,6 @@ func TestDeserializeV2(t *testing.T) {
 	r.NoError(err)
 	serializer := NewHTTPTransactionsSerializer(log, res)
 
-	// Two V2 transactions: first embeds placeholder index 0, second embeds index 1.
 	var bytes = []byte{
 		0x8, 0x2, 0x12, 0x45, 0x12, 0x18, 0xa, 0x10, 0x72, 0x6f, 0x75, 0x74, 0x65, 0xfe, 0x41, 0x50, 0x49, 0x5f, 0x4b,
 		0x45, 0x59, 0xfe, 0x30, 0xfe, 0x12, 0x4, 0x6e, 0x61, 0x6d, 0x65, 0x1a, 0x14, 0xa, 0x3, 0x4b, 0x65, 0x79, 0x12,
@@ -637,29 +582,7 @@ func TestDeserializeV2(t *testing.T) {
 		0x6, 0x38, 0x1, 0x40, 0x1, 0x48, 0xa, 0x50, 0x1,
 	}
 
-	txns, errorCount, err := serializer.Deserialize(bytes)
-	r.NoError(err)
-	r.Equal(0, errorCount)
-	r.Len(txns, 2)
-
-	expectedIndices := []uint{0, 1}
-	expectedKeys := []string{apiKey1, apiKey2}
-
-	for i, txn := range txns {
-		txn := txn.(*transaction.HTTPTransaction)
-		t.Run(fmt.Sprintf("payload %d", i), func(t *testing.T) {
-			r := require.New(t)
-			r.Equal(expectedIndices[i], txn.APIKeyIndex)
-			r.NotNil(txn.Resolver, "Resolver must be set for V2 transactions")
-			// The placeholder has been stripped; the raw key is not in headers.
-			r.Empty(txn.Headers.Get("Key"), "Headers must not contain the API key value")
-			// Authorize() applies the correct key.
-			r.Equal(expectedKeys[i], resolveKey(txn, log))
-			r.Equal(domain, txn.Domain)
-			// Placeholder is stripped from the route too.
-			r.Equal("route", txn.Endpoint.Route)
-			r.Equal([]byte{1, 2, 3}, txn.Payload.GetContent())
-			r.Equal(10, txn.Payload.GetPointCount())
-		})
-	}
+	txns, _, err := serializer.Deserialize(bytes)
+	r.Error(err, "V2 collections must be discarded")
+	r.Empty(txns)
 }

--- a/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
+++ b/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
@@ -11,12 +11,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/config",
-        "//comp/core/delegatedauth/def",
         "//comp/core/log/def",
         "//comp/forwarder/defaultforwarder/endpoints",
         "//comp/forwarder/defaultforwarder/transaction",
         "//pkg/config/model",
         "//pkg/config/utils",
+        "//pkg/credential",
         "//pkg/util/scrubber",
     ],
 )

--- a/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
+++ b/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/config",
+        "//comp/core/delegatedauth/def",
         "//comp/core/log/def",
         "//comp/forwarder/defaultforwarder/endpoints",
         "//comp/forwarder/defaultforwarder/transaction",

--- a/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
+++ b/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
@@ -11,12 +11,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/config",
-        "//comp/core/delegatedauth/def",
         "//comp/core/log/def",
         "//comp/forwarder/defaultforwarder/endpoints",
         "//comp/forwarder/defaultforwarder/transaction",
         "//pkg/config/model",
         "//pkg/config/utils",
+        "//pkg/credential",
         "//pkg/util/scrubber",
     ],
 )
@@ -29,6 +29,7 @@ dd_agent_go_test(
     ],
     embed = [":resolver"],
     deps = [
+        "//comp/core/delegatedauth/mock",
         "//comp/core/log/mock",
         "//comp/forwarder/defaultforwarder/endpoints",
         "//comp/forwarder/defaultforwarder/transaction",

--- a/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
+++ b/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//comp/forwarder/defaultforwarder/transaction",
         "//pkg/config/model",
         "//pkg/config/utils",
-        "//pkg/credential",
         "//pkg/util/scrubber",
     ],
 )
@@ -30,7 +29,6 @@ dd_agent_go_test(
     ],
     embed = [":resolver"],
     deps = [
-        "//comp/core/delegatedauth/mock",
         "//comp/core/log/mock",
         "//comp/forwarder/defaultforwarder/endpoints",
         "//comp/forwarder/defaultforwarder/transaction",

--- a/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
+++ b/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
@@ -29,6 +29,7 @@ dd_agent_go_test(
     ],
     embed = [":resolver"],
     deps = [
+        "//comp/core/delegatedauth/mock",
         "//comp/core/log/mock",
         "//comp/forwarder/defaultforwarder/endpoints",
         "//comp/forwarder/defaultforwarder/transaction",

--- a/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
+++ b/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/config",
+        "//comp/core/delegatedauth/def",
         "//comp/core/log/def",
         "//comp/forwarder/defaultforwarder/endpoints",
         "//comp/forwarder/defaultforwarder/transaction",
@@ -22,7 +23,10 @@ go_library(
 
 dd_agent_go_test(
     name = "resolver_test",
-    srcs = ["domain_resolver_test.go"],
+    srcs = [
+        "credential_provider_test.go",
+        "domain_resolver_test.go",
+    ],
     embed = [":resolver"],
     deps = [
         "//comp/core/log/mock",

--- a/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
+++ b/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
@@ -103,3 +103,14 @@ func TestAuthorizeRejectsOutOfRangeSlot(t *testing.T) {
 	require.Error(t, r.Authorize(99, h, log))
 	assert.Empty(t, h)
 }
+
+// An ENC[...] key resolved by the secrets backend is a normal static key from the resolver's
+// perspective. The provider path must not interfere with it.
+func TestResolvedEncKeyUnaffectedByProvider(t *testing.T) {
+	r := resolverWithProvider(t, []string{"resolved-enc-key"}, &stubProvider{ready: false})
+	log := logmock.New(t)
+
+	h := http.Header{}
+	require.NoError(t, r.Authorize(1, h, log), "the ENC[] key slot must authorize independently of the provider")
+	assert.Equal(t, "resolved-enc-key", h.Get("DD-Api-Key"))
+}

--- a/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
+++ b/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
@@ -10,26 +10,11 @@ import (
 	"testing"
 
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// stubProvider is a CredentialProvider whose readiness the test controls.
-type stubProvider struct {
-	key   string
-	ready bool
-}
-
-func (p *stubProvider) Authorize(h http.Header) bool {
-	if !p.ready {
-		return false
-	}
-	h.Set("DD-Api-Key", p.key)
-	return true
-}
-
-func (p *stubProvider) Refresh() bool { return false }
 
 func resolverWithProvider(t *testing.T, staticKeys []string, p CredentialProvider) DomainResolver {
 	t.Helper()
@@ -46,7 +31,7 @@ func resolverWithProvider(t *testing.T, staticKeys []string, p CredentialProvide
 // forwarder would create no transaction for that destination and the payload would be dropped at
 // creation, which is exactly what the buffering behaviour has to avoid.
 func TestProviderGetsAnAuthorizationSlotWhileStillResolving(t *testing.T) {
-	r := resolverWithProvider(t, []string{"static-key"}, &stubProvider{ready: false})
+	r := resolverWithProvider(t, []string{"static-key"}, &delegatedauthmock.StubProvider{})
 
 	assert.Len(t, r.GetAuthorizers(), 2,
 		"a provider without a credential must still occupy a slot so a transaction is created for it")
@@ -55,7 +40,7 @@ func TestProviderGetsAnAuthorizationSlotWhileStillResolving(t *testing.T) {
 // While the provider has no credential, Authorize must refuse rather than send a request with no
 // (or someone else's) key.
 func TestAuthorizeReportsNotReadyWhileResolving(t *testing.T) {
-	r := resolverWithProvider(t, nil, &stubProvider{ready: false})
+	r := resolverWithProvider(t, nil, &delegatedauthmock.StubProvider{})
 	log := logmock.New(t)
 
 	h := http.Header{}
@@ -67,13 +52,13 @@ func TestAuthorizeReportsNotReadyWhileResolving(t *testing.T) {
 
 // Once the credential lands, the same slot starts authorizing - no rebuild, no new resolver.
 func TestAuthorizeSucceedsOnceCredentialArrives(t *testing.T) {
-	p := &stubProvider{key: "resolved-key"}
+	p := &delegatedauthmock.StubProvider{Key: "resolved-key"}
 	r := resolverWithProvider(t, nil, p)
 	log := logmock.New(t)
 
 	require.ErrorIs(t, r.Authorize(0, http.Header{}, log), ErrCredentialNotReady)
 
-	p.ready = true
+	p.SetReady(true)
 
 	h := http.Header{}
 	require.NoError(t, r.Authorize(0, h, log))
@@ -84,7 +69,7 @@ func TestAuthorizeSucceedsOnceCredentialArrives(t *testing.T) {
 // whether the provider has resolved. Providers come first in the authorizer list, so the
 // provider is at index 0 and the static key at index 1.
 func TestStaticKeysUnaffectedByAPendingProvider(t *testing.T) {
-	r := resolverWithProvider(t, []string{"static-key"}, &stubProvider{ready: false})
+	r := resolverWithProvider(t, []string{"static-key"}, &delegatedauthmock.StubProvider{})
 	log := logmock.New(t)
 
 	require.ErrorIs(t, r.Authorize(0, http.Header{}, log), ErrCredentialNotReady,
@@ -98,7 +83,9 @@ func TestStaticKeysUnaffectedByAPendingProvider(t *testing.T) {
 // An out-of-range slot is an error rather than a silent unauthenticated send. On-disk transactions
 // serialized when more slots existed can land here after a restart.
 func TestAuthorizeRejectsOutOfRangeSlot(t *testing.T) {
-	r := resolverWithProvider(t, []string{"static-key"}, &stubProvider{ready: true})
+	p := &delegatedauthmock.StubProvider{Key: "k"}
+	p.SetReady(true)
+	r := resolverWithProvider(t, []string{"static-key"}, p)
 	log := logmock.New(t)
 
 	h := http.Header{}
@@ -109,7 +96,7 @@ func TestAuthorizeRejectsOutOfRangeSlot(t *testing.T) {
 // An ENC[...] key resolved by the secrets backend is a normal static key from the resolver's
 // perspective. The provider path must not interfere with it.
 func TestResolvedEncKeyUnaffectedByProvider(t *testing.T) {
-	r := resolverWithProvider(t, []string{"resolved-enc-key"}, &stubProvider{ready: false})
+	r := resolverWithProvider(t, []string{"resolved-enc-key"}, &delegatedauthmock.StubProvider{})
 	log := logmock.New(t)
 
 	h := http.Header{}

--- a/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
+++ b/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
@@ -29,6 +29,8 @@ func (p *stubProvider) Authorize(h http.Header) bool {
 	return true
 }
 
+func (p *stubProvider) Refresh() bool { return false }
+
 func resolverWithProvider(t *testing.T, staticKeys []string, p CredentialProvider) DomainResolver {
 	t.Helper()
 	r, err := NewSingleDomainResolver2(utils.EndpointDescriptor{

--- a/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
+++ b/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
@@ -83,14 +83,23 @@ func TestStaticKeysUnaffectedByAPendingProvider(t *testing.T) {
 // An out-of-range slot is an error rather than a silent unauthenticated send. On-disk transactions
 // serialized when more slots existed can land here after a restart.
 func TestAuthorizeRejectsOutOfRangeSlot(t *testing.T) {
-	r := resolverWithProvider(t, []string{"static-key"}, func() *delegatedauthmock.StubProvider {
-		p := &delegatedauthmock.StubProvider{}
-		p.SetReady(true)
-		return p
-	}())
+	p := &delegatedauthmock.StubProvider{Key: "k"}
+	p.SetReady(true)
+	r := resolverWithProvider(t, []string{"static-key"}, p)
 	log := logmock.New(t)
 
 	h := http.Header{}
 	require.Error(t, r.Authorize(99, h, log))
 	assert.Empty(t, h)
+}
+
+// An ENC[...] key resolved by the secrets backend is a normal static key from the resolver's
+// perspective. The provider path must not interfere with it.
+func TestResolvedEncKeyUnaffectedByProvider(t *testing.T) {
+	r := resolverWithProvider(t, []string{"resolved-enc-key"}, &delegatedauthmock.StubProvider{})
+	log := logmock.New(t)
+
+	h := http.Header{}
+	require.NoError(t, r.Authorize(1, h, log), "the ENC[] key slot must authorize independently of the provider")
+	assert.Equal(t, "resolved-enc-key", h.Get("DD-Api-Key"))
 }

--- a/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
+++ b/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"testing"
 
-	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
+++ b/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
@@ -9,25 +9,12 @@ import (
 	"net/http"
 	"testing"
 
+	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// stubProvider is a CredentialProvider whose readiness the test controls.
-type stubProvider struct {
-	key   string
-	ready bool
-}
-
-func (p *stubProvider) Authorize(h http.Header) bool {
-	if !p.ready {
-		return false
-	}
-	h.Set("DD-Api-Key", p.key)
-	return true
-}
 
 func resolverWithProvider(t *testing.T, staticKeys []string, p CredentialProvider) DomainResolver {
 	t.Helper()
@@ -44,7 +31,7 @@ func resolverWithProvider(t *testing.T, staticKeys []string, p CredentialProvide
 // forwarder would create no transaction for that destination and the payload would be dropped at
 // creation, which is exactly what the buffering behaviour has to avoid.
 func TestProviderGetsAnAuthorizationSlotWhileStillResolving(t *testing.T) {
-	r := resolverWithProvider(t, []string{"static-key"}, &stubProvider{ready: false})
+	r := resolverWithProvider(t, []string{"static-key"}, &delegatedauthmock.StubProvider{})
 
 	assert.Len(t, r.GetAuthorizers(), 2,
 		"a provider without a credential must still occupy a slot so a transaction is created for it")
@@ -53,7 +40,7 @@ func TestProviderGetsAnAuthorizationSlotWhileStillResolving(t *testing.T) {
 // While the provider has no credential, Authorize must refuse rather than send a request with no
 // (or someone else's) key.
 func TestAuthorizeReportsNotReadyWhileResolving(t *testing.T) {
-	r := resolverWithProvider(t, nil, &stubProvider{ready: false})
+	r := resolverWithProvider(t, nil, &delegatedauthmock.StubProvider{})
 	log := logmock.New(t)
 
 	h := http.Header{}
@@ -65,13 +52,13 @@ func TestAuthorizeReportsNotReadyWhileResolving(t *testing.T) {
 
 // Once the credential lands, the same slot starts authorizing - no rebuild, no new resolver.
 func TestAuthorizeSucceedsOnceCredentialArrives(t *testing.T) {
-	p := &stubProvider{key: "resolved-key"}
+	p := &delegatedauthmock.StubProvider{Key: "resolved-key"}
 	r := resolverWithProvider(t, nil, p)
 	log := logmock.New(t)
 
 	require.ErrorIs(t, r.Authorize(0, http.Header{}, log), ErrCredentialNotReady)
 
-	p.ready = true
+	p.SetReady(true)
 
 	h := http.Header{}
 	require.NoError(t, r.Authorize(0, h, log))
@@ -82,7 +69,7 @@ func TestAuthorizeSucceedsOnceCredentialArrives(t *testing.T) {
 // whether the provider has resolved. Providers come first in the authorizer list, so the
 // provider is at index 0 and the static key at index 1.
 func TestStaticKeysUnaffectedByAPendingProvider(t *testing.T) {
-	r := resolverWithProvider(t, []string{"static-key"}, &stubProvider{ready: false})
+	r := resolverWithProvider(t, []string{"static-key"}, &delegatedauthmock.StubProvider{})
 	log := logmock.New(t)
 
 	require.ErrorIs(t, r.Authorize(0, http.Header{}, log), ErrCredentialNotReady,
@@ -96,7 +83,11 @@ func TestStaticKeysUnaffectedByAPendingProvider(t *testing.T) {
 // An out-of-range slot is an error rather than a silent unauthenticated send. On-disk transactions
 // serialized when more slots existed can land here after a restart.
 func TestAuthorizeRejectsOutOfRangeSlot(t *testing.T) {
-	r := resolverWithProvider(t, []string{"static-key"}, &stubProvider{ready: true})
+	r := resolverWithProvider(t, []string{"static-key"}, func() *delegatedauthmock.StubProvider {
+		p := &delegatedauthmock.StubProvider{}
+		p.SetReady(true)
+		return p
+	}())
 	log := logmock.New(t)
 
 	h := http.Header{}

--- a/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
+++ b/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
@@ -9,12 +9,25 @@ import (
 	"net/http"
 	"testing"
 
-	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// stubProvider is a CredentialProvider whose readiness the test controls.
+type stubProvider struct {
+	key   string
+	ready bool
+}
+
+func (p *stubProvider) Authorize(h http.Header) bool {
+	if !p.ready {
+		return false
+	}
+	h.Set("DD-Api-Key", p.key)
+	return true
+}
 
 func resolverWithProvider(t *testing.T, staticKeys []string, p CredentialProvider) DomainResolver {
 	t.Helper()
@@ -31,7 +44,7 @@ func resolverWithProvider(t *testing.T, staticKeys []string, p CredentialProvide
 // forwarder would create no transaction for that destination and the payload would be dropped at
 // creation, which is exactly what the buffering behaviour has to avoid.
 func TestProviderGetsAnAuthorizationSlotWhileStillResolving(t *testing.T) {
-	r := resolverWithProvider(t, []string{"static-key"}, &delegatedauthmock.StubProvider{})
+	r := resolverWithProvider(t, []string{"static-key"}, &stubProvider{ready: false})
 
 	assert.Len(t, r.GetAuthorizers(), 2,
 		"a provider without a credential must still occupy a slot so a transaction is created for it")
@@ -40,7 +53,7 @@ func TestProviderGetsAnAuthorizationSlotWhileStillResolving(t *testing.T) {
 // While the provider has no credential, Authorize must refuse rather than send a request with no
 // (or someone else's) key.
 func TestAuthorizeReportsNotReadyWhileResolving(t *testing.T) {
-	r := resolverWithProvider(t, nil, &delegatedauthmock.StubProvider{})
+	r := resolverWithProvider(t, nil, &stubProvider{ready: false})
 	log := logmock.New(t)
 
 	h := http.Header{}
@@ -52,13 +65,13 @@ func TestAuthorizeReportsNotReadyWhileResolving(t *testing.T) {
 
 // Once the credential lands, the same slot starts authorizing - no rebuild, no new resolver.
 func TestAuthorizeSucceedsOnceCredentialArrives(t *testing.T) {
-	p := &delegatedauthmock.StubProvider{Key: "resolved-key"}
+	p := &stubProvider{key: "resolved-key"}
 	r := resolverWithProvider(t, nil, p)
 	log := logmock.New(t)
 
 	require.ErrorIs(t, r.Authorize(0, http.Header{}, log), ErrCredentialNotReady)
 
-	p.SetReady(true)
+	p.ready = true
 
 	h := http.Header{}
 	require.NoError(t, r.Authorize(0, h, log))
@@ -69,7 +82,7 @@ func TestAuthorizeSucceedsOnceCredentialArrives(t *testing.T) {
 // whether the provider has resolved. Providers come first in the authorizer list, so the
 // provider is at index 0 and the static key at index 1.
 func TestStaticKeysUnaffectedByAPendingProvider(t *testing.T) {
-	r := resolverWithProvider(t, []string{"static-key"}, &delegatedauthmock.StubProvider{})
+	r := resolverWithProvider(t, []string{"static-key"}, &stubProvider{ready: false})
 	log := logmock.New(t)
 
 	require.ErrorIs(t, r.Authorize(0, http.Header{}, log), ErrCredentialNotReady,
@@ -83,23 +96,10 @@ func TestStaticKeysUnaffectedByAPendingProvider(t *testing.T) {
 // An out-of-range slot is an error rather than a silent unauthenticated send. On-disk transactions
 // serialized when more slots existed can land here after a restart.
 func TestAuthorizeRejectsOutOfRangeSlot(t *testing.T) {
-	p := &delegatedauthmock.StubProvider{Key: "k"}
-	p.SetReady(true)
-	r := resolverWithProvider(t, []string{"static-key"}, p)
+	r := resolverWithProvider(t, []string{"static-key"}, &stubProvider{ready: true})
 	log := logmock.New(t)
 
 	h := http.Header{}
 	require.Error(t, r.Authorize(99, h, log))
 	assert.Empty(t, h)
-}
-
-// An ENC[...] key resolved by the secrets backend is a normal static key from the resolver's
-// perspective. The provider path must not interfere with it.
-func TestResolvedEncKeyUnaffectedByProvider(t *testing.T) {
-	r := resolverWithProvider(t, []string{"resolved-enc-key"}, &delegatedauthmock.StubProvider{})
-	log := logmock.New(t)
-
-	h := http.Header{}
-	require.NoError(t, r.Authorize(1, h, log), "the ENC[] key slot must authorize independently of the provider")
-	assert.Equal(t, "resolved-enc-key", h.Get("DD-Api-Key"))
 }

--- a/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
+++ b/comp/forwarder/defaultforwarder/resolver/credential_provider_test.go
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package resolver
+
+import (
+	"net/http"
+	"testing"
+
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubProvider is a CredentialProvider whose readiness the test controls.
+type stubProvider struct {
+	key   string
+	ready bool
+}
+
+func (p *stubProvider) Authorize(h http.Header) bool {
+	if !p.ready {
+		return false
+	}
+	h.Set("DD-Api-Key", p.key)
+	return true
+}
+
+func resolverWithProvider(t *testing.T, staticKeys []string, p CredentialProvider) DomainResolver {
+	t.Helper()
+	r, err := NewSingleDomainResolver2(utils.EndpointDescriptor{
+		BaseURL:   "https://example.com",
+		APIKeySet: []utils.APIKeys{{ConfigSettingPath: "additional_endpoints", Keys: staticKeys}},
+	})
+	require.NoError(t, err)
+	r.SetCredentialProviders([]CredentialProvider{p})
+	return r
+}
+
+// A provider gets its own authorization slot even before it has a credential. Without the slot the
+// forwarder would create no transaction for that destination and the payload would be dropped at
+// creation, which is exactly what the buffering behaviour has to avoid.
+func TestProviderGetsAnAuthorizationSlotWhileStillResolving(t *testing.T) {
+	r := resolverWithProvider(t, []string{"static-key"}, &stubProvider{ready: false})
+
+	assert.Len(t, r.GetAuthorizers(), 2,
+		"a provider without a credential must still occupy a slot so a transaction is created for it")
+}
+
+// While the provider has no credential, Authorize must refuse rather than send a request with no
+// (or someone else's) key.
+func TestAuthorizeReportsNotReadyWhileResolving(t *testing.T) {
+	r := resolverWithProvider(t, nil, &stubProvider{ready: false})
+	log := logmock.New(t)
+
+	h := http.Header{}
+	err := r.Authorize(0, h, log)
+
+	require.ErrorIs(t, err, ErrCredentialNotReady)
+	assert.Empty(t, h, "no header may be stamped when the credential is not ready")
+}
+
+// Once the credential lands, the same slot starts authorizing - no rebuild, no new resolver.
+func TestAuthorizeSucceedsOnceCredentialArrives(t *testing.T) {
+	p := &stubProvider{key: "resolved-key"}
+	r := resolverWithProvider(t, nil, p)
+	log := logmock.New(t)
+
+	require.ErrorIs(t, r.Authorize(0, http.Header{}, log), ErrCredentialNotReady)
+
+	p.ready = true
+
+	h := http.Header{}
+	require.NoError(t, r.Authorize(0, h, log))
+	assert.Equal(t, "resolved-key", h.Get("DD-Api-Key"))
+}
+
+// Static keys and providers coexist on one domain: the static slots keep working regardless of
+// whether the provider has resolved. Providers come first in the authorizer list, so the
+// provider is at index 0 and the static key at index 1.
+func TestStaticKeysUnaffectedByAPendingProvider(t *testing.T) {
+	r := resolverWithProvider(t, []string{"static-key"}, &stubProvider{ready: false})
+	log := logmock.New(t)
+
+	require.ErrorIs(t, r.Authorize(0, http.Header{}, log), ErrCredentialNotReady,
+		"the provider slot (index 0) must refuse while pending")
+
+	h := http.Header{}
+	require.NoError(t, r.Authorize(1, h, log), "the static slot (index 1) must authorize independently")
+	assert.Equal(t, "static-key", h.Get("DD-Api-Key"))
+}
+
+// An out-of-range slot is an error rather than a silent unauthenticated send. On-disk transactions
+// serialized when more slots existed can land here after a restart.
+func TestAuthorizeRejectsOutOfRangeSlot(t *testing.T) {
+	r := resolverWithProvider(t, []string{"static-key"}, &stubProvider{ready: true})
+	log := logmock.New(t)
+
+	h := http.Header{}
+	require.Error(t, r.Authorize(99, h, log))
+	assert.Empty(t, h)
+}

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/endpoints"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
@@ -54,6 +55,10 @@ type domainResolver struct {
 	apiKeys        []utils.APIKeys
 	keyVersion     int
 	dedupedAPIKeys []string
+	// credentialProviders supply credentials at send time for destinations whose key is not a
+	// config value - delegated auth, today. Each one gets its own authorization slot, and hence
+	// its own transaction, even before it has a credential to offer.
+	credentialProviders []CredentialProvider
 	// hasPendingDelegatedAuth mirrors HasPendingDelegatedAuth across apiKeys: true when the domain
 	// has no real API key yet but is waiting on one from the delegatedauth component. Kept in sync
 	// with apiKeys by hasPendingDelegatedAuthKeys() wherever apiKeys is replaced.
@@ -438,25 +443,58 @@ func (r *domainResolver) IsMetricToVector() bool {
 	return r.isMetricToVector
 }
 
-type authHeader struct {
+// CredentialProvider supplies a credential for outbound requests at send time, rather than the
+// resolver holding a key string up front. It is an alias for delegatedauth.Provider so consumers
+// that import this package get the canonical interface without a separate import.
+type CredentialProvider = delegatedauth.Provider
+
+// credentialSource is one authorization slot on a domain. The forwarder creates one transaction
+// per slot, so a slot must exist even when its credential has not arrived yet - otherwise the
+// payload is dropped at creation instead of being retried once the credential lands.
+type credentialSource interface {
+	// authorize stamps credentials onto headers and reports whether it could.
+	authorize(http.Header) bool
+}
+
+// staticAuthHeader is a fixed header/value pair, known at construction: an API key from config, or
+// the cluster-agent bearer token.
+type staticAuthHeader struct {
 	key, value string
 }
 
-// Authorize sets the auth header on the provided headers map.
-func (ah authHeader) Authorize(headers http.Header) {
-	headers.Set(ah.key, ah.value)
+func (a staticAuthHeader) authorize(headers http.Header) bool {
+	headers.Set(a.key, a.value)
+	return true
 }
 
-// GetAuthHeaders returns
-func (r *domainResolver) GetAuthorizers() (res []authHeader) {
+// providerAuth defers to a CredentialProvider on every request, so a credential that resolves
+// after startup is picked up with no rebuild and no config write.
+type providerAuth struct {
+	provider CredentialProvider
+}
+
+func (a providerAuth) authorize(headers http.Header) bool {
+	return a.provider.Authorize(headers)
+}
+
+// GetAuthorizers returns one entry per authorization slot on this domain: one per credential
+// provider, then the deduped static API keys. Providers come first so their indices are stable
+// regardless of how many static keys are configured: a config update that adds or removes a
+// static key shifts only the static-key indices, not the provider indices. This matters because
+// on-disk transactions carry their APIKeyIndex, and a provider slot that shifted would either
+// be dropped (out of range) or, worse, authenticated under a different credential.
+func (r *domainResolver) GetAuthorizers() (res []credentialSource) {
 	if r.IsLocal() {
-		res = append(res, authHeader{
+		res = append(res, staticAuthHeader{
 			key:   "Authorization",
 			value: "Bearer " + r.authToken,
 		})
 	} else {
+		for _, p := range r.GetCredentialProviders() {
+			res = append(res, providerAuth{provider: p})
+		}
 		for _, key := range r.GetAPIKeys() {
-			res = append(res, authHeader{
+			res = append(res, staticAuthHeader{
 				key:   "DD-Api-Key",
 				value: key,
 			})
@@ -465,14 +503,43 @@ func (r *domainResolver) GetAuthorizers() (res []authHeader) {
 	return
 }
 
-func (r *domainResolver) Authorize(apiKeyIdx uint, headers http.Header, log log.Component) {
+// GetCredentialProviders returns the providers supplying credentials for this domain.
+func (r *domainResolver) GetCredentialProviders() []CredentialProvider {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.credentialProviders
+}
+
+// SetCredentialProviders attaches credential providers to this domain, each getting its own
+// authorization slot. Call it before the resolver is handed to the forwarder: the slot count
+// determines how many transactions a payload fans out to, and on-disk transactions serialized
+// against a different count are discarded on load.
+func (r *domainResolver) SetCredentialProviders(providers []CredentialProvider) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.credentialProviders = providers
+}
+
+// ErrCredentialNotReady reports that a credential for this slot has not arrived yet. Callers must
+// not send. It is defined in the transaction package so the forwarder's circuit breaker can
+// recognize it without resolver importing back into it.
+var ErrCredentialNotReady = transaction.ErrCredentialNotReady
+
+// Authorize stamps the credential for slot apiKeyIdx onto headers.
+//
+// It returns ErrCredentialNotReady when the slot is backed by a provider that has nothing yet. The
+// caller must treat that as "retry later", never as "send unauthenticated".
+func (r *domainResolver) Authorize(apiKeyIdx uint, headers http.Header, log log.Component) error {
 	authorizers := r.GetAuthorizers()
 
 	if apiKeyIdx >= uint(len(authorizers)) {
 		log.Errorf("API key index %d is greater than the number of available authorizers (%d)", apiKeyIdx, len(authorizers))
-	} else {
-		authorizers[apiKeyIdx].Authorize(headers)
+		return fmt.Errorf("API key index %d out of range (have %d authorizers)", apiKeyIdx, len(authorizers))
 	}
+	if !authorizers[apiKeyIdx].authorize(headers) {
+		return ErrCredentialNotReady
+	}
+	return nil
 }
 
 // GetConfigName returns the base url as it was originally written in the config.

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
@@ -16,12 +16,12 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/endpoints"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	"github.com/DataDog/datadog-agent/pkg/credential"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 )
 
@@ -444,9 +444,9 @@ func (r *domainResolver) IsMetricToVector() bool {
 }
 
 // CredentialProvider supplies a credential for outbound requests at send time, rather than the
-// resolver holding a key string up front. It is an alias for delegatedauth.Provider so consumers
+// resolver holding a key string up front. It is an alias for credential.Provider so consumers
 // that import this package get the canonical interface without a separate import.
-type CredentialProvider = delegatedauth.Provider
+type CredentialProvider = credential.Provider
 
 // credentialSource is one authorization slot on a domain. The forwarder creates one transaction
 // per slot, so a slot must exist even when its credential has not arrived yet - otherwise the

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
@@ -16,12 +16,12 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/endpoints"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
-	"github.com/DataDog/datadog-agent/pkg/credential"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 )
 
@@ -444,9 +444,9 @@ func (r *domainResolver) IsMetricToVector() bool {
 }
 
 // CredentialProvider supplies a credential for outbound requests at send time, rather than the
-// resolver holding a key string up front. It is an alias for credential.Provider so consumers
+// resolver holding a key string up front. It is an alias for delegatedauth.Provider so consumers
 // that import this package get the canonical interface without a separate import.
-type CredentialProvider = credential.Provider
+type CredentialProvider = delegatedauth.Provider
 
 // credentialSource is one authorization slot on a domain. The forwarder creates one transaction
 // per slot, so a slot must exist even when its credential has not arrived yet - otherwise the

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver_test.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver_test.go
@@ -18,9 +18,9 @@ import (
 )
 
 func assertKeys(t *testing.T, expect []string, resolver DomainResolver) {
-	expectHdr := make([]authHeader, len(expect))
+	expectHdr := make([]credentialSource, len(expect))
 	for i, key := range expect {
-		expectHdr[i] = authHeader{"DD-Api-Key", key}
+		expectHdr[i] = staticAuthHeader{"DD-Api-Key", key}
 	}
 	assert.Equal(t, expect, resolver.GetAPIKeys())
 	assert.Equal(t, expectHdr, resolver.GetAuthorizers())

--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -385,6 +385,14 @@ func (t *HTTPTransaction) Process(ctx context.Context, config config.Component, 
 
 	statusCode, body, err := t.internalProcess(ctx, config, log, secrets, client, pointCountTelemetry)
 
+	// A missing credential is not a permanent failure: the endpoint is unprovisioned, not broken.
+	// Suppress completion and return the error so the worker can requeue the transaction; it will
+	// be retried once the credential lands. Without this guard the completion handler fires now
+	// (reporting a failure) and again when the retried transaction finishes, sending stale data.
+	if errors.Is(err, ErrCredentialNotReady) {
+		return err
+	}
+
 	if err == nil || !t.Retryable {
 		t.CompletionHandler(t, statusCode, body, err)
 	}
@@ -392,13 +400,6 @@ func (t *HTTPTransaction) Process(ctx context.Context, config config.Component, 
 	// If the txn is retryable, return the error (if present) to the worker to allow it to be retried
 	// Otherwise, return nil so the txn won't be retried.
 	if t.Retryable {
-		return err
-	}
-
-	// A missing credential is not a permanent failure: the endpoint is unprovisioned, not broken.
-	// Return the error even for non-retryable transactions so the worker can requeue instead of
-	// silently dropping the payload.
-	if errors.Is(err, ErrCredentialNotReady) {
 		return err
 	}
 

--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -403,6 +403,13 @@ func (t *HTTPTransaction) Process(ctx context.Context, config config.Component, 
 		return err
 	}
 
+	// A missing credential is not a permanent failure: the endpoint is unprovisioned, not broken.
+	// Return the error even for non-retryable transactions so the worker can requeue instead of
+	// silently dropping the payload.
+	if errors.Is(err, ErrCredentialNotReady) {
+		return err
+	}
+
 	return nil
 }
 

--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"expvar"
 	"fmt"
 	"io"
@@ -233,8 +234,19 @@ func (d Destination) String() string {
 	}
 }
 
+// ErrCredentialNotReady reports that the credential for a transaction's authorization slot has not
+// arrived yet, so nothing was sent. It is distinct from a delivery failure: the endpoint is not
+// unhealthy, it is unprovisioned, and treating it as a failure would trip the circuit breaker for
+// every other slot sharing the same domain and route.
+var ErrCredentialNotReady = errors.New("no credential available yet for this endpoint")
+
 type Authorizer interface {
-	Authorize(apiKeyIdx uint, headers http.Header, log log.Component)
+	// Authorize stamps the credential for slot apiKeyIdx onto headers.
+	//
+	// A non-nil error means the request must not be sent. When the credential simply has not
+	// arrived yet the transaction is rescheduled rather than dropped, so the payload waits in the
+	// retry queue instead of going out unauthenticated or being lost.
+	Authorize(apiKeyIdx uint, headers http.Header, log log.Component) error
 }
 
 // HTTPTransaction represents one Payload for one Endpoint on one Domain.
@@ -383,6 +395,13 @@ func (t *HTTPTransaction) Process(ctx context.Context, config config.Component, 
 		return err
 	}
 
+	// A missing credential is not a permanent failure: the endpoint is unprovisioned, not broken.
+	// Return the error even for non-retryable transactions so the worker can requeue instead of
+	// silently dropping the payload.
+	if errors.Is(err, ErrCredentialNotReady) {
+		return err
+	}
+
 	return nil
 }
 
@@ -407,7 +426,16 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, config config.Com
 		req.Header[k] = v
 	}
 	if t.Resolver != nil {
-		t.Resolver.Authorize(t.APIKeyIndex, req.Header, log)
+		if err := t.Resolver.Authorize(t.APIKeyIndex, req.Header, log); err != nil {
+			// No credential for this endpoint yet. Return an error without sending: a retryable
+			// transaction goes back on the retry queue (and to disk, if persistence is on) and is
+			// tried again once the credential lands. This is what keeps payloads from being
+			// dropped while the first exchange with the cloud provider is still in flight.
+			t.ErrorCount++
+			transactionsErrors.Add(1)
+			tlmTxErrors.Inc(t.Domain, transactionEndpointName, "no_credential")
+			return 0, nil, fmt.Errorf("not sending transaction to %q: %w", logURL, err)
+		}
 	}
 	log.Tracef("Sending %s request to %s with body size %d and headers %v", req.Method, logURL, len(payload), req.Header)
 	resp, err := client.Do(req)

--- a/comp/forwarder/defaultforwarder/transaction/transaction_test.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction_test.go
@@ -7,6 +7,7 @@ package transaction
 
 import (
 	"context"
+	"errors"
 	"expvar"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
@@ -198,8 +200,64 @@ func Test_truncateBodyForLog(t *testing.T) {
 
 type mockAuthorizer struct{}
 
-func (mockAuthorizer) Authorize(_ uint, h http.Header, _ log.Component) {
+func (mockAuthorizer) Authorize(_ uint, h http.Header, _ log.Component) error {
 	h.Set("DD-Api-Key", "secret")
+	return nil
+}
+
+// notReadyAuthorizer stands in for a delegated-auth slot whose credential has not arrived yet.
+type notReadyAuthorizer struct{}
+
+func (notReadyAuthorizer) Authorize(_ uint, _ http.Header, _ log.Component) error {
+	return errors.New("no credential available yet for this endpoint")
+}
+
+// A transaction whose credential has not resolved yet must be rescheduled, not sent and not
+// dropped. Process returning a non-nil error is what puts it back on the retry queue, and that
+// queue is the buffer that holds the payload until the first exchange with the cloud provider
+// completes. Critically, the request must never leave the process without a credential.
+func TestProcessBuffersWhenCredentialNotReady(t *testing.T) {
+	var requests int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	transaction := NewHTTPTransaction()
+	transaction.Domain = ts.URL
+	transaction.Endpoint.Route = "/"
+	transaction.Payload = NewBytesPayloadWithoutMetaData([]byte("payload"))
+	transaction.Resolver = notReadyAuthorizer{}
+	require.True(t, transaction.Retryable, "the buffer relies on the transaction being retryable")
+
+	err := transaction.Process(context.Background(), configmock.New(t), logmock.New(t), secretsmock.New(t), &http.Client{}, nil)
+
+	require.Error(t, err, "must report an error so the worker reschedules instead of completing")
+	assert.Zero(t, requests, "must not reach the intake without a credential")
+	assert.Equal(t, 1, transaction.ErrorCount)
+}
+
+// A non-retryable transaction still must not be sent unauthenticated; it is simply not requeued.
+func TestProcessDoesNotSendUnauthenticatedWhenNotRetryable(t *testing.T) {
+	var requests int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	transaction := NewHTTPTransaction()
+	transaction.Domain = ts.URL
+	transaction.Endpoint.Route = "/"
+	transaction.Payload = NewBytesPayloadWithoutMetaData([]byte("payload"))
+	transaction.Resolver = notReadyAuthorizer{}
+	transaction.Retryable = false
+
+	err := transaction.Process(context.Background(), configmock.New(t), logmock.New(t), secretsmock.New(t), &http.Client{}, nil)
+
+	assert.NoError(t, err, "a non-retryable transaction is not requeued")
+	assert.Zero(t, requests, "but it still must not reach the intake without a credential")
 }
 
 // TestProcessDoesNotMutateHeaders verifies that internalProcess does not add the

--- a/comp/logs-library/client/http/destination.go
+++ b/comp/logs-library/client/http/destination.go
@@ -322,6 +322,10 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 	}
 }
 
+// errCredentialNotReady means the endpoint's delegated-auth credential has not arrived yet, so
+// nothing was sent. It is retryable: the endpoint is unprovisioned, not unhealthy.
+var errCredentialNotReady = errors.New("no delegated auth credential available yet for this endpoint")
+
 func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 	defer func() {
 		tlmSend.Inc(d.host, errorToTag(err))
@@ -358,7 +362,12 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 		return err
 	}
 
-	req.Header.Set("DD-API-KEY", d.endpoint.GetAPIKey())
+	// A delegated-auth endpoint has no credential until its first exchange with the cloud provider
+	// completes. Returning a retryable error keeps the payload in the sender's retry loop rather
+	// than shipping it to that org's intake with no key.
+	if !d.endpoint.Authorize(req.Header) {
+		return client.NewRetryableError(errCredentialNotReady)
+	}
 	req.Header.Set("Content-Type", d.contentType)
 	req.Header.Set("User-Agent", "datadog-agent/"+version.AgentVersion)
 

--- a/comp/logs/agent/config/BUILD.bazel
+++ b/comp/logs/agent/config/BUILD.bazel
@@ -18,12 +18,12 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/logs/agent/config",
     visibility = ["//visibility:public"],
     deps = [
-        "//comp/core/delegatedauth/def",
         "//comp/logs-library/utils/tls",
         "//pkg/config/model",
         "//pkg/config/setup/constants",
         "//pkg/config/structure",
         "//pkg/config/utils",
+        "//pkg/credential",
         "//pkg/logs/types",
         "//pkg/util/log",
         "//pkg/util/scrubber",
@@ -47,6 +47,7 @@ dd_agent_go_test(
     embed = [":config"],
     deps = [
         "//comp/core/config",
+        "//comp/core/delegatedauth/mock",
         "//pkg/config/mock",
         "//pkg/config/model",
         "//pkg/config/setup/constants",

--- a/comp/logs/agent/config/BUILD.bazel
+++ b/comp/logs/agent/config/BUILD.bazel
@@ -47,6 +47,7 @@ dd_agent_go_test(
     embed = [":config"],
     deps = [
         "//comp/core/config",
+        "//comp/core/delegatedauth/mock",
         "//pkg/config/mock",
         "//pkg/config/model",
         "//pkg/config/setup/constants",

--- a/comp/logs/agent/config/BUILD.bazel
+++ b/comp/logs/agent/config/BUILD.bazel
@@ -52,6 +52,7 @@ dd_agent_go_test(
         "//pkg/config/model",
         "//pkg/config/setup/constants",
         "//pkg/config/utils",
+        "//pkg/credential",
         "//pkg/logs/types",
         "//pkg/util/log",
         "//pkg/util/pointer",

--- a/comp/logs/agent/config/BUILD.bazel
+++ b/comp/logs/agent/config/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/logs/agent/config",
     visibility = ["//visibility:public"],
     deps = [
+        "//comp/core/delegatedauth/def",
         "//comp/logs-library/utils/tls",
         "//pkg/config/model",
         "//pkg/config/setup/constants",
@@ -36,6 +37,7 @@ dd_agent_go_test(
     srcs = [
         "config_keys_test.go",
         "config_test.go",
+        "credential_provider_test.go",
         "endpoints_test.go",
         "integration_config_test.go",
         "messages_test.go",
@@ -45,6 +47,7 @@ dd_agent_go_test(
     embed = [":config"],
     deps = [
         "//comp/core/config",
+        "//pkg/config/mock",
         "//pkg/config/model",
         "//pkg/config/setup/constants",
         "//pkg/config/utils",

--- a/comp/logs/agent/config/BUILD.bazel
+++ b/comp/logs/agent/config/BUILD.bazel
@@ -18,12 +18,12 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/logs/agent/config",
     visibility = ["//visibility:public"],
     deps = [
+        "//comp/core/delegatedauth/def",
         "//comp/logs-library/utils/tls",
         "//pkg/config/model",
         "//pkg/config/setup/constants",
         "//pkg/config/structure",
         "//pkg/config/utils",
-        "//pkg/credential",
         "//pkg/logs/types",
         "//pkg/util/log",
         "//pkg/util/scrubber",
@@ -47,7 +47,6 @@ dd_agent_go_test(
     embed = [":config"],
     deps = [
         "//comp/core/config",
-        "//comp/core/delegatedauth/mock",
         "//pkg/config/mock",
         "//pkg/config/model",
         "//pkg/config/setup/constants",

--- a/comp/logs/agent/config/BUILD.bazel
+++ b/comp/logs/agent/config/BUILD.bazel
@@ -18,12 +18,12 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/logs/agent/config",
     visibility = ["//visibility:public"],
     deps = [
-        "//comp/core/delegatedauth/def",
         "//comp/logs-library/utils/tls",
         "//pkg/config/model",
         "//pkg/config/setup/constants",
         "//pkg/config/structure",
         "//pkg/config/utils",
+        "//pkg/credential",
         "//pkg/logs/types",
         "//pkg/util/log",
         "//pkg/util/scrubber",

--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -121,6 +121,14 @@ func BuildEndpointsWithVectorOverride(coreConfig pkgconfigmodel.Reader, httpConn
 	return BuildEndpointsWithConfig(coreConfig, defaultLogsConfigKeysWithVectorOverride(coreConfig), httpEndpointPrefix, httpConnectivity, intakeTrackType, intakeProtocol, intakeOrigin)
 }
 
+// BuildEndpointsWithVectorOverrideAndProviders is BuildEndpointsWithVectorOverride with a
+// delegated-auth lookup attached, so additional endpoints configured with a DELA(...) directive
+// take their credential from a provider instead of a configured API key.
+func BuildEndpointsWithVectorOverrideAndProviders(coreConfig pkgconfigmodel.Reader, httpConnectivity HTTPConnectivity, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin, lookup CredentialProviderLookup) (*Endpoints, error) {
+	keys := defaultLogsConfigKeysWithVectorOverride(coreConfig).WithCredentialProviders(lookup)
+	return BuildEndpointsWithConfig(coreConfig, keys, httpEndpointPrefix, httpConnectivity, intakeTrackType, intakeProtocol, intakeOrigin)
+}
+
 // BuildEndpointsWithConfig returns the endpoints to send logs.
 func BuildEndpointsWithConfig(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigKeys, endpointPrefix string, httpConnectivity HTTPConnectivity, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin) (*Endpoints, error) {
 	if logsConfig.devModeNoSSL() {

--- a/comp/logs/agent/config/config_keys.go
+++ b/comp/logs/agent/config/config_keys.go
@@ -20,6 +20,10 @@ type LogsConfigKeys struct {
 	prefix       string
 	vectorPrefix string
 	config       pkgconfigmodel.Reader
+
+	// credentialProviders, when set, resolves delegated-auth credentials for additional endpoints
+	// built from these keys. Nil means no delegated auth is wired for this subsystem.
+	credentialProviders CredentialProviderLookup
 }
 
 // CompressionKind constants
@@ -38,6 +42,22 @@ func defaultLogsConfigKeys(config pkgconfigmodel.Reader) *LogsConfigKeys {
 // defaultLogsConfigKeys defines the default YAML keys used to retrieve logs configuration
 func defaultLogsConfigKeysWithVectorOverride(config pkgconfigmodel.Reader) *LogsConfigKeys {
 	return NewLogsConfigKeysWithVector("logs_config.", "logs.", config)
+}
+
+// CredentialProviderLookup resolves the delegated-auth credential provider for one additional
+// endpoint, identified by the setting it came from, its host, and its DELA(...) directive.
+// It returns nil when that endpoint has no delegated-auth instance.
+type CredentialProviderLookup func(configKey, host, directive string) CredentialProvider
+
+// WithCredentialProviders attaches a lookup so endpoints built from these keys can take their
+// credential from a provider instead of a configured API key. Returns l for chaining.
+//
+// Without it, a DELA(...) directive in additional_endpoints produces an endpoint that can never
+// authorize, so nothing is sent there - deliberately, since the alternative is sending the
+// directive text to the intake as if it were an API key.
+func (l *LogsConfigKeys) WithCredentialProviders(lookup CredentialProviderLookup) *LogsConfigKeys {
+	l.credentialProviders = lookup
+	return l
 }
 
 // NewLogsConfigKeys returns a new logs configuration keys set

--- a/comp/logs/agent/config/config_keys.go
+++ b/comp/logs/agent/config/config_keys.go
@@ -12,6 +12,7 @@ import (
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
 	"github.com/DataDog/datadog-agent/pkg/config/structure"
+	"github.com/DataDog/datadog-agent/pkg/credential"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -23,7 +24,7 @@ type LogsConfigKeys struct {
 
 	// credentialProviders, when set, resolves delegated-auth credentials for additional endpoints
 	// built from these keys. Nil means no delegated auth is wired for this subsystem.
-	credentialProviders CredentialProviderLookup
+	credentialProviders credential.Lookup
 }
 
 // CompressionKind constants
@@ -44,10 +45,9 @@ func defaultLogsConfigKeysWithVectorOverride(config pkgconfigmodel.Reader) *Logs
 	return NewLogsConfigKeysWithVector("logs_config.", "logs.", config)
 }
 
-// CredentialProviderLookup resolves the delegated-auth credential provider for one additional
-// endpoint, identified by the setting it came from, its host, and its DELA(...) directive.
-// It returns nil when that endpoint has no delegated-auth instance.
-type CredentialProviderLookup func(configKey, host, directive string) CredentialProvider
+// CredentialProviderLookup is retained for backward compatibility. New code should use
+// credential.Lookup directly.
+type CredentialProviderLookup = credential.Lookup
 
 // WithCredentialProviders attaches a lookup so endpoints built from these keys can take their
 // credential from a provider instead of a configured API key. Returns l for chaining.
@@ -55,7 +55,7 @@ type CredentialProviderLookup func(configKey, host, directive string) Credential
 // Without it, a DELA(...) directive in additional_endpoints produces an endpoint that can never
 // authorize, so nothing is sent there - deliberately, since the alternative is sending the
 // directive text to the intake as if it were an API key.
-func (l *LogsConfigKeys) WithCredentialProviders(lookup CredentialProviderLookup) *LogsConfigKeys {
+func (l *LogsConfigKeys) WithCredentialProviders(lookup credential.Lookup) *LogsConfigKeys {
 	l.credentialProviders = lookup
 	return l
 }

--- a/comp/logs/agent/config/config_keys.go
+++ b/comp/logs/agent/config/config_keys.go
@@ -12,7 +12,6 @@ import (
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
 	"github.com/DataDog/datadog-agent/pkg/config/structure"
-	"github.com/DataDog/datadog-agent/pkg/credential"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -24,7 +23,7 @@ type LogsConfigKeys struct {
 
 	// credentialProviders, when set, resolves delegated-auth credentials for additional endpoints
 	// built from these keys. Nil means no delegated auth is wired for this subsystem.
-	credentialProviders credential.Lookup
+	credentialProviders CredentialProviderLookup
 }
 
 // CompressionKind constants
@@ -45,9 +44,10 @@ func defaultLogsConfigKeysWithVectorOverride(config pkgconfigmodel.Reader) *Logs
 	return NewLogsConfigKeysWithVector("logs_config.", "logs.", config)
 }
 
-// CredentialProviderLookup is retained for backward compatibility. New code should use
-// credential.Lookup directly.
-type CredentialProviderLookup = credential.Lookup
+// CredentialProviderLookup resolves the delegated-auth credential provider for one additional
+// endpoint, identified by the setting it came from, its host, and its DELA(...) directive.
+// It returns nil when that endpoint has no delegated-auth instance.
+type CredentialProviderLookup func(configKey, host, directive string) CredentialProvider
 
 // WithCredentialProviders attaches a lookup so endpoints built from these keys can take their
 // credential from a provider instead of a configured API key. Returns l for chaining.
@@ -55,7 +55,7 @@ type CredentialProviderLookup = credential.Lookup
 // Without it, a DELA(...) directive in additional_endpoints produces an endpoint that can never
 // authorize, so nothing is sent there - deliberately, since the alternative is sending the
 // directive text to the intake as if it were an API key.
-func (l *LogsConfigKeys) WithCredentialProviders(lookup credential.Lookup) *LogsConfigKeys {
+func (l *LogsConfigKeys) WithCredentialProviders(lookup CredentialProviderLookup) *LogsConfigKeys {
 	l.credentialProviders = lookup
 	return l
 }

--- a/comp/logs/agent/config/credential_provider_test.go
+++ b/comp/logs/agent/config/credential_provider_test.go
@@ -12,24 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
 	mock "github.com/DataDog/datadog-agent/pkg/config/mock"
 )
-
-// stubProvider is a CredentialProvider whose readiness the test controls.
-type stubProvider struct {
-	key   string
-	ready bool
-}
-
-func (p *stubProvider) Authorize(h http.Header) bool {
-	if !p.ready {
-		return false
-	}
-	h.Set("DD-API-KEY", p.key)
-	return true
-}
-
-func (p *stubProvider) Refresh() bool { return false }
 
 // An ordinary endpoint must be completely unaffected by any of this.
 func TestAuthorizeStampsTheConfiguredKey(t *testing.T) {
@@ -42,8 +27,10 @@ func TestAuthorizeStampsTheConfiguredKey(t *testing.T) {
 
 // A provider replaces the API key entirely: a delegated-auth endpoint has no key of its own.
 func TestAuthorizeUsesTheProviderWhenSet(t *testing.T) {
+	p := &delegatedauthmock.StubProvider{Key: "delegated-key"}
+	p.SetReady(true)
 	e := NewEndpoint("", "logs_config.additional_endpoints", "host", 0, "", false)
-	e.SetCredentialProvider(&stubProvider{key: "delegated-key", ready: true})
+	e.SetCredentialProvider(p)
 
 	h := http.Header{}
 	require.True(t, e.Authorize(h))
@@ -54,7 +41,7 @@ func TestAuthorizeUsesTheProviderWhenSet(t *testing.T) {
 // of shipping the payload with no key.
 func TestAuthorizeRefusesWhileTheCredentialResolves(t *testing.T) {
 	e := NewEndpoint("", "logs_config.additional_endpoints", "host", 0, "", false)
-	e.SetCredentialProvider(&stubProvider{key: "delegated-key"})
+	e.SetCredentialProvider(&delegatedauthmock.StubProvider{Key: "delegated-key"})
 
 	h := http.Header{}
 	assert.False(t, e.Authorize(h))
@@ -129,7 +116,7 @@ func TestDirectiveIsNeverUsedAsAnAPIKey(t *testing.T) {
 
 // With a lookup wired, the endpoint gets its own credential and starts authorizing once it lands.
 func TestDirectiveTakesItsCredentialFromTheLookup(t *testing.T) {
-	p := &stubProvider{key: "org2-key"}
+	p := &delegatedauthmock.StubProvider{Key: "org2-key"}
 	var gotConfigKey, gotHost, gotDirective string
 
 	e := buildAdditionalWithDirective(t, func(configKey, host, directive string) CredentialProvider {
@@ -145,7 +132,7 @@ func TestDirectiveTakesItsCredentialFromTheLookup(t *testing.T) {
 
 	assert.False(t, e.Authorize(http.Header{}), "must buffer until the credential arrives")
 
-	p.ready = true
+	p.SetReady(true)
 	h := http.Header{}
 	require.True(t, e.Authorize(h))
 	assert.Equal(t, "org2-key", h.Get("DD-API-KEY"))
@@ -216,10 +203,12 @@ func TestADirectiveInTheAPIKeyIsStillNeverStamped(t *testing.T) {
 
 // A resolved provider still wins over whatever apiKey happens to hold.
 func TestProviderStillWinsWhenTheKeyHoldsADirective(t *testing.T) {
+	p := &delegatedauthmock.StubProvider{Key: "org2-key"}
+	p.SetReady(true)
 	e := NewEndpoint("", "logs_config.additional_endpoints", "org2.datadoghq.com", 0, "", false)
 	e.credentialDirective = "DELA(org-uuid-2, aws)"
 	e.apiKey.Store("DELA(org-uuid-2, aws)")
-	e.SetCredentialProvider(&stubProvider{key: "org2-key", ready: true})
+	e.SetCredentialProvider(p)
 
 	h := http.Header{}
 	require.True(t, e.Authorize(h))

--- a/comp/logs/agent/config/credential_provider_test.go
+++ b/comp/logs/agent/config/credential_provider_test.go
@@ -1,0 +1,225 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mock "github.com/DataDog/datadog-agent/pkg/config/mock"
+)
+
+// stubProvider is a CredentialProvider whose readiness the test controls.
+type stubProvider struct {
+	key   string
+	ready bool
+}
+
+func (p *stubProvider) Authorize(h http.Header) bool {
+	if !p.ready {
+		return false
+	}
+	h.Set("DD-API-KEY", p.key)
+	return true
+}
+
+// An ordinary endpoint must be completely unaffected by any of this.
+func TestAuthorizeStampsTheConfiguredKey(t *testing.T) {
+	e := NewEndpoint("plain-key", "logs_config.api_key", "host", 0, "", false)
+
+	h := http.Header{}
+	require.True(t, e.Authorize(h))
+	assert.Equal(t, "plain-key", h.Get("DD-API-KEY"))
+}
+
+// A provider replaces the API key entirely: a delegated-auth endpoint has no key of its own.
+func TestAuthorizeUsesTheProviderWhenSet(t *testing.T) {
+	e := NewEndpoint("", "logs_config.additional_endpoints", "host", 0, "", false)
+	e.SetCredentialProvider(&stubProvider{key: "delegated-key", ready: true})
+
+	h := http.Header{}
+	require.True(t, e.Authorize(h))
+	assert.Equal(t, "delegated-key", h.Get("DD-API-KEY"))
+}
+
+// While the credential is resolving the endpoint must refuse, so the destination retries instead
+// of shipping the payload with no key.
+func TestAuthorizeRefusesWhileTheCredentialResolves(t *testing.T) {
+	e := NewEndpoint("", "logs_config.additional_endpoints", "host", 0, "", false)
+	e.SetCredentialProvider(&stubProvider{key: "delegated-key"})
+
+	h := http.Header{}
+	assert.False(t, e.Authorize(h))
+	assert.Empty(t, h, "nothing may be stamped without a credential")
+}
+
+// An endpoint built from a directive that never produced an instance - an unsupported cloud
+// provider, or a subsystem with no provider lookup wired - has no key and no provider. It must
+// refuse rather than stamp the empty string, which would reach the intake unauthenticated.
+func TestAuthorizeRefusesForADirectiveWithNoInstance(t *testing.T) {
+	e := NewEndpoint("", "logs_config.additional_endpoints", "host", 0, "", false)
+	e.credentialDirective = "DELA(org-uuid-1, aws)"
+
+	h := http.Header{}
+	assert.False(t, e.Authorize(h))
+	assert.Empty(t, h)
+}
+
+// A genuinely empty API key with no directive keeps its long-standing behaviour, so this change
+// does not start silently dropping traffic for an unrelated misconfiguration.
+func TestAuthorizeStillAllowsAnEmptyKeyWithoutADirective(t *testing.T) {
+	e := NewEndpoint("", "logs_config.api_key", "host", 0, "", false)
+
+	assert.True(t, e.Authorize(http.Header{}))
+}
+
+func TestIsDelaDirective(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{"DELA(org, aws)", true},
+		{"   DELA(org, aws)  ", true},
+		{"dela(org, aws)", false},
+		{"abcdef0123456789", false},
+		{"", false},
+	} {
+		assert.Equal(t, tc.want, isDelaDirective(tc.value), "isDelaDirective(%q)", tc.value)
+	}
+}
+
+// buildAdditionalWithDirective loads one additional endpoint whose api_key is a DELA directive.
+func buildAdditionalWithDirective(t *testing.T, lookup CredentialProviderLookup) Endpoint {
+	t.Helper()
+	cfg := mock.New(t)
+	cfg.SetInTest("logs_config.additional_endpoints", []map[string]interface{}{
+		{"host": "org2.datadoghq.com", "api_key": "DELA(org-uuid-2, aws)"},
+	})
+
+	keys := defaultLogsConfigKeys(cfg)
+	if lookup != nil {
+		keys = keys.WithCredentialProviders(lookup)
+	}
+
+	endpoints := loadHTTPAdditionalEndpoints(newHTTPEndpoint(keys, false), keys, "", "", "", false)
+	require.Len(t, endpoints, 1)
+	return endpoints[0]
+}
+
+// The directive is a placeholder, never a credential. Before this change it was stored verbatim as
+// the API key and stamped onto every request, sending the literal text "DELA(org-uuid-2, aws)" to
+// that org's intake in the DD-API-KEY header.
+func TestDirectiveIsNeverUsedAsAnAPIKey(t *testing.T) {
+	e := buildAdditionalWithDirective(t, nil)
+
+	assert.Empty(t, e.GetAPIKey(), "the directive must not become the endpoint's API key")
+
+	h := http.Header{}
+	assert.False(t, e.Authorize(h), "with no provider wired the endpoint must not send at all")
+	assert.Empty(t, h.Get("DD-API-KEY"))
+}
+
+// With a lookup wired, the endpoint gets its own credential and starts authorizing once it lands.
+func TestDirectiveTakesItsCredentialFromTheLookup(t *testing.T) {
+	p := &stubProvider{key: "org2-key"}
+	var gotConfigKey, gotHost, gotDirective string
+
+	e := buildAdditionalWithDirective(t, func(configKey, host, directive string) CredentialProvider {
+		gotConfigKey, gotHost, gotDirective = configKey, host, directive
+		return p
+	})
+
+	// The lookup is keyed on the directive, not just the host, so two orgs sharing a host each get
+	// their own credential.
+	assert.Equal(t, "logs_config.additional_endpoints", gotConfigKey)
+	assert.Equal(t, "org2.datadoghq.com", gotHost)
+	assert.Equal(t, "DELA(org-uuid-2, aws)", gotDirective)
+
+	assert.False(t, e.Authorize(http.Header{}), "must buffer until the credential arrives")
+
+	p.ready = true
+	h := http.Header{}
+	require.True(t, e.Authorize(h))
+	assert.Equal(t, "org2-key", h.Get("DD-API-KEY"))
+}
+
+// An ordinary additional endpoint must not be routed through the lookup at all.
+func TestPlainAdditionalEndpointIgnoresTheLookup(t *testing.T) {
+	cfg := mock.New(t)
+	cfg.SetInTest("logs_config.additional_endpoints", []map[string]interface{}{
+		{"host": "other.datadoghq.com", "api_key": "a-real-key"},
+	})
+	called := false
+	keys := defaultLogsConfigKeys(cfg).WithCredentialProviders(
+		func(_, _, _ string) CredentialProvider { called = true; return nil })
+
+	endpoints := loadHTTPAdditionalEndpoints(newHTTPEndpoint(keys, false), keys, "", "", "", false)
+	require.Len(t, endpoints, 1)
+
+	assert.False(t, called, "a plain API key must not consult the provider lookup")
+	h := http.Header{}
+	require.True(t, endpoints[0].Authorize(h))
+	assert.Equal(t, "a-real-key", h.Get("DD-API-KEY"))
+}
+
+// The TCP framing prefixes every log line with the API key verbatim, and there is no Authorize
+// gate on that path. A directive there would be written to the wire in cleartext, including any
+// fallback=<real key> it carries, so the endpoint must not be built at all.
+//
+// This is the default path for this feature, not an edge case: shouldUseTCP() returns true as soon
+// as logs_config.additional_endpoints is set, so TCP is chosen unless HTTP is explicitly forced.
+func TestTCPAdditionalEndpointDropsADirectiveRatherThanPuttingItOnTheWire(t *testing.T) {
+	cfg := mock.New(t)
+	cfg.SetInTest("logs_config.additional_endpoints", []map[string]interface{}{
+		{"host": "org2.datadoghq.com", "port": 10516, "api_key": "DELA(org-uuid-2, aws, fallback=abcdef0123456789abcdef0123456789)"},
+		{"host": "org3.datadoghq.com", "port": 10516, "api_key": "a-real-key"},
+	})
+	keys := defaultLogsConfigKeys(cfg)
+
+	endpoints := loadTCPAdditionalEndpoints(newTCPEndpoint(keys, false), keys, false)
+
+	require.Len(t, endpoints, 1, "the delegated-auth endpoint must be dropped, the plain one kept")
+	assert.Equal(t, "org3.datadoghq.com", endpoints[0].Host)
+	for _, e := range endpoints {
+		assert.NotContains(t, e.GetAPIKey(), "DELA(", "a directive must never become a TCP prefix")
+		assert.NotContains(t, e.GetAPIKey(), "abcdef0123456789", "the fallback key must never reach the wire")
+	}
+}
+
+// SkipConfigWriteback leaves the directive in the config tree, so the rotation callback re-reads
+// it on every update to additional_endpoints. If that value ever lands in apiKey, Authorize must
+// still refuse: the directive is not a credential, and stamping it would send the org UUID and any
+// fallback=<real key> it carries to the intake.
+//
+// Asserted against apiKey directly rather than by driving a config update, because the config
+// mock's SetInTest does not fire OnUpdate - a test written that way passes whether or not the
+// protection exists.
+func TestADirectiveInTheAPIKeyIsStillNeverStamped(t *testing.T) {
+	e := NewEndpoint("", "logs_config.additional_endpoints", "org2.datadoghq.com", 0, "", false)
+	e.credentialDirective = "DELA(org-uuid-2, aws, fallback=abcdef0123456789abcdef0123456789)"
+
+	// Simulate the rotation callback having written the raw config value back into the key.
+	e.apiKey.Store("DELA(org-uuid-2, aws, fallback=abcdef0123456789abcdef0123456789)")
+
+	h := http.Header{}
+	assert.False(t, e.Authorize(h), "an endpoint with a directive and no provider must never send")
+	assert.Empty(t, h.Get("DD-API-KEY"))
+}
+
+// A resolved provider still wins over whatever apiKey happens to hold.
+func TestProviderStillWinsWhenTheKeyHoldsADirective(t *testing.T) {
+	e := NewEndpoint("", "logs_config.additional_endpoints", "org2.datadoghq.com", 0, "", false)
+	e.credentialDirective = "DELA(org-uuid-2, aws)"
+	e.apiKey.Store("DELA(org-uuid-2, aws)")
+	e.SetCredentialProvider(&stubProvider{key: "org2-key", ready: true})
+
+	h := http.Header{}
+	require.True(t, e.Authorize(h))
+	assert.Equal(t, "org2-key", h.Get("DD-API-KEY"))
+}

--- a/comp/logs/agent/config/credential_provider_test.go
+++ b/comp/logs/agent/config/credential_provider_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
-
 	mock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/credential"
 )
@@ -29,12 +28,10 @@ func TestAuthorizeStampsTheConfiguredKey(t *testing.T) {
 
 // A provider replaces the API key entirely: a delegated-auth endpoint has no key of its own.
 func TestAuthorizeUsesTheProviderWhenSet(t *testing.T) {
+	p := &delegatedauthmock.StubProvider{Key: "delegated-key"}
+	p.SetReady(true)
 	e := NewEndpoint("", "logs_config.additional_endpoints", "host", 0, "", false)
-	e.SetCredentialProvider(func() *delegatedauthmock.StubProvider {
-		p := &delegatedauthmock.StubProvider{Key: "delegated-key"}
-		p.SetReady(true)
-		return p
-	}())
+	e.SetCredentialProvider(p)
 
 	h := http.Header{}
 	require.True(t, e.Authorize(h))
@@ -207,16 +204,24 @@ func TestADirectiveInTheAPIKeyIsStillNeverStamped(t *testing.T) {
 
 // A resolved provider still wins over whatever apiKey happens to hold.
 func TestProviderStillWinsWhenTheKeyHoldsADirective(t *testing.T) {
+	p := &delegatedauthmock.StubProvider{Key: "org2-key"}
+	p.SetReady(true)
 	e := NewEndpoint("", "logs_config.additional_endpoints", "org2.datadoghq.com", 0, "", false)
 	e.credentialDirective = "DELA(org-uuid-2, aws)"
 	e.apiKey.Store("DELA(org-uuid-2, aws)")
-	e.SetCredentialProvider(func() *delegatedauthmock.StubProvider {
-		p := &delegatedauthmock.StubProvider{Key: "org2-key"}
-		p.SetReady(true)
-		return p
-	}())
+	e.SetCredentialProvider(p)
 
 	h := http.Header{}
 	require.True(t, e.Authorize(h))
 	assert.Equal(t, "org2-key", h.Get("DD-API-KEY"))
+}
+
+// An endpoint with an ENC[...] key resolved by the secrets backend must be unaffected by the
+// provider path. It behaves like a plain key from the endpoint's perspective.
+func TestAuthorizeStampsResolvedEncKey(t *testing.T) {
+	e := NewEndpoint("resolved-enc-key", "logs_config.api_key", "host", 0, "", false)
+
+	h := http.Header{}
+	require.True(t, e.Authorize(h))
+	assert.Equal(t, "resolved-enc-key", h.Get("DD-API-KEY"))
 }

--- a/comp/logs/agent/config/credential_provider_test.go
+++ b/comp/logs/agent/config/credential_provider_test.go
@@ -12,23 +12,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
+
 	mock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/credential"
 )
-
-// stubProvider is a CredentialProvider whose readiness the test controls.
-type stubProvider struct {
-	key   string
-	ready bool
-}
-
-func (p *stubProvider) Authorize(h http.Header) bool {
-	if !p.ready {
-		return false
-	}
-	h.Set("DD-API-KEY", p.key)
-	return true
-}
 
 // An ordinary endpoint must be completely unaffected by any of this.
 func TestAuthorizeStampsTheConfiguredKey(t *testing.T) {
@@ -42,7 +30,11 @@ func TestAuthorizeStampsTheConfiguredKey(t *testing.T) {
 // A provider replaces the API key entirely: a delegated-auth endpoint has no key of its own.
 func TestAuthorizeUsesTheProviderWhenSet(t *testing.T) {
 	e := NewEndpoint("", "logs_config.additional_endpoints", "host", 0, "", false)
-	e.SetCredentialProvider(&stubProvider{key: "delegated-key", ready: true})
+	e.SetCredentialProvider(func() *delegatedauthmock.StubProvider {
+		p := &delegatedauthmock.StubProvider{Key: "delegated-key"}
+		p.SetReady(true)
+		return p
+	}())
 
 	h := http.Header{}
 	require.True(t, e.Authorize(h))
@@ -53,7 +45,7 @@ func TestAuthorizeUsesTheProviderWhenSet(t *testing.T) {
 // of shipping the payload with no key.
 func TestAuthorizeRefusesWhileTheCredentialResolves(t *testing.T) {
 	e := NewEndpoint("", "logs_config.additional_endpoints", "host", 0, "", false)
-	e.SetCredentialProvider(&stubProvider{key: "delegated-key"})
+	e.SetCredentialProvider(&delegatedauthmock.StubProvider{Key: "delegated-key"})
 
 	h := http.Header{}
 	assert.False(t, e.Authorize(h))
@@ -128,7 +120,7 @@ func TestDirectiveIsNeverUsedAsAnAPIKey(t *testing.T) {
 
 // With a lookup wired, the endpoint gets its own credential and starts authorizing once it lands.
 func TestDirectiveTakesItsCredentialFromTheLookup(t *testing.T) {
-	p := &stubProvider{key: "org2-key"}
+	p := &delegatedauthmock.StubProvider{Key: "org2-key"}
 	var gotConfigKey, gotHost, gotDirective string
 
 	e := buildAdditionalWithDirective(t, func(configKey, host, directive string) CredentialProvider {
@@ -144,7 +136,7 @@ func TestDirectiveTakesItsCredentialFromTheLookup(t *testing.T) {
 
 	assert.False(t, e.Authorize(http.Header{}), "must buffer until the credential arrives")
 
-	p.ready = true
+	p.SetReady(true)
 	h := http.Header{}
 	require.True(t, e.Authorize(h))
 	assert.Equal(t, "org2-key", h.Get("DD-API-KEY"))
@@ -218,7 +210,11 @@ func TestProviderStillWinsWhenTheKeyHoldsADirective(t *testing.T) {
 	e := NewEndpoint("", "logs_config.additional_endpoints", "org2.datadoghq.com", 0, "", false)
 	e.credentialDirective = "DELA(org-uuid-2, aws)"
 	e.apiKey.Store("DELA(org-uuid-2, aws)")
-	e.SetCredentialProvider(&stubProvider{key: "org2-key", ready: true})
+	e.SetCredentialProvider(func() *delegatedauthmock.StubProvider {
+		p := &delegatedauthmock.StubProvider{Key: "org2-key"}
+		p.SetReady(true)
+		return p
+	}())
 
 	h := http.Header{}
 	require.True(t, e.Authorize(h))

--- a/comp/logs/agent/config/credential_provider_test.go
+++ b/comp/logs/agent/config/credential_provider_test.go
@@ -12,10 +12,23 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
 	mock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/credential"
 )
+
+// stubProvider is a CredentialProvider whose readiness the test controls.
+type stubProvider struct {
+	key   string
+	ready bool
+}
+
+func (p *stubProvider) Authorize(h http.Header) bool {
+	if !p.ready {
+		return false
+	}
+	h.Set("DD-API-KEY", p.key)
+	return true
+}
 
 // An ordinary endpoint must be completely unaffected by any of this.
 func TestAuthorizeStampsTheConfiguredKey(t *testing.T) {
@@ -28,10 +41,8 @@ func TestAuthorizeStampsTheConfiguredKey(t *testing.T) {
 
 // A provider replaces the API key entirely: a delegated-auth endpoint has no key of its own.
 func TestAuthorizeUsesTheProviderWhenSet(t *testing.T) {
-	p := &delegatedauthmock.StubProvider{Key: "delegated-key"}
-	p.SetReady(true)
 	e := NewEndpoint("", "logs_config.additional_endpoints", "host", 0, "", false)
-	e.SetCredentialProvider(p)
+	e.SetCredentialProvider(&stubProvider{key: "delegated-key", ready: true})
 
 	h := http.Header{}
 	require.True(t, e.Authorize(h))
@@ -42,7 +53,7 @@ func TestAuthorizeUsesTheProviderWhenSet(t *testing.T) {
 // of shipping the payload with no key.
 func TestAuthorizeRefusesWhileTheCredentialResolves(t *testing.T) {
 	e := NewEndpoint("", "logs_config.additional_endpoints", "host", 0, "", false)
-	e.SetCredentialProvider(&delegatedauthmock.StubProvider{Key: "delegated-key"})
+	e.SetCredentialProvider(&stubProvider{key: "delegated-key"})
 
 	h := http.Header{}
 	assert.False(t, e.Authorize(h))
@@ -117,7 +128,7 @@ func TestDirectiveIsNeverUsedAsAnAPIKey(t *testing.T) {
 
 // With a lookup wired, the endpoint gets its own credential and starts authorizing once it lands.
 func TestDirectiveTakesItsCredentialFromTheLookup(t *testing.T) {
-	p := &delegatedauthmock.StubProvider{Key: "org2-key"}
+	p := &stubProvider{key: "org2-key"}
 	var gotConfigKey, gotHost, gotDirective string
 
 	e := buildAdditionalWithDirective(t, func(configKey, host, directive string) CredentialProvider {
@@ -133,7 +144,7 @@ func TestDirectiveTakesItsCredentialFromTheLookup(t *testing.T) {
 
 	assert.False(t, e.Authorize(http.Header{}), "must buffer until the credential arrives")
 
-	p.SetReady(true)
+	p.ready = true
 	h := http.Header{}
 	require.True(t, e.Authorize(h))
 	assert.Equal(t, "org2-key", h.Get("DD-API-KEY"))
@@ -204,24 +215,12 @@ func TestADirectiveInTheAPIKeyIsStillNeverStamped(t *testing.T) {
 
 // A resolved provider still wins over whatever apiKey happens to hold.
 func TestProviderStillWinsWhenTheKeyHoldsADirective(t *testing.T) {
-	p := &delegatedauthmock.StubProvider{Key: "org2-key"}
-	p.SetReady(true)
 	e := NewEndpoint("", "logs_config.additional_endpoints", "org2.datadoghq.com", 0, "", false)
 	e.credentialDirective = "DELA(org-uuid-2, aws)"
 	e.apiKey.Store("DELA(org-uuid-2, aws)")
-	e.SetCredentialProvider(p)
+	e.SetCredentialProvider(&stubProvider{key: "org2-key", ready: true})
 
 	h := http.Header{}
 	require.True(t, e.Authorize(h))
 	assert.Equal(t, "org2-key", h.Get("DD-API-KEY"))
-}
-
-// An endpoint with an ENC[...] key resolved by the secrets backend must be unaffected by the
-// provider path. It behaves like a plain key from the endpoint's perspective.
-func TestAuthorizeStampsResolvedEncKey(t *testing.T) {
-	e := NewEndpoint("resolved-enc-key", "logs_config.api_key", "host", 0, "", false)
-
-	h := http.Header{}
-	require.True(t, e.Authorize(h))
-	assert.Equal(t, "resolved-enc-key", h.Get("DD-API-KEY"))
 }

--- a/comp/logs/agent/config/credential_provider_test.go
+++ b/comp/logs/agent/config/credential_provider_test.go
@@ -14,6 +14,7 @@ import (
 
 	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
 	mock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/credential"
 )
 
 // An ordinary endpoint must be completely unaffected by any of this.
@@ -79,7 +80,7 @@ func TestIsDelaDirective(t *testing.T) {
 		{"abcdef0123456789", false},
 		{"", false},
 	} {
-		assert.Equal(t, tc.want, isDelaDirective(tc.value), "isDelaDirective(%q)", tc.value)
+		assert.Equal(t, tc.want, credential.IsDirective(tc.value), "credential.IsDirective(%q)", tc.value)
 	}
 }
 

--- a/comp/logs/agent/config/credential_provider_test.go
+++ b/comp/logs/agent/config/credential_provider_test.go
@@ -223,3 +223,13 @@ func TestProviderStillWinsWhenTheKeyHoldsADirective(t *testing.T) {
 	require.True(t, e.Authorize(h))
 	assert.Equal(t, "org2-key", h.Get("DD-API-KEY"))
 }
+
+// An endpoint with an ENC[...] key resolved by the secrets backend must be unaffected by the
+// provider path. It behaves like a plain key from the endpoint's perspective.
+func TestAuthorizeStampsResolvedEncKey(t *testing.T) {
+	e := NewEndpoint("resolved-enc-key", "logs_config.api_key", "host", 0, "", false)
+
+	h := http.Header{}
+	require.True(t, e.Authorize(h))
+	assert.Equal(t, "resolved-enc-key", h.Get("DD-API-KEY"))
+}

--- a/comp/logs/agent/config/credential_provider_test.go
+++ b/comp/logs/agent/config/credential_provider_test.go
@@ -29,6 +29,8 @@ func (p *stubProvider) Authorize(h http.Header) bool {
 	return true
 }
 
+func (p *stubProvider) Refresh() bool { return false }
+
 // An ordinary endpoint must be completely unaffected by any of this.
 func TestAuthorizeStampsTheConfiguredKey(t *testing.T) {
 	e := NewEndpoint("plain-key", "logs_config.api_key", "host", 0, "", false)

--- a/comp/logs/agent/config/endpoints.go
+++ b/comp/logs/agent/config/endpoints.go
@@ -7,10 +7,13 @@ package config
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	"go.uber.org/atomic"
 
+	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
 	pkgconfigutils "github.com/DataDog/datadog-agent/pkg/config/utils"
@@ -66,6 +69,13 @@ type Endpoint struct {
 	// the index of this endpoint config within "additional_endpoints" settings. This is needed to not
 	// wrongly update an endpoint when an API key is linked to multuple endpoints.
 	additionalEndpointsIdx int
+
+	// credentialProvider, when set, supplies this endpoint's credential instead of apiKey. It may
+	// have no credential yet, in which case the destination waits rather than sending.
+	credentialProvider CredentialProvider
+	// credentialDirective is the DELA(...) text this endpoint was configured with, if any. It
+	// identifies which credential is this endpoint's when several share a host.
+	credentialDirective string
 
 	Host                    string `mapstructure:"host" json:"host"`
 	Port                    int
@@ -184,6 +194,15 @@ func loadTCPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys, registerCallba
 
 	newEndpoints := make([]Endpoint, 0, len(additionals))
 	for idx, e := range additionals {
+		// Delegated auth is HTTP-only. The TCP framing prefixes every log line with the API key
+		// verbatim, so a directive here would be written to the wire in cleartext - including any
+		// fallback=<key> it carries - and would authenticate nothing. There is no Authorize gate on
+		// this path to hold the payload instead, so the endpoint is dropped rather than built.
+		if isDelaDirective(e.APIKey) {
+			log.Warnf("Additional endpoint %q at %q uses delegated auth, which is not supported over TCP; this endpoint is disabled. Set logs_config.force_use_http to use it.", e.Host, configKeyUsed)
+			continue
+		}
+
 		newE := NewEndpoint(e.APIKey, configKeyUsed, e.Host, e.Port, EmptyPathPrefix, false)
 
 		newE.isAdditionalEndpoint = true
@@ -229,7 +248,19 @@ func loadHTTPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys, intakeTrackTy
 
 	newEndpoints := make([]Endpoint, 0, len(additionals))
 	for idx, e := range additionals {
-		newE := NewEndpoint(e.APIKey, configKeyUsed, e.Host, e.Port, e.PathPrefix, false)
+		apiKey := e.APIKey
+		var directive string
+		if isDelaDirective(apiKey) {
+			// The directive is a placeholder, not a key. The endpoint is still built so a provider
+			// has somewhere to deliver; until one is attached it simply cannot authorize.
+			directive, apiKey = apiKey, ""
+		}
+
+		newE := NewEndpoint(apiKey, configKeyUsed, e.Host, e.Port, e.PathPrefix, false)
+		newE.credentialDirective = directive
+		if directive != "" && l.credentialProviders != nil {
+			newE.credentialProvider = l.credentialProviders(configKeyUsed, e.Host, directive)
+		}
 
 		newE.isAdditionalEndpoint = true
 		newE.additionalEndpointsIdx = idx
@@ -279,6 +310,45 @@ func loadHTTPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys, intakeTrackTy
 // GetAPIKey returns the latest API Key for the Endpoint, including when the configuration gets updated at runtime
 func (e *Endpoint) GetAPIKey() string {
 	return e.apiKey.Load()
+}
+
+// isDelaDirective reports whether a configured api_key is a delegated-auth placeholder rather than
+// a real key. Uses the shared prefix constant from pkg/config/model so this check cannot drift
+// from the canonical one in pkg/config/utils.
+func isDelaDirective(value string) bool {
+	return strings.HasPrefix(strings.TrimSpace(value), model.DelaDirectivePrefix)
+}
+
+// CredentialProvider supplies the credential for one destination. It is an alias for
+// delegatedauth.Provider so consumers that import this package get the canonical interface
+// without a separate import.
+type CredentialProvider = delegatedauth.Provider
+
+// SetCredentialProvider makes this endpoint take its credential from p rather than from a
+// configured API key. Call it during endpoint construction, before any destination uses it.
+func (e *Endpoint) SetCredentialProvider(p CredentialProvider) {
+	e.credentialProvider = p
+}
+
+// Authorize stamps this endpoint's credential onto h and reports whether it did.
+//
+// It returns false only when the endpoint is backed by a delegated-auth provider that has no
+// credential yet; the caller must then retry rather than send. An endpoint with an ordinary API
+// key always authorizes, so nothing about the existing path changes.
+func (e *Endpoint) Authorize(h http.Header) bool {
+	if e.credentialProvider != nil {
+		return e.credentialProvider.Authorize(h)
+	}
+	if e.credentialDirective != "" {
+		// Built from a directive that never produced an instance - an unsupported cloud provider,
+		// say. There is no credential to send, and whatever apiKey holds is not one: the config
+		// still contains the directive text, so a config update can put it back into apiKey (see
+		// onConfigUpdateAdditionalEndpoints). Refuse on the directive rather than on the key being
+		// empty, so that cannot turn into stamping the directive as a credential.
+		return false
+	}
+	h.Set("DD-API-KEY", e.GetAPIKey())
+	return true
 }
 
 // UseSSL returns the useSSL config setting
@@ -379,6 +449,12 @@ func (e *Endpoint) onConfigUpdateAdditionalEndpoints(l *LogsConfigKeys) {
 		}
 
 		newAPIKey := newAdditionalEndpoints[e.additionalEndpointsIdx].APIKey
+		if isDelaDirective(newAPIKey) {
+			// SkipConfigWriteback leaves the directive in the config tree permanently, so every
+			// update re-reads it here. Storing it would put the directive text back into apiKey,
+			// where it would be stamped onto requests as if it were a credential.
+			return
+		}
 		log.Infof("rotating API key for '%s' endpoints number %d: %s -> %s",
 			e.configSettingPath,
 			e.additionalEndpointsIdx,

--- a/comp/logs/agent/config/endpoints.go
+++ b/comp/logs/agent/config/endpoints.go
@@ -8,14 +8,15 @@ package config
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"go.uber.org/atomic"
 
+	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
 	pkgconfigutils "github.com/DataDog/datadog-agent/pkg/config/utils"
-	"github.com/DataDog/datadog-agent/pkg/credential"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 )
@@ -197,7 +198,7 @@ func loadTCPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys, registerCallba
 		// verbatim, so a directive here would be written to the wire in cleartext - including any
 		// fallback=<key> it carries - and would authenticate nothing. There is no Authorize gate on
 		// this path to hold the payload instead, so the endpoint is dropped rather than built.
-		if credential.IsDirective(e.APIKey) {
+		if isDelaDirective(e.APIKey) {
 			log.Warnf("Additional endpoint %q at %q uses delegated auth, which is not supported over TCP; this endpoint is disabled. Set logs_config.force_use_http to use it.", e.Host, configKeyUsed)
 			continue
 		}
@@ -249,7 +250,7 @@ func loadHTTPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys, intakeTrackTy
 	for idx, e := range additionals {
 		apiKey := e.APIKey
 		var directive string
-		if credential.IsDirective(apiKey) {
+		if isDelaDirective(apiKey) {
 			// The directive is a placeholder, not a key. The endpoint is still built so a provider
 			// has somewhere to deliver; until one is attached it simply cannot authorize.
 			directive, apiKey = apiKey, ""
@@ -311,10 +312,17 @@ func (e *Endpoint) GetAPIKey() string {
 	return e.apiKey.Load()
 }
 
+// isDelaDirective reports whether a configured api_key is a delegated-auth placeholder rather than
+// a real key. Uses the shared prefix constant from pkg/config/model so this check cannot drift
+// from the canonical one in pkg/config/utils.
+func isDelaDirective(value string) bool {
+	return strings.HasPrefix(strings.TrimSpace(value), model.DelaDirectivePrefix)
+}
+
 // CredentialProvider supplies the credential for one destination. It is an alias for
-// credential.Provider so consumers that import this package get the canonical interface
+// delegatedauth.Provider so consumers that import this package get the canonical interface
 // without a separate import.
-type CredentialProvider = credential.Provider
+type CredentialProvider = delegatedauth.Provider
 
 // SetCredentialProvider makes this endpoint take its credential from p rather than from a
 // configured API key. Call it during endpoint construction, before any destination uses it.
@@ -328,15 +336,19 @@ func (e *Endpoint) SetCredentialProvider(p CredentialProvider) {
 // credential yet; the caller must then retry rather than send. An endpoint with an ordinary API
 // key always authorizes, so nothing about the existing path changes.
 func (e *Endpoint) Authorize(h http.Header) bool {
-	// A directive that never produced an instance has no credential to send. Whatever apiKey
-	// holds is not a real key — the config still contains the directive text, so a config update
-	// can put it back into apiKey (see onConfigUpdateAdditionalEndpoints). Refuse on the
-	// directive rather than on the key being empty, so that cannot turn into stamping the
-	// directive as a credential.
-	if e.credentialDirective != "" && e.credentialProvider == nil {
+	if e.credentialProvider != nil {
+		return e.credentialProvider.Authorize(h)
+	}
+	if e.credentialDirective != "" {
+		// Built from a directive that never produced an instance - an unsupported cloud provider,
+		// say. There is no credential to send, and whatever apiKey holds is not one: the config
+		// still contains the directive text, so a config update can put it back into apiKey (see
+		// onConfigUpdateAdditionalEndpoints). Refuse on the directive rather than on the key being
+		// empty, so that cannot turn into stamping the directive as a credential.
 		return false
 	}
-	return credential.StampAuth(h, e.credentialProvider, e.GetAPIKey())
+	h.Set("DD-API-KEY", e.GetAPIKey())
+	return true
 }
 
 // UseSSL returns the useSSL config setting
@@ -437,7 +449,7 @@ func (e *Endpoint) onConfigUpdateAdditionalEndpoints(l *LogsConfigKeys) {
 		}
 
 		newAPIKey := newAdditionalEndpoints[e.additionalEndpointsIdx].APIKey
-		if credential.IsDirective(newAPIKey) {
+		if isDelaDirective(newAPIKey) {
 			// SkipConfigWriteback leaves the directive in the config tree permanently, so every
 			// update re-reads it here. Storing it would put the directive text back into apiKey,
 			// where it would be stamped onto requests as if it were a credential.

--- a/comp/logs/agent/config/endpoints.go
+++ b/comp/logs/agent/config/endpoints.go
@@ -197,7 +197,7 @@ func loadTCPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys, registerCallba
 		// verbatim, so a directive here would be written to the wire in cleartext - including any
 		// fallback=<key> it carries - and would authenticate nothing. There is no Authorize gate on
 		// this path to hold the payload instead, so the endpoint is dropped rather than built.
-		if isDelaDirective(e.APIKey) {
+		if credential.IsDirective(e.APIKey) {
 			log.Warnf("Additional endpoint %q at %q uses delegated auth, which is not supported over TCP; this endpoint is disabled. Set logs_config.force_use_http to use it.", e.Host, configKeyUsed)
 			continue
 		}
@@ -249,7 +249,7 @@ func loadHTTPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys, intakeTrackTy
 	for idx, e := range additionals {
 		apiKey := e.APIKey
 		var directive string
-		if isDelaDirective(apiKey) {
+		if credential.IsDirective(apiKey) {
 			// The directive is a placeholder, not a key. The endpoint is still built so a provider
 			// has somewhere to deliver; until one is attached it simply cannot authorize.
 			directive, apiKey = apiKey, ""
@@ -311,12 +311,6 @@ func (e *Endpoint) GetAPIKey() string {
 	return e.apiKey.Load()
 }
 
-// isDelaDirective reports whether a configured api_key is a delegated-auth placeholder rather than
-// a real key. Delegates to credential.IsDirective so there is one canonical check.
-func isDelaDirective(value string) bool {
-	return credential.IsDirective(value)
-}
-
 // CredentialProvider supplies the credential for one destination. It is an alias for
 // credential.Provider so consumers that import this package get the canonical interface
 // without a separate import.
@@ -334,19 +328,15 @@ func (e *Endpoint) SetCredentialProvider(p CredentialProvider) {
 // credential yet; the caller must then retry rather than send. An endpoint with an ordinary API
 // key always authorizes, so nothing about the existing path changes.
 func (e *Endpoint) Authorize(h http.Header) bool {
-	if e.credentialProvider != nil {
-		return e.credentialProvider.Authorize(h)
-	}
-	if e.credentialDirective != "" {
-		// Built from a directive that never produced an instance - an unsupported cloud provider,
-		// say. There is no credential to send, and whatever apiKey holds is not one: the config
-		// still contains the directive text, so a config update can put it back into apiKey (see
-		// onConfigUpdateAdditionalEndpoints). Refuse on the directive rather than on the key being
-		// empty, so that cannot turn into stamping the directive as a credential.
+	// A directive that never produced an instance has no credential to send. Whatever apiKey
+	// holds is not a real key — the config still contains the directive text, so a config update
+	// can put it back into apiKey (see onConfigUpdateAdditionalEndpoints). Refuse on the
+	// directive rather than on the key being empty, so that cannot turn into stamping the
+	// directive as a credential.
+	if e.credentialDirective != "" && e.credentialProvider == nil {
 		return false
 	}
-	h.Set("DD-API-KEY", e.GetAPIKey())
-	return true
+	return credential.StampAuth(h, e.credentialProvider, e.GetAPIKey())
 }
 
 // UseSSL returns the useSSL config setting
@@ -447,7 +437,7 @@ func (e *Endpoint) onConfigUpdateAdditionalEndpoints(l *LogsConfigKeys) {
 		}
 
 		newAPIKey := newAdditionalEndpoints[e.additionalEndpointsIdx].APIKey
-		if isDelaDirective(newAPIKey) {
+		if credential.IsDirective(newAPIKey) {
 			// SkipConfigWriteback leaves the directive in the config tree permanently, so every
 			// update re-reads it here. Storing it would put the directive text back into apiKey,
 			// where it would be stamped onto requests as if it were a credential.

--- a/comp/logs/agent/config/endpoints.go
+++ b/comp/logs/agent/config/endpoints.go
@@ -8,15 +8,14 @@ package config
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"go.uber.org/atomic"
 
-	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
 	pkgconfigutils "github.com/DataDog/datadog-agent/pkg/config/utils"
+	"github.com/DataDog/datadog-agent/pkg/credential"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 )
@@ -198,7 +197,7 @@ func loadTCPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys, registerCallba
 		// verbatim, so a directive here would be written to the wire in cleartext - including any
 		// fallback=<key> it carries - and would authenticate nothing. There is no Authorize gate on
 		// this path to hold the payload instead, so the endpoint is dropped rather than built.
-		if isDelaDirective(e.APIKey) {
+		if credential.IsDirective(e.APIKey) {
 			log.Warnf("Additional endpoint %q at %q uses delegated auth, which is not supported over TCP; this endpoint is disabled. Set logs_config.force_use_http to use it.", e.Host, configKeyUsed)
 			continue
 		}
@@ -250,7 +249,7 @@ func loadHTTPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys, intakeTrackTy
 	for idx, e := range additionals {
 		apiKey := e.APIKey
 		var directive string
-		if isDelaDirective(apiKey) {
+		if credential.IsDirective(apiKey) {
 			// The directive is a placeholder, not a key. The endpoint is still built so a provider
 			// has somewhere to deliver; until one is attached it simply cannot authorize.
 			directive, apiKey = apiKey, ""
@@ -312,17 +311,10 @@ func (e *Endpoint) GetAPIKey() string {
 	return e.apiKey.Load()
 }
 
-// isDelaDirective reports whether a configured api_key is a delegated-auth placeholder rather than
-// a real key. Uses the shared prefix constant from pkg/config/model so this check cannot drift
-// from the canonical one in pkg/config/utils.
-func isDelaDirective(value string) bool {
-	return strings.HasPrefix(strings.TrimSpace(value), model.DelaDirectivePrefix)
-}
-
 // CredentialProvider supplies the credential for one destination. It is an alias for
-// delegatedauth.Provider so consumers that import this package get the canonical interface
+// credential.Provider so consumers that import this package get the canonical interface
 // without a separate import.
-type CredentialProvider = delegatedauth.Provider
+type CredentialProvider = credential.Provider
 
 // SetCredentialProvider makes this endpoint take its credential from p rather than from a
 // configured API key. Call it during endpoint construction, before any destination uses it.
@@ -336,19 +328,15 @@ func (e *Endpoint) SetCredentialProvider(p CredentialProvider) {
 // credential yet; the caller must then retry rather than send. An endpoint with an ordinary API
 // key always authorizes, so nothing about the existing path changes.
 func (e *Endpoint) Authorize(h http.Header) bool {
-	if e.credentialProvider != nil {
-		return e.credentialProvider.Authorize(h)
-	}
-	if e.credentialDirective != "" {
-		// Built from a directive that never produced an instance - an unsupported cloud provider,
-		// say. There is no credential to send, and whatever apiKey holds is not one: the config
-		// still contains the directive text, so a config update can put it back into apiKey (see
-		// onConfigUpdateAdditionalEndpoints). Refuse on the directive rather than on the key being
-		// empty, so that cannot turn into stamping the directive as a credential.
+	// A directive that never produced an instance has no credential to send. Whatever apiKey
+	// holds is not a real key — the config still contains the directive text, so a config update
+	// can put it back into apiKey (see onConfigUpdateAdditionalEndpoints). Refuse on the
+	// directive rather than on the key being empty, so that cannot turn into stamping the
+	// directive as a credential.
+	if e.credentialDirective != "" && e.credentialProvider == nil {
 		return false
 	}
-	h.Set("DD-API-KEY", e.GetAPIKey())
-	return true
+	return credential.StampAuth(h, e.credentialProvider, e.GetAPIKey())
 }
 
 // UseSSL returns the useSSL config setting
@@ -449,7 +437,7 @@ func (e *Endpoint) onConfigUpdateAdditionalEndpoints(l *LogsConfigKeys) {
 		}
 
 		newAPIKey := newAdditionalEndpoints[e.additionalEndpointsIdx].APIKey
-		if isDelaDirective(newAPIKey) {
+		if credential.IsDirective(newAPIKey) {
 			// SkipConfigWriteback leaves the directive in the config tree permanently, so every
 			// update re-reads it here. Storing it would put the directive text back into apiKey,
 			// where it would be stamped onto requests as if it were a credential.

--- a/comp/logs/agent/config/endpoints.go
+++ b/comp/logs/agent/config/endpoints.go
@@ -8,15 +8,14 @@ package config
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"go.uber.org/atomic"
 
-	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
 	pkgconfigutils "github.com/DataDog/datadog-agent/pkg/config/utils"
+	"github.com/DataDog/datadog-agent/pkg/credential"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 )
@@ -313,16 +312,15 @@ func (e *Endpoint) GetAPIKey() string {
 }
 
 // isDelaDirective reports whether a configured api_key is a delegated-auth placeholder rather than
-// a real key. Uses the shared prefix constant from pkg/config/model so this check cannot drift
-// from the canonical one in pkg/config/utils.
+// a real key. Delegates to credential.IsDirective so there is one canonical check.
 func isDelaDirective(value string) bool {
-	return strings.HasPrefix(strings.TrimSpace(value), model.DelaDirectivePrefix)
+	return credential.IsDirective(value)
 }
 
 // CredentialProvider supplies the credential for one destination. It is an alias for
-// delegatedauth.Provider so consumers that import this package get the canonical interface
+// credential.Provider so consumers that import this package get the canonical interface
 // without a separate import.
-type CredentialProvider = delegatedauth.Provider
+type CredentialProvider = credential.Provider
 
 // SetCredentialProvider makes this endpoint take its credential from p rather than from a
 // configured API key. Call it during endpoint construction, before any destination uses it.

--- a/comp/logs/agent/config/go.mod
+++ b/comp/logs/agent/config/go.mod
@@ -4,7 +4,9 @@ go 1.26.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel
+	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/logs-library v0.0.0-00010101000000-000000000000
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.75.4
 	github.com/DataDog/datadog-agent/pkg/config/model v0.77.2
 	github.com/DataDog/datadog-agent/pkg/config/setup/constants v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.77.0-devel.0.20260211235139-a5361978c2b6
@@ -20,7 +22,6 @@ require (
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/configstreamconsumer/def v0.0.0-00010101000000-000000000000 // indirect
-	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.72.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.75.4 // indirect
@@ -30,7 +31,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/create v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/helper v0.0.0-00010101000000-000000000000 // indirect
-	github.com/DataDog/datadog-agent/pkg/config/mock v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/credential v0.0.0-00010101000000-000000000000 // indirect

--- a/comp/logs/agent/config/go.mod
+++ b/comp/logs/agent/config/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/setup/constants v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.75.4
-	github.com/DataDog/datadog-agent/pkg/credential v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/logs/types v0.75.4
 	github.com/DataDog/datadog-agent/pkg/util/log v0.75.4
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.75.4
@@ -34,6 +33,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/helper v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.75.4 // indirect
+	github.com/DataDog/datadog-agent/pkg/credential v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.83.0-devel.0.20260729075015-99ed037f1c29 // indirect
 	github.com/DataDog/datadog-agent/pkg/template v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths v0.64.0-devel // indirect

--- a/comp/logs/agent/config/go.mod
+++ b/comp/logs/agent/config/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/setup/constants v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.75.4
+	github.com/DataDog/datadog-agent/pkg/credential v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/logs/types v0.75.4
 	github.com/DataDog/datadog-agent/pkg/util/log v0.75.4
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.75.4
@@ -33,7 +34,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/helper v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.75.4 // indirect
-	github.com/DataDog/datadog-agent/pkg/credential v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.83.0-devel.0.20260729075015-99ed037f1c29 // indirect
 	github.com/DataDog/datadog-agent/pkg/template v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths v0.64.0-devel // indirect

--- a/comp/logs/agent/impl/BUILD.bazel
+++ b/comp/logs/agent/impl/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//comp/api/api/def",
         "//comp/api/api/utils/stream",
         "//comp/core/config",
+        "//comp/core/delegatedauth/def",
         "//comp/core/flare/types",
         "//comp/core/hostname",
         "//comp/core/hostname/hostnameinterface/def",

--- a/comp/logs/agent/impl/agent.go
+++ b/comp/logs/agent/impl/agent.go
@@ -19,6 +19,7 @@ import (
 	api "github.com/DataDog/datadog-agent/comp/api/api/def"
 	apiutils "github.com/DataDog/datadog-agent/comp/api/api/utils/stream"
 	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
+	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -80,6 +81,7 @@ type Requires struct {
 	Tagger             tagger.Component
 	Compression        logscompression.Component
 	Secrets            secrets.Component
+	DelegatedAuth      delegatedauth.Component
 }
 
 type Provides struct {
@@ -119,6 +121,10 @@ type logAgent struct {
 	integrationsLogs          integrations.Component
 	compression               logscompression.Component
 
+	// credentialProviders resolves delegated-auth credentials for additional endpoints configured
+	// with a DELA(...) directive. Nil when the component is unavailable.
+	credentialProviders config.CredentialProviderLookup
+
 	// make sure this is done only once, when we're ready
 	prepareSchedulers sync.Once
 
@@ -144,22 +150,23 @@ func NewComponent(deps Requires) Provides {
 		integrationsLogs := integrationsimpl.NewLogsIntegration()
 
 		logsAgent := &logAgent{
-			log:                deps.Log,
-			config:             deps.Config,
-			inventoryAgent:     deps.InventoryAgent,
-			hostname:           deps.Hostname,
-			started:            atomic.NewUint32(status.StatusNotStarted),
-			auditor:            deps.Auditor,
-			sources:            sources.NewLogSources(),
-			services:           service.NewServices(),
-			tracker:            tailers.NewTailerTracker(),
-			flarecontroller:    flareController.NewFlareController(),
-			wmeta:              deps.WMeta,
-			schedulerProviders: deps.SchedulerProviders,
-			integrationsLogs:   integrationsLogs,
-			tagger:             deps.Tagger,
-			compression:        deps.Compression,
-			secrets:            deps.Secrets,
+			log:                 deps.Log,
+			config:              deps.Config,
+			inventoryAgent:      deps.InventoryAgent,
+			hostname:            deps.Hostname,
+			started:             atomic.NewUint32(status.StatusNotStarted),
+			auditor:             deps.Auditor,
+			sources:             sources.NewLogSources(),
+			services:            service.NewServices(),
+			tracker:             tailers.NewTailerTracker(),
+			flarecontroller:     flareController.NewFlareController(),
+			wmeta:               deps.WMeta,
+			schedulerProviders:  deps.SchedulerProviders,
+			integrationsLogs:    integrationsLogs,
+			tagger:              deps.Tagger,
+			compression:         deps.Compression,
+			secrets:             deps.Secrets,
+			credentialProviders: credentialProviderLookup(deps.DelegatedAuth),
 		}
 		deps.Lc.Append(compdef.Hook{
 			OnStart: logsAgent.start,
@@ -193,7 +200,7 @@ func (a *logAgent) start(context.Context) error {
 	a.log.Info("Starting logs-agent...")
 
 	// setup the server config
-	endpoints, err := buildEndpoints(a.config)
+	endpoints, err := buildEndpoints(a.config, a.credentialProviders)
 
 	if err != nil {
 		message := fmt.Sprintf("Invalid endpoints: %v", err)
@@ -395,4 +402,20 @@ func streamLogsEvents(logsAgent agent.Component) func(w http.ResponseWriter, r *
 	return apiutils.GetStreamFunc(func() apiutils.MessageReceiver {
 		return logsAgent.GetMessageReceiver()
 	}, "logs", "logs agent")
+}
+
+// credentialProviderLookup adapts the delegatedauth component to the lookup the logs config
+// package expects. Matching on the directive rather than the host alone matters because two orgs
+// may dual-ship to the same host; picking either one's credential for both would ship one org's
+// logs twice and the other's not at all.
+func credentialProviderLookup(d delegatedauth.Component) config.CredentialProviderLookup {
+	if d == nil {
+		return nil
+	}
+	return func(configKey, host, directive string) config.CredentialProvider {
+		if p := d.ProviderForDirective(configKey, host, directive); p != nil {
+			return p
+		}
+		return nil
+	}
 }

--- a/comp/logs/agent/impl/agent_core_init.go
+++ b/comp/logs/agent/impl/agent_core_init.go
@@ -57,7 +57,7 @@ func (a *logAgent) SetupPipeline(processingRules []*config.ProcessingRule, wmeta
 
 // buildEndpoints builds endpoints for the logs agent, either HTTP or TCP,
 // dependent on configuration and connectivity
-func buildEndpoints(coreConfig model.Reader) (*config.Endpoints, error) {
+func buildEndpoints(coreConfig model.Reader, lookup config.CredentialProviderLookup) (*config.Endpoints, error) {
 	httpConnectivity := config.HTTPConnectivityFailure
 	if endpoints, err := buildHTTPEndpointsForConnectivityCheck(coreConfig); err == nil {
 		httpConnectivity = http.CheckConnectivity(endpoints.Main, coreConfig)
@@ -70,7 +70,7 @@ func buildEndpoints(coreConfig model.Reader) (*config.Endpoints, error) {
 		metrics.TlmHTTPConnectivityCheck.Inc("failure")
 	}
 
-	return config.BuildEndpointsWithVectorOverride(coreConfig, httpConnectivity, intakeTrackType, config.AgentJSONIntakeProtocol, config.DefaultIntakeOrigin)
+	return config.BuildEndpointsWithVectorOverrideAndProviders(coreConfig, httpConnectivity, intakeTrackType, config.AgentJSONIntakeProtocol, config.DefaultIntakeOrigin, lookup)
 }
 
 // buildHTTPEndpointsForConnectivityCheck builds HTTP endpoints for connectivity testing only.

--- a/comp/logs/agent/impl/agent_core_init_test.go
+++ b/comp/logs/agent/impl/agent_core_init_test.go
@@ -17,7 +17,7 @@ import (
 func TestBuildEndpoints(t *testing.T) {
 	config := config.NewMock(t)
 
-	endpoints, err := buildEndpoints(config)
+	endpoints, err := buildEndpoints(config, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "agent-intake.logs.datadoghq.com.", endpoints.Main.Host)
 }

--- a/comp/logs/agent/impl/agent_serverless_init.go
+++ b/comp/logs/agent/impl/agent_serverless_init.go
@@ -88,7 +88,9 @@ func (a *logAgent) SetupPipeline(
 }
 
 // buildEndpoints builds endpoints for the logs agent
-func buildEndpoints(coreConfig model.Reader) (*config.Endpoints, error) {
+// The serverless build has no delegated auth, so the lookup is accepted and ignored to keep
+// this in step with the core implementation.
+func buildEndpoints(coreConfig model.Reader, _ config.CredentialProviderLookup) (*config.Endpoints, error) {
 	config, err := config.BuildServerlessEndpoints(coreConfig, intakeTrackType, config.DefaultIntakeProtocol)
 	if err != nil {
 		return nil, err

--- a/comp/logs/agent/impl/agent_serverless_init_test.go
+++ b/comp/logs/agent/impl/agent_serverless_init_test.go
@@ -22,7 +22,7 @@ import (
 func TestBuildServerlessEndpoints(t *testing.T) {
 	config := config.NewMock(t)
 
-	endpoints, err := buildEndpoints(config)
+	endpoints, err := buildEndpoints(config, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "http-intake.logs.datadoghq.com.", endpoints.Main.Host)
 	assert.Equal(t, "serverless", string(endpoints.Main.Origin))
@@ -39,7 +39,7 @@ func TestServerlessLogsAgent(t *testing.T) {
 	assert.True(t, ok, "Expected NewServerlessLogsAgent to return *logAgent type")
 
 	// Build endpoints first, setupAgent() calls SetupPipeline which references logsAgent.endpoints
-	endpoints, err := buildEndpoints(config)
+	endpoints, err := buildEndpoints(config, nil)
 	assert.NoError(t, err, "buildEndpoints should not fail")
 	logsAgent.endpoints = endpoints
 

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/BUILD.bazel
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/config",
+        "//comp/core/delegatedauth/def",
         "//comp/core/delegatedauth/fx-noop",
         "//comp/core/log/def",
         "//comp/core/secrets/def",

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
@@ -1213,7 +1213,7 @@ func initSyncSerializerForTest(t testing.TB, logger *zap.Logger, cfg *ExporterCo
 			if err != nil {
 				return nil, err
 			}
-			return defaultforwarderimpl.NewOTelSyncForwarder(c, l, sec, eds, httpClient)
+			return defaultforwarderimpl.NewOTelSyncForwarder(c, l, sec, eds, httpClient, nil)
 		}),
 	}
 

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	delegatedauthnoopfx "github.com/DataDog/datadog-agent/comp/core/delegatedauth/fx-noop"
 	logdef "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
@@ -214,7 +215,7 @@ func initSerializerInternal(logger *zap.Logger, cfg *ExporterConfig, sourceProvi
 
 	if IsSyncForwarderEnabled() {
 		opts = append(opts,
-			fx.Provide(func(c config.Component, l logdef.Component, sec secrets.Component) (defaultforwarder.Forwarder, error) {
+			fx.Provide(func(c config.Component, l logdef.Component, sec secrets.Component, delegatedAuth delegatedauth.Component) (defaultforwarder.Forwarder, error) {
 				eds, err := configutils.GetMultipleEndpoints(c)
 				if err != nil {
 					return nil, err
@@ -227,7 +228,7 @@ func initSerializerInternal(logger *zap.Logger, cfg *ExporterConfig, sourceProvi
 					Timeout:   timeout,
 					Transport: utilhttp.CreateHTTPTransport(c),
 				}
-				return defaultforwarderimpl.NewOTelSyncForwarder(c, l, sec, eds, httpClient)
+				return defaultforwarderimpl.NewOTelSyncForwarder(c, l, sec, eds, httpClient, delegatedAuth)
 			}),
 		)
 	} else {

--- a/comp/trace/BUILD.bazel
+++ b/comp/trace/BUILD.bazel
@@ -10,11 +10,14 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/trace",
     visibility = ["//visibility:public"],
     deps = [
+        "//comp/core/delegatedauth/def",
+        "//comp/core/delegatedauth/noop-impl",
         "//comp/trace/agent/fx",
         "//comp/trace/agent/fx-mock",
         "//comp/trace/config/fx",
         "//comp/trace/config/mock",
         "//pkg/util/fxutil",
+        "@org_uber_go_fx//:fx",
     ],
 )
 

--- a/comp/trace/agent/impl/BUILD.bazel
+++ b/comp/trace/agent/impl/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/trace-agent/config/remote",
+        "//comp/core/delegatedauth/def",
         "//comp/core/ipc/def",
         "//comp/core/secrets/def",
         "//comp/core/tagger/def",

--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/fx"
 
+	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
@@ -62,6 +63,7 @@ type dependencies struct {
 
 	Config                traceconfigdef.Component
 	Secrets               secrets.Component
+	DelegatedAuth         delegatedauth.Component
 	Context               context.Context
 	Params                *Params
 	TelemetryCollector    telemetry.TelemetryCollector
@@ -154,6 +156,7 @@ func NewAgent(deps dependencies) (traceagent.Component, error) {
 	tracecfg.APIKeyIsFromSecretFn = func(apiKey string) bool {
 		return deps.Secrets != nil && deps.Secrets.IsValueFromSecret(apiKey)
 	}
+	tracecfg.CredentialProviderFn = credentialProviderLookup(deps.DelegatedAuth)
 
 	c.Agent = pkgagent.NewAgent(
 		ctx,
@@ -173,6 +176,25 @@ func NewAgent(deps dependencies) (traceagent.Component, error) {
 		OnStop:  func(_ context.Context) error { return stop(c) },
 	})
 	return c, nil
+}
+
+// credentialProviderLookup resolves an endpoint's delegated-auth provider. It is a package-level
+// function because inside start the tracecfg identifier is shadowed by the config value.
+func credentialProviderLookup(d delegatedauth.Component) func(configSettingPath, host, directive string) tracecfg.CredentialProvider {
+	return func(configSettingPath, host, directive string) tracecfg.CredentialProvider {
+		if d == nil || directive == "" {
+			return nil
+		}
+		// Match on the directive, not just the host: two orgs may dual-ship to the same host, and
+		// picking the first provider there would ship both endpoints under one org's credential
+		// while the other org received nothing.
+		p := d.ProviderForDirective(configSettingPath, host, directive)
+		if p == nil {
+			log.Warnf("no delegated auth instance for the directive on endpoint %q at %q; that endpoint will not send", host, configSettingPath)
+			return nil
+		}
+		return p
+	}
 }
 
 func prepGoRuntime(tracecfg *tracecfg.AgentConfig) {

--- a/comp/trace/bundle_mock.go
+++ b/comp/trace/bundle_mock.go
@@ -16,6 +16,10 @@
 package trace
 
 import (
+	"go.uber.org/fx"
+
+	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
+	delegatedauthnoop "github.com/DataDog/datadog-agent/comp/core/delegatedauth/noop-impl"
 	traceagentfx "github.com/DataDog/datadog-agent/comp/trace/agent/fx-mock"
 	traceconfigmock "github.com/DataDog/datadog-agent/comp/trace/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -27,5 +31,8 @@ import (
 func MockBundle() fxutil.BundleOptions {
 	return fxutil.Bundle(
 		traceconfigmock.MockModule(),
+		// The trace agent resolves delegated-auth credential providers, so the mock graph has to
+		// supply the component too. The noop never has a credential, which is what a test wants.
+		fx.Provide(func() delegatedauth.Component { return delegatedauthnoop.NewComponent().Comp }),
 		traceagentfx.MockModule())
 }

--- a/comp/trace/config/impl/setup.go
+++ b/comp/trace/config/impl/setup.go
@@ -183,7 +183,11 @@ func prepareConfig(c corecompcfg.Component, tagger tagger.Component, ipc ipc.Com
 // appendEndpoints appends any endpoint configuration found at the given cfgKey.
 // The format for cfgKey should be a map which has the URL as a key and one or
 // more API keys as an array value.
-func appendEndpoints(endpoints []*config.Endpoint, cfgKey string) []*config.Endpoint {
+// appendEndpoints adds the endpoints configured at cfgKey. supportsDelegatedAuth says whether the
+// consumer of this endpoint list takes credentials from a provider; when it does not, a DELA(...)
+// value is skipped entirely rather than becoming a key-less endpoint that would send
+// unauthenticated.
+func appendEndpoints(endpoints []*config.Endpoint, cfgKey string, supportsDelegatedAuth bool) []*config.Endpoint {
 	if !pkgconfigsetup.Datadog().IsConfigured(cfgKey) {
 		return endpoints
 	}
@@ -193,6 +197,17 @@ func appendEndpoints(endpoints []*config.Endpoint, cfgKey string) []*config.Endp
 			continue
 		}
 		for _, key := range keys {
+			// A DELA(...) directive is not an API key. The endpoint is still created, with no key,
+			// so a credential provider can serve it; without the endpoint there would be nothing
+			// for the credential to arrive at.
+			if utils.IsDelaDirective(key) {
+				if !supportsDelegatedAuth {
+					log.Warnf("'%s' has a delegated auth directive for %q, which is not supported for this setting; that endpoint is skipped", cfgKey, url)
+					continue
+				}
+				endpoints = append(endpoints, &config.Endpoint{Host: url, ConfigSettingPath: cfgKey, CredentialDirective: key})
+				continue
+			}
 			endpoints = append(endpoints, &config.Endpoint{Host: url, APIKey: utils.SanitizeAPIKey(key)})
 		}
 	}
@@ -251,7 +266,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 		})
 	}
 
-	c.Endpoints = appendEndpoints(c.Endpoints, "apm_config.additional_endpoints")
+	c.Endpoints = appendEndpoints(c.Endpoints, "apm_config.additional_endpoints", true)
 
 	if core.IsConfigured("proxy.no_proxy") {
 		proxyList := core.GetStringSlice("proxy.no_proxy")
@@ -497,7 +512,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 			Host:   utils.GetMainEndpoint(pkgconfigsetup.Datadog(), config.TelemetryEndpointPrefix, "apm_config.telemetry.dd_url"),
 			APIKey: c.Endpoints[0].APIKey,
 		}}
-		c.TelemetryConfig.Endpoints = appendEndpoints(c.TelemetryConfig.Endpoints, "apm_config.telemetry.additional_endpoints")
+		c.TelemetryConfig.Endpoints = appendEndpoints(c.TelemetryConfig.Endpoints, "apm_config.telemetry.additional_endpoints", false)
 	}
 	c.Obfuscation = new(config.ObfuscationConfig)
 	c.Obfuscation.ES.Enabled = pkgconfigsetup.Datadog().GetBool("apm_config.obfuscation.elasticsearch.enabled")

--- a/pkg/trace/api/BUILD.bazel
+++ b/pkg/trace/api/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "container.go",
         "container_linux.go",
         "converter.go",
+        "credential.go",
         "debug_server.go",
         "debug_server_serverless.go",
         "debugger.go",

--- a/pkg/trace/api/BUILD.bazel
+++ b/pkg/trace/api/BUILD.bazel
@@ -143,6 +143,7 @@ dd_agent_go_test(
         "connection_type_test.go",
         "container_linux_test.go",
         "converter_test.go",
+        "credential_test.go",
         "debugger_test.go",
         "dogstatsd_test.go",
         "dogstatsd_uds_test.go",
@@ -166,6 +167,7 @@ dd_agent_go_test(
     args = ["-test.short"],
     embed = [":api"],
     deps = [
+        "//comp/core/delegatedauth/mock",
         "//comp/core/tagger/origindetection",
         "//pkg/obfuscate",
         "//pkg/opentelemetry-mapping-go/otlp/attributes",

--- a/pkg/trace/api/BUILD.bazel
+++ b/pkg/trace/api/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
     deps = [
         "//comp/core/telemetry/def",
         "//comp/core/telemetry/impl/noops",
+        "//pkg/credential",
         "//pkg/obfuscate",
         "//pkg/opentelemetry-mapping-go/otlp/attributes",
         "//pkg/opentelemetry-mapping-go/otlp/attributes/source",

--- a/pkg/trace/api/credential.go
+++ b/pkg/trace/api/credential.go
@@ -20,16 +20,11 @@ func authorizeEndpoint(e config.Endpoint, h http.Header) bool {
 	return credential.StampAuth(h, e.CredentialProvider, e.APIKey)
 }
 
-// isDelaDirective reports whether a value is a DELA(...) directive.
-func isDelaDirective(value string) bool {
-	return credential.IsDirective(value)
-}
-
 // resolveCredentialProvider resolves the CredentialProvider for endpoint e when its
 // API key is a DELA(...) directive. The directive text, configSettingPath, and host
 // together identify the provider via AgentConfig.CredentialProviderFn.
 func resolveCredentialProvider(conf *config.AgentConfig, e *config.Endpoint, apiKey, configSettingPath string) {
-	if !isDelaDirective(apiKey) {
+	if !credential.IsDirective(apiKey) {
 		return
 	}
 	e.CredentialDirective = apiKey

--- a/pkg/trace/api/credential.go
+++ b/pkg/trace/api/credential.go
@@ -7,8 +7,8 @@ package api
 
 import (
 	"net/http"
-	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/credential"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 )
 
@@ -17,22 +17,12 @@ import (
 // and false when the credential is not yet available, meaning the caller should
 // skip this endpoint rather than send unauthenticated.
 func authorizeEndpoint(e config.Endpoint, h http.Header) bool {
-	if e.CredentialProvider != nil {
-		return e.CredentialProvider.Authorize(h)
-	}
-	if e.APIKey == "" {
-		return false
-	}
-	h.Set("DD-API-KEY", e.APIKey)
-	return true
+	return credential.StampAuth(h, e.CredentialProvider, e.APIKey)
 }
-
-// delaDirectivePrefix identifies a delegated-auth directive in an API key field.
-const delaDirectivePrefix = "DELA("
 
 // isDelaDirective reports whether a value is a DELA(...) directive.
 func isDelaDirective(value string) bool {
-	return strings.HasPrefix(strings.TrimSpace(value), delaDirectivePrefix)
+	return credential.IsDirective(value)
 }
 
 // resolveCredentialProvider resolves the CredentialProvider for endpoint e when its

--- a/pkg/trace/api/credential.go
+++ b/pkg/trace/api/credential.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+)
+
+// authorizeEndpoint stamps the credential for endpoint e onto h. It returns true
+// when the endpoint has a credential (either from a provider or a static API key)
+// and false when the credential is not yet available, meaning the caller should
+// skip this endpoint rather than send unauthenticated.
+func authorizeEndpoint(e config.Endpoint, h http.Header) bool {
+	if e.CredentialProvider != nil {
+		return e.CredentialProvider.Authorize(h)
+	}
+	if e.APIKey == "" {
+		return false
+	}
+	h.Set("DD-API-KEY", e.APIKey)
+	return true
+}
+
+// delaDirectivePrefix identifies a delegated-auth directive in an API key field.
+const delaDirectivePrefix = "DELA("
+
+// isDelaDirective reports whether a value is a DELA(...) directive.
+func isDelaDirective(value string) bool {
+	return strings.HasPrefix(strings.TrimSpace(value), delaDirectivePrefix)
+}
+
+// resolveCredentialProvider resolves the CredentialProvider for endpoint e when its
+// API key is a DELA(...) directive. The directive text, configSettingPath, and host
+// together identify the provider via AgentConfig.CredentialProviderFn.
+func resolveCredentialProvider(conf *config.AgentConfig, e *config.Endpoint, apiKey, configSettingPath string) {
+	if !isDelaDirective(apiKey) {
+		return
+	}
+	e.CredentialDirective = apiKey
+	e.APIKey = "" // clear the directive text so it can't leak as a literal key
+	e.ConfigSettingPath = configSettingPath
+	if conf.CredentialProviderFn != nil {
+		e.CredentialProvider = conf.CredentialProviderFn(configSettingPath, e.Host, apiKey)
+	}
+}

--- a/pkg/trace/api/credential_test.go
+++ b/pkg/trace/api/credential_test.go
@@ -1,0 +1,115 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+)
+
+// stubProvider is a CredentialProvider whose readiness the test controls.
+type stubProvider struct {
+	key   string
+	ready bool
+}
+
+func (p *stubProvider) Authorize(h http.Header) bool {
+	if !p.ready {
+		return false
+	}
+	h.Set("DD-API-KEY", p.key)
+	return true
+}
+
+// Normal API keys in evp_proxy endpoints must be unaffected by the provider path.
+// The endpoint has no CredentialProvider, so authorizeEndpoint stamps the static key.
+func TestEVPProxyNormalAPIKeyUnaffected(t *testing.T) {
+	conf := newTestReceiverConfig()
+	conf.EVPProxy.DDURL = "https://example.com"
+	conf.EVPProxy.APIKey = "plain-key"
+
+	endpoints := evpProxyEndpointsFromConfig(conf)
+	require.Len(t, endpoints, 1)
+	assert.Nil(t, endpoints[0].CredentialProvider, "a normal key must not get a provider")
+
+	h := http.Header{}
+	require.True(t, authorizeEndpoint(endpoints[0], h), "a normal key must authorize")
+	assert.Equal(t, "plain-key", h.Get("DD-API-KEY"))
+}
+
+// ENC[...] keys resolved by the secrets backend are normal static keys from
+// the proxy's perspective. The provider path must not interfere.
+func TestEVPProxyResolvedEncKeyUnaffected(t *testing.T) {
+	conf := newTestReceiverConfig()
+	conf.EVPProxy.DDURL = "https://example.com"
+	conf.EVPProxy.APIKey = "resolved-enc-key"
+
+	endpoints := evpProxyEndpointsFromConfig(conf)
+	require.Len(t, endpoints, 1)
+	assert.Nil(t, endpoints[0].CredentialProvider, "a resolved ENC[] key must not get a provider")
+
+	h := http.Header{}
+	require.True(t, authorizeEndpoint(endpoints[0], h), "a resolved ENC[] key must authorize")
+	assert.Equal(t, "resolved-enc-key", h.Get("DD-API-KEY"))
+}
+
+// A DELA directive endpoint with a resolved provider authorizes via the provider.
+// A normal key alongside it is unaffected.
+func TestEVPProxyMixedKeysAndDirective(t *testing.T) {
+	conf := newTestReceiverConfig()
+	conf.EVPProxy.DDURL = "https://example.com"
+	conf.EVPProxy.APIKey = "plain-key"
+	conf.EVPProxy.AdditionalEndpoints = map[string][]string{
+		"https://additional.com": {"DELA(org-uuid, aws)"},
+	}
+	conf.CredentialProviderFn = func(_, _, _ string) config.CredentialProvider {
+		return &stubProvider{key: "delegated-key", ready: true}
+	}
+
+	endpoints := evpProxyEndpointsFromConfig(conf)
+	require.Len(t, endpoints, 2)
+
+	// Main endpoint: normal key, no provider
+	assert.Nil(t, endpoints[0].CredentialProvider)
+	h0 := http.Header{}
+	require.True(t, authorizeEndpoint(endpoints[0], h0))
+	assert.Equal(t, "plain-key", h0.Get("DD-API-KEY"))
+
+	// Additional endpoint: directive, has provider
+	require.NotNil(t, endpoints[1].CredentialProvider, "a DELA directive must get a provider")
+	assert.Empty(t, endpoints[1].APIKey, "the directive text must not leak as a key")
+	h1 := http.Header{}
+	require.True(t, authorizeEndpoint(endpoints[1], h1))
+	assert.Equal(t, "delegated-key", h1.Get("DD-API-KEY"))
+}
+
+// A DELA directive with no provider (unsupported cloud, or no lookup wired)
+// must refuse rather than send unauthenticated.
+func TestEVPProxyDirectiveWithNoProviderRefuses(t *testing.T) {
+	conf := newTestReceiverConfig()
+	conf.EVPProxy.DDURL = "https://example.com"
+	conf.EVPProxy.APIKey = "plain-key"
+	conf.EVPProxy.AdditionalEndpoints = map[string][]string{
+		"https://additional.com": {"DELA(org-uuid, aws)"},
+	}
+	// No CredentialProviderFn set
+
+	endpoints := evpProxyEndpointsFromConfig(conf)
+	require.Len(t, endpoints, 2)
+
+	// The directive endpoint has no provider and no key
+	assert.Empty(t, endpoints[1].APIKey)
+	assert.Nil(t, endpoints[1].CredentialProvider)
+
+	h := http.Header{}
+	assert.False(t, authorizeEndpoint(endpoints[1], h), "a directive with no provider must not authorize")
+	assert.Empty(t, h, "nothing may be stamped without a credential")
+}

--- a/pkg/trace/api/credential_test.go
+++ b/pkg/trace/api/credential_test.go
@@ -29,6 +29,8 @@ func (p *stubProvider) Authorize(h http.Header) bool {
 	return true
 }
 
+func (p *stubProvider) Refresh() bool { return false }
+
 // Normal API keys in evp_proxy endpoints must be unaffected by the provider path.
 // The endpoint has no CredentialProvider, so authorizeEndpoint stamps the static key.
 func TestEVPProxyNormalAPIKeyUnaffected(t *testing.T) {

--- a/pkg/trace/api/credential_test.go
+++ b/pkg/trace/api/credential_test.go
@@ -12,24 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 )
-
-// stubProvider is a CredentialProvider whose readiness the test controls.
-type stubProvider struct {
-	key   string
-	ready bool
-}
-
-func (p *stubProvider) Authorize(h http.Header) bool {
-	if !p.ready {
-		return false
-	}
-	h.Set("DD-API-KEY", p.key)
-	return true
-}
-
-func (p *stubProvider) Refresh() bool { return false }
 
 // Normal API keys in evp_proxy endpoints must be unaffected by the provider path.
 // The endpoint has no CredentialProvider, so authorizeEndpoint stamps the static key.
@@ -73,7 +58,9 @@ func TestEVPProxyMixedKeysAndDirective(t *testing.T) {
 		"https://additional.com": {"DELA(org-uuid, aws)"},
 	}
 	conf.CredentialProviderFn = func(_, _, _ string) config.CredentialProvider {
-		return &stubProvider{key: "delegated-key", ready: true}
+		p := &delegatedauthmock.StubProvider{Key: "delegated-key"}
+		p.SetReady(true)
+		return p
 	}
 
 	endpoints := evpProxyEndpointsFromConfig(conf)

--- a/pkg/trace/api/debugger.go
+++ b/pkg/trace/api/debugger.go
@@ -96,7 +96,7 @@ func (r *HTTPReceiver) debuggerProxyHandler(urlTemplate string, proxyConfig conf
 		apiKey = strings.TrimSpace(k)
 	}
 	transport := newMeasuringForwardingTransport(
-		r.conf.NewHTTPTransport(), target, apiKey, proxyConfig.AdditionalEndpoints, r.conf.MaxRequestBytes, "datadog.trace_agent.debugger", []string{}, r.statsd)
+		r.conf.NewHTTPTransport(), target, apiKey, "api_key", proxyConfig.AdditionalEndpoints, "apm_config.debugger.additional_endpoints", r.conf, r.conf.MaxRequestBytes, "datadog.trace_agent.debugger", []string{}, r.statsd)
 	return newDebuggerProxy(r.conf, transport, hostTags)
 }
 

--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -49,10 +49,12 @@ func evpProxyEndpointsFromConfig(conf *config.AgentConfig) []config.Endpoint {
 	endpoints := []config.Endpoint{{Host: endpoint, APIKey: apiKey}} // main endpoint
 	for host, keys := range conf.EVPProxy.AdditionalEndpoints {
 		for _, key := range keys {
-			endpoints = append(endpoints, config.Endpoint{
+			ep := config.Endpoint{
 				Host:   host,
 				APIKey: key,
-			})
+			}
+			resolveCredentialProvider(conf, &ep, key, "apm_config.evp_proxy.additional_endpoints")
+			endpoints = append(endpoints, ep)
 		}
 	}
 	return endpoints
@@ -185,16 +187,18 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 
 	// Set target URL and API key header (per domain)
 	req.URL.Scheme = "https"
-	setTarget := func(r *http.Request, host, apiKey string) {
-		targetHost := subdomain + "." + host
+	setTarget := func(r *http.Request, e config.Endpoint) bool {
+		targetHost := subdomain + "." + e.Host
 		r.Host = targetHost
 		r.URL.Host = targetHost
-		r.Header.Set("DD-API-KEY", apiKey)
+		return authorizeEndpoint(e, r.Header)
 	}
 
 	// Shortcut if we only have one endpoint
 	if len(t.endpoints) == 1 {
-		setTarget(req, t.endpoints[0].Host, t.endpoints[0].APIKey)
+		if !setTarget(req, t.endpoints[0]) {
+			return nil, fmt.Errorf("no credential available for endpoint %q", t.endpoints[0].Host)
+		}
 		return t.transport.RoundTrip(req)
 	}
 
@@ -212,7 +216,9 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 		if slurp != nil {
 			newreq.Body = io.NopCloser(bytes.NewReader(slurp))
 		}
-		setTarget(newreq, endpointDomain.Host, endpointDomain.APIKey)
+		if !setTarget(newreq, endpointDomain) {
+			continue
+		}
 		if i == 0 {
 			// given the way we construct the list of targets the main endpoint
 			// will be the first one called, we return its response and error

--- a/pkg/trace/api/openlineage.go
+++ b/pkg/trace/api/openlineage.go
@@ -29,7 +29,7 @@ const (
 )
 
 // openLineageEndpoint returns the openlineage intake url and the corresponding API key.
-func openLineageEndpoints(cfg *config.AgentConfig) (urls []*url.URL, apiKeys []string, err error) {
+func openLineageEndpoints(cfg *config.AgentConfig) (urls []*url.URL, endpoints []config.Endpoint, err error) {
 	host := openlineageURLDefault
 	apiKey := cfg.OpenLineageProxy.APIKey
 	if apiKey == "" {
@@ -59,7 +59,7 @@ func openLineageEndpoints(cfg *config.AgentConfig) (urls []*url.URL, apiKeys []s
 	}
 
 	urls = append(urls, u)
-	apiKeys = append(apiKeys, apiKey)
+	endpoints = append(endpoints, config.Endpoint{Host: u.String(), APIKey: apiKey, ConfigSettingPath: "api_key"})
 
 	for host, keys := range cfg.OpenLineageProxy.AdditionalEndpoints {
 		for _, key := range keys {
@@ -72,11 +72,13 @@ func openLineageEndpoints(cfg *config.AgentConfig) (urls []*url.URL, apiKeys []s
 			if cfg.OpenLineageProxy.APIVersion >= 2 {
 				addOpenLineageAPIVersion(u, cfg.OpenLineageProxy.APIVersion)
 			}
+			ep := config.Endpoint{Host: u.String(), APIKey: key}
+			resolveCredentialProvider(cfg, &ep, key, "apm_config.openlineage.additional_endpoints")
 			urls = append(urls, u)
-			apiKeys = append(apiKeys, key)
+			endpoints = append(endpoints, ep)
 		}
 	}
-	return urls, apiKeys, nil
+	return urls, endpoints, nil
 }
 
 func addOpenLineageAPIVersion(u *url.URL, version int) {
@@ -100,17 +102,17 @@ func (r *HTTPReceiver) openLineageProxyHandler() http.Handler {
 		return openLineageErrorHandler("Has been disabled in config")
 	}
 	log.Debug("[openlineage] Creating proxy handler")
-	urls, apiKeys, err := openLineageEndpoints(r.conf)
+	urls, endpoints, err := openLineageEndpoints(r.conf)
 	if err != nil {
 		return openLineageErrorHandler(err.Error())
 	}
 	tags := fmt.Sprintf("host:%s,default_env:%s,agent_version:%s", r.conf.Hostname, r.conf.DefaultEnv, r.conf.AgentVersion)
-	return newOpenLineageProxy(r.conf, urls, apiKeys, tags, r.statsd)
+	return newOpenLineageProxy(r.conf, urls, endpoints, tags, r.statsd)
 }
 
 // newOpenLineageProxy creates an http.ReverseProxy which forwards requests to the openlineage intake.
 // The tags will be added as a header to all proxied requests.
-func newOpenLineageProxy(conf *config.AgentConfig, urls []*url.URL, keys []string, tags string, statsd statsd.ClientInterface) *httputil.ReverseProxy {
+func newOpenLineageProxy(conf *config.AgentConfig, urls []*url.URL, endpoints []config.Endpoint, tags string, statsd statsd.ClientInterface) *httputil.ReverseProxy {
 	log.Debug("[openlineage] Creating reverse proxy")
 	cidProvider := NewContainerIDProviderFromConfig(conf)
 	director := func(req *http.Request) {
@@ -136,7 +138,7 @@ func newOpenLineageProxy(conf *config.AgentConfig, urls []*url.URL, keys []strin
 	return &httputil.ReverseProxy{
 		Director:  director,
 		ErrorLog:  stdlog.New(logger, "openlineage.Proxy: ", 0),
-		Transport: &openLineageTransport{rt: conf.NewHTTPTransport(), urls: urls, keys: keys, maxRequestBytes: conf.MaxRequestBytes},
+		Transport: &openLineageTransport{rt: conf.NewHTTPTransport(), urls: urls, endpoints: endpoints, maxRequestBytes: conf.MaxRequestBytes},
 	}
 }
 
@@ -149,19 +151,28 @@ func newOpenLineageProxy(conf *config.AgentConfig, urls []*url.URL, keys []strin
 type openLineageTransport struct {
 	rt              http.RoundTripper
 	urls            []*url.URL
-	keys            []string
+	endpoints       []config.Endpoint
 	maxRequestBytes int64
 }
 
 func (m *openLineageTransport) RoundTrip(req *http.Request) (rresp *http.Response, rerr error) {
-	setTarget := func(r *http.Request, u *url.URL, apiKey string) {
+	setTarget := func(r *http.Request, u *url.URL, e config.Endpoint) bool {
 		r.Host = u.Host
 		r.URL = u
+		if e.CredentialProvider != nil {
+			return e.CredentialProvider.Authorize(r.Header)
+		}
+		if e.APIKey == "" {
+			return false
+		}
 		// OL endpoint follows where OL OSS client puts API key
-		r.Header.Set("Authorization", "Bearer "+apiKey)
+		r.Header.Set("Authorization", "Bearer "+e.APIKey)
+		return true
 	}
 	if len(m.urls) == 1 {
-		setTarget(req, m.urls[0], m.keys[0])
+		if !setTarget(req, m.urls[0], m.endpoints[0]) {
+			return nil, fmt.Errorf("no credential available for endpoint %q", m.endpoints[0].Host)
+		}
 		rresp, rerr = m.rt.RoundTrip(req)
 		if rerr != nil {
 			log.Errorf("[openlineage] RoundTrip failed: %v", rerr)
@@ -179,7 +190,9 @@ func (m *openLineageTransport) RoundTrip(req *http.Request) (rresp *http.Respons
 	for i, u := range m.urls {
 		newreq := req.Clone(req.Context())
 		newreq.Body = io.NopCloser(bytes.NewReader(slurp))
-		setTarget(newreq, u, m.keys[i])
+		if !setTarget(newreq, u, m.endpoints[i]) {
+			continue
+		}
 		if i == 0 {
 			// given the way we construct the list of targets the main endpoint
 			// will be the first one called, we return its response and error

--- a/pkg/trace/api/openlineage_test.go
+++ b/pkg/trace/api/openlineage_test.go
@@ -49,7 +49,7 @@ func TestOpenLineageProxy(t *testing.T) {
 	}
 	rec := httptest.NewRecorder()
 	c := &config.AgentConfig{ContainerIDFromOriginInfo: config.NoopContainerIDFromOriginInfoFunc}
-	newOpenLineageProxy(c, []*url.URL{u}, []string{"123"}, "key:val", &statsd.NoOpClient{}).ServeHTTP(rec, req)
+	newOpenLineageProxy(c, []*url.URL{u}, []config.Endpoint{{APIKey: "123"}}, "key:val", &statsd.NoOpClient{}).ServeHTTP(rec, req)
 	result := rec.Result()
 	slurp, err := io.ReadAll(result.Body)
 	result.Body.Close()
@@ -89,10 +89,10 @@ func TestOpenLineageEndpoint(t *testing.T) {
 			"test_api_key_5": false,
 		}
 
-		urls, keys, err := openLineageEndpoints(&cfg)
+		urls, endpoints, err := openLineageEndpoints(&cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, 5, len(urls))
-		assert.Equal(t, 5, len(keys))
+		assert.Equal(t, 5, len(endpoints))
 
 		for _, url := range urls {
 			urlStr := url.String()
@@ -103,7 +103,7 @@ func TestOpenLineageEndpoint(t *testing.T) {
 			}
 		}
 
-		for _, key := range keys {
+		for _, ep := range endpoints { key := ep.APIKey
 			if _, exists := expectedKeys[key]; exists {
 				expectedKeys[key] = true
 			} else {
@@ -148,10 +148,10 @@ func TestOpenLineageEndpoint(t *testing.T) {
 			"test_api_key_5": false,
 		}
 
-		urls, keys, err := openLineageEndpoints(&cfg)
+		urls, endpoints, err := openLineageEndpoints(&cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, 5, len(urls))
-		assert.Equal(t, 5, len(keys))
+		assert.Equal(t, 5, len(endpoints))
 
 		for _, url := range urls {
 			urlStr := url.String()
@@ -162,7 +162,7 @@ func TestOpenLineageEndpoint(t *testing.T) {
 			}
 		}
 
-		for _, key := range keys {
+		for _, ep := range endpoints { key := ep.APIKey
 			if _, exists := expectedKeys[key]; exists {
 				expectedKeys[key] = true
 			} else {
@@ -185,10 +185,10 @@ func TestOpenLineageEndpoint(t *testing.T) {
 		cfg.OpenLineageProxy.APIKey = "test_api_key"
 		cfg.OpenLineageProxy.APIVersion = 1
 
-		urls, keys, err := openLineageEndpoints(&cfg)
+		urls, endpoints, err := openLineageEndpoints(&cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, "https://data-obs-intake.datadoghq.eu/api/v1/lineage", urls[0].String())
-		assert.Equal(t, []string{"test_api_key"}, keys)
+		assert.Equal(t, []string{"test_api_key"}, endpointKeys(endpoints))
 	})
 
 	t.Run("dd-site-fallback", func(t *testing.T) {
@@ -196,10 +196,10 @@ func TestOpenLineageEndpoint(t *testing.T) {
 		cfg.Site = "datadoghq.eu"
 		cfg.OpenLineageProxy.APIKey = "test_api_key"
 
-		urls, keys, err := openLineageEndpoints(&cfg)
+		urls, endpoints, err := openLineageEndpoints(&cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, "https://data-obs-intake.datadoghq.eu/api/v1/lineage", urls[0].String())
-		assert.Equal(t, []string{"test_api_key"}, keys)
+		assert.Equal(t, []string{"test_api_key"}, endpointKeys(endpoints))
 	})
 
 	t.Run("datadoghq.com", func(t *testing.T) {
@@ -209,10 +209,10 @@ func TestOpenLineageEndpoint(t *testing.T) {
 		cfg.OpenLineageProxy.APIVersion = 17
 		cfg.OpenLineageProxy.AdditionalEndpoints = map[string][]string{}
 
-		urls, keys, err := openLineageEndpoints(&cfg)
+		urls, endpoints, err := openLineageEndpoints(&cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, "https://data-obs-intake.datadoghq.com/api/v1/lineage?api-version=17", urls[0].String())
-		assert.Equal(t, []string{"test_api_key"}, keys)
+		assert.Equal(t, []string{"test_api_key"}, endpointKeys(endpoints))
 
 	})
 

--- a/pkg/trace/api/openlineage_test.go
+++ b/pkg/trace/api/openlineage_test.go
@@ -103,7 +103,8 @@ func TestOpenLineageEndpoint(t *testing.T) {
 			}
 		}
 
-		for _, ep := range endpoints { key := ep.APIKey
+		for _, ep := range endpoints {
+			key := ep.APIKey
 			if _, exists := expectedKeys[key]; exists {
 				expectedKeys[key] = true
 			} else {
@@ -162,7 +163,8 @@ func TestOpenLineageEndpoint(t *testing.T) {
 			}
 		}
 
-		for _, ep := range endpoints { key := ep.APIKey
+		for _, ep := range endpoints {
+			key := ep.APIKey
 			if _, exists := expectedKeys[key]; exists {
 				expectedKeys[key] = true
 			} else {

--- a/pkg/trace/api/pipeline_stats.go
+++ b/pkg/trace/api/pipeline_stats.go
@@ -33,6 +33,12 @@ func pipelineStatsEndpoints(cfg *config.AgentConfig) (urls []*url.URL, apiKeys [
 		return nil, nil, errors.New("config was not properly validated")
 	}
 	for _, e := range cfg.Endpoints {
+		// A delegated-auth endpoint carries no API key of its own; this proxy has no provider
+		// wiring, so including it would forward pipeline stats with an empty DD-API-KEY.
+		if e.APIKey == "" {
+			log.Warnf("[pipeline_stats] skipping endpoint %q: delegated auth is not supported for this proxy", e.Host)
+			continue
+		}
 		urlStr := e.Host + pipelineStatsURLSuffix
 		log.Debugf("[pipeline_stats] Intake URL %s", urlStr)
 		url, err := url.Parse(urlStr)

--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -39,7 +39,7 @@ const (
 // profilingEndpoints returns the profiling intake urls and their corresponding
 // api keys based on agent configuration. Unless the main endpoint is skipped
 // via MainEndpointMode, it is returned as the first element in the slice.
-func profilingEndpoints(conf *config.AgentConfig) (urls []*url.URL, apiKeys []string, err error) {
+func profilingEndpoints(conf *config.AgentConfig) (urls []*url.URL, endpoints []config.Endpoint, err error) {
 	if conf.ProfilingProxy.MainEndpointMode == config.ProfilingMainEndpointSend {
 		main := mainProfilingURL(conf)
 		u, err := url.Parse(main)
@@ -48,7 +48,7 @@ func profilingEndpoints(conf *config.AgentConfig) (urls []*url.URL, apiKeys []st
 			return nil, nil, fmt.Errorf("error parsing main profiling intake URL %s: %v", main, err)
 		}
 		urls = append(urls, u)
-		apiKeys = append(apiKeys, conf.APIKey())
+		endpoints = append(endpoints, config.Endpoint{Host: u.String(), APIKey: conf.APIKey(), ConfigSettingPath: "api_key"})
 	}
 
 	if extra := conf.ProfilingProxy.AdditionalEndpoints; extra != nil {
@@ -57,27 +57,29 @@ func profilingEndpoints(conf *config.AgentConfig) (urls []*url.URL, apiKeys []st
 		// response from index 0 to the client; without sorting, when the main
 		// endpoint is skipped the "primary" additional endpoint would be picked
 		// at random from Go's map iteration order.
-		endpoints := make([]string, 0, len(extra))
+		epKeys := make([]string, 0, len(extra))
 		for endpoint := range extra {
-			endpoints = append(endpoints, endpoint)
+			epKeys = append(epKeys, endpoint)
 		}
-		sort.Strings(endpoints)
-		for _, endpoint := range endpoints {
+		sort.Strings(epKeys)
+		for _, endpoint := range epKeys {
 			u, err := url.Parse(endpoint)
 			if err != nil {
 				log.Errorf("Error parsing additional profiling intake URL %s: %v", endpoint, err)
 				continue
 			}
 			for _, key := range extra[endpoint] {
+				ep := config.Endpoint{Host: u.String(), APIKey: key}
+				resolveCredentialProvider(conf, &ep, key, "apm_config.profiling.additional_endpoints")
 				urls = append(urls, u)
-				apiKeys = append(apiKeys, key)
+				endpoints = append(endpoints, ep)
 			}
 		}
 	}
 	if len(urls) == 0 {
 		return nil, nil, errors.New("profiling proxy has no valid endpoints configured")
 	}
-	return urls, apiKeys, nil
+	return urls, endpoints, nil
 }
 
 // mainProfilingURL returns the main profiling intake URL, preferring an
@@ -101,7 +103,7 @@ func mainProfilingURL(conf *config.AgentConfig) string {
 // If the main intake URL can not be computed because of config, the returned handler will always
 // return http.StatusInternalServerError along with a clarification.
 func (r *HTTPReceiver) profileProxyHandler() http.Handler {
-	targets, keys, err := profilingEndpoints(r.conf)
+	targets, endpoints, err := profilingEndpoints(r.conf)
 	if err != nil {
 		return errorHandler(err)
 	}
@@ -116,7 +118,7 @@ func (r *HTTPReceiver) profileProxyHandler() http.Handler {
 		tags.WriteString(fmt.Sprintf(",%s:%s", k, v))
 	}
 
-	return newProfileProxy(r.conf, targets, keys, tags.String(), r.statsd)
+	return newProfileProxy(r.conf, targets, endpoints, tags.String(), r.statsd)
 }
 
 func errorHandler(err error) http.Handler {
@@ -162,7 +164,7 @@ func isRetryableBodyReadError(err error) bool {
 //
 // The tags will be added as a header to all proxied requests.
 // For more details please see multiTransport.
-func newProfileProxy(conf *config.AgentConfig, targets []*url.URL, keys []string, tags string, statsd statsd.ClientInterface) *httputil.ReverseProxy {
+func newProfileProxy(conf *config.AgentConfig, targets []*url.URL, endpoints []config.Endpoint, tags string, statsd statsd.ClientInterface) *httputil.ReverseProxy {
 	cidProvider := NewContainerIDProviderFromConfig(conf)
 	director := func(req *http.Request) {
 		req.Header.Set("Via", "trace-agent "+conf.AgentVersion)
@@ -196,7 +198,7 @@ func newProfileProxy(conf *config.AgentConfig, targets []*url.URL, keys []string
 	return &httputil.ReverseProxy{
 		Director:     director,
 		ErrorLog:     stdlog.New(logger, "profiling.Proxy: ", 0),
-		Transport:    &multiTransport{rt: ptransport, targets: targets, keys: keys, maxRequestBytes: conf.ProfilingProxy.MaxRequestBytes},
+		Transport:    &multiTransport{rt: ptransport, targets: targets, endpoints: endpoints, maxRequestBytes: conf.ProfilingProxy.MaxRequestBytes},
 		ErrorHandler: handleProxyError,
 	}
 }
@@ -267,15 +269,15 @@ func handleProxyError(w http.ResponseWriter, r *http.Request, err error) {
 type multiTransport struct {
 	rt              http.RoundTripper
 	targets         []*url.URL
-	keys            []string
+	endpoints       []config.Endpoint
 	maxRequestBytes int64
 }
 
 func (m *multiTransport) RoundTrip(req *http.Request) (rresp *http.Response, rerr error) {
-	setTarget := func(r *http.Request, u *url.URL, apiKey string) {
+	setTarget := func(r *http.Request, u *url.URL, e config.Endpoint) bool {
 		r.Host = u.Host
 		r.URL = u
-		r.Header.Set("DD-API-KEY", apiKey)
+		return authorizeEndpoint(e, r.Header)
 	}
 	defer func() {
 		// Hack for backwards-compatibility
@@ -288,7 +290,9 @@ func (m *multiTransport) RoundTrip(req *http.Request) (rresp *http.Response, rer
 		}
 	}()
 	if len(m.targets) == 1 {
-		setTarget(req, m.targets[0], m.keys[0])
+		if !setTarget(req, m.targets[0], m.endpoints[0]) {
+			return nil, fmt.Errorf("no credential available for endpoint %q", m.endpoints[0].Host)
+		}
 		rresp, rerr = m.rt.RoundTrip(req)
 		// Avoid sub-sequent requests from getting a use of closed network connection error
 		if rerr != nil && req.Body != nil {
@@ -304,7 +308,9 @@ func (m *multiTransport) RoundTrip(req *http.Request) (rresp *http.Response, rer
 	for i, u := range m.targets {
 		newreq := req.Clone(req.Context())
 		newreq.Body = io.NopCloser(bytes.NewReader(slurp))
-		setTarget(newreq, u, m.keys[i])
+		if !setTarget(newreq, u, m.endpoints[i]) {
+			continue
+		}
 		if i == 0 {
 			// given the way we construct the list of targets the main endpoint
 			// will be the first one called, we return its response and error

--- a/pkg/trace/api/profiles_bodyclose_test.go
+++ b/pkg/trace/api/profiles_bodyclose_test.go
@@ -43,8 +43,8 @@ func TestSingleTargetClosesBodyOnError(t *testing.T) {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 	mt := &multiTransport{
-		rt:      errorRoundTripper{},
-		targets: []*url.URL{u},
+		rt:        errorRoundTripper{},
+		targets:   []*url.URL{u},
 		endpoints: []config.Endpoint{{APIKey: "dummy"}},
 	}
 

--- a/pkg/trace/api/profiles_bodyclose_test.go
+++ b/pkg/trace/api/profiles_bodyclose_test.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
 )
 
 // trackingBody is an io.ReadCloser that tracks whether Close was called.
@@ -43,7 +45,7 @@ func TestSingleTargetClosesBodyOnError(t *testing.T) {
 	mt := &multiTransport{
 		rt:      errorRoundTripper{},
 		targets: []*url.URL{u},
-		keys:    []string{"dummy"},
+		endpoints: []config.Endpoint{{APIKey: "dummy"}},
 	}
 
 	// Request with a tracking body.

--- a/pkg/trace/api/profiles_test.go
+++ b/pkg/trace/api/profiles_test.go
@@ -22,6 +22,15 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
+// endpointKeys extracts the API keys from a slice of config.Endpoint for test assertions.
+func endpointKeys(eps []config.Endpoint) []string {
+	keys := make([]string, len(eps))
+	for i, ep := range eps {
+		keys[i] = ep.APIKey
+	}
+	return keys
+}
+
 func makeURLs(t *testing.T, ss ...string) []*url.URL {
 	var urls []*url.URL
 	for _, s := range ss {
@@ -65,7 +74,7 @@ func TestProfileProxy(t *testing.T) {
 	}
 	rec := httptest.NewRecorder()
 	c := &config.AgentConfig{ContainerIDFromOriginInfo: config.NoopContainerIDFromOriginInfoFunc}
-	newProfileProxy(c, []*url.URL{u}, []string{"123"}, "key:val", &statsd.NoOpClient{}).ServeHTTP(rec, req)
+	newProfileProxy(c, []*url.URL{u}, []config.Endpoint{{APIKey: "123"}}, "key:val", &statsd.NoOpClient{}).ServeHTTP(rec, req)
 	result := rec.Result()
 	slurp, err := io.ReadAll(result.Body)
 	result.Body.Close()
@@ -84,29 +93,29 @@ func TestProfilingEndpoints(t *testing.T) {
 		cfg.ProfilingProxy = config.ProfilingProxyConfig{
 			DDURL: "https://intake.profile.datadoghq.fr/api/v2/profile",
 		}
-		urls, keys, err := profilingEndpoints(cfg)
+		urls, endpoints, err := profilingEndpoints(cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, urls, makeURLs(t, "https://intake.profile.datadoghq.fr/api/v2/profile"))
-		assert.Equal(t, keys, []string{"test_api_key"})
+		assert.Equal(t, endpointKeys(endpoints), []string{"test_api_key"})
 	})
 
 	t.Run("site", func(t *testing.T) {
 		cfg := config.New()
 		cfg.Endpoints[0].APIKey = "test_api_key"
 		cfg.Site = "datadoghq.eu"
-		urls, keys, err := profilingEndpoints(cfg)
+		urls, endpoints, err := profilingEndpoints(cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, urls, makeURLs(t, "https://intake.profile.datadoghq.eu/api/v2/profile"))
-		assert.Equal(t, keys, []string{"test_api_key"})
+		assert.Equal(t, endpointKeys(endpoints), []string{"test_api_key"})
 	})
 
 	t.Run("default", func(t *testing.T) {
 		cfg := config.New()
 		cfg.Endpoints[0].APIKey = "test_api_key"
-		urls, keys, err := profilingEndpoints(cfg)
+		urls, endpoints, err := profilingEndpoints(cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, urls, makeURLs(t, "https://intake.profile.datadoghq.com/api/v2/profile"))
-		assert.Equal(t, keys, []string{"test_api_key"})
+		assert.Equal(t, endpointKeys(endpoints), []string{"test_api_key"})
 	})
 
 	t.Run("multiple", func(t *testing.T) {
@@ -119,7 +128,7 @@ func TestProfilingEndpoints(t *testing.T) {
 				"https://dd.datad0g.com":          {"api_key_3"},
 			},
 		}
-		urls, keys, err := profilingEndpoints(cfg)
+		urls, endpoints, err := profilingEndpoints(cfg)
 		assert.NoError(t, err)
 		expectedURLs := makeURLs(t,
 			"https://intake.profile.datadoghq.jp/api/v2/profile",
@@ -128,19 +137,20 @@ func TestProfilingEndpoints(t *testing.T) {
 			"https://dd.datad0g.com",
 		)
 		expectedKeys := []string{"api_key_0", "api_key_1", "api_key_2", "api_key_3"}
+		endpointKeySlice := endpointKeys(endpoints)
 
 		// Because we're using a map to mock the config we can't assert on the
 		// order of the endpoints. We check the main endpoints separately.
 		assert.Equal(t, urls[0], expectedURLs[0], "The main endpoint should be the first in the slice")
-		assert.Equal(t, keys[0], expectedKeys[0], "The main api key should be the first in the slice")
+		assert.Equal(t, endpointKeySlice[0], expectedKeys[0], "The main api key should be the first in the slice")
 
 		assert.ElementsMatch(t, urls, expectedURLs, "All urls from the config should be returned")
-		assert.ElementsMatch(t, keys, keys, "All keys from the config should be returned")
+		assert.ElementsMatch(t, endpointKeySlice, expectedKeys, "All keys from the config should be returned")
 
 		// check that we have the correct pairing between urls and api keys
-		for i := range keys {
+		for i := range endpointKeySlice {
 			for j := range expectedKeys {
-				if keys[i] == expectedKeys[j] {
+				if endpointKeySlice[i] == expectedKeys[j] {
 					assert.Equal(t, urls[i], expectedURLs[j])
 				}
 			}
@@ -157,19 +167,19 @@ func TestProfilingEndpoints(t *testing.T) {
 				"https://ddstaging.datadoghq.com": {"api_key_1", "api_key_2"},
 			},
 		}
-		urls, keys, err := profilingEndpoints(cfg)
+		urls, endpoints, err := profilingEndpoints(cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, makeURLs(t, "https://ddstaging.datadoghq.com", "https://ddstaging.datadoghq.com"), urls)
-		assert.Equal(t, []string{"api_key_1", "api_key_2"}, keys)
+		assert.Equal(t, []string{"api_key_1", "api_key_2"}, endpointKeys(endpoints))
 	})
 
 	t.Run("skip_main_endpoint_without_additional_endpoints", func(t *testing.T) {
 		cfg := config.New()
 		cfg.Endpoints[0].APIKey = "main_api_key"
 		cfg.ProfilingProxy = config.ProfilingProxyConfig{MainEndpointMode: config.ProfilingMainEndpointSkip}
-		urls, keys, err := profilingEndpoints(cfg)
+		urls, endpoints, err := profilingEndpoints(cfg)
 		assert.Nil(t, urls)
-		assert.Nil(t, keys)
+		assert.Nil(t, endpoints)
 		assert.EqualError(t, err, "profiling proxy has no valid endpoints configured")
 	})
 
@@ -190,7 +200,7 @@ func TestProfilingEndpoints(t *testing.T) {
 					"https://intake.mmm.example.com": {"key_m1", "key_m2"},
 				},
 			}
-			urls, keys, err := profilingEndpoints(cfg)
+			urls, endpoints, err := profilingEndpoints(cfg)
 			assert.NoError(t, err)
 			assert.Equal(t, makeURLs(t,
 				"https://intake.aaa.example.com",
@@ -198,7 +208,7 @@ func TestProfilingEndpoints(t *testing.T) {
 				"https://intake.mmm.example.com",
 				"https://intake.zzz.example.com",
 			), urls)
-			assert.Equal(t, []string{"key_a", "key_m1", "key_m2", "key_z"}, keys)
+			assert.Equal(t, []string{"key_a", "key_m1", "key_m2", "key_z"}, endpointKeys(endpoints))
 		}
 	})
 }

--- a/pkg/trace/api/symdb.go
+++ b/pkg/trace/api/symdb.go
@@ -43,7 +43,7 @@ func (r *HTTPReceiver) symDBProxyHandler() http.Handler {
 		apiKey = strings.TrimSpace(k)
 	}
 	transport := newMeasuringForwardingTransport(
-		r.conf.NewHTTPTransport(), target, apiKey, r.conf.SymDBProxy.AdditionalEndpoints, r.conf.MaxRequestBytes, "datadog.trace_agent.debugger.", []string{}, r.statsd)
+		r.conf.NewHTTPTransport(), target, apiKey, "api_key", r.conf.SymDBProxy.AdditionalEndpoints, "apm_config.symdb.additional_endpoints", r.conf, r.conf.MaxRequestBytes, "datadog.trace_agent.debugger.", []string{}, r.statsd)
 	return newSymDBProxy(r.conf, transport, hostTags)
 }
 

--- a/pkg/trace/api/transports.go
+++ b/pkg/trace/api/transports.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/api/apiutil"
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 )
 
@@ -56,8 +57,8 @@ func (m *measuringTransport) RoundTrip(req *http.Request) (rres *http.Response, 
 // slice are dropped. Errors on additional endpoints will be logged.
 type forwardingTransport struct {
 	rt              http.RoundTripper
+	endpoints       []config.Endpoint
 	targets         []*url.URL
-	keys            []string
 	logger          *log.ThrottledLogger
 	maxRequestBytes int64
 }
@@ -69,37 +70,44 @@ func newForwardingTransport(
 	rt http.RoundTripper,
 	mainEndpoint *url.URL,
 	mainEndpointKey string,
+	mainConfigPath string,
 	additionalEndpoints map[string][]string,
+	additionalConfigPath string,
+	conf *config.AgentConfig,
 	maxRequestBytes int64,
 ) *forwardingTransport {
+	endpoints := []config.Endpoint{{Host: mainEndpoint.String(), APIKey: mainEndpointKey, ConfigSettingPath: mainConfigPath}}
 	targets := []*url.URL{mainEndpoint}
-	apiKeys := []string{mainEndpointKey}
-	for endpoint, keys := range additionalEndpoints {
-		u, err := url.Parse(endpoint)
+	for endpointURL, keys := range additionalEndpoints {
+		u, err := url.Parse(endpointURL)
 		if err != nil {
-			log.Errorf("Error parsing additional intake URL %s: %v", endpoint, err)
+			log.Errorf("Error parsing additional intake URL %s: %v", endpointURL, err)
 			continue
 		}
 		for _, key := range keys {
+			ep := config.Endpoint{Host: u.String(), APIKey: strings.TrimSpace(key)}
+			resolveCredentialProvider(conf, &ep, key, additionalConfigPath)
+			endpoints = append(endpoints, ep)
 			targets = append(targets, u)
-			apiKeys = append(apiKeys, strings.TrimSpace(key))
 		}
 	}
-	return &forwardingTransport{rt: rt, targets: targets, keys: apiKeys, logger: log.NewThrottled(10, 10*time.Second), maxRequestBytes: maxRequestBytes}
+	return &forwardingTransport{rt: rt, endpoints: endpoints, targets: targets, logger: log.NewThrottled(10, 10*time.Second), maxRequestBytes: maxRequestBytes}
 }
 
 // RoundTrip makes an HTTP round trip forwarding one request to multiple
 // additional endpoints.
 func (m *forwardingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	setTarget := func(r *http.Request, u *url.URL, apiKey string) {
+	setTarget := func(r *http.Request, u *url.URL, e config.Endpoint) bool {
 		q := r.URL.Query()
 		u.RawQuery = q.Encode()
 		r.Host = u.Host
 		r.URL = u
-		r.Header.Set("DD-API-KEY", apiKey)
+		return authorizeEndpoint(e, r.Header)
 	}
 	if len(m.targets) == 1 {
-		setTarget(req, m.targets[0], m.keys[0])
+		if !setTarget(req, m.targets[0], m.endpoints[0]) {
+			return nil, fmt.Errorf("no credential available for endpoint %q", m.endpoints[0].Host)
+		}
 		return m.rt.RoundTrip(req)
 	}
 
@@ -134,14 +142,18 @@ func (m *forwardingTransport) RoundTrip(req *http.Request) (*http.Response, erro
 		if body != nil {
 			newreq.Body = io.NopCloser(bytes.NewReader(body))
 		}
-		setTarget(newreq, u, m.keys[i])
+		if !setTarget(newreq, u, m.endpoints[i]) {
+			continue
+		}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			roundTripAdditional(newreq)
 		}()
 	}
-	setTarget(req, m.targets[0], m.keys[0])
+	if !setTarget(req, m.targets[0], m.endpoints[0]) {
+		return nil, fmt.Errorf("no credential available for endpoint %q", m.endpoints[0].Host)
+	}
 	if body != nil {
 		req.Body = io.NopCloser(bytes.NewReader(body))
 	}
@@ -155,12 +167,15 @@ func newMeasuringForwardingTransport(
 	rt http.RoundTripper,
 	mainEndpoint *url.URL,
 	mainEndpointKey string,
+	mainConfigPath string,
 	additionalEndpoints map[string][]string,
+	additionalConfigPath string,
+	conf *config.AgentConfig,
 	maxRequestBytes int64,
 	metricPrefix string,
 	metricTags []string,
 	statsd statsd.ClientInterface,
 ) http.RoundTripper {
-	forwardingTransport := newForwardingTransport(rt, mainEndpoint, mainEndpointKey, additionalEndpoints, maxRequestBytes)
+	forwardingTransport := newForwardingTransport(rt, mainEndpoint, mainEndpointKey, mainConfigPath, additionalEndpoints, additionalConfigPath, conf, maxRequestBytes)
 	return newMeasuringTransport(forwardingTransport, metricPrefix, metricTags, statsd)
 }

--- a/pkg/trace/api/transports_test.go
+++ b/pkg/trace/api/transports_test.go
@@ -27,7 +27,7 @@ func (m *nilResponseTransport) RoundTrip(_ *http.Request) (*http.Response, error
 // when the underlying transport returns a nil response with an error.
 func TestForwardingTransport_NilResponse(t *testing.T) {
 	mainEndpoint, _ := url.Parse("http://localhost:8080")
-	ft := newForwardingTransport(&nilResponseTransport{}, mainEndpoint, "test-key", nil, 25*1024*1024)
+	ft := newForwardingTransport(&nilResponseTransport{}, mainEndpoint, "test-key", "api_key", nil, "", nil, 25*1024*1024)
 	req, err := http.NewRequest("POST", "http://localhost:8080/v1/traces", strings.NewReader("test body"))
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
@@ -56,7 +56,7 @@ func TestForwardingTransport_MultipleTargetsNilResponse(t *testing.T) {
 		"http://localhost:8081": {"key1"},
 	}
 
-	ft := newForwardingTransport(&nilResponseTransport{}, mainEndpoint, "test-key", additionalEndpoints, 25*1024*1024)
+	ft := newForwardingTransport(&nilResponseTransport{}, mainEndpoint, "test-key", "api_key", additionalEndpoints, "additional_endpoints", nil, 25*1024*1024)
 	req, err := http.NewRequest("POST", "http://localhost:8080/v1/traces", strings.NewReader("test body"))
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
@@ -96,7 +96,7 @@ func TestForwardingTransport_MultipleTargets(t *testing.T) {
 		additionalEndpoints := map[string][]string{
 			additionalEndpoint.String(): {"key1"},
 		}
-		return newForwardingTransport(http.DefaultTransport, mainEndpoint, "test-key", additionalEndpoints, 25*1024*1024)
+		return newForwardingTransport(http.DefaultTransport, mainEndpoint, "test-key", "api_key", additionalEndpoints, "additional_endpoints", nil, 25*1024*1024)
 	}
 	validateResponse := func(t *testing.T, rt http.RoundTripper, req *http.Request) {
 		resp, err := rt.RoundTrip(req)

--- a/pkg/trace/config/BUILD.bazel
+++ b/pkg/trace/config/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/tagger/origindetection",
+        "//pkg/credential",
         "//pkg/obfuscate",
         "//pkg/opentelemetry-mapping-go/otlp/attributes",
         "//pkg/remoteconfig/state",

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -60,6 +60,11 @@ type Endpoint struct {
 
 	// IsMRF determines whether this is a Multi-Region Failover endpoint.
 	IsMRF bool `mapstructure:"-" json:"-"`
+
+	// CredentialProvider, when set, supplies the credential for this endpoint at request
+	// time. Resolved from AgentConfig.CredentialProviderFn at construction. When nil, the
+	// endpoint uses its static APIKey.
+	CredentialProvider CredentialProvider `mapstructure:"-" json:"-"`
 }
 
 // TelemetryEndpointPrefix specifies the prefix of the telemetry endpoint URL.

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
-	"github.com/DataDog/datadog-agent/pkg/credential"
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	ddattributes "github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
@@ -33,10 +32,13 @@ const ServiceName = "datadog-trace-agent"
 var ErrMissingAPIKey = errors.New("you must specify an API Key, either via a configuration file or the DD_API_KEY env var")
 
 // Endpoint specifies an endpoint that the trace agent will write data (traces, stats & services) to.
-// CredentialProvider is an alias for credential.Provider, the canonical interface declared
-// in pkg/credential. pkg/trace depends on pkg/credential (not comp/) so it gets the same
-// type that the agent uses.
-type CredentialProvider = credential.Provider
+// CredentialProvider supplies the credential for one destination. It mirrors
+// comp/core/delegatedauth's Provider; see CredentialProviderFn for why it is redeclared here.
+type CredentialProvider interface {
+	// Authorize stamps the credential onto h and reports whether it did. A false return means
+	// no credential is available yet and the caller must not send.
+	Authorize(h http.Header) bool
+}
 
 type Endpoint struct {
 	APIKey string `json:"-"` // never marshal this
@@ -648,7 +650,7 @@ type AgentConfig struct {
 	// returning nil when that endpoint uses a plain API key. Declared as a func field, like
 	// SecretsRefreshFn below, so pkg/trace stays free of a dependency on comp/core/delegatedauth:
 	// this module is vendored by the OTel Collector distribution and has to stay lean.
-	CredentialProviderFn credential.Lookup `json:"-"`
+	CredentialProviderFn func(configSettingPath, host, directive string) CredentialProvider `json:"-"`
 
 	// SecretsRefreshFn is called when a 403 response is received to trigger
 	// API key refresh from the secrets backend. It blocks until the refresh

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
+	"github.com/DataDog/datadog-agent/pkg/credential"
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	ddattributes "github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
@@ -32,13 +33,10 @@ const ServiceName = "datadog-trace-agent"
 var ErrMissingAPIKey = errors.New("you must specify an API Key, either via a configuration file or the DD_API_KEY env var")
 
 // Endpoint specifies an endpoint that the trace agent will write data (traces, stats & services) to.
-// CredentialProvider supplies the credential for one destination. It mirrors
-// comp/core/delegatedauth's Provider; see CredentialProviderFn for why it is redeclared here.
-type CredentialProvider interface {
-	// Authorize stamps the credential onto h and reports whether it did. A false return means
-	// no credential is available yet and the caller must not send.
-	Authorize(h http.Header) bool
-}
+// CredentialProvider is an alias for credential.Provider, the canonical interface declared
+// in pkg/credential. pkg/trace depends on pkg/credential (not comp/) so it gets the same
+// type that the agent uses.
+type CredentialProvider = credential.Provider
 
 type Endpoint struct {
 	APIKey string `json:"-"` // never marshal this
@@ -650,7 +648,7 @@ type AgentConfig struct {
 	// returning nil when that endpoint uses a plain API key. Declared as a func field, like
 	// SecretsRefreshFn below, so pkg/trace stays free of a dependency on comp/core/delegatedauth:
 	// this module is vendored by the OTel Collector distribution and has to stay lean.
-	CredentialProviderFn func(configSettingPath, host, directive string) CredentialProvider `json:"-"`
+	CredentialProviderFn credential.Lookup `json:"-"`
 
 	// SecretsRefreshFn is called when a 403 response is received to trigger
 	// API key refresh from the secrets backend. It blocks until the refresh

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
+	"github.com/DataDog/datadog-agent/pkg/credential"
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	ddattributes "github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
@@ -32,13 +33,10 @@ const ServiceName = "datadog-trace-agent"
 var ErrMissingAPIKey = errors.New("you must specify an API Key, either via a configuration file or the DD_API_KEY env var")
 
 // Endpoint specifies an endpoint that the trace agent will write data (traces, stats & services) to.
-// CredentialProvider supplies the credential for one destination. It mirrors
-// comp/core/delegatedauth's Provider; see CredentialProviderFn for why it is redeclared here.
-type CredentialProvider interface {
-	// Authorize stamps the credential onto h and reports whether it did. A false return means
-	// no credential is available yet and the caller must not send.
-	Authorize(h http.Header) bool
-}
+// CredentialProvider is an alias for credential.Provider, the canonical interface declared
+// in pkg/credential. pkg/trace depends on pkg/credential (not comp/) so it gets the same
+// type that the agent uses.
+type CredentialProvider = credential.Provider
 
 type Endpoint struct {
 	APIKey string `json:"-"` // never marshal this
@@ -655,7 +653,7 @@ type AgentConfig struct {
 	// returning nil when that endpoint uses a plain API key. Declared as a func field, like
 	// SecretsRefreshFn below, so pkg/trace stays free of a dependency on comp/core/delegatedauth:
 	// this module is vendored by the OTel Collector distribution and has to stay lean.
-	CredentialProviderFn func(configSettingPath, host, directive string) CredentialProvider `json:"-"`
+	CredentialProviderFn credential.Lookup `json:"-"`
 
 	// SecretsRefreshFn is called when a 403 response is received to trigger
 	// API key refresh from the secrets backend. It blocks until the refresh

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -32,9 +32,27 @@ const ServiceName = "datadog-trace-agent"
 var ErrMissingAPIKey = errors.New("you must specify an API Key, either via a configuration file or the DD_API_KEY env var")
 
 // Endpoint specifies an endpoint that the trace agent will write data (traces, stats & services) to.
+// CredentialProvider supplies the credential for one destination. It mirrors
+// comp/core/delegatedauth's Provider; see CredentialProviderFn for why it is redeclared here.
+type CredentialProvider interface {
+	// Authorize stamps the credential onto h and reports whether it did. A false return means
+	// no credential is available yet and the caller must not send.
+	Authorize(h http.Header) bool
+}
+
 type Endpoint struct {
 	APIKey string `json:"-"` // never marshal this
 	Host   string
+
+	// CredentialDirective is the DELA(...) text this endpoint was built from, empty for an
+	// endpoint with a plain API key. With ConfigSettingPath and Host it identifies which
+	// credential is this endpoint's, where the host alone would be ambiguous across orgs.
+	CredentialDirective string `mapstructure:"-" json:"-"`
+
+	// ConfigSettingPath is the config setting this endpoint was built from, e.g.
+	// "apm_config.additional_endpoints". With Host it identifies the endpoint to
+	// AgentConfig.CredentialProviderFn.
+	ConfigSettingPath string `mapstructure:"-" json:"-"`
 
 	// NoProxy will be set to true when the proxy setting for the trace API endpoint
 	// needs to be ignored (e.g. it is part of the "no_proxy" list in the yaml settings).
@@ -627,6 +645,12 @@ type AgentConfig struct {
 	// the OPM background fetch. Derived from dd_url / site via utils.GetMainEndpoint.
 	// Empty when EnableOPMFetch is false.
 	OPMValidateURL string
+
+	// CredentialProviderFn resolves the delegated-auth credential provider for an endpoint,
+	// returning nil when that endpoint uses a plain API key. Declared as a func field, like
+	// SecretsRefreshFn below, so pkg/trace stays free of a dependency on comp/core/delegatedauth:
+	// this module is vendored by the OTel Collector distribution and has to stay lean.
+	CredentialProviderFn func(configSettingPath, host, directive string) CredentialProvider `json:"-"`
 
 	// SecretsRefreshFn is called when a 403 response is received to trigger
 	// API key refresh from the secrets backend. It blocks until the refresh

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -7,6 +7,7 @@ go 1.26.0
 // for more details.
 
 require (
+	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.72.0-rc.5
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.72.0-rc.5
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.61.0

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-zstd v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/api v0.72.0-rc.5
 	github.com/DataDog/datadog-agent/pkg/config/env v0.72.0-rc.5
+	github.com/DataDog/datadog-agent/pkg/credential v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.71.0
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.72.0-rc.5
 	github.com/DataDog/datadog-agent/pkg/proto v0.74.1

--- a/pkg/trace/stats/go.mod
+++ b/pkg/trace/stats/go.mod
@@ -19,6 +19,7 @@ require (
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.72.0-rc.5 // indirect
+	github.com/DataDog/datadog-agent/pkg/credential v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.72.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.61.0 // indirect
 	github.com/DataDog/go-sqllexer v0.2.4 // indirect

--- a/pkg/trace/writer/BUILD.bazel
+++ b/pkg/trace/writer/BUILD.bazel
@@ -41,6 +41,7 @@ dd_agent_go_test(
     ],
     embed = [":writer"],
     deps = [
+        "//comp/core/delegatedauth/mock",
         "//comp/trace/compression/def",
         "//comp/trace/compression/impl-gzip",
         "//comp/trace/compression/impl-zstd",

--- a/pkg/trace/writer/BUILD.bazel
+++ b/pkg/trace/writer/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
 dd_agent_go_test(
     name = "writer_test",
     srcs = [
+        "credential_provider_test.go",
         "sender_test.go",
         "stats_test.go",
         "testserver_test.go",

--- a/pkg/trace/writer/BUILD.bazel
+++ b/pkg/trace/writer/BUILD.bazel
@@ -41,7 +41,6 @@ dd_agent_go_test(
     ],
     embed = [":writer"],
     deps = [
-        "//comp/core/delegatedauth/mock",
         "//comp/trace/compression/def",
         "//comp/trace/compression/impl-gzip",
         "//comp/trace/compression/impl-zstd",

--- a/pkg/trace/writer/BUILD.bazel
+++ b/pkg/trace/writer/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/trace/compression/def",
+        "//pkg/credential",
         "//pkg/proto/pbgo/trace",
         "//pkg/proto/pbgo/trace/idx",
         "//pkg/trace/config",

--- a/pkg/trace/writer/BUILD.bazel
+++ b/pkg/trace/writer/BUILD.bazel
@@ -40,6 +40,7 @@ dd_agent_go_test(
     ],
     embed = [":writer"],
     deps = [
+        "//comp/core/delegatedauth/mock",
         "//comp/trace/compression/def",
         "//comp/trace/compression/impl-gzip",
         "//comp/trace/compression/impl-zstd",

--- a/pkg/trace/writer/credential_provider_test.go
+++ b/pkg/trace/writer/credential_provider_test.go
@@ -17,26 +17,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
+	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 )
 
 // resetClient wraps a test server's client in the ResetClient the sender expects.
 func resetClient(c *http.Client) *config.ResetClient {
 	return config.NewResetClient(0, func() *http.Client { return c })
-}
-
-// stubProvider is a CredentialProvider whose readiness the test controls.
-type stubProvider struct {
-	key   string
-	ready atomic.Bool
-}
-
-func (p *stubProvider) Authorize(h http.Header) bool {
-	if !p.ready.Load() {
-		return false
-	}
-	h.Set("DD-Api-Key", p.key)
-	return true
 }
 
 // An endpoint with a plain API key must be unaffected by any of this.
@@ -50,8 +37,8 @@ func TestAuthorizeStampsThePlainAPIKeyWhenThereIsNoProvider(t *testing.T) {
 
 // A provider replaces the API key entirely - the endpoint has no key of its own to fall back to.
 func TestAuthorizeUsesTheProviderWhenOneIsSet(t *testing.T) {
-	p := &stubProvider{key: "delegated-key"}
-	p.ready.Store(true)
+	p := &delegatedauthmock.StubProvider{Key: "delegated-key"}
+	p.SetReady(true)
 	m := &apiKeyManager{provider: p}
 
 	h := http.Header{}
@@ -60,7 +47,7 @@ func TestAuthorizeUsesTheProviderWhenOneIsSet(t *testing.T) {
 }
 
 func TestAuthorizeReportsNotReadyWhileTheCredentialIsResolving(t *testing.T) {
-	m := &apiKeyManager{provider: &stubProvider{key: "delegated-key"}}
+	m := &apiKeyManager{provider: &delegatedauthmock.StubProvider{Key: "delegated-key"}}
 
 	h := http.Header{}
 	assert.False(t, m.Authorize(h))
@@ -79,7 +66,7 @@ func TestDoDoesNotSendWithoutACredential(t *testing.T) {
 
 	s := &sender{
 		cfg:           &senderConfig{client: resetClient(srv.Client()), userAgent: "test"},
-		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
+		apiKeyManager: &apiKeyManager{provider: &delegatedauthmock.StubProvider{Key: "delegated-key"}},
 	}
 	req, err := http.NewRequest(http.MethodPost, srv.URL, http.NoBody)
 	require.NoError(t, err)
@@ -100,7 +87,7 @@ func TestDoSendsOnceTheCredentialArrives(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := &stubProvider{key: "delegated-key"}
+	p := &delegatedauthmock.StubProvider{Key: "delegated-key"}
 	s := &sender{
 		cfg:           &senderConfig{client: resetClient(srv.Client()), userAgent: "test"},
 		apiKeyManager: &apiKeyManager{provider: p},
@@ -110,7 +97,7 @@ func TestDoSendsOnceTheCredentialArrives(t *testing.T) {
 	require.NoError(t, err)
 	require.IsType(t, &credentialNotReadyError{}, s.do(req))
 
-	p.ready.Store(true)
+	p.SetReady(true)
 
 	req, err = http.NewRequest(http.MethodPost, srv.URL, http.NoBody)
 	require.NoError(t, err)
@@ -129,7 +116,7 @@ func TestWaitingForACredentialDoesNotExhaustRetries(t *testing.T) {
 
 	s := &sender{
 		cfg:           &senderConfig{client: resetClient(srv.Client()), userAgent: "test", url: mustParseURL(t, srv.URL), recorder: &mockRecorder{}},
-		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
+		apiKeyManager: &apiKeyManager{provider: &delegatedauthmock.StubProvider{Key: "delegated-key"}},
 		maxRetries:    3,
 		inflight:      atomic.NewInt32(0),
 		enabled:       atomic.NewBool(true),
@@ -147,7 +134,7 @@ func TestWaitingForACredentialDoesNotExhaustRetries(t *testing.T) {
 func TestPayloadIsReleasedWhenTheSenderClosesWhileWaiting(t *testing.T) {
 	s := &sender{
 		cfg:           &senderConfig{client: resetClient(http.DefaultClient), userAgent: "test", url: mustParseURL(t, "http://localhost:0"), recorder: &mockRecorder{}},
-		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
+		apiKeyManager: &apiKeyManager{provider: &delegatedauthmock.StubProvider{Key: "delegated-key"}},
 		maxRetries:    3,
 		closed:        true,
 		inflight:      atomic.NewInt32(0),
@@ -183,7 +170,7 @@ func TestAuthorizeRefusesWhenThereIsNeitherProviderNorKey(t *testing.T) {
 func TestPushDoesNotBlockOnASenderAwaitingACredential(t *testing.T) {
 	s := &sender{
 		cfg:           &senderConfig{maxQueued: 1},
-		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
+		apiKeyManager: &apiKeyManager{provider: &delegatedauthmock.StubProvider{Key: "delegated-key"}},
 		queue:         make(chan *payload, 1),
 		inflight:      atomic.NewInt32(0),
 		enabled:       atomic.NewBool(true),

--- a/pkg/trace/writer/credential_provider_test.go
+++ b/pkg/trace/writer/credential_provider_test.go
@@ -1,0 +1,234 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package writer
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+)
+
+// resetClient wraps a test server's client in the ResetClient the sender expects.
+func resetClient(c *http.Client) *config.ResetClient {
+	return config.NewResetClient(0, func() *http.Client { return c })
+}
+
+// stubProvider is a CredentialProvider whose readiness the test controls.
+type stubProvider struct {
+	key   string
+	ready atomic.Bool
+}
+
+func (p *stubProvider) Authorize(h http.Header) bool {
+	if !p.ready.Load() {
+		return false
+	}
+	h.Set("DD-Api-Key", p.key)
+	return true
+}
+
+// An endpoint with a plain API key must be unaffected by any of this.
+func TestAuthorizeStampsThePlainAPIKeyWhenThereIsNoProvider(t *testing.T) {
+	m := &apiKeyManager{apiKey: "plain-key"}
+
+	h := http.Header{}
+	require.True(t, m.Authorize(h))
+	assert.Equal(t, "plain-key", h.Get("DD-Api-Key"))
+}
+
+// A provider replaces the API key entirely - the endpoint has no key of its own to fall back to.
+func TestAuthorizeUsesTheProviderWhenOneIsSet(t *testing.T) {
+	p := &stubProvider{key: "delegated-key"}
+	p.ready.Store(true)
+	m := &apiKeyManager{provider: p}
+
+	h := http.Header{}
+	require.True(t, m.Authorize(h))
+	assert.Equal(t, "delegated-key", h.Get("DD-Api-Key"))
+}
+
+func TestAuthorizeReportsNotReadyWhileTheCredentialIsResolving(t *testing.T) {
+	m := &apiKeyManager{provider: &stubProvider{key: "delegated-key"}}
+
+	h := http.Header{}
+	assert.False(t, m.Authorize(h))
+	assert.Empty(t, h, "nothing may be stamped when there is no credential")
+}
+
+// The payload must not reach the intake before a credential exists, and do must say so with the
+// error type that holds it rather than one that burns a retry.
+func TestDoDoesNotSendWithoutACredential(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := &sender{
+		cfg:           &senderConfig{client: resetClient(srv.Client()), userAgent: "test"},
+		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, http.NoBody)
+	require.NoError(t, err)
+
+	err = s.do(req)
+
+	require.IsType(t, &credentialNotReadyError{}, err,
+		"must not be a retriableError, which would count against maxRetries and drop the payload")
+	assert.Zero(t, requests.Load(), "nothing may reach the intake without a credential")
+}
+
+// Once the credential lands the same sender starts sending, with no rebuild.
+func TestDoSendsOnceTheCredentialArrives(t *testing.T) {
+	var gotKey atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey.Store(r.Header.Get("DD-Api-Key"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := &stubProvider{key: "delegated-key"}
+	s := &sender{
+		cfg:           &senderConfig{client: resetClient(srv.Client()), userAgent: "test"},
+		apiKeyManager: &apiKeyManager{provider: p},
+	}
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL, http.NoBody)
+	require.NoError(t, err)
+	require.IsType(t, &credentialNotReadyError{}, s.do(req))
+
+	p.ready.Store(true)
+
+	req, err = http.NewRequest(http.MethodPost, srv.URL, http.NoBody)
+	require.NoError(t, err)
+	require.NoError(t, s.do(req))
+	assert.Equal(t, "delegated-key", gotKey.Load())
+}
+
+// The point of the separate error type: a payload waiting on a credential must survive more
+// attempts than maxRetries, because the wait is not a delivery failure. With a retriableError it
+// would be dropped after maxRetries and the data lost during startup.
+func TestWaitingForACredentialDoesNotExhaustRetries(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := &sender{
+		cfg:           &senderConfig{client: resetClient(srv.Client()), userAgent: "test", url: mustParseURL(t, srv.URL), recorder: &mockRecorder{}},
+		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
+		maxRetries:    3,
+		inflight:      atomic.NewInt32(0),
+		enabled:       atomic.NewBool(true),
+	}
+	p := newPayload(nil)
+
+	for i := 0; i < 10; i++ {
+		require.False(t, s.sendOnce(p), "attempt %d must keep the payload queued, not drop it", i)
+	}
+	assert.Zero(t, p.retries.Load(), "waiting on a credential must not consume retries")
+}
+
+// A sender shutting down must not hold payloads forever waiting for a credential that will never
+// come; it drops them like the retriable path does.
+func TestPayloadIsReleasedWhenTheSenderClosesWhileWaiting(t *testing.T) {
+	s := &sender{
+		cfg:           &senderConfig{client: resetClient(http.DefaultClient), userAgent: "test", url: mustParseURL(t, "http://localhost:0"), recorder: &mockRecorder{}},
+		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
+		maxRetries:    3,
+		closed:        true,
+		inflight:      atomic.NewInt32(0),
+		enabled:       atomic.NewBool(true),
+	}
+	p := newPayload(nil)
+
+	assert.True(t, s.sendOnce(p), "a closed sender must let the payload go rather than wait forever")
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+// An endpoint built from a directive that never produced an instance - an unsupported cloud
+// provider, or a consumer with no provider wiring - has neither a provider nor a key. Stamping the
+// empty key would send that org's payload to its intake unauthenticated.
+func TestAuthorizeRefusesWhenThereIsNeitherProviderNorKey(t *testing.T) {
+	m := &apiKeyManager{}
+
+	h := http.Header{}
+	assert.False(t, m.Authorize(h))
+	assert.Empty(t, h, "an empty API key must never be stamped")
+}
+
+// sendPayloads pushes to each sender in turn, and the queue is only one deep, so a blocking send
+// on a full queue stalls every sender after it. A sender whose credential never arrives stays full
+// indefinitely, which used to stop trace delivery to the primary org entirely. Pushing to such a
+// sender must drop for that endpoint alone instead of blocking.
+func TestPushDoesNotBlockOnASenderAwaitingACredential(t *testing.T) {
+	s := &sender{
+		cfg:           &senderConfig{maxQueued: 1},
+		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
+		queue:         make(chan *payload, 1),
+		inflight:      atomic.NewInt32(0),
+		enabled:       atomic.NewBool(true),
+		statsd:        &statsd.NoOpClient{},
+	}
+	s.awaitingCredential.Store(true)
+	s.queue <- newPayload(nil) // queue is now full
+
+	done := make(chan struct{})
+	go func() {
+		s.Push(newPayload(nil))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Push blocked on a sender with no credential; this stalls delivery to every other endpoint")
+	}
+}
+
+// The drop above must be limited to the no-credential case: an ordinary busy sender must keep its
+// blocking behaviour, which is what applies backpressure instead of losing traces.
+func TestPushStillBlocksForAnOrdinaryFullSender(t *testing.T) {
+	s := &sender{
+		cfg:           &senderConfig{maxQueued: 1},
+		apiKeyManager: &apiKeyManager{apiKey: "plain-key"},
+		queue:         make(chan *payload, 1),
+		inflight:      atomic.NewInt32(0),
+		enabled:       atomic.NewBool(true),
+		statsd:        &statsd.NoOpClient{},
+	}
+	s.queue <- newPayload(nil)
+
+	pushed := make(chan struct{})
+	go func() {
+		s.Push(newPayload(nil))
+		close(pushed)
+	}()
+
+	select {
+	case <-pushed:
+		t.Fatal("a healthy full sender must block to apply backpressure, not drop")
+	case <-time.After(100 * time.Millisecond):
+	}
+	<-s.queue // unblock the goroutine
+	<-pushed
+}

--- a/pkg/trace/writer/credential_provider_test.go
+++ b/pkg/trace/writer/credential_provider_test.go
@@ -39,6 +39,8 @@ func (p *stubProvider) Authorize(h http.Header) bool {
 	return true
 }
 
+func (p *stubProvider) Refresh() bool { return false }
+
 // An endpoint with a plain API key must be unaffected by any of this.
 func TestAuthorizeStampsThePlainAPIKeyWhenThereIsNoProvider(t *testing.T) {
 	m := &apiKeyManager{apiKey: "plain-key"}

--- a/pkg/trace/writer/credential_provider_test.go
+++ b/pkg/trace/writer/credential_provider_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
+	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 )
 
@@ -24,22 +25,6 @@ import (
 func resetClient(c *http.Client) *config.ResetClient {
 	return config.NewResetClient(0, func() *http.Client { return c })
 }
-
-// stubProvider is a CredentialProvider whose readiness the test controls.
-type stubProvider struct {
-	key   string
-	ready atomic.Bool
-}
-
-func (p *stubProvider) Authorize(h http.Header) bool {
-	if !p.ready.Load() {
-		return false
-	}
-	h.Set("DD-Api-Key", p.key)
-	return true
-}
-
-func (p *stubProvider) Refresh() bool { return false }
 
 // An endpoint with a plain API key must be unaffected by any of this.
 func TestAuthorizeStampsThePlainAPIKeyWhenThereIsNoProvider(t *testing.T) {
@@ -52,8 +37,8 @@ func TestAuthorizeStampsThePlainAPIKeyWhenThereIsNoProvider(t *testing.T) {
 
 // A provider replaces the API key entirely - the endpoint has no key of its own to fall back to.
 func TestAuthorizeUsesTheProviderWhenOneIsSet(t *testing.T) {
-	p := &stubProvider{key: "delegated-key"}
-	p.ready.Store(true)
+	p := &delegatedauthmock.StubProvider{Key: "delegated-key"}
+	p.SetReady(true)
 	m := &apiKeyManager{provider: p}
 
 	h := http.Header{}
@@ -62,7 +47,7 @@ func TestAuthorizeUsesTheProviderWhenOneIsSet(t *testing.T) {
 }
 
 func TestAuthorizeReportsNotReadyWhileTheCredentialIsResolving(t *testing.T) {
-	m := &apiKeyManager{provider: &stubProvider{key: "delegated-key"}}
+	m := &apiKeyManager{provider: &delegatedauthmock.StubProvider{Key: "delegated-key"}}
 
 	h := http.Header{}
 	assert.False(t, m.Authorize(h))
@@ -81,7 +66,7 @@ func TestDoDoesNotSendWithoutACredential(t *testing.T) {
 
 	s := &sender{
 		cfg:           &senderConfig{client: resetClient(srv.Client()), userAgent: "test"},
-		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
+		apiKeyManager: &apiKeyManager{provider: &delegatedauthmock.StubProvider{Key: "delegated-key"}},
 	}
 	req, err := http.NewRequest(http.MethodPost, srv.URL, http.NoBody)
 	require.NoError(t, err)
@@ -102,7 +87,7 @@ func TestDoSendsOnceTheCredentialArrives(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := &stubProvider{key: "delegated-key"}
+	p := &delegatedauthmock.StubProvider{Key: "delegated-key"}
 	s := &sender{
 		cfg:           &senderConfig{client: resetClient(srv.Client()), userAgent: "test"},
 		apiKeyManager: &apiKeyManager{provider: p},
@@ -112,7 +97,7 @@ func TestDoSendsOnceTheCredentialArrives(t *testing.T) {
 	require.NoError(t, err)
 	require.IsType(t, &credentialNotReadyError{}, s.do(req))
 
-	p.ready.Store(true)
+	p.SetReady(true)
 
 	req, err = http.NewRequest(http.MethodPost, srv.URL, http.NoBody)
 	require.NoError(t, err)
@@ -131,7 +116,7 @@ func TestWaitingForACredentialDoesNotExhaustRetries(t *testing.T) {
 
 	s := &sender{
 		cfg:           &senderConfig{client: resetClient(srv.Client()), userAgent: "test", url: mustParseURL(t, srv.URL), recorder: &mockRecorder{}},
-		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
+		apiKeyManager: &apiKeyManager{provider: &delegatedauthmock.StubProvider{Key: "delegated-key"}},
 		maxRetries:    3,
 		inflight:      atomic.NewInt32(0),
 		enabled:       atomic.NewBool(true),
@@ -149,7 +134,7 @@ func TestWaitingForACredentialDoesNotExhaustRetries(t *testing.T) {
 func TestPayloadIsReleasedWhenTheSenderClosesWhileWaiting(t *testing.T) {
 	s := &sender{
 		cfg:           &senderConfig{client: resetClient(http.DefaultClient), userAgent: "test", url: mustParseURL(t, "http://localhost:0"), recorder: &mockRecorder{}},
-		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
+		apiKeyManager: &apiKeyManager{provider: &delegatedauthmock.StubProvider{Key: "delegated-key"}},
 		maxRetries:    3,
 		closed:        true,
 		inflight:      atomic.NewInt32(0),
@@ -185,7 +170,7 @@ func TestAuthorizeRefusesWhenThereIsNeitherProviderNorKey(t *testing.T) {
 func TestPushDoesNotBlockOnASenderAwaitingACredential(t *testing.T) {
 	s := &sender{
 		cfg:           &senderConfig{maxQueued: 1},
-		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
+		apiKeyManager: &apiKeyManager{provider: &delegatedauthmock.StubProvider{Key: "delegated-key"}},
 		queue:         make(chan *payload, 1),
 		inflight:      atomic.NewInt32(0),
 		enabled:       atomic.NewBool(true),

--- a/pkg/trace/writer/credential_provider_test.go
+++ b/pkg/trace/writer/credential_provider_test.go
@@ -17,13 +17,26 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
-	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 )
 
 // resetClient wraps a test server's client in the ResetClient the sender expects.
 func resetClient(c *http.Client) *config.ResetClient {
 	return config.NewResetClient(0, func() *http.Client { return c })
+}
+
+// stubProvider is a CredentialProvider whose readiness the test controls.
+type stubProvider struct {
+	key   string
+	ready atomic.Bool
+}
+
+func (p *stubProvider) Authorize(h http.Header) bool {
+	if !p.ready.Load() {
+		return false
+	}
+	h.Set("DD-Api-Key", p.key)
+	return true
 }
 
 // An endpoint with a plain API key must be unaffected by any of this.
@@ -37,8 +50,8 @@ func TestAuthorizeStampsThePlainAPIKeyWhenThereIsNoProvider(t *testing.T) {
 
 // A provider replaces the API key entirely - the endpoint has no key of its own to fall back to.
 func TestAuthorizeUsesTheProviderWhenOneIsSet(t *testing.T) {
-	p := &delegatedauthmock.StubProvider{Key: "delegated-key"}
-	p.SetReady(true)
+	p := &stubProvider{key: "delegated-key"}
+	p.ready.Store(true)
 	m := &apiKeyManager{provider: p}
 
 	h := http.Header{}
@@ -47,7 +60,7 @@ func TestAuthorizeUsesTheProviderWhenOneIsSet(t *testing.T) {
 }
 
 func TestAuthorizeReportsNotReadyWhileTheCredentialIsResolving(t *testing.T) {
-	m := &apiKeyManager{provider: &delegatedauthmock.StubProvider{Key: "delegated-key"}}
+	m := &apiKeyManager{provider: &stubProvider{key: "delegated-key"}}
 
 	h := http.Header{}
 	assert.False(t, m.Authorize(h))
@@ -66,7 +79,7 @@ func TestDoDoesNotSendWithoutACredential(t *testing.T) {
 
 	s := &sender{
 		cfg:           &senderConfig{client: resetClient(srv.Client()), userAgent: "test"},
-		apiKeyManager: &apiKeyManager{provider: &delegatedauthmock.StubProvider{Key: "delegated-key"}},
+		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
 	}
 	req, err := http.NewRequest(http.MethodPost, srv.URL, http.NoBody)
 	require.NoError(t, err)
@@ -87,7 +100,7 @@ func TestDoSendsOnceTheCredentialArrives(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := &delegatedauthmock.StubProvider{Key: "delegated-key"}
+	p := &stubProvider{key: "delegated-key"}
 	s := &sender{
 		cfg:           &senderConfig{client: resetClient(srv.Client()), userAgent: "test"},
 		apiKeyManager: &apiKeyManager{provider: p},
@@ -97,7 +110,7 @@ func TestDoSendsOnceTheCredentialArrives(t *testing.T) {
 	require.NoError(t, err)
 	require.IsType(t, &credentialNotReadyError{}, s.do(req))
 
-	p.SetReady(true)
+	p.ready.Store(true)
 
 	req, err = http.NewRequest(http.MethodPost, srv.URL, http.NoBody)
 	require.NoError(t, err)
@@ -116,7 +129,7 @@ func TestWaitingForACredentialDoesNotExhaustRetries(t *testing.T) {
 
 	s := &sender{
 		cfg:           &senderConfig{client: resetClient(srv.Client()), userAgent: "test", url: mustParseURL(t, srv.URL), recorder: &mockRecorder{}},
-		apiKeyManager: &apiKeyManager{provider: &delegatedauthmock.StubProvider{Key: "delegated-key"}},
+		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
 		maxRetries:    3,
 		inflight:      atomic.NewInt32(0),
 		enabled:       atomic.NewBool(true),
@@ -134,7 +147,7 @@ func TestWaitingForACredentialDoesNotExhaustRetries(t *testing.T) {
 func TestPayloadIsReleasedWhenTheSenderClosesWhileWaiting(t *testing.T) {
 	s := &sender{
 		cfg:           &senderConfig{client: resetClient(http.DefaultClient), userAgent: "test", url: mustParseURL(t, "http://localhost:0"), recorder: &mockRecorder{}},
-		apiKeyManager: &apiKeyManager{provider: &delegatedauthmock.StubProvider{Key: "delegated-key"}},
+		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
 		maxRetries:    3,
 		closed:        true,
 		inflight:      atomic.NewInt32(0),
@@ -170,7 +183,7 @@ func TestAuthorizeRefusesWhenThereIsNeitherProviderNorKey(t *testing.T) {
 func TestPushDoesNotBlockOnASenderAwaitingACredential(t *testing.T) {
 	s := &sender{
 		cfg:           &senderConfig{maxQueued: 1},
-		apiKeyManager: &apiKeyManager{provider: &delegatedauthmock.StubProvider{Key: "delegated-key"}},
+		apiKeyManager: &apiKeyManager{provider: &stubProvider{key: "delegated-key"}},
 		queue:         make(chan *payload, 1),
 		inflight:      atomic.NewInt32(0),
 		enabled:       atomic.NewBool(true),
@@ -218,14 +231,4 @@ func TestPushStillBlocksForAnOrdinaryFullSender(t *testing.T) {
 	}
 	<-s.queue // unblock the goroutine
 	<-pushed
-}
-
-// An endpoint with an ENC[...] key resolved by the secrets backend must be unaffected by the
-// provider path. The apiKeyManager has no provider set, so Authorize stamps the resolved key.
-func TestAuthorizeStampsResolvedEncKeyWhenThereIsNoProvider(t *testing.T) {
-	m := &apiKeyManager{apiKey: "resolved-enc-key"}
-
-	h := http.Header{}
-	require.True(t, m.Authorize(h))
-	assert.Equal(t, "resolved-enc-key", h.Get("DD-Api-Key"))
 }

--- a/pkg/trace/writer/credential_provider_test.go
+++ b/pkg/trace/writer/credential_provider_test.go
@@ -219,3 +219,13 @@ func TestPushStillBlocksForAnOrdinaryFullSender(t *testing.T) {
 	<-s.queue // unblock the goroutine
 	<-pushed
 }
+
+// An endpoint with an ENC[...] key resolved by the secrets backend must be unaffected by the
+// provider path. The apiKeyManager has no provider set, so Authorize stamps the resolved key.
+func TestAuthorizeStampsResolvedEncKeyWhenThereIsNoProvider(t *testing.T) {
+	m := &apiKeyManager{apiKey: "resolved-enc-key"}
+
+	h := http.Header{}
+	require.True(t, m.Authorize(h))
+	assert.Equal(t, "resolved-enc-key", h.Get("DD-Api-Key"))
+}

--- a/pkg/trace/writer/credential_provider_test.go
+++ b/pkg/trace/writer/credential_provider_test.go
@@ -232,3 +232,13 @@ func TestPushStillBlocksForAnOrdinaryFullSender(t *testing.T) {
 	<-s.queue // unblock the goroutine
 	<-pushed
 }
+
+// An endpoint with an ENC[...] key resolved by the secrets backend must be unaffected by the
+// provider path. The apiKeyManager has no provider set, so Authorize stamps the resolved key.
+func TestAuthorizeStampsResolvedEncKeyWhenThereIsNoProvider(t *testing.T) {
+	m := &apiKeyManager{apiKey: "resolved-enc-key"}
+
+	h := http.Header{}
+	require.True(t, m.Authorize(h))
+	assert.Equal(t, "resolved-enc-key", h.Get("DD-Api-Key"))
+}

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -362,6 +362,11 @@ func (s *sender) Push(p *payload) {
 		// for that endpoint alone rather than blocking the others.
 		if s.awaitingCredential.Load() {
 			_ = s.statsd.Count("datadog.trace_agent.sender.payload_dropped_awaiting_credential", 1, nil, 1)
+			// Return the payload to the pool and record the drop so the writer recorder reports
+			// the loss. Without this the buffer leaks (GC pressure) and telemetry underreports.
+			stats := &eventData{}
+			s.recordEvent(eventTypeDropped, stats)
+			ppool.Put(p)
 			return
 		}
 		_ = s.statsd.Count("datadog.trace_agent.sender.push_blocked", 1, nil, 1)

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -23,6 +23,7 @@ import (
 
 	"go.uber.org/atomic"
 
+	"github.com/DataDog/datadog-agent/pkg/credential"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
@@ -198,18 +199,7 @@ type apiKeyManager struct {
 // Authorize stamps this endpoint's credential onto h and reports whether it did. It returns false
 // only for a delegated-auth endpoint whose credential has not arrived yet.
 func (m *apiKeyManager) Authorize(h http.Header) bool {
-	if m.provider != nil {
-		return m.provider.Authorize(h)
-	}
-	// No provider and no key means the endpoint was built from a directive that never produced
-	// an instance - an unsupported provider, or a consumer with no provider wiring. Stamping the
-	// empty key would send the payload to that org's intake unauthenticated, so refuse instead.
-	key := m.Get()
-	if key == "" {
-		return false
-	}
-	h.Set(headerAPIKey, key)
-	return true
+	return credential.StampAuth(h, m.provider, m.Get())
 }
 
 func (m *apiKeyManager) Get() string {
@@ -525,7 +515,6 @@ type retriableError struct{ err error }
 func (e retriableError) Error() string { return e.err.Error() }
 
 const (
-	headerAPIKey    = "DD-Api-Key"
 	headerUserAgent = "User-Agent"
 )
 

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -23,6 +23,7 @@ import (
 
 	"go.uber.org/atomic"
 
+	"github.com/DataDog/datadog-agent/pkg/credential"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
@@ -192,24 +193,13 @@ type apiKeyManager struct {
 
 	// provider, when set, supplies this endpoint's credential instead of apiKey. It may have no
 	// credential yet, in which case the payload waits rather than being sent unauthenticated.
-	provider config.CredentialProvider
+	provider credential.Provider
 }
 
 // Authorize stamps this endpoint's credential onto h and reports whether it did. It returns false
 // only for a delegated-auth endpoint whose credential has not arrived yet.
 func (m *apiKeyManager) Authorize(h http.Header) bool {
-	if m.provider != nil {
-		return m.provider.Authorize(h)
-	}
-	// No provider and no key means the endpoint was built from a directive that never produced
-	// an instance - an unsupported provider, or a consumer with no provider wiring. Stamping the
-	// empty key would send the payload to that org's intake unauthenticated, so refuse instead.
-	key := m.Get()
-	if key == "" {
-		return false
-	}
-	h.Set(headerAPIKey, key)
-	return true
+	return credential.StampAuth(h, m.provider, m.Get())
 }
 
 func (m *apiKeyManager) Get() string {
@@ -520,7 +510,6 @@ type retriableError struct{ err error }
 func (e retriableError) Error() string { return e.err.Error() }
 
 const (
-	headerAPIKey    = "DD-Api-Key"
 	headerUserAgent = "User-Agent"
 )
 

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -23,7 +23,6 @@ import (
 
 	"go.uber.org/atomic"
 
-	"github.com/DataDog/datadog-agent/pkg/credential"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
@@ -199,7 +198,18 @@ type apiKeyManager struct {
 // Authorize stamps this endpoint's credential onto h and reports whether it did. It returns false
 // only for a delegated-auth endpoint whose credential has not arrived yet.
 func (m *apiKeyManager) Authorize(h http.Header) bool {
-	return credential.StampAuth(h, m.provider, m.Get())
+	if m.provider != nil {
+		return m.provider.Authorize(h)
+	}
+	// No provider and no key means the endpoint was built from a directive that never produced
+	// an instance - an unsupported provider, or a consumer with no provider wiring. Stamping the
+	// empty key would send the payload to that org's intake unauthenticated, so refuse instead.
+	key := m.Get()
+	if key == "" {
+		return false
+	}
+	h.Set(headerAPIKey, key)
+	return true
 }
 
 func (m *apiKeyManager) Get() string {
@@ -352,11 +362,6 @@ func (s *sender) Push(p *payload) {
 		// for that endpoint alone rather than blocking the others.
 		if s.awaitingCredential.Load() {
 			_ = s.statsd.Count("datadog.trace_agent.sender.payload_dropped_awaiting_credential", 1, nil, 1)
-			// Return the payload to the pool and record the drop so the writer recorder reports
-			// the loss. Without this the buffer leaks (GC pressure) and telemetry underreports.
-			stats := &eventData{}
-			s.recordEvent(eventTypeDropped, stats)
-			ppool.Put(p)
 			return
 		}
 		_ = s.statsd.Count("datadog.trace_agent.sender.push_blocked", 1, nil, 1)
@@ -515,6 +520,7 @@ type retriableError struct{ err error }
 func (e retriableError) Error() string { return e.err.Error() }
 
 const (
+	headerAPIKey    = "DD-Api-Key"
 	headerUserAgent = "User-Agent"
 )
 

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -62,6 +62,9 @@ func newSenders(cfg *config.AgentConfig, r eventRecorder, path string, climit, q
 			throttleInterval: cfg.APIKeyRefreshThrottleInterval,
 			isFromSecret:     cfg.APIKeyIsFromSecretFn,
 		}
+		if cfg.CredentialProviderFn != nil {
+			apiKeyManager.provider = cfg.CredentialProviderFn(endpoint.ConfigSettingPath, endpoint.Host, endpoint.CredentialDirective)
+		}
 
 		senders[i] = newSender(scfg, apiKeyManager, statsd)
 	}
@@ -186,12 +189,42 @@ type apiKeyManager struct {
 
 	// lastRefresh tracks when the last refresh occurred
 	lastRefresh time.Time
+
+	// provider, when set, supplies this endpoint's credential instead of apiKey. It may have no
+	// credential yet, in which case the payload waits rather than being sent unauthenticated.
+	provider config.CredentialProvider
+}
+
+// Authorize stamps this endpoint's credential onto h and reports whether it did. It returns false
+// only for a delegated-auth endpoint whose credential has not arrived yet.
+func (m *apiKeyManager) Authorize(h http.Header) bool {
+	if m.provider != nil {
+		return m.provider.Authorize(h)
+	}
+	// No provider and no key means the endpoint was built from a directive that never produced
+	// an instance - an unsupported provider, or a consumer with no provider wiring. Stamping the
+	// empty key would send the payload to that org's intake unauthenticated, so refuse instead.
+	key := m.Get()
+	if key == "" {
+		return false
+	}
+	h.Set(headerAPIKey, key)
+	return true
 }
 
 func (m *apiKeyManager) Get() string {
 	m.RLock()
 	defer m.RUnlock()
 	return m.apiKey
+}
+
+// hasProvider reports whether this sender's credential comes from a delegated-auth Provider
+// rather than a static API key. Push uses it to decide whether an Authorize failure means
+// "buffer until the credential arrives" (provider) or "back-pressure" (static key).
+func (m *apiKeyManager) hasProvider() bool {
+	m.RLock()
+	defer m.RUnlock()
+	return m.provider != nil
 }
 
 func (m *apiKeyManager) Update(newKey string) {
@@ -245,6 +278,10 @@ type sender struct {
 	closed  bool         // closed reports if the loop is stopped
 	statsd  statsd.ClientInterface
 	enabled *atomic.Bool // false on inactive MRF senders. True otherwise
+
+	// awaitingCredential is true while this sender's delegated-auth credential has not arrived.
+	// Push consults it so one unprovisioned endpoint cannot stall delivery to the others.
+	awaitingCredential atomic.Bool
 }
 
 // newSender returns a new sender based on the given config cfg.
@@ -319,6 +356,14 @@ func (s *sender) Push(p *payload) {
 	select {
 	case s.queue <- p:
 	default:
+		// sendPayloads pushes to each sender in turn and the queue is shallow, so a blocking send
+		// here stalls every sender after this one. A sender whose credential has not arrived can
+		// stay full indefinitely, which would stop delivery to the primary org outright, so drop
+		// for that endpoint alone rather than blocking the others.
+		if s.awaitingCredential.Load() {
+			_ = s.statsd.Count("datadog.trace_agent.sender.payload_dropped_awaiting_credential", 1, nil, 1)
+			return
+		}
 		_ = s.statsd.Count("datadog.trace_agent.sender.push_blocked", 1, nil, 1)
 		s.queue <- p
 	}
@@ -357,6 +402,17 @@ func (s *sender) sendOnce(p *payload) bool {
 		log.Tracef("Error submitting payload: %v\n", err)
 	}
 	switch err.(type) {
+	case *credentialNotReadyError:
+		// Hold the payload without consuming a retry, so it is still here when the credential
+		// lands. Dropping on sender shutdown matches the retriable path.
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		if s.closed {
+			s.releasePayload(p, eventTypeDropped, stats)
+			return true
+		}
+		s.recordEvent(eventTypeRetry, stats)
+		return false
 	case *retriableError:
 		// request failed again, but can be retried
 		s.mu.RLock()
@@ -446,6 +502,17 @@ func (s *sender) isEnabled() bool {
 	return false
 }
 
+// credentialNotReadyError means the endpoint's delegated-auth credential has not arrived yet, so
+// nothing was sent. It is deliberately not a retriableError: waiting on a credential is not a
+// failed delivery attempt, and counting it as one would exhaust maxRetries and drop the payload
+// during the very startup window the wait exists to cover.
+type credentialNotReadyError struct{}
+
+// Error implements error.
+func (credentialNotReadyError) Error() string {
+	return "no delegated-auth credential available yet for this endpoint"
+}
+
 // retriableError is an error returned by the server which may be retried at a later time.
 type retriableError struct{ err error }
 
@@ -458,7 +525,22 @@ const (
 )
 
 func (s *sender) do(req *http.Request) error {
-	req.Header.Set(headerAPIKey, s.apiKeyManager.Get())
+	if !s.apiKeyManager.Authorize(req.Header) {
+		if s.apiKeyManager.hasProvider() {
+			// A provider-backed endpoint whose credential hasn't arrived yet. This is transient:
+			// latch so Push drops for this sender alone rather than blocking the shared flusher,
+			// and return a credentialNotReadyError so the payload is requeued without consuming
+			// a retry.
+			s.awaitingCredential.Store(true)
+			return &credentialNotReadyError{}
+		}
+		// No provider and no key: the endpoint was built from a directive that never produced
+		// an instance (malformed, unsupported provider, or noop component). This is a permanent
+		// failure, not a credential that may resolve. Return a fatal error so the payload is
+		// dropped rather than retried forever, which would fill the queue and block the flusher.
+		return errors.New("endpoint has no credential and no delegated-auth provider; it will not send")
+	}
+	s.awaitingCredential.Store(false)
 	req.Header.Set(headerUserAgent, s.cfg.userAgent)
 	resp, err := s.cfg.client.Do(req)
 	if err != nil {

--- a/pkg/trace/writer/sender_test.go
+++ b/pkg/trace/writer/sender_test.go
@@ -195,7 +195,7 @@ func TestSender(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
-			assert.Equal(testAPIKey, req.Header.Get(headerAPIKey))
+			assert.Equal(testAPIKey, req.Header.Get("DD-Api-Key"))
 			assert.Equal("testUserAgent", req.Header.Get(headerUserAgent))
 			wg.Done()
 		}))

--- a/pkg/trace/writer/stats.go
+++ b/pkg/trace/writer/stats.go
@@ -106,6 +106,11 @@ func NewStatsWriter(
 // UpdateAPIKey updates the API Key, if needed, on Stats Writer senders.
 func (w *DatadogStatsWriter) UpdateAPIKey(oldKey, newKey string) {
 	for _, s := range w.senders {
+		// A provider-backed sender has apiKey == ""; oldKey == "" would match it.
+		// See TraceWriter.UpdateAPIKey for the full rationale.
+		if s.apiKeyManager.hasProvider() {
+			continue
+		}
 		if oldKey == s.apiKeyManager.Get() {
 			s.apiKeyManager.Update(newKey)
 			log.Debugf("API Key updated for stats endpoint=%s", s.cfg.url)

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -154,6 +154,12 @@ func NewTraceWriter(
 // UpdateAPIKey updates the API Key, if needed, on Trace Writer senders.
 func (w *TraceWriter) UpdateAPIKey(oldKey, newKey string) {
 	for _, s := range w.senders {
+		// A provider-backed sender has apiKey == ""; oldKey == "" would match it and overwrite
+		// the (irrelevant) static key, but more importantly it signals that the sender's
+		// credential comes from a Provider, not from this rotation. Skip it.
+		if s.apiKeyManager.hasProvider() {
+			continue
+		}
 		if oldKey == s.apiKeyManager.Get() {
 			s.apiKeyManager.Update(newKey)
 			log.Debugf("API Key updated for traces endpoint=%s", s.cfg.url)


### PR DESCRIPTION
## Summary

Wire credential providers into the four trace agent proxy paths (evp_proxy, openlineage, profiles, transports) so they can authenticate to DELA-directive endpoints instead of setting a static API key.

### What changed

Each proxy previously set `DD-API-KEY` (or `Authorization: Bearer` for openlineage) directly from the config value. Now each proxy resolves a `CredentialProvider` at construction time via `AgentConfig.CredentialProviderFn`, then calls `authorizeEndpoint` at request time. When the provider returns `false` (credential not yet resolved), the endpoint is skipped rather than sending unauthenticated.

```
evp_proxy          openlineage         profiles           transports
    │                   │                   │                   │
    ▼                   ▼                   ▼                   ▼
resolveCredentialProvider at construction time (via CredentialProviderFn)
    │                   │                   │                   │
    ▼                   ▼                   ▼                   ▼
authorizeEndpoint(e, h) on each request — skip endpoint if false
```

### Files (8)

- `pkg/trace/api/credential.go` (NEW) — shared `authorizeEndpoint` and `resolveCredentialProvider` helpers
- `pkg/trace/api/evp_proxy.go` — resolve providers, use `authorizeEndpoint` in `setTarget`
- `pkg/trace/api/transports.go` — refactored from parallel targets/keys slices to `config.Endpoint`, updated `setTarget`
- `pkg/trace/api/profiles.go` — same pattern, `profilingEndpoints` returns `[]config.Endpoint`
- `pkg/trace/api/openlineage.go` — same pattern, uses `Bearer` auth (not `DD-API-KEY`)
- `pkg/trace/api/symdb.go` — updated caller of `newMeasuringForwardingTransport`
- `pkg/trace/api/debugger.go` — updated caller of `newMeasuringForwardingTransport`
- `pkg/trace/config/config.go` — added `CredentialProvider` field to `Endpoint`

## Architecture doc

See [Delegated Authentication in the Agent: Architecture and Path Forward](https://datadoghq.atlassian.net/wiki/spaces/~62ead694da8620d53392de7c/pages/7140704257/Delegated+Authentication+in+the+Agent+Architecture+and+Path+Forward) for the full design, including the previous approach vs. the new Provider interface, locking, and future work.

## Stacked PRs

```
PR1: #55479  foundation (base: main)
 │
 └──► PR2: #55480  consumers (base: PR1)
       │
       ├──► PR3: #55481  otel (base: PR2)
       │
       ├──► #55564  process + orchestrator (base: PR2)
       │
       └──► This PR (base: PR2)
```

WIF-48