### PR TITLE
[CXP-3857] Clarify Service Discovery in process status

### DIFF
--- a/pkg/process/checks/checks.go
+++ b/pkg/process/checks/checks.go
@@ -16,12 +16,13 @@ import (
 
 // Name for check performed by process-agent or system-probe
 const (
-	ProcessCheckName     = "process"
-	RTProcessCheckName   = "rtprocess"
-	ContainerCheckName   = "container"
-	RTContainerCheckName = "rtcontainer"
-	ConnectionsCheckName = "connections"
-	DiscoveryCheckName   = "process_discovery"
+	ProcessCheckName          = "process"
+	RTProcessCheckName        = "rtprocess"
+	ContainerCheckName        = "container"
+	RTContainerCheckName      = "rtcontainer"
+	ConnectionsCheckName      = "connections"
+	DiscoveryCheckName        = "process_discovery"
+	ServiceDiscoveryCheckName = "service_discovery"
 )
 
 // SysProbeConfig provides access to system probe configuration

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -217,8 +217,20 @@ func (p *ProcessCheck) SupportsRunOptions() bool {
 	return true
 }
 
-// Name returns the name of the ProcessCheck.
+// Name returns the operational name of the ProcessCheck.
 func (p *ProcessCheck) Name() string { return ProcessCheckName }
+
+// StatusNames returns the user-facing names of the features using the ProcessCheck for Agent status.
+func (p *ProcessCheck) StatusNames() []string {
+	names := make([]string, 0, 2)
+	if p.config.GetBool("process_config.process_collection.enabled") {
+		names = append(names, ProcessCheckName)
+	}
+	if p.sysConfig.GetBool("discovery.enabled") {
+		names = append(names, ServiceDiscoveryCheckName)
+	}
+	return names
+}
 
 // Realtime indicates if this check only runs in real-time mode.
 func (p *ProcessCheck) Realtime() bool { return false }

--- a/pkg/process/checks/process_test.go
+++ b/pkg/process/checks/process_test.go
@@ -149,6 +149,32 @@ func mockProcesses(wlmEnabled bool, probe *mocks.Probe, wmeta workloadmetamock.M
 	}
 }
 
+func TestProcessCheckStatusName(t *testing.T) {
+	tests := []struct {
+		name                     string
+		processCollectionEnabled bool
+		serviceDiscoveryEnabled  bool
+		expected                 []string
+	}{
+		{name: "neither enabled", expected: []string{}},
+		{name: "process collection enabled", processCollectionEnabled: true, expected: []string{ProcessCheckName}},
+		{name: "service discovery enabled", serviceDiscoveryEnabled: true, expected: []string{ServiceDiscoveryCheckName}},
+		{name: "both enabled", processCollectionEnabled: true, serviceDiscoveryEnabled: true, expected: []string{ProcessCheckName, ServiceDiscoveryCheckName}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config := configmock.New(t)
+			config.SetInTest("process_config.process_collection.enabled", tc.processCollectionEnabled)
+			sysConfig := configmock.New(t)
+			sysConfig.SetInTest("discovery.enabled", tc.serviceDiscoveryEnabled)
+			check := &ProcessCheck{config: config, sysConfig: sysConfig}
+
+			assert.Equal(t, tc.expected, check.StatusNames())
+		})
+	}
+}
+
 func TestProcessCheckFirstRunWithProbe(t *testing.T) {
 	processCheck, probe, wmeta := processCheckWithMocks(t)
 

--- a/pkg/process/runner/runner.go
+++ b/pkg/process/runner/runner.go
@@ -256,24 +256,7 @@ const (
 //nolint:revive // TODO(PROC) Fix revive linter
 func (l *CheckRunner) Run() error {
 	realTimeAllowed := !l.config.GetBool("process_config.disable_realtime_checks")
-
-	checkNamesLength := len(l.enabledChecks)
-	if realTimeAllowed {
-		// checkNamesLength is double when realtime checks is enabled as we append the Process real time name
-		// as well as the original check name
-		checkNamesLength = checkNamesLength * 2
-	}
-
-	checkNames := make([]string, 0, checkNamesLength)
-	for _, check := range l.enabledChecks {
-		checkNames = append(checkNames, check.Name())
-
-		// Append `process_rt` if process check is enabled, and rt is enabled, so the customer doesn't get confused if
-		// process_rt doesn't show up in the enabled checks
-		if check.Name() == checks.ProcessCheckName && realTimeAllowed {
-			checkNames = append(checkNames, checks.RTProcessCheckName)
-		}
-	}
+	checkNames := enabledCheckNames(l.enabledChecks, realTimeAllowed)
 	status.UpdateEnabledChecks(checkNames)
 
 	runnerName := "process-agent"
@@ -303,6 +286,28 @@ func (l *CheckRunner) Run() error {
 	}
 
 	return nil
+}
+
+type statusNamesProvider interface {
+	StatusNames() []string
+}
+
+func enabledCheckNames(enabledChecks []checks.Check, realTimeAllowed bool) []string {
+	checkNames := make([]string, 0, len(enabledChecks)*2)
+	for _, check := range enabledChecks {
+		statusNames := []string{check.Name()}
+		if provider, ok := check.(statusNamesProvider); ok {
+			statusNames = provider.StatusNames()
+		}
+
+		for _, statusName := range statusNames {
+			checkNames = append(checkNames, statusName)
+			if statusName == checks.ProcessCheckName && realTimeAllowed {
+				checkNames = append(checkNames, checks.RTProcessCheckName)
+			}
+		}
+	}
+	return checkNames
 }
 
 func (l *CheckRunner) listenForRTUpdates() {

--- a/pkg/process/runner/runner.go
+++ b/pkg/process/runner/runner.go
@@ -288,6 +288,9 @@ func (l *CheckRunner) Run() error {
 	return nil
 }
 
+// statusNamesProvider lets a check override the names published in Agent status.
+// The runner continues to use Check.Name as the check's operational identity for
+// execution, intervals, and payload submission.
 type statusNamesProvider interface {
 	StatusNames() []string
 }

--- a/pkg/process/runner/runner_test.go
+++ b/pkg/process/runner/runner_test.go
@@ -125,6 +125,77 @@ func TestHasContainers(t *testing.T) {
 	assert.Equal(1, getContainerCount(&collectorContainerRealTime))
 }
 
+type statusNamedCheck struct {
+	checks.Check
+	statusNames []string
+}
+
+func (c statusNamedCheck) StatusNames() []string { return c.statusNames }
+
+func TestEnabledCheckNames(t *testing.T) {
+	tests := []struct {
+		name            string
+		checkName       string
+		statusNames     []string
+		realTimeAllowed bool
+		expected        []string
+	}{
+		{
+			name:     "no checks enabled",
+			expected: []string{},
+		},
+		{
+			name:            "process collection enabled",
+			checkName:       checks.ProcessCheckName,
+			statusNames:     []string{checks.ProcessCheckName},
+			realTimeAllowed: true,
+			expected:        []string{checks.ProcessCheckName, checks.RTProcessCheckName},
+		},
+		{
+			name:            "service discovery enabled",
+			checkName:       checks.ProcessCheckName,
+			statusNames:     []string{checks.ServiceDiscoveryCheckName},
+			realTimeAllowed: true,
+			expected:        []string{checks.ServiceDiscoveryCheckName},
+		},
+		{
+			name:            "both features enabled",
+			checkName:       checks.ProcessCheckName,
+			statusNames:     []string{checks.ProcessCheckName, checks.ServiceDiscoveryCheckName},
+			realTimeAllowed: true,
+			expected:        []string{checks.ProcessCheckName, checks.RTProcessCheckName, checks.ServiceDiscoveryCheckName},
+		},
+		{
+			name:        "realtime disabled",
+			checkName:   checks.ProcessCheckName,
+			statusNames: []string{checks.ProcessCheckName},
+			expected:    []string{checks.ProcessCheckName},
+		},
+		{
+			name:      "unrelated check remains visible",
+			checkName: checks.ConnectionsCheckName,
+			expected:  []string{checks.ConnectionsCheckName},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			enabledChecks := []checks.Check{}
+			if tc.checkName != "" {
+				check := checkmocks.NewCheck(t)
+				check.On("Name").Return(tc.checkName)
+				enabledChecks = append(enabledChecks, check)
+				if tc.statusNames != nil {
+					enabledChecks[0] = statusNamedCheck{Check: check, statusNames: tc.statusNames}
+				}
+			}
+
+			actual := enabledCheckNames(enabledChecks, tc.realTimeAllowed)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
 func TestDisableRealTimeProcessCheck(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/releasenotes/notes/clarify-service-discovery-status-90fecb522a532ec1.yaml
+++ b/releasenotes/notes/clarify-service-discovery-status-90fecb522a532ec1.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Clarify the Process Component status when Service Discovery is enabled
+    without Live Process collection. The enabled checks now report
+    ``service_discovery`` instead of ``process`` and ``rtprocess`` in this
+    configuration.

--- a/test/new-e2e/tests/process/docker_test.go
+++ b/test/new-e2e/tests/process/docker_test.go
@@ -57,7 +57,7 @@ func (s *dockerTestSuite) TestDockerProcessCheck() {
 		assert.Empty(t, status.ProcessAgentStatus.Expvars.Map.EnabledChecks)
 
 		// Verify the process component is running in the core agent
-		assert.ElementsMatch(t, status.ProcessComponentStatus.Expvars.Map.EnabledChecks, []string{"process", "rtprocess"})
+		assert.ElementsMatch(t, status.ProcessComponentStatus.Expvars.Map.EnabledChecks, []string{"process", "rtprocess", "service_discovery"})
 	}, 2*time.Minute, 5*time.Second)
 
 	// Flush fake intake to remove any early payloads
@@ -116,7 +116,7 @@ func (s *dockerTestSuite) TestProcessCheckWithIO() {
 	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess"}, true)
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess", "service_discovery"}, true)
 	}, 1*time.Minute, 5*time.Second)
 
 	var payloads []*aggregator.ProcessPayload
@@ -144,7 +144,7 @@ func (s *dockerTestSuite) TestProcessChecksWithNPM() {
 	s.UpdateEnv(awsdocker.Provisioner(awsdocker.WithRunOptions(scendocker.WithAgentOptions(agentOpts...))))
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess", "connections"}, false)
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess", "service_discovery", "connections"}, false)
 	}, 1*time.Minute, 5*time.Second)
 
 	var payloads []*aggregator.ProcessPayload

--- a/test/new-e2e/tests/process/k8s_test.go
+++ b/test/new-e2e/tests/process/k8s_test.go
@@ -99,7 +99,7 @@ func (s *K8sSuite) TestProcessCheck() {
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		status := k8sAgentStatus(c, s.Env().KubernetesCluster)
 		// On Linux, process checks run in the core agent's process component
-		assert.ElementsMatch(c, []string{"process", "rtprocess"}, status.ProcessComponentStatus.Expvars.Map.EnabledChecks)
+		assert.ElementsMatch(c, []string{"process", "rtprocess", "service_discovery"}, status.ProcessComponentStatus.Expvars.Map.EnabledChecks)
 	}, 5*time.Minute, 10*time.Second)
 
 	var payloads []*aggregator.ProcessPayload
@@ -200,7 +200,7 @@ func (s *K8sSuite) TestProcessCheckWithNPM() {
 	}()
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		status = k8sAgentStatus(c, s.Env().KubernetesCluster)
-		assert.ElementsMatch(c, []string{"process", "rtprocess"}, status.ProcessComponentStatus.Expvars.Map.EnabledChecks)
+		assert.ElementsMatch(c, []string{"process", "rtprocess", "service_discovery"}, status.ProcessComponentStatus.Expvars.Map.EnabledChecks)
 		assert.ElementsMatch(c, []string{"connections"}, status.ProcessAgentStatus.Expvars.Map.EnabledChecks)
 	}, 5*time.Minute, 10*time.Second)
 

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -145,7 +145,7 @@ func (s *linuxTestSuite) TestProcessCheck() {
 	s.UpdateEnv(awshost.Provisioner(awshost.WithRunOptions(scenec2.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr)))))
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess"}, false)
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess", "service_discovery"}, false)
 	}, 2*time.Minute, 5*time.Second)
 
 	var payloads []*aggregator.ProcessPayload
@@ -188,7 +188,7 @@ func (s *linuxTestSuite) TestProcessCheckWithIO() {
 	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess"}, true)
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess", "service_discovery"}, true)
 	}, 1*time.Minute, 5*time.Second)
 
 	var payloads []*aggregator.ProcessPayload
@@ -209,7 +209,7 @@ func (s *linuxTestSuite) TestProcessChecksWithNPM() {
 	s.UpdateEnv(awshost.Provisioner(awshost.WithRunOptions(scenec2.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeNPMConfigStr)))))
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess", "connections"}, false)
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess", "service_discovery", "connections"}, false)
 	}, 1*time.Minute, 5*time.Second)
 
 	// Flush fake intake to remove any payloads which may have


### PR DESCRIPTION
### What does this PR do?

Updates the Process Component's `Enabled Checks` status to report `service_discovery` when Service Discovery alone is responsible for running the underlying process check.

`ProcessCheck.Name()` remains the operational `process` identity. Status-specific names are exposed through an optional interface, so submission routing, intervals, realtime processing, and all other checks remain unchanged. When both features are enabled, status reports `[process rtprocess service_discovery]` so both remain visible.

### Motivation

Service Discovery intentionally uses the process check even when Live Process collection is disabled. Reporting the internal `process` and `rtprocess` checks in that configuration made it appear that Live Processes data was being collected and billed.

This makes the effective user-facing configuration clear in Agent status without duplicating Service Discovery configuration in the runner.

Jira: [CXP-3857](https://datadoghq.atlassian.net/browse/CXP-3857)

### Describe how you validated your changes

- `dda inv test --targets=./pkg/process/checks/...`
- `dda inv test --targets=./pkg/process/runner/...`
- `dda inv linter.go --targets=./pkg/process/checks/...,./pkg/process/runner/...`
- Commit and push pre-commit hooks

Added tests for the Process Check's status names across all Live Processes and Service Discovery combinations, including both features enabled, plus runner status-name and realtime behavior.

### Additional Notes

None.

[CXP-3857]: https://datadoghq.atlassian.net/browse/CXP-3857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ