### PR TITLE
ci: add explicit timeout to long-running jobs missing one

### DIFF
--- a/.gitlab/test/e2e/e2e_containers.yml
+++ b/.gitlab/test/e2e/e2e_containers.yml
@@ -102,6 +102,7 @@ new-e2e-containers-k8s-rc-latest:
 new-e2e-containers-eks-init:
   stage: e2e_init
   extends: .new_e2e_template
+  timeout: 1h 05m
   needs:
     - go_e2e_deps
     - !reference [.needs_fakeintake_publish]

--- a/.gitlab/test/e2e/e2e_fleet.yml
+++ b/.gitlab/test/e2e/e2e_fleet.yml
@@ -35,6 +35,7 @@
 # (whole suite minus shard 1), so any newly added test still runs on Windows via shard 2.
 new-e2e-fleet-config:
   extends: .new_e2e_fleet_template
+  timeout: 1h 35m
   parallel:
     matrix:
       - E2E_FLEET_PLATFORM_GROUP: linux
@@ -46,6 +47,7 @@ new-e2e-fleet-config:
 
 new-e2e-fleet-upgrade:
   extends: .new_e2e_fleet_template
+  timeout: 1h 25m
   parallel:
     matrix:
       # TestFleetIntegrationPreservation is a separate Linux-only suite (provisions no
@@ -59,6 +61,7 @@ new-e2e-fleet-upgrade:
 
 new-e2e-fleet-extensions:
   extends: .new_e2e_fleet_template
+  timeout: 55m
   parallel:
     matrix:
       - E2E_FLEET_PLATFORM_GROUP: linux
@@ -70,6 +73,7 @@ new-e2e-fleet-extensions:
 
 new-e2e-installer-script:
   extends: .new_e2e_template
+  timeout: 25m
   rules:
     - !reference [.on_installer_or_e2e_changes]
     - !reference [.manual]

--- a/.gitlab/test/e2e/e2e_npm.yml
+++ b/.gitlab/test/e2e/e2e_npm.yml
@@ -35,6 +35,7 @@ new-e2e-npm-docker:
 new-e2e-npm-eks-init:
   stage: e2e_init
   extends: .new_e2e_template
+  timeout: 1h 05m
   needs:
     - go_e2e_deps
     - !reference [.needs_fakeintake_publish]

--- a/.gitlab/test/e2e/e2e_otel.yml
+++ b/.gitlab/test/e2e/e2e_otel.yml
@@ -5,6 +5,7 @@
 new-e2e-otel-eks-init:
   stage: e2e_init
   extends: .new_e2e_template
+  timeout: 1h 05m
   rules:
     - !reference [.on_otel_or_e2e_changes]
     - !reference [.manual]

--- a/.gitlab/test/e2e/e2e_ssi.yml
+++ b/.gitlab/test/e2e/e2e_ssi.yml
@@ -113,6 +113,7 @@ new-e2e-ssi-gke:
 
 new-e2e-ssi-gke-autopilot-init:
   extends: .new-e2e_ssi_extra_distribution_init
+  timeout: 1h 05m
   variables:
     E2E_PROVISIONER: gke-autopilot
     E2E_STACK_NAME_SUFFIX: gke-autopilot
@@ -133,6 +134,7 @@ new-e2e-ssi-gke-autopilot:
 
 new-e2e-ssi-openshift-init:
   extends: .new-e2e_ssi_extra_distribution_init
+  timeout: 1h 05m
   before_script:
     # We need to also fetch the OpenShift CRC pull secret and write it to a temp file, so we reference the new_e2e_template before_script first
     - !reference [.new_e2e_template, before_script]
@@ -161,6 +163,7 @@ new-e2e-ssi-openshift:
 
 new-e2e-ssi-aks:
   extends: .new-e2e_ssi_extra_distribution
+  timeout: 1h 40m
   variables:
     E2E_PROVISIONER: aks
     E2E_STACK_NAME_SUFFIX: aks

--- a/.gitlab/test/e2e_install_packages/ubuntu.yml
+++ b/.gitlab/test/e2e_install_packages/ubuntu.yml
@@ -132,6 +132,7 @@ new-e2e-agent-platform-ddot-ubuntu-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_ddot
     - .new-e2e_ubuntu_a7_x86_64
+  timeout: 35m
   rules: !reference [.on_ddot_tests]
   variables:
     E2E_OSDESCRIPTORS: "ubuntu/x86_64/16-04,ubuntu/x86_64/18-04,ubuntu/x86_64/20-04,ubuntu/x86_64/22-04,ubuntu/x86_64/24-04"

--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -193,6 +193,7 @@ docker_image_build_otel:
 
 ddot_byoc_package_build_test_linux_oci:
   extends: .ddot_byoc_oci_build_test
+  timeout: 1h 15m
   variables:
     DDOT_BYOC_PACKAGE_TYPE: linux
     DDOT_BYOC_OCI_REPO: ddot-byoc-linux
@@ -200,6 +201,7 @@ ddot_byoc_package_build_test_linux_oci:
 
 ddot_byoc_package_build_test_windows_oci:
   extends: .ddot_byoc_oci_build_test
+  timeout: 1h 40m
   variables:
     DDOT_BYOC_PACKAGE_TYPE: windows
     DDOT_BYOC_OCI_REPO: ddot-byoc-windows

--- a/.gitlab/test/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/test/kernel_matrix_testing/system_probe.yml
@@ -14,6 +14,7 @@ upload_dependencies_sysprobe_x64:
 upload_dependencies_sysprobe_arm64:
   extends:
     - .package_dependencies
+  timeout: 1h 05m
   needs:
     - !reference [.kmt_setup_needs]
     - pull_test_dockers_arm64
@@ -106,6 +107,7 @@ upload_minimized_btfs_sysprobe_x64:
 upload_minimized_btfs_sysprobe_arm64:
   extends:
     - .upload_minimized_btfs
+  timeout: 1h 00m
   needs:
     - !reference [.kmt_setup_needs]
     - generate_minimized_btfs_arm64
@@ -119,6 +121,7 @@ upload_minimized_btfs_sysprobe_arm64:
 kmt_setup_env_sysprobe_arm64:
   extends:
     - .kmt_setup_env
+  timeout: 1h 10m
   rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   variables:
     INSTANCE_TYPE: "r6gd.metal"
@@ -193,6 +196,7 @@ upload_sysprobe_tests_x64:
 upload_sysprobe_tests_arm64:
   extends:
     - .upload_sysprobe_tests
+  timeout: 55m
   needs:
     - !reference [.kmt_setup_needs]
     - prepare_sysprobe_ebpf_functional_tests_arm64

--- a/.gitlab/windows/build/source_test/windows.yml
+++ b/.gitlab/windows/build/source_test/windows.yml
@@ -73,6 +73,7 @@
 tests_windows-x64:
   extends: .tests_windows_base
   #parallel: 10
+  timeout: 1h 20m
   variables:
     ARCH: "x64"
 

--- a/.gitlab/windows/test/e2e/windows_products.yml
+++ b/.gitlab/windows/test/e2e/windows_products.yml
@@ -21,6 +21,7 @@ new-e2e-windows-fips-compliance-test:
 
 new-e2e-windows-service-test:
   extends: .new_e2e_template
+  timeout: 50m
   needs:
     - !reference [.needs_new_e2e_template]
     - windows_msi_and_bosh_zip_x64-a7


### PR DESCRIPTION
### What does this PR do?
Adds an explicit `timeout:` to ~20 jobs that currently have none, so they fail promptly on a hang instead of riding to GitLab's implicit ~2h default. Values are based on each job's p99 successful duration in the last month plus a small margin (~5min, rounded up to the nearest 5 minutes).

### Motivation
Recent pipelines on `main` have been slow, partly because jobs without a `timeout:` that hang only fail after ~2h, triggering retries that waste even more time. This is a first pass targeting the jobs with the longest durations and/or the largest gap between success and failure duration (a signal that failures are timeout-driven rather than fast failures).

### Additional Notes
This covers the highest-impact jobs identified from CI Visibility data; there are still many other jobs without a `timeout:` that could be swept in a follow-up.