### PR TITLE
Try skipping TestDNSResponse test in CI

### DIFF
--- a/pkg/security/tests/dns_response_test.go
+++ b/pkg/security/tests/dns_response_test.go
@@ -17,10 +17,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"github.com/stretchr/testify/assert"
 )
 
 const DNSPort = 5553
@@ -46,6 +47,7 @@ func justBind() *net.UDPConn {
 }
 
 func TestDNSResponse(t *testing.T) {
+	t.Skip("Skipping DNSResponse test") // This test is flaky on CI and lead to timeout
 	SkipIfNotAvailable(t)
 	checkNetworkCompatibility(t)
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Try to skip a test that is potentially timing out in CI

### Motivation

### Describe how you validated your changes

### Additional Notes
