### PR TITLE
logs Quality Gate memory limit adjustment

### DIFF
--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 30% higher than the memory_usage check value
-  memory_allotment: 286 MiB
+  memory_allotment: 296 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -31,7 +31,7 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 30% higher
-      upper_bound: "220 MiB"
+      upper_bound: "228 MiB"
 
   - name: missed_bytes
     description: "Allowable bytes not polled by log Agent"


### PR DESCRIPTION
### What does this PR do?

- adjusts the memory limit for the `logs` quality gate given the new buffer for the `memory_allotment`

### Motivation
In the last PR (https://github.com/DataDog/datadog-agent/pull/55517), the `memory_allotment` buffer was recalculated to be 30% across the board for quality gates.

The original 20% buffer for the `logs` quality gate resulted in better performance for the Agent because of the downwards pressure from the OS/etc. 

`memory_allotment` in memory bound quality gates should not be a lever that is used to gain performance. It's something that SMP needs to tackle.

### Describe how you validated your changes
A nightly sized job was run with this configuration exactly on `agent-nightlies`, the `job_id` is: `70d20df4-9c79-4b69-a640-ce7aad1cd3e5`.

### Additional Notes
N/A
