### PR TITLE
Deflake `TestStopDrainsBeforeFlush`: count only sketches reaching intake

### DIFF
--- a/pkg/serverless/metrics/BUILD.bazel
+++ b/pkg/serverless/metrics/BUILD.bazel
@@ -35,6 +35,7 @@ dd_agent_go_test(
         "//comp/core/tagger/impl-noop",
         "//comp/filterlist/fx-mock",
         "//comp/forwarder/defaultforwarder/def",
+        "//comp/forwarder/defaultforwarder/endpoints",
         "//comp/forwarder/defaultforwarder/noop-impl",
         "//comp/forwarder/defaultforwarder/resolver",
         "//comp/forwarder/defaultforwarder/transaction",

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
@@ -30,6 +29,7 @@ import (
 	nooptagger "github.com/DataDog/datadog-agent/comp/core/tagger/impl-noop"
 	filterlistmock "github.com/DataDog/datadog-agent/comp/filterlist/fx-mock"
 	defaultforwarder "github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/def"
+	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/endpoints"
 	defaultforwardernoop "github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/noop-impl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/resolver"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
@@ -87,9 +87,9 @@ func (f *countingForwarder) GetDomainResolvers() []resolver.DomainResolver {
 	return f.resolvers
 }
 
-// SubmitTransaction increments the sketch counter when a sketch-series transaction arrives.
+// SubmitTransaction increments the sketch counter when a sketch-series transaction reaches the intake.
 func (f *countingForwarder) SubmitTransaction(txn *transaction.HTTPTransaction) error {
-	if strings.Contains(txn.Endpoint.Name, "sketch") {
+	if txn.Endpoint.Name == endpoints.SketchSeriesEndpoint.Name {
 		f.sketchCount.Add(1)
 	}
 	return nil


### PR DESCRIPTION
### What does this PR do?
Match `countingForwarder`'s sketch counter on the sketch-series intake endpoint instead of any endpoint whose name contains "sketch".

### Motivation
Despite #54469, `TestStopDrainsBeforeFlush` still fails at times ([example job output](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1993173424), [Flaky Management dashboard](https://app.datadoghq.com/ci/ci-cd/flaky-management/explorer?query=fingerprint_fqn%3A60e9b51ef57d69be&sort=-impact&viewMode=flaky)) with:
```
FAIL   //pkg/serverless/metrics:metrics_test :: TestStopDrainsBeforeFlush
type: assertion
metric_test.go:150: Not equal:, expected: 100, actual  : 101, every
 AddEnhancedMetric followed by Stop() must produce exactly one sketch flush
```
=> an _over_-count, where #54469 fixed an _under_-count.

It turns out that `buildPipelinesRng` adds a second pipeline shipping a duplicate of every sketch payload to the `v3beta` validation route, on a per-flush coin flip whose default rate is 0.001[^1] and whose default site allow-list matches the fake `datadoghq.com` resolver the test installs.

💡 That endpoint is named `sketches_v3beta`, so the substring match **takes it for an extra flush**.

`TestWaitForPendingSamplesDrainsThroughWrappedDemux` asserts the same exact count and is [equally affected](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20FAIL%20%28TestStopDrainsBeforeFlush%20OR%20TestWaitForPendingSamplesDrainsThroughWrappedDemux%29&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2Cci.node.name&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1787324973736&to_ts=1787929773736&live=true), hence the fix sits in the shared forwarder rather than in one test.

### Describe how you validated your changes
A stack trace per submission shows both copies leaving a single `SendSketch` call, and forcing `sketches.shadow_sample_rate` to 1.0 counts 200 sketches for 100 iterations before, 100 after.

Before, under `--config=gorace --runs_per_test=30`, `TestStopDrainsBeforeFlush` failed 7 times and
`TestWaitForPendingSamplesDrainsThroughWrappedDemux` 2 times.

After, 60 runs of the whole package pass under race and 20 without, along with `//pkg/aggregator/...` and `//pkg/serializer/...`.

### Additional Notes
Naming the one authoritative route keeps any future duplicate, shadow or otherwise, out of the count by construction.

Should the sketches v3 rollout make `sketches_v3` authoritative, every run counts 0 and fails outright rather than flaking.

[^1]: the low rate is why it went unnoticed for 18 days rather than being caught by #54581's own pipeline:
- at 1.0 that PR's CI would have gone red on the spot,
- at 0.001[^1] it slipped through review, through the author's local runs, and through every serverless CI run until the dice came up.