### PR TITLE
fix(static-quality-gates): really skip per-PR size thresholds on `main`

### DIFF
--- a/tasks/git.py
+++ b/tasks/git.py
@@ -56,13 +56,8 @@ def push_signed_commits(ctx: Context, branch: str, commit_message: str, source_b
 def get_ancestor(ctx, branch: str) -> str:
     base_branch = get_ancestor_base_branch(branch)
     ancestor = get_common_ancestor(ctx, "HEAD", base_branch)
-    current_commit = get_commit_sha(ctx)
-    # Detect if we're on main branch (ancestor == current commit means merge-base is HEAD itself)
-    # This is used to determine if bypass tolerance should apply (only for PRs, not main)
-    is_on_main_branch = ancestor == current_commit
-    # When on main/release branch, get_common_ancestor returns HEAD itself since merge-base of HEAD and origin/<branch>
-    # is the current commit. In this case, use the parent commit as the ancestor instead.
-    if is_on_main_branch:
+    # When HEAD is the tip of its own base branch, the merge-base is HEAD itself: use the parent commit instead
+    if ancestor == get_commit_sha(ctx):
         ancestor = get_commit_sha(ctx, commit="HEAD~1")
-        print(color_message(f"On main branch, using parent commit {ancestor} as ancestor", "cyan"))
+        print(color_message(f"On {base_branch}, using parent commit {ancestor} as ancestor", "cyan"))
     return ancestor

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -11,7 +11,7 @@ from tasks.git import get_ancestor
 from tasks.libs.ciproviders.github_api import GithubAPI
 from tasks.libs.common.color import color_message
 from tasks.libs.common.git import (
-    get_commit_sha,
+    get_default_branch,
     is_a_release_branch,
 )
 from tasks.libs.package.size import InfraError
@@ -99,14 +99,15 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
 
     nightly_run = os.environ.get("BUCKET_BRANCH") == "nightly"
     branch = os.environ["CI_COMMIT_BRANCH"]
+    is_on_main_branch = branch == get_default_branch()
 
     # Early PR lookup - cache for later use in metrics and PR comment
-    # Skip for release branches since they don't have associated PRs
+    # Skip for release branches since they don't have associated PRs, and for main whose open PRs target other branches
     pr = None
     pr_number = None
     pr_author = None
     if not is_a_release_branch(ctx, branch):
-        pr = get_pr_for_branch(branch)
+        pr = None if is_on_main_branch else get_pr_for_branch(branch)
         if pr:
             print(color_message(f"Found PR #{pr.number}: {pr.title}", "cyan"))
             pr_number = str(pr.number)
@@ -174,8 +175,6 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
     ancestor = get_ancestor(ctx, branch)
     metric_handler.generate_relative_size(ancestor=ancestor)
     metric_handler.send_metrics_to_datadog()
-    current_commit = get_commit_sha(ctx)
-    is_on_main_branch = ancestor == current_commit
     is_merge_queue = branch.startswith("mq-working-branch-")
 
     # Take a decision on gate results based on measurements

--- a/tasks/unit_tests/static_quality_gates/decisions_tests.py
+++ b/tasks/unit_tests/static_quality_gates/decisions_tests.py
@@ -94,37 +94,6 @@ class TestBypassOnlyAppliesToPRs(unittest.TestCase):
     These tests document the expected behavior at the integration level.
     """
 
-    def test_main_branch_detection_logic(self):
-        """
-        Document: On main branch, ancestor == current_commit, so is_on_main_branch = True.
-
-        When is_on_main_branch is True, the bypass loop in parse_and_trigger_gates
-        is skipped entirely, meaning all failures remain blocking regardless of delta.
-        """
-        # This test documents the detection logic:
-        # ancestor = get_common_ancestor(ctx, "HEAD", base_branch)
-        # is_on_main_branch = ancestor == current_commit
-        # On main, merge-base of HEAD and origin/main is HEAD itself
-
-        # Simulate: on main branch, ancestor equals current commit
-        ancestor = "abc123"
-        current_commit = "abc123"
-        is_on_main_branch = ancestor == current_commit
-        self.assertTrue(is_on_main_branch)
-
-    def test_pr_branch_detection_logic(self):
-        """
-        Document: On PR branches, ancestor != current_commit, so is_on_main_branch = False.
-
-        When is_on_main_branch is False, the bypass loop runs and failures with
-        delta <= 2KiB threshold can be marked non-blocking.
-        """
-        # Simulate: on PR branch, ancestor is different from current commit
-        ancestor = "abc123"  # Common ancestor with main
-        current_commit = "def456"  # PR's HEAD
-        is_on_main_branch = ancestor == current_commit
-        self.assertFalse(is_on_main_branch)
-
     def test_bypass_logic_skipped_on_main_conceptually(self):
         """
         Document: The bypass logic should NOT run on main branch.

--- a/tasks/unit_tests/static_quality_gates/tasks_tests.py
+++ b/tasks/unit_tests/static_quality_gates/tasks_tests.py
@@ -33,6 +33,7 @@ def gitlab_ref_slug(git_ref):
 
 _PR_BRANCH_NAME = "feature/branch"
 _PR_BUCKET_BRANCH = 'dev'
+_MAIN_BRANCH = 'main'
 _CI_PIPELINE_ID = '999999999'
 _CI_COMMIT_SHA = '1234567890abcdef'
 _ANCESTOR_SHA = 'ancestor-sha'
@@ -45,6 +46,11 @@ _PR_ENV_VARS = {
     'CI_COMMIT_REF_SLUG': gitlab_ref_slug(_PR_BRANCH_NAME),
     'CI_PIPELINE_ID': _CI_PIPELINE_ID,
     'CI_COMMIT_SHA': _CI_COMMIT_SHA,
+}
+
+_MAIN_ENV_VARS = _PR_ENV_VARS | {
+    'CI_COMMIT_BRANCH': _MAIN_BRANCH,
+    'CI_COMMIT_REF_SLUG': _MAIN_BRANCH,
 }
 
 
@@ -137,6 +143,7 @@ def _gate_scenarios_fixture(*scenarios: GateScenario, ancestor_sha: str):
             yield config_path
 
 
+@patch("tasks.quality_gates.get_default_branch", new=MagicMock(return_value=_MAIN_BRANCH))
 class TestQualityGatesIntegration(unittest.TestCase):
     def _assert_gate_metrics(self, sent, gate_name, *, on_disk, on_wire, max_disk, max_wire, rel_disk, rel_wire):
         metric_prefix = "datadog.agent.static_quality_gate."
@@ -172,7 +179,6 @@ class TestQualityGatesIntegration(unittest.TestCase):
         with (
             _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
             patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
-            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
             patch("tasks.static_quality_gates.gates.send_metrics") as mock_send_metrics,
             patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
@@ -251,7 +257,6 @@ class TestQualityGatesIntegration(unittest.TestCase):
         with (
             _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
             patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
-            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
             patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_relative_size"),
             patch(
@@ -294,7 +299,6 @@ class TestQualityGatesIntegration(unittest.TestCase):
         with (
             _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
             patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
-            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
             patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_relative_size"),
             patch(
@@ -337,7 +341,6 @@ class TestQualityGatesIntegration(unittest.TestCase):
         with (
             _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
             patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
-            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
             patch("tasks.static_quality_gates.gates.send_metrics"),
             patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
@@ -386,7 +389,6 @@ class TestQualityGatesIntegration(unittest.TestCase):
         with (
             _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
             patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
-            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.quality_gates.get_pr_for_branch", return_value=approved_pr),
             patch("tasks.static_quality_gates.gates.send_metrics"),
             patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
@@ -435,7 +437,6 @@ class TestQualityGatesIntegration(unittest.TestCase):
         with (
             _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
             patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
-            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
             patch("tasks.static_quality_gates.gates.send_metrics"),
             patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
@@ -484,7 +485,6 @@ class TestQualityGatesIntegration(unittest.TestCase):
         with (
             _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
             patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
-            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.quality_gates.get_pr_for_branch", return_value=approved_pr),
             patch("tasks.static_quality_gates.gates.send_metrics"),
             patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
@@ -533,7 +533,6 @@ class TestQualityGatesIntegration(unittest.TestCase):
         with (
             _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
             patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
-            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.static_quality_gates.github.GithubAPI", new=FakeGithubAPI),
             patch("tasks.static_quality_gates.gates.send_metrics"),
             patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
@@ -624,7 +623,6 @@ class TestQualityGatesIntegration(unittest.TestCase):
         with (
             _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
             patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
-            patch("tasks.quality_gates.get_commit_sha", return_value=_CI_COMMIT_SHA),
             patch("tasks.quality_gates.get_pr_for_branch", return_value=None),
             patch("tasks.quality_gates.get_pr_number_from_commit", return_value=None),
             patch("tasks.static_quality_gates.gates.send_metrics"),
@@ -635,6 +633,47 @@ class TestQualityGatesIntegration(unittest.TestCase):
             )
             # Should NOT raise Exit — per-PR threshold is skipped on merge queue branches
             parse_and_trigger_gates(ctx, config_path)
+
+    @patch.dict('os.environ', _MAIN_ENV_VARS, clear=True)
+    def test_per_pr_threshold_skipped_on_main(self):
+        """Per-PR threshold check is not applied on main, where deltas belong to the merged PR."""
+        gate_scenarios = [
+            GateScenario(
+                name=_DEB_GATE,
+                ancestor_disk=100 * _MiB,
+                ancestor_wire=50 * _MiB,
+                current_disk=100 * _MiB,
+                current_wire=50 * _MiB + 5.1 * _MiB,  # > 5 MiB wire threshold
+                max_disk=105 * _MiB,
+                max_wire=60 * _MiB,
+            ),
+            GateScenario(
+                name=_DOCKER_GATE,
+                ancestor_disk=600 * _MiB,
+                ancestor_wire=240 * _MiB,
+                current_disk=600 * _MiB + 700 * _KiB,  # > 600 KiB disk threshold
+                current_wire=240 * _MiB,
+                max_disk=700 * _MiB,
+                max_wire=250 * _MiB,
+            ),
+        ]
+        with (
+            _gate_scenarios_fixture(*gate_scenarios, ancestor_sha=_ANCESTOR_SHA) as config_path,
+            patch("tasks.quality_gates.get_ancestor", return_value=_ANCESTOR_SHA),
+            patch("tasks.quality_gates.get_pr_for_branch") as mock_get_pr_for_branch,
+            patch("tasks.quality_gates.get_pr_number_from_commit", return_value=None),
+            patch("tasks.static_quality_gates.gates.send_metrics"),
+            patch("tasks.static_quality_gates.pr_comment.pr_commenter") as mock_pr_commenter,
+            patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports"),
+        ):
+            ctx = MockContext(
+                run={"datadog-ci tag --level job --tags static_quality_gates:\"success\"": Result("Done")}
+            )
+            # Should NOT raise Exit — per-PR thresholds are skipped on main
+            parse_and_trigger_gates(ctx, config_path)
+            # Open PRs whose head branch is main are none of main's business
+            mock_get_pr_for_branch.assert_not_called()
+            mock_pr_commenter.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?
Derive `is_on_main_branch` from the branch name, the way `tasks/package.py` **already** does, instead of comparing the ancestor to `HEAD`: `get_ancestor` replaces the ancestor with the parent commit on `main`, so that comparison was **always** `False` and `main` pipelines were evaluated as pull requests.

The flag now also skips the PR lookup, and `get_ancestor` no longer computes a flag it throws away.

### Motivation
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1993405414 failed on `main` for a test-only fix, 7 of 33 gates reporting growth nobody introduced:
```
Gate static_quality_gate_agent_deb_amd64 failed ❌ with the following message:
On-wire size increase of 90.02 MiB exceeds the per-PR wire threshold of 5.0 MiB
Gate static_quality_gate_agent_msi failed ❌ with the following message:
On-wire size increase of 75.83 MiB exceeds the per-PR wire threshold of 5.0 MiB
Gate static_quality_gate_agent_rpm_arm64 failed ❌ with the following message:
On-wire size increase of 81.56 MiB exceeds the per-PR wire threshold of 5.0 MiB
Gate static_quality_gate_agent_suse_arm64 failed ❌ with the following message:
On-wire size increase of 81.56 MiB exceeds the per-PR wire threshold of 5.0 MiB
Gate static_quality_gate_agent_suse_arm64_fips failed ❌ with the following message:
On-wire size increase of 76.9 MiB exceeds the per-PR wire threshold of 5.0 MiB
Gate static_quality_gate_docker_cluster_agent_amd64 failed ❌ with the following message:
On-wire size increase of 36.81 MiB exceeds the per-PR wire threshold of 5.0 MiB
Gate static_quality_gate_docker_dogstatsd_amd64 failed ❌ with the following message:
On-wire size increase of 7.65 MiB exceeds the per-PR wire threshold of 5.0 MiB
```
The baseline was garbage (#55595 is meant to fix it): the parent commit was built by 2 concurrent push pipelines (https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/133869316 / https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/133869408), and reading their duplicate gauges mid-submission made the averaging ancestor query return exactly half the real size.

Deltas measured against a parent commit are not a pipeline's own work, so the per-PR check has no business running on `main`.

The same PR lookup also made the job comment on #55434, an **unrelated** pull request whose head branch happens to be `main`:
```
Updated comment on PR #55434 - fix(data-race): lock ntmConfig.GetNode for concurrent access (#55389)
```

### Describe how you validated your changes
`dda inv invoke-unit-tests.run
--directory=tasks/unit_tests/static_quality_gates` runs 194 tests green, and the added `test_per_pr_threshold_skipped_on_main` is the only failure once `is_on_main_branch` is forced back to `False`.

### Additional Notes
Release-branch pipelines still evaluate the per-PR thresholds, since `get_default_branch()` returns `main` there, but they cannot fail on it because the `Exit` is intentionally skipped for release branches.