### PR TITLE
Revert "docs(gpu): add known issue for A100 nvlink_fields check delay"

### DIFF
--- a/releasenotes/notes/gpu-a100-nvlink-fields-known-issue-afa6fe8552af5007.yaml
+++ b/releasenotes/notes/gpu-a100-nvlink-fields-known-issue-afa6fe8552af5007.yaml
@@ -1,7 +1,0 @@
----
-issues:
-  - |
-    GPU Monitoring: 7.83 and previous versions could see longer check run times under
-    specific workloads on A100 GPUs. If GPU metrics are appearing delayed, set
-    ``gpu.disabled_collectors: [nvlink_fields]`` to mitigate the issue. This will be
-    fixed in a future release.


### PR DESCRIPTION
Reverts DataDog/datadog-agent#55366, as the issue is fixed with #55579 