### PR TITLE
[ACTP] Subscribe earlier to PAR signing keys

### DIFF
--- a/comp/privateactionrunner/fx/BUILD.bazel
+++ b/comp/privateactionrunner/fx/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "fx",
@@ -6,9 +7,26 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/privateactionrunner/fx",
     visibility = ["//visibility:public"],
     deps = [
+        "//comp/core/config",
         "//comp/privateactionrunner/def",
         "//comp/privateactionrunner/impl",
+        "//comp/remote-config/rcclient/types",
+        "//pkg/privateactionrunner/task-verifier",
+        "//pkg/remoteconfig/state",
         "//pkg/util/fxutil",
         "@org_uber_go_fx//:fx",
+    ],
+)
+
+dd_agent_go_test(
+    name = "fx_test",
+    srcs = ["fx_test.go"],
+    embed = [":fx"],
+    deps = [
+        "//comp/core/config",
+        "//comp/privateactionrunner/def",
+        "//pkg/remoteconfig/state",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/comp/privateactionrunner/fx/fx.go
+++ b/comp/privateactionrunner/fx/fx.go
@@ -7,15 +7,21 @@
 package fx
 
 import (
+	"go.uber.org/fx"
+
+	config "github.com/DataDog/datadog-agent/comp/core/config"
 	privateactionrunner "github.com/DataDog/datadog-agent/comp/privateactionrunner/def"
 	privateactionrunnerimpl "github.com/DataDog/datadog-agent/comp/privateactionrunner/impl"
+	rctypes "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/types"
+	taskverifier "github.com/DataDog/datadog-agent/pkg/privateactionrunner/task-verifier"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 )
 
 // Module defines the fx options for this component
 func Module() fxutil.Module {
 	return fxutil.Component(
+		fx.Provide(newKeysManager),
 		fxutil.ProvideComponentConstructor(
 			privateactionrunnerimpl.NewComponent,
 		),
@@ -28,6 +34,7 @@ func Module() fxutil.Module {
 // ExecutorModule defines the fx options for the on-demand executor mode.
 func ExecutorModule() fxutil.Module {
 	return fxutil.Component(
+		fx.Provide(newKeysManager),
 		fxutil.ProvideComponentConstructor(
 			privateactionrunnerimpl.NewExecutorComponent,
 		),
@@ -35,4 +42,22 @@ func ExecutorModule() fxutil.Module {
 		// Force instantiation since no other component depends on privateactionrunner
 		fx.Invoke(func(_ privateactionrunner.Component) {}),
 	)
+}
+
+type keysManagerProvides struct {
+	fx.Out
+
+	Manager  taskverifier.KeysManager
+	Listener rctypes.RCListener `group:"rCListener"`
+}
+
+func newKeysManager(cfg config.Component) keysManagerProvides {
+	manager, callback := taskverifier.NewKeyManagerWithCallback()
+	var listener rctypes.RCListener
+	if callback != nil && cfg.GetBool(privateactionrunner.PAREnabled) {
+		listener = rctypes.RCListener{
+			state.ProductActionPlatformRunnerKeys: callback,
+		}
+	}
+	return keysManagerProvides{Manager: manager, Listener: listener}
 }

--- a/comp/privateactionrunner/fx/fx_test.go
+++ b/comp/privateactionrunner/fx/fx_test.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package fx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
+	privateactionrunner "github.com/DataDog/datadog-agent/comp/privateactionrunner/def"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+)
+
+func TestNewKeysManagerProvidesRCListener(t *testing.T) {
+	t.Setenv("DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION", "false")
+	cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+		privateactionrunner.PAREnabled: true,
+	})
+
+	provides := newKeysManager(cfg)
+	callback, found := provides.Listener[state.ProductActionPlatformRunnerKeys]
+	require.True(t, found)
+
+	callback(nil, func(string, state.ApplyStatus) {})
+	provides.Manager.WaitForReady()
+}
+
+func TestNewKeysManagerDoesNotRegisterWhenPARIsDisabled(t *testing.T) {
+	t.Setenv("DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION", "false")
+	cfg := coreconfig.NewMock(t)
+
+	provides := newKeysManager(cfg)
+
+	assert.Empty(t, provides.Listener)
+}

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -67,6 +67,7 @@ type Requires struct {
 	Lifecycle     compdef.Lifecycle
 	Shutdowner    compdef.Shutdowner
 	RcClient      rcclient.Component
+	KeysManager   taskverifier.KeysManager
 	Hostname      hostname.Component
 	Tagger        tagger.Component
 	Traceroute    traceroute.Component
@@ -105,7 +106,8 @@ type PrivateActionRunner struct {
 	executorDone    chan struct{}
 	shutdowner      compdef.Shutdowner
 
-	telemetry *telemetry.Telemetry
+	telemetry   *telemetry.Telemetry
+	keysManager taskverifier.KeysManager
 
 	started     bool
 	startOnce   sync.Once
@@ -134,6 +136,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 	if err != nil {
 		return Provides{}, err
 	}
+	runner.keysManager = reqs.KeysManager
 	runner.ownsMetricsClient = true
 	reqs.Lifecycle.Append(compdef.Hook{
 		OnStart: runner.Start,
@@ -161,6 +164,7 @@ func NewExecutorComponent(reqs Requires) (Provides, error) {
 	if err != nil {
 		return Provides{}, err
 	}
+	runner.keysManager = reqs.KeysManager
 	runner.ownsMetricsClient = true
 	runner.shutdowner = reqs.Shutdowner
 	reqs.Lifecycle.Append(compdef.Hook{
@@ -294,7 +298,7 @@ func (p *PrivateActionRunner) startExecutor(ctx context.Context) error {
 	p.logger.Info("==> Version : " + parversion.RunnerVersion)
 	p.logger.Info("==> URN : " + cfg.Urn)
 
-	keysManager := taskverifier.NewKeyManager(p.rcClient)
+	keysManager := p.getKeysManager()
 	taskVerifier := taskverifier.NewTaskVerifier(keysManager, cfg)
 	p.encryptionStore = encryptioncontext.NewStore()
 	taskExecutor := runners.NewWorkflowTaskExecutor(cfg, taskVerifier, p.traceroute, p.eventPlatform, p.ipc.GetClient(), p.encryptionStore, p.ha, p.ka)
@@ -343,6 +347,13 @@ func (p *PrivateActionRunner) startExecutor(ctx context.Context) error {
 		}
 	}()
 	return nil
+}
+
+func (p *PrivateActionRunner) getKeysManager() taskverifier.KeysManager {
+	if p.keysManager == nil {
+		p.keysManager = taskverifier.NewKeyManager(p.rcClient)
+	}
+	return p.keysManager
 }
 
 func executorIdleTimeout(idleSeconds int) time.Duration {
@@ -424,7 +435,7 @@ func (p *PrivateActionRunner) start(ctx context.Context) error {
 	p.logger.Info("==> API Host : " + cfg.DDApiHost)
 	p.logger.Info("==> URN : " + cfg.Urn)
 
-	keysManager := taskverifier.NewKeyManager(p.rcClient)
+	keysManager := p.getKeysManager()
 	taskVerifier := taskverifier.NewTaskVerifier(keysManager, cfg)
 	opmsClient := opms.NewClient(p.coreConfig, cfg)
 

--- a/pkg/privateactionrunner/task-verifier/keys_manager.go
+++ b/pkg/privateactionrunner/task-verifier/keys_manager.go
@@ -24,6 +24,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 )
 
+// UpdateCallback receives signing-key updates from Remote Config.
+type UpdateCallback func(map[string]state.RawConfig, func(string, state.ApplyStatus))
+
 type keysManager struct {
 	rcClient               rcclient.Client
 	stopChan               chan bool
@@ -44,20 +47,32 @@ func (n *noOpKeysManager) WaitForReady()                    {}
 // NewKeyManager returns a KeysManager appropriate for the current environment.
 // When DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION=true, a no-op manager is returned.
 func NewKeyManager(rcClient rcclient.Client) KeysManager {
-	if os.Getenv(app.InternalSkipTaskVerificationEnvVar) == "true" {
-		return &noOpKeysManager{}
+	manager, _ := NewKeyManagerWithCallback()
+	if manager, ok := manager.(*keysManager); ok {
+		manager.rcClient = rcClient
 	}
-	return &keysManager{
+	return manager
+}
+
+// NewKeyManagerWithCallback returns a key manager and the callback to register
+// with Remote Config before its polling loop starts.
+func NewKeyManagerWithCallback() (KeysManager, UpdateCallback) {
+	if os.Getenv(app.InternalSkipTaskVerificationEnvVar) == "true" {
+		return &noOpKeysManager{}, nil
+	}
+	manager := &keysManager{
 		stopChan: make(chan bool),
 		keys:     make(map[string]types.DecodedKey),
 		ready:    make(chan struct{}),
-		rcClient: rcClient,
 	}
+	return manager, manager.AgentConfigUpdateCallback
 }
 
 func (k *keysManager) Start(ctx context.Context) {
-	log.FromContext(ctx).Info("Subscribing to remote config updates")
-	k.rcClient.Subscribe(state.ProductActionPlatformRunnerKeys, k.AgentConfigUpdateCallback)
+	if k.rcClient != nil {
+		log.FromContext(ctx).Info("Subscribing to remote config updates")
+		k.rcClient.Subscribe(state.ProductActionPlatformRunnerKeys, k.AgentConfigUpdateCallback)
+	}
 }
 
 func (k *keysManager) GetKey(keyId string) types.DecodedKey {

--- a/releasenotes/notes/improve-par-signing-key-readiness-e3795fc38613f48c.yaml
+++ b/releasenotes/notes/improve-par-signing-key-readiness-e3795fc38613f48c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix Private Action Runner startup delays when signing keys are already
+    available from Remote Config.

--- a/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
+++ b/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
@@ -22,9 +22,8 @@ import (
 )
 
 const (
-	privateActionRunnerStartedLogLine      = "Private action runner starting"
-	privateActionRunnerRCSubscribedLogLine = "Subscribing to remote config updates"
-	privateActionRunnerKeysManagerLogLine  = "Keys manager ready"
+	privateActionRunnerStartedLogLine     = "Private action runner starting"
+	privateActionRunnerKeysManagerLogLine = "Keys manager ready"
 )
 
 func generateTestPrivateActionRunnerConfig(t *testing.T) string {
@@ -80,12 +79,7 @@ func (s *linuxPrivateActionRunnerEnabledSuite) TestPrivateActionRunnerStartsWhen
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -i %q %s", privateActionRunnerStartedLogLine, privateActionRunnerLogFile))
 	}, 2*time.Minute, 5*time.Second, "private action runner log should contain the started message")
 
-	// Push the key only after PAR has subscribed and the Core Agent has had time
-	// to report the AP_RUNNER_KEYS client in its backend requests.
-	s.Require().EventuallyWithT(func(c *assert.CollectT) {
-		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -F %q %s", privateActionRunnerRCSubscribedLogLine, privateActionRunnerLogFile))
-	}, 2*time.Minute, 5*time.Second, "private action runner should subscribe to remote config")
-
+	// Wait for the Core Agent to report the AP_RUNNER_KEYS client in its backend requests.
 	client := s.Env().FakeIntake.Client()
 	stats, err := client.RCStats()
 	s.Require().NoError(err)


### PR DESCRIPTION
### What does this PR do?

Registers the Private Action Runner signing-key callback as a Remote Config listener during `Fx` construction instead of subscribing after the runner starts. This significantly speeds up key retrieval and therefore runner readiness.

This applies to both the current monolith and upcoming split mode PARs:

- the monolith registers before its Remote Config client starts polling;
- a cold split-mode executor registers with the Core Agent before it needs the current `AP_RUNNER_KEYS` snapshot.

Registering early prevents the runner from missing the initial key callback and waiting for a later Remote Config polling cycle.

### Motivation

Signing keys gate runner readiness. If registration happens after the Remote Config client has already delivered its initial snapshot, the monolith or split executor can remain blocked until the next poll.

The monolithic E2E confirmed the runner becomes ready through the eager listener path. In the deployed split-mode E2E, a cold executor received the existing key snapshot and became ready about 175 ms after process spawn.

### Describe how you validated your changes

- `dda inv test --targets=./comp/privateactionrunner/fx,./comp/privateactionrunner/impl,./pkg/privateactionrunner/task-verifier`
- Local Pulumi monolithic E2E using Agent and Fake Intake artifacts from pipeline `133978527`:
  - `TestLinuxPrivateActionRunnerEnabledSuite/TestPrivateActionRunnerStartsWhenEnabled`
  - Passed and reached `Keys manager ready` through the eager listener path.
- Local Pulumi split-mode E2E using the same pipeline artifacts:
  - `TestLinuxPARSplitSuite/TestSplitControlPlaneEndToEnd`
  - Passed with real ED25519 task verification, key rotation/revocation, and cold executor restart.
  - Initial cold executor became ready about 175 ms after process spawn.

### Additional Notes

Extracted from the Private Action Runner split-deployment stack so it can merge independently.
