### PR TITLE
Pin Windows helm chart version as well

### DIFF
--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -318,6 +318,7 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 			InstallName: windowsInstallName,
 			Namespace:   args.Namespace,
 			ValuesYAML:  windowsValuesYAML,
+			Version:     pulumi.String(chartVersion),
 		}, windowsOpts...)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Pin the version of the helm chart used to install the agent on Windows as well. It was an oversight from the PR pinning the version of the helm chart, that only handled Linux install

### Motivation

Fix an issue that started with new version of the helm chart, also improve reproducibility

### Describe how you validated your changes

### Additional Notes
