### PR TITLE
fix(ci): stop fully buffering output (twice) in `gotest-scrubbed.sh`

### DIFF
--- a/tasks/tools/gotest-scrubbed.sh
+++ b/tasks/tools/gotest-scrubbed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ### This script is used to run go test and scrub the output, the command can be used as follow:
 ### ./gotest-scrubbed.sh <packages comma separated> -- <go tests flags>
 ### Use GOTEST_COMMAND environment variable to override the default "go test -json" command
@@ -7,6 +7,7 @@ set -euo pipefail
 # Use custom command if provided, otherwise default to "go test -json"
 GOTEST_CMD="${GOTEST_COMMAND:-go test -json}"
 
-$GOTEST_CMD "$1" "${@:3}" | 
-sed -E 's/\b[a-fA-F0-9]{27}([a-fA-F0-9]{5})\b/**************************\1/g' | # Scrub API keys
-sed -E 's/\b[a-fA-F0-9]{35}([a-fA-F0-9]{5})\b/************************************\1/g' # Scrub APP keys
+# Scrub API \ APP keys
+$GOTEST_CMD "$1" "${@:3}" | sed --unbuffered -E \
+  -e 's/\b[a-fA-F0-9]{27}([a-fA-F0-9]{5})\b/**************************\1/g' \
+  -e 's/\b[a-fA-F0-9]{35}([a-fA-F0-9]{5})\b/************************************\1/g'


### PR DESCRIPTION
### What does this PR do?
Consolidate `tasks/tools/gotest-scrubbed.sh`'s 2 piped `sed` invocations into a single `sed` call with two `-e` expressions and add `--unbuffered` so scrubbed output is flushed line by line instead of sitting in `sed`'s block buffer.

### Motivation
Jobs involving `gotest-scrubbed.sh` seem to be stuck at times: for instance, a [`new-e2e-installer-windows` job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1992313873) produced zero trace output for the rest of its run right after `gotest-scrubbed.sh` started, and was later killed by GitLab as a `stuck_or_timeout_failure`.

`gotest-scrubbed.sh` indeed pipes Go test commands through `sed` **twice**, and `sed`'s default stdio buffering is **fully buffered** once stdout is a pipe instead of a terminal, which is always the case here since `gotestsum`'s `--raw-command` **itself reads this script's stdout through a pipe**.

Sparse test output is can then sit unflushed in `sed`'s buffer well past the point where CI needs to see it move, which is indistinguishable from a genuinely hung test until GitLab's stuck-job detector kills the job.

### Describe how you validated your changes
Ran `bash -n` against the script and piped sample API and APP key strings through the exact `sed --unbuffered -E -e ... -e ...` command to confirm the combined single-pass substitution still redacts both patterns identically to the previous two-stage pipeline.

### Additional Notes
`#!/usr/bin/env bash` is the most portable shebang syntax, because `/bin` is _at most as symlink_ on modern Linux distributions.

This script only ever runs on Linux CI runners under GNU `sed`, gated behind `running_in_ci()` in `tasks/new_e2e_tests.py`, so no macOS or POSIX-portability constraint applies here.