### PR TITLE
[NDM] Reset the `server_timeout` deadline in the connectivity check endpoint

### DIFF
--- a/comp/networkdevices/impl/BUILD.bazel
+++ b/comp/networkdevices/impl/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/api/api/def",
+        "//comp/api/api/utils",
         "//comp/core/log/def",
         "//comp/def",
         "//comp/networkdevices/def",

--- a/comp/networkdevices/impl/connectivity_endpoint.go
+++ b/comp/networkdevices/impl/connectivity_endpoint.go
@@ -10,7 +10,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
+	apiutils "github.com/DataDog/datadog-agent/comp/api/api/utils"
 	"github.com/DataDog/datadog-agent/pkg/networkdevices/connectivity"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 )
@@ -21,6 +23,12 @@ func (c *networkDevicesImpl) ConnectivityCheckEndpointHandler() http.HandlerFunc
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			httputils.SetJSONError(w, err, http.StatusBadRequest)
 			return
+		}
+
+		// Reset the `server_timeout` deadline for this connection as checking a large
+		// subnet can take much longer than the default timeout.
+		if conn, ok := apiutils.GetConnection(r); ok {
+			_ = conn.SetDeadline(time.Time{})
 		}
 
 		res, err := c.CheckConnectivity(r.Context(), req)


### PR DESCRIPTION
Fix the `connectivityCheck` Private Action failing on large subnets by clearing the `server_timeout` deadline in the connectivity check endpoint.

The CMD API server arms a write deadline on the connection for every request (`server_timeout`, 30s by default, via `TimeoutHandlerFunc` in `comp/api/grpcserver/helpers/grpc.go`). A connectivity check over a large subnet outlives it, so the response write fails and the connection is torn down mid-scan.

- **Previously**: running the action on a `10.0.0.0/23` failed after 2-4 minutes with `failed to run connectivity checks: failed to reach the Agent: Post "https://localhost:5001/agent/networkdevices/connectivity-check": local error: tls: bad record MAC`. A `10.0.0.0/29` worked, because it completes well under 30s.
- **Now**: the endpoint clears the deadline before running the checks, the same way the flare, diagnose and log-stream endpoints already do.

The error is misleading because it doesn't surface as a timeout. `writeRecordLocked` encrypts a record — advancing the TLS sequence number — *before* writing it, so the write failing on the expired deadline leaves the sequence number ahead of what actually reached the wire. `closeNotify` then re-arms the deadline and successfully sends `close_notify` at the advanced sequence number, which the client authenticates at the old one and rejects with `bad_record_mac`. The timing tracks the scan duration rather than `server_timeout` because nothing is written at the 30s mark.

Extending the deadline instead of clearing it wouldn't help: any finite value just moves the same failure to a larger subnet, since a connection deadline can't fail gracefully. Bounding belongs at the context level, and the caller already provides it — `private_action_runner.task_timeout_seconds` cancels the request, which cancels the handler's errgroup.

Related: #52174 (original implementation).

## Validation
- `bazel test //comp/networkdevices/impl:impl_test` passes.
- Checked the cancellation path in a standalone harness replicating the server wiring (`ConnContext` + `TimeoutHandlerFunc` + forced-`h2` TLS), with 10s of work and a 1s client timeout: the handler observes cancellation at 1.02s both with and without the deadline cleared. So clearing it doesn't leave the check running unbounded once the caller gives up.
- <screenshot: `connectivityCheck` action run against a `10.0.0.0/23`, completing successfully>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
