### PR TITLE
ci: skip code review workflow for bot-authored PRs

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   review:
-    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'no-draft-review'))) }}
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.user.login, '[bot]') && github.event.pull_request.head.repo.full_name == github.repository && (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'no-draft-review'))) }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
### What does this PR do?

Skips the `review` job in `code-review.yml` when the PR author is a bot (e.g. `renovate[bot]`, `dependabot[bot]`), by checking `github.event.pull_request.user.login` — the same check already used in `add-dependabot-pr-to-mq.yml` and `deps-tidy.yml`.

### Motivation

Bot-authored PRs run with a restricted `GITHUB_TOKEN` and no repo secrets, so the "Run Codex" step always fails for them (e.g. [this run](https://github.com/DataDog/datadog-agent/actions/runs/33287155950/job/99192401888)).