### PR TITLE
fix(ci): fail fast on a missing `BUILDBARN_ID_TOKEN` in CI

### DIFF
--- a/.gitlab/build/binary_build/cws_instrumentation.yml
+++ b/.gitlab/build/binary_build/cws_instrumentation.yml
@@ -1,5 +1,6 @@
 ---
 .cws_instrumentation-build_common:
+  extends: .bazel:defs:cache:progressive
   stage: binary_build
   timeout: 20m
   needs: []
@@ -41,6 +42,7 @@ cws_instrumentation-build_arm64:
   extends: [.cws_instrumentation-build_common, .cws_instrumentation_arm64]
 
 .cws_instrumentation-build_injector_common:
+  extends: .bazel:defs:cache:progressive
   stage: binary_build
   timeout: 20m
   needs: []

--- a/.gitlab/build/binary_build/linux.yml
+++ b/.gitlab/build/binary_build/linux.yml
@@ -1,5 +1,6 @@
 ---
 build_dogstatsd_static-binary_x64:
+  extends: .bazel:defs:cache:progressive
   stage: binary_build
   timeout: 20m
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
@@ -15,6 +16,7 @@ build_dogstatsd_static-binary_x64:
     - $S3_CP_CMD $CI_PROJECT_DIR/$STATIC_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/static/dogstatsd.$ARCH
 
 build_dogstatsd_static-binary_arm64:
+  extends: .bazel:defs:cache:progressive
   stage: binary_build
   timeout: 20m
   rules:
@@ -32,6 +34,7 @@ build_dogstatsd_static-binary_arm64:
     - $S3_CP_CMD $CI_PROJECT_DIR/$STATIC_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/static/dogstatsd.$ARCH
 
 build_dogstatsd-binary_x64:
+  extends: .bazel:defs:cache:progressive
   stage: binary_build
   timeout: 20m
   rules:
@@ -48,6 +51,7 @@ build_dogstatsd-binary_x64:
     - $S3_CP_CMD $CI_PROJECT_DIR/$DOGSTATSD_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/dogstatsd/dogstatsd
 
 build_dogstatsd-binary_arm64:
+  extends: .bazel:defs:cache:progressive
   rules:
     - !reference [.except_mergequeue]
     - when: on_success

--- a/.gitlab/build/binary_build/secret_generic_connector.yml
+++ b/.gitlab/build/binary_build/secret_generic_connector.yml
@@ -1,5 +1,6 @@
 ---
 .secret_generic_connector-build_common:
+  extends: .bazel:defs:cache:progressive
   stage: binary_build
   needs: []
   script:

--- a/tools/bazel
+++ b/tools/bazel
@@ -33,6 +33,10 @@ if [ -n "${XDG_CACHE_HOME-}" ]; then
   # https://github.com/bazelbuild/bazel/issues/26384
   [ "$XDG_CACHE_HOME" = "$(dirname "$(dirname "$0")")/.cache" ] && extra_args+=(--repo_contents_cache=)
   if [ -n "${CI-}" ] && [ -z "${GITHUB_ACTIONS-}" ]; then
+    if [ -z "${BUILDBARN_ID_TOKEN-}" ]; then
+      >&2 echo "🔴 BUILDBARN_ID_TOKEN must be populated in CI!"
+      exit 2
+    fi
     extra_args+=(--config=ci)
     # Edge cache is only reachable from inside the k8s cluster (Linux CI runners).
     if [ "$(uname -s)" = Linux ]; then

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -35,7 +35,10 @@ if defined XDG_CACHE_HOME (
   set extra_args="--disk_cache=!bazel_home!\disk-cache"
   :: https://github.com/bazelbuild/bazel/issues/26384
   for %%i in ("%~dp0..\.cache") do if "!XDG_CACHE_HOME!" == "%%~fi" set "extra_args=!extra_args! --repo_contents_cache="
-  if defined CI if not defined GITHUB_ACTIONS set "extra_args=!extra_args! --config=ci --config=cache:frontend"
+  if defined CI if not defined GITHUB_ACTIONS (
+    if not defined BUILDBARN_ID_TOKEN goto :error_buildbarn_id_token_must_be_set
+    set "extra_args=!extra_args! --config=ci --config=cache:frontend"
+  )
 ) else (
   :: Without XDG_CACHE_HOME, fall back Go caches to official defaults so Go repo rules work under strict repo_env
   if not defined GOCACHE set "GOCACHE=%LOCALAPPDATA%\go-build"
@@ -77,6 +80,10 @@ set "args=%*"
 if defined args if defined extra_args call :insert_extra_args
 "%BAZEL_REAL%" !startup_options! !args!
 exit /b !errorlevel!
+
+:error_buildbarn_id_token_must_be_set
+>&2 echo 🔴 BUILDBARN_ID_TOKEN must be populated in CI
+exit /b 2
 
 :error_xdg_cache_home_must_exist
 >&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote a directory in CI


### PR DESCRIPTION
### What does this PR do?
Make `tools/bazel` and `tools/bazel.bat` exit rather than point Bazel at Buildbarn in CI without a populated (present and non-empty) `BUILDBARN_ID_TOKEN` environment variable.

Fix the 10 jobs still reaching `bazel` without explicit cache definition:
- the 4 `build_dogstatsd*`,
- the 4 `cws_instrumentation-build*`,
- the 2 `secret_generic_connector-build*`.

### Motivation
Both wrappers only ever checked `XDG_CACHE_HOME`, which the Linux build image exports as `/var/cache/dd`, so a job declaring no cache definition still got `--config=cache:edge` and silently reached the remote cache unauthenticated.

`bazel/tools/credential-helper` returns `{}` under `CI` and `--remote_local_fallback` absorbs the resulting `PERMISSION_DENIED`, leaving such a job green while it builds uncached, which is why #54577 and #55617 each caught a single job at a time.

The 10 jobs above reach `bazel run
@com_github_aarzilli_whydeadcode//:whydeadcode` through `go_build` whenever `DEPLOY_AGENT` is `true`.

### Describe how you validated your changes
`dda inv gitlab.print-ci --no-resolve-only-includes` resolves the 10 jobs with `id_tokens`, both bazel caches, `BAZELISK_HOME` and `XDG_CACHE_HOME`, while their own `ARCH`, `needs`, `artifacts` and `timeout` survive the merge.

### Additional Notes
No job left in that resolved configuration reaches `bazel` without the token, so the check fails nothing at the moment.