### PR TITLE
fix(ci): raise `bazel:coverage:linux-*` memory to match job count

### DIFF
--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -52,6 +52,8 @@
       - coverage-bazel-*.out
   variables:
     KUBERNETES_CPU_REQUEST: 16
+    KUBERNETES_MEMORY_REQUEST: "64Gi"
+    KUBERNETES_MEMORY_LIMIT: "64Gi"
 
 bazel:coverage:linux-amd64:
   extends: [.bazel:runner:linux-amd64, .bazel:coverage:linux]


### PR DESCRIPTION
### What does this PR do?
Request 64Gi for `.bazel:coverage:linux`, **restoring** 4Gi per concurrent action.

### Motivation
`bazel:coverage:linux-amd64` failed 3 attempts in a row on #55574, a 22-module `aws-sdk-go-v2` bump ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1993173424)):
```
ERROR: GoLink .../cwsinstrumentation_test_dca failed:
 (Segmentation fault)
runtime: memory allocated by OS [0x0, 0x323d55da6080) not in usable
 address space: fatal error: unexpected signal during runtime execution
[signal SIGSEGV] runtime.(*mheap).sysAlloc
```
Three tests were also killed at the 600s **timeout** having emitted no output, though each passes in under a second locally under the very same `bazel coverage` command.

`.bazel:runner:linux-*` requests 8 CPUs and 32Gi.
`.bazel:coverage:linux` overrides the CPU request to 16, which `--jobs=$KUBERNETES_CPU_REQUEST` follows, yet leaves memory untouched: 2Gi per concurrent action, half of what `.bazel:test:linux` gets, for the one job pairing coverage instrumentation with the **way more demanding** `--config=gorace`.

Cold caches expose it, as that bump invalidated ten large generated service clients at once (`ec2`, `s3`, `ssm`, `rds`, `eks`, ...): every slot held a multi-minute compile and the action counter advanced by 121 in 44 minutes.

### Describe how you validated your changes
`extends` lists `.bazel:coverage:linux` last, so its `variables` win over the runner's, as the observed `--jobs=16` already demonstrates.

### Additional Notes
Lowering `--jobs` back to 8 would equally relieve the pressure, at the cost of the parallelism the job was granted in #54613.

`.bazel:coverage:macos` passes no `--jobs`, letting Bazel size the pool from the host, so it needs nothing here.