### PR TITLE
fix(static-quality-gates): query ancestor sizes with `max`, not `avg`

### DIFF
--- a/tasks/libs/common/datadog_api.py
+++ b/tasks/libs/common/datadog_api.py
@@ -247,7 +247,8 @@ def query_gate_metrics_for_commit(commit_sha: str, lookback: str = "now-7d") -> 
 
     for metric_key, metric_name in metrics_to_query.items():
         # Query all gates at once using "by {gate_name}" aggregation
-        query = f"avg:{metric_name}{{ci_commit_sha:{commit_sha}}} by {{gate_name}}"
+        # `max` because `avg` includes 0s from concurrent pipelines that are still running, dividing the result by 2+
+        query = f"max:{metric_name}{{ci_commit_sha:{commit_sha}}} by {{gate_name}}"
 
         try:
             series_list = query_metrics(query, lookback, "now")

--- a/tasks/unit_tests/static_quality_gates/metrics_tests.py
+++ b/tasks/unit_tests/static_quality_gates/metrics_tests.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch
 
+from tasks.libs.common.datadog_api import query_gate_metrics_for_commit
 from tasks.static_quality_gates.metrics import (
     GateMetricsData,
     _extract_gate_name_from_scope,
@@ -316,6 +317,27 @@ class TestGateMetricsData(unittest.TestCase):
         self.assertEqual(metrics.max_on_wire_size, 75)
         self.assertEqual(metrics.relative_on_disk_size, 10)
         self.assertEqual(metrics.relative_on_wire_size, 5)
+
+
+class TestQueryGateMetricsForCommit(unittest.TestCase):
+    """Test the query_gate_metrics_for_commit function."""
+
+    @patch("tasks.libs.common.datadog_api.query_metrics")
+    def test_keeps_the_largest_measurement(self, mock_query):
+        """Should not average the series of the pipelines having built the commit."""
+        mock_query.return_value = [
+            {
+                "scope": "gate_name:static_quality_gate_agent_deb_amd64",
+                "expression": "max:datadog.agent.static_quality_gate.on_wire_size{...}",
+                "pointlist": make_pointlist([[1704240000, 188744948]]),
+            },
+        ]
+
+        result = query_gate_metrics_for_commit("abc123def456")
+
+        for call in mock_query.call_args_list:
+            self.assertTrue(call.args[0].startswith("max:"), call.args[0])
+        self.assertEqual(result["static_quality_gate_agent_deb_amd64"]["current_on_wire_size"], 188744948)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?
Aggregate the size series of an ancestor commit with `max` instead of `avg`, so that a series still being published cannot spuriously lower the baseline the per-PR size deltas are measured against.

### Motivation
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1993405414 read its parent commit as exactly **half** its size on 7 of the 33 gates, for instance 94,372,474 rather than 188,744,948 bytes on `static_quality_gate_agent_deb_amd64`, and turned that into:
```
Gate static_quality_gate_agent_deb_amd64 failed ❌ with the following message:
On-wire size increase of 90.02 MiB exceeds the per-PR wire threshold of 5.0 MiB
```
That parent commit was built by 2 concurrent push pipelines (https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/133869316 / https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/133869408), hence 2 series per gate, one of them being published while the query ran: by design, `avg` **counts it as 0** , whereas `max` filters it out.

Package sizes being positive, `max` can only ever return one of the measurements.

#55592 is meant to stop these deltas from failing `main` pipelines, where they mean nothing.
=> this one repairs the baseline itself, which pull requests are meant to measure against.

### Describe how you validated your changes
`dda inv invoke-unit-tests.run
--directory=tasks/unit_tests/static_quality_gates` runs 196 tests green, the added test being the only failure once `avg` is used.

### Additional Notes
Both series come from the very same commit, so keeping their largest measurement costs **at most** their spread, 25 KB here against a 600 KiB per-PR threshold.