### PR TITLE
[procmgr] Trim unused ProcessState transitions

### DIFF
--- a/pkg/procmgr/rust/src/state.rs
+++ b/pkg/procmgr/rust/src/state.rs
@@ -7,19 +7,12 @@ use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProcessState {
-    /// Config loaded, never started.
     Created,
-    /// Spawn requested, child not yet confirmed alive.
     Starting,
-    /// Child process is alive.
     Running,
-    /// Stop requested, waiting for child to exit.
     Stopping,
-    /// Exited with code 0.
     Exited,
-    /// Exited with non-zero code or signal.
     Failed,
-    /// Explicitly stopped during shutdown.
     Stopped,
 }
 
@@ -36,8 +29,6 @@ impl ProcessState {
         matches!(
             (self, next),
             (Created, Starting)
-                | (Created, Running)
-                | (Created, Failed)
                 | (Starting, Running)
                 | (Starting, Failed)
                 | (Running, Stopping)
@@ -45,14 +36,9 @@ impl ProcessState {
                 | (Running, Failed)
                 | (Running, Stopped)
                 | (Stopping, Stopped)
-                | (Stopping, Exited)
-                | (Stopping, Failed)
                 | (Exited, Starting)
-                | (Exited, Running)
                 | (Failed, Starting)
-                | (Failed, Running)
                 | (Stopped, Starting)
-                | (Stopped, Running)
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

Tightens `ProcessState::can_transition_to` so it only allows transitions that production code actually uses. Removes eight unused shortcut edges (e.g. `Created → Running`, `Exited → Running`, `Stopping → Exited`) and drops redundant doc comments on the enum variants.

### Motivation

The transition table included paths that never occur in runtime code. Every spawn goes through `Starting`, every restart re-enters via `Starting`, and `set_last_status` always maps `Stopping` to `Stopped`. The extra edges made the state machine harder to reason about and could mask invalid transitions in tests.

### Describe how you validated your changes

- `cargo test -p dd-procmgrd` (full unit test suite)

### Additional Notes

Stacked procmgr PRs that add `(Starting, Stopped)` (e.g. #55505) should rebase on this and re-add that single edge to `can_transition_to`.