### PR TITLE
[procmgr] Add TestEnv list catalog charter tests

### DIFF
--- a/pkg/procmgr/rust/tests/e2e.rs
+++ b/pkg/procmgr/rust/tests/e2e.rs
@@ -217,6 +217,49 @@ fn stop_process_kills_child() {
 }
 
 #[test]
+fn list_empty_when_no_processes() {
+    let procmgr = TestEnv::new().start();
+    procmgr.assert_status_ready();
+    procmgr.assert_list_empty();
+}
+
+#[test]
+fn list_shows_running_and_created_mix() {
+    let env = TestEnv::new()
+        .with_process("sleeper")
+        .with_process("sleeper_idle");
+    let procmgr = env.start();
+    procmgr.assert_status_ready();
+    procmgr.assert_list_len(2);
+    procmgr.assert_process_running("sleeper");
+    procmgr.assert_process_state("sleeper_idle", ProcessExpect::Created);
+}
+
+#[test]
+fn list_shows_exited_with_last_exit_code() {
+    let env = TestEnv::new()
+        .with_process("exit_ok")
+        .with_process("exit_fail");
+    let procmgr = env.start();
+    procmgr.assert_status_ready();
+    procmgr.assert_process_state_within("exit_ok", ProcessExpect::Exited);
+    procmgr.assert_process_state_within("exit_fail", ProcessExpect::Failed);
+    procmgr.assert_list_len(2);
+    procmgr.assert_process_state("exit_ok", ProcessExpect::Exited);
+    procmgr.assert_process_state("exit_fail", ProcessExpect::Failed);
+
+    let ok = procmgr.process("exit_ok").expect("exit_ok listed");
+    assert_eq!(ok.last_exit_code, Some(0), "exit_ok last_exit_code: {ok:?}");
+
+    let fail = procmgr.process("exit_fail").expect("exit_fail listed");
+    assert_eq!(
+        fail.last_exit_code,
+        Some(1),
+        "exit_fail last_exit_code: {fail:?}"
+    );
+}
+
+#[test]
 fn test_cli_config_basic() {
     let env = TestEnv::new()
         .with_config("sleeper", test_helpers::sleep_config_yaml())
@@ -408,131 +451,6 @@ fn test_cli_config_with_runtime_processes() {
         .assert_success()
         .assert_field("Loaded Processes", "1")
         .assert_field("Runtime Processes", "1");
-}
-
-#[test]
-fn test_cli_list_empty() {
-    let env = TestEnv::new().start();
-
-    env.cli(&["list"])
-        .assert_success()
-        .assert_stdout_contains("No processes");
-}
-
-#[test]
-fn test_cli_list_one_running() {
-    let env = TestEnv::new()
-        .with_config("sleeper", test_helpers::sleep_config_yaml())
-        .start();
-
-    env.daemon().wait_for_log_default("[sleeper] spawned");
-
-    let out = env.cli(&["list"]);
-    out.assert_success()
-        .assert_table_row(
-            "sleeper",
-            &[
-                ("STATE", "Running"),
-                ("COMMAND", test_helpers::sleep_cmd(300).0),
-            ],
-        )
-        .assert_table_row_count(1);
-
-    let pid = out.pid_from_table_row("sleeper");
-    assert!(pid_is_alive(pid), "PID {pid} should be alive");
-}
-
-#[test]
-fn test_cli_list_multiple_processes() {
-    let env = TestEnv::new()
-        .with_config("alpha", test_helpers::sleep_config_yaml())
-        .with_config("beta", test_helpers::sleep_config_yaml())
-        .start();
-
-    env.daemon().wait_for_log_default("[alpha] spawned");
-    env.daemon().wait_for_log_default("[beta] spawned");
-
-    let out = env.cli(&["list"]);
-    out.assert_success()
-        .assert_table_row("alpha", &[("STATE", "Running")])
-        .assert_table_row("beta", &[("STATE", "Running")])
-        .assert_table_row_count(2);
-
-    let pid_a = out.pid_from_table_row("alpha");
-    let pid_b = out.pid_from_table_row("beta");
-    assert!(pid_is_alive(pid_a), "alpha PID {pid_a} should be alive");
-    assert!(pid_is_alive(pid_b), "beta PID {pid_b} should be alive");
-}
-
-#[test]
-fn test_cli_list_mixed_states() {
-    let env = TestEnv::new()
-        .with_config("runner", test_helpers::sleep_config_yaml())
-        .with_config(
-            "idle",
-            &test_helpers::sleep_config_with("auto_start: false\n"),
-        )
-        .start();
-
-    env.daemon().wait_for_log_default("[runner] spawned");
-
-    let out = env.cli(&["list"]);
-    out.assert_success()
-        .assert_table_row("runner", &[("STATE", "Running")])
-        .assert_table_row("idle", &[("STATE", "Created"), ("PID", "-")])
-        .assert_table_row_count(2);
-
-    let pid = out.pid_from_table_row("runner");
-    assert!(pid_is_alive(pid), "runner PID {pid} should be alive");
-}
-
-#[test]
-fn test_cli_list_spawn_failure() {
-    let env = TestEnv::new()
-        .with_config("bad", "command: /nonexistent/binary\n")
-        .start();
-
-    env.daemon().wait_for_log_default("[bad] failed to spawn");
-
-    env.cli(&["list"])
-        .assert_success()
-        .assert_table_row("bad", &[("STATE", "Failed"), ("PID", "-")])
-        .assert_table_row_count(1);
-}
-
-#[test]
-fn test_cli_list_exited_state() {
-    let env = TestEnv::new()
-        .with_config("quick", test_helpers::true_config_yaml())
-        .start();
-
-    env.daemon().wait_for_log_default("[quick] exited with");
-
-    env.cli(&["list"])
-        .assert_success()
-        .assert_table_row(
-            "quick",
-            &[("STATE", "Exited"), ("PID", "-"), ("LAST EXIT", "exit 0")],
-        )
-        .assert_table_row_count(1);
-}
-
-#[test]
-fn test_cli_list_last_exit_column() {
-    let env = TestEnv::new()
-        .with_config("ok", test_helpers::true_config_yaml())
-        .with_config("fail", test_helpers::false_config_yaml())
-        .with_config("alive", test_helpers::sleep_config_yaml())
-        .start();
-
-    env.daemon().wait_for_log_default("[ok] exited with");
-    env.daemon().wait_for_log_default("[fail] exited with");
-
-    env.cli(&["list"])
-        .assert_success()
-        .assert_table_row("ok", &[("LAST EXIT", "exit 0")])
-        .assert_table_row("fail", &[("LAST EXIT", "exit 1")])
-        .assert_table_row("alive", &[("LAST EXIT", "-")]);
 }
 
 #[test]

--- a/pkg/procmgr/rust/tests/e2e.rs
+++ b/pkg/procmgr/rust/tests/e2e.rs
@@ -109,7 +109,6 @@ fn exit_ok_fixture_exits_cleanly() {
         failed: Some(0),
         ..Default::default()
     });
-    procmgr.assert_process_state("exit_ok", ProcessExpect::Exited);
 }
 
 #[test]
@@ -125,7 +124,6 @@ fn exit_fail_fixture_exits_with_failure() {
         exited: Some(0),
         ..Default::default()
     });
-    procmgr.assert_process_state("exit_fail", ProcessExpect::Failed);
 }
 
 #[test]
@@ -245,18 +243,8 @@ fn list_shows_exited_with_last_exit_code() {
     procmgr.assert_process_state_within("exit_ok", ProcessExpect::Exited);
     procmgr.assert_process_state_within("exit_fail", ProcessExpect::Failed);
     procmgr.assert_list_len(2);
-    procmgr.assert_process_state("exit_ok", ProcessExpect::Exited);
-    procmgr.assert_process_state("exit_fail", ProcessExpect::Failed);
-
-    let ok = procmgr.process("exit_ok").expect("exit_ok listed");
-    assert_eq!(ok.last_exit_code, Some(0), "exit_ok last_exit_code: {ok:?}");
-
-    let fail = procmgr.process("exit_fail").expect("exit_fail listed");
-    assert_eq!(
-        fail.last_exit_code,
-        Some(1),
-        "exit_fail last_exit_code: {fail:?}"
-    );
+    procmgr.assert_process_last_exit_code("exit_ok", 0);
+    procmgr.assert_process_last_exit_code("exit_fail", 1);
 }
 
 #[test]

--- a/pkg/procmgr/rust/tests/e2e.rs
+++ b/pkg/procmgr/rust/tests/e2e.rs
@@ -7,9 +7,10 @@ mod helpers;
 
 use dd_procmgrd::test_helpers;
 use helpers::{
-    ProcessExpect, StatusProcessesCount, TestEnv, kill_pid_force, pid_is_alive, wait_for_pid_gone,
-    write_config,
+    DescribeExpect, ProcessExpect, ReloadExpect, StatusProcessesCount, TestEnv, kill_pid_force,
+    pid_is_alive, wait_for_pid_gone, write_config,
 };
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 #[test]
@@ -245,6 +246,216 @@ fn list_shows_exited_with_last_exit_code() {
     procmgr.assert_list_len(2);
     procmgr.assert_process_last_exit_code("exit_ok", 0);
     procmgr.assert_process_last_exit_code("exit_fail", 1);
+}
+
+#[test]
+fn reload_unchanged_leaves_running_process() {
+    let procmgr = TestEnv::new().with_process("sleeper").start();
+    procmgr.assert_process_running("sleeper");
+    procmgr.assert_reload_matches(ReloadExpect {
+        unchanged: Some(vec!["sleeper".into()]),
+        added: Some(vec![]),
+        removed: Some(vec![]),
+        modified: Some(vec![]),
+        preserve_running_pids: vec!["sleeper".into()],
+    });
+}
+
+#[test]
+fn reload_adds_fixture_to_catalog() {
+    let procmgr = TestEnv::new().start();
+    procmgr.assert_list_empty();
+
+    procmgr.install_fixture("sleeper");
+    procmgr.assert_reload_matches(ReloadExpect {
+        added: Some(vec!["sleeper".into()]),
+        ..Default::default()
+    });
+    procmgr.assert_list_len(1);
+    procmgr.assert_process_running("sleeper");
+}
+
+#[test]
+fn reload_removes_deleted_yaml_from_catalog() {
+    let procmgr = TestEnv::new()
+        .with_process("sleeper")
+        .with_process("sleeper_idle")
+        .start();
+    procmgr.assert_list_len(2);
+    procmgr.assert_process_running("sleeper");
+    procmgr.assert_process_state("sleeper_idle", ProcessExpect::Created);
+
+    procmgr.remove_process_yaml("sleeper_idle");
+    procmgr.assert_reload_matches(ReloadExpect {
+        removed: Some(vec!["sleeper_idle".into()]),
+        unchanged: Some(vec!["sleeper".into()]),
+        added: Some(vec![]),
+        modified: Some(vec![]),
+        preserve_running_pids: vec!["sleeper".into()],
+    });
+    procmgr.assert_list_len(1);
+    procmgr.assert_process_absent("sleeper_idle");
+}
+
+#[test]
+fn reload_remove_only_empties_catalog() {
+    let procmgr = TestEnv::new().with_process("sleeper").start();
+    procmgr.assert_process_running("sleeper");
+    procmgr.assert_list_len(1);
+    let old_pid = procmgr.process("sleeper").expect("sleeper").pid;
+
+    procmgr.remove_process_yaml("sleeper");
+    procmgr.assert_reload_matches(ReloadExpect {
+        removed: Some(vec!["sleeper".into()]),
+        added: Some(vec![]),
+        modified: Some(vec![]),
+        unchanged: Some(vec![]),
+        ..Default::default()
+    });
+
+    procmgr.assert_pid_gone(old_pid);
+    procmgr.assert_list_empty();
+}
+
+#[test]
+fn reload_adds_no_auto_start_stays_created() {
+    let procmgr = TestEnv::new().start();
+    procmgr.assert_list_empty();
+
+    procmgr.install_fixture("sleeper_idle");
+    procmgr.assert_reload_matches(ReloadExpect {
+        added: Some(vec!["sleeper_idle".into()]),
+        ..Default::default()
+    });
+    procmgr.assert_list_len(1);
+    procmgr.assert_process_state("sleeper_idle", ProcessExpect::Created);
+}
+
+#[test]
+fn reload_modify_respawns_with_new_pid() {
+    let procmgr = TestEnv::new().with_process("sleeper").start();
+    procmgr.assert_process_running("sleeper");
+    let count_before = procmgr.list_processes().expect("list before reload").len();
+    let old_pid = procmgr.process("sleeper").expect("sleeper").pid;
+
+    procmgr.overwrite_with_fixture("sleeper", "sleeper_long");
+
+    procmgr.assert_reload_matches(ReloadExpect {
+        modified: Some(vec!["sleeper".into()]),
+        added: Some(vec![]),
+        removed: Some(vec![]),
+        unchanged: Some(vec![]),
+        ..Default::default()
+    });
+
+    let count_after = procmgr.list_processes().expect("list after reload").len();
+    assert_eq!(
+        count_before, count_after,
+        "modify reload should not change catalog size"
+    );
+    procmgr.assert_process_pid_changed("sleeper", old_pid);
+}
+
+#[test]
+fn reload_remove_and_add_swaps_catalog() {
+    let procmgr = TestEnv::new().with_process("sleeper").start();
+    procmgr.assert_process_running("sleeper");
+    let old_pid = procmgr.process("sleeper").expect("sleeper").pid;
+
+    procmgr.remove_process_yaml("sleeper");
+    procmgr.install_fixture("sleeper_idle");
+
+    procmgr.assert_reload_matches(ReloadExpect {
+        removed: Some(vec!["sleeper".into()]),
+        added: Some(vec!["sleeper_idle".into()]),
+        modified: Some(vec![]),
+        unchanged: Some(vec![]),
+        ..Default::default()
+    });
+
+    procmgr.assert_pid_gone(old_pid);
+    procmgr.assert_process_state("sleeper_idle", ProcessExpect::Created);
+}
+
+#[test]
+fn describe_running_process_matches_fixture() {
+    let procmgr = TestEnv::new().with_process("sleeper").start();
+    procmgr.assert_process_running("sleeper");
+
+    let list_snap = procmgr.process("sleeper").expect("sleeper");
+    procmgr.assert_describe_matches(
+        "sleeper",
+        DescribeExpect {
+            name: Some("sleeper".into()),
+            state: Some("Running".into()),
+            command: Some(list_snap.command),
+            args: Some(list_snap.args),
+            has_uuid: Some(true),
+            pid_alive: Some(true),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn describe_resolves_uuid_prefix() {
+    let procmgr = TestEnv::new().with_process("sleeper").start();
+    procmgr.assert_process_running("sleeper");
+
+    let uuid = procmgr.process("sleeper").expect("sleeper").uuid.clone();
+    let prefix = uuid[..8].to_string();
+
+    for id in [&prefix, uuid.as_str()] {
+        procmgr.assert_describe_matches(
+            id,
+            DescribeExpect {
+                name: Some("sleeper".into()),
+                uuid: Some(uuid.clone()),
+                ..Default::default()
+            },
+        );
+    }
+}
+
+#[test]
+fn describe_shows_static_config_fields() {
+    let procmgr = TestEnv::new().with_process("full").start();
+    procmgr.assert_process_running("full");
+
+    let root = procmgr.env_root().display().to_string();
+    procmgr.assert_describe_matches(
+        "full",
+        DescribeExpect {
+            name: Some("full".into()),
+            state: Some("Running".into()),
+            description: Some("a test process".into()),
+            working_dir: Some(root),
+            restart_policy: Some("always".into()),
+            auto_start: Some(true),
+            env_contains: Some(BTreeMap::from([("MY_VAR".into(), "hello".into())])),
+            after: Some(vec!["other".into()]),
+            has_stdout_path: Some(true),
+            has_stderr_path: Some(true),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn describe_after_exit_shows_last_exit() {
+    let procmgr = TestEnv::new().with_process("exit_fail").start();
+    procmgr.assert_process_state_within("exit_fail", ProcessExpect::Failed);
+
+    procmgr.assert_describe_matches(
+        "exit_fail",
+        DescribeExpect {
+            name: Some("exit_fail".into()),
+            state: Some("Failed".into()),
+            pid: Some(0),
+            last_exit_code: Some(Some(1)),
+            ..Default::default()
+        },
+    );
 }
 
 #[test]
@@ -544,97 +755,12 @@ fn test_cli_list_shows_restart_count() {
 }
 
 #[test]
-fn test_cli_describe_by_name() {
-    let env = TestEnv::new()
-        .with_config("sleeper", test_helpers::sleep_config_yaml())
-        .start();
+fn test_cli_describe_last_exit_text() {
+    let env = TestEnv::new().with_process("exit_fail").start();
+    env.assert_process_state_within("exit_fail", ProcessExpect::Failed);
 
-    env.daemon().wait_for_log_default("[sleeper] spawned");
-
-    let out = env.cli(&["describe", "sleeper"]);
-    out.assert_success()
-        .assert_field("Name", "sleeper")
-        .assert_field("State", "Running")
-        .assert_field("Command", test_helpers::sleep_cmd(300).0)
-        .assert_field("Args", &test_helpers::sleep_args_display())
-        .assert_has_field("UUID");
-
-    let pid = out.pid_from_field("PID");
-    assert!(pid_is_alive(pid), "PID {pid} should be alive");
-}
-
-#[test]
-fn test_cli_describe_by_uuid() {
-    let env = TestEnv::new()
-        .with_config("sleeper", test_helpers::sleep_config_yaml())
-        .start();
-
-    env.daemon().wait_for_log_default("[sleeper] spawned");
-
-    let list_out = env.cli(&["list", "--json"]);
-    let json = list_out.stdout_json();
-    let uuid = json[0]["uuid"].as_str().expect("uuid should be a string");
-    let prefix = &uuid[..8];
-
-    let out = env.cli(&["describe", prefix]);
-    out.assert_success()
-        .assert_field("Name", "sleeper")
-        .assert_field("UUID", uuid);
-
-    let pid = out.pid_from_field("PID");
-    assert!(pid_is_alive(pid), "PID {pid} should be alive");
-
-    env.cli(&["describe", uuid])
+    env.cli(&["describe", "exit_fail"])
         .assert_success()
-        .assert_field("Name", "sleeper")
-        .assert_field("UUID", uuid);
-}
-
-#[test]
-fn test_cli_describe_shows_all_fields() {
-    let tmp = test_helpers::temp_dir_str();
-    let env = TestEnv::new()
-        .with_config(
-            "full",
-            &test_helpers::sleep_config_with(&format!(
-                "description: a test process\nworking_dir: {tmp}\nenv:\n  MY_VAR: hello\nrestart: always\nafter:\n  - other\n"
-            )),
-        )
-        .start();
-
-    env.daemon().wait_for_log_default("[full] spawned");
-
-    let out = env.cli(&["describe", "full"]);
-    out.assert_success()
-        .assert_field("Name", "full")
-        .assert_field("State", "Running")
-        .assert_field("Command", test_helpers::sleep_cmd(300).0)
-        .assert_field("Args", &test_helpers::sleep_args_display())
-        .assert_field("Description", "a test process")
-        .assert_field("Working Dir", &tmp)
-        .assert_field("Restart Policy", "always")
-        .assert_field("Auto Start", "true")
-        .assert_has_field("UUID")
-        .assert_has_field("Stdout")
-        .assert_has_field("Stderr");
-
-    let pid = out.pid_from_field("PID");
-    assert!(pid_is_alive(pid), "PID {pid} should be alive");
-}
-
-#[test]
-fn test_cli_describe_after_exit() {
-    let env = TestEnv::new()
-        .with_config("quick", test_helpers::false_config_yaml())
-        .start();
-
-    env.daemon().wait_for_log_default("[quick] exited with");
-
-    env.cli(&["describe", "quick"])
-        .assert_success()
-        .assert_field("Name", "quick")
-        .assert_field("State", "Failed")
-        .assert_field("PID", "-")
         .assert_field("Last Exit", "exit 1");
 }
 
@@ -980,150 +1106,25 @@ fn test_cli_create_env_vars() {
 }
 
 #[test]
-fn test_cli_reload_no_changes() {
-    let env = TestEnv::new()
-        .with_config("sleeper", test_helpers::sleep_config_yaml())
-        .start();
-
-    env.daemon().wait_for_log_default("[sleeper] spawned");
+fn test_cli_reload_text_modified() {
+    let env = TestEnv::new().with_process("sleeper").start();
+    env.overwrite_with_fixture("sleeper", "sleeper_long");
 
     env.cli(&["reload"])
         .assert_success()
-        .assert_field("Unchanged", "sleeper");
+        .assert_field("Modified", "sleeper");
 }
 
 #[test]
-fn test_cli_reload_add_process() {
-    let env = TestEnv::new()
-        .with_config("existing", test_helpers::sleep_config_yaml())
-        .start();
-
-    env.daemon().wait_for_log_default("[existing] spawned");
-
-    write_config(
-        env.config_dir(),
-        "new-svc",
-        test_helpers::sleep_config_yaml(),
-    );
+fn test_cli_reload_text_added_removed() {
+    let env = TestEnv::new().with_process("sleeper").start();
+    env.remove_process_yaml("sleeper");
+    env.install_fixture("sleeper_idle");
 
     env.cli(&["reload"])
         .assert_success()
-        .assert_field("Added", "new-svc");
-
-    env.daemon().wait_for_log_default("[new-svc] spawned");
-
-    let out = env.cli(&["list"]);
-    out.assert_success()
-        .assert_table_row("new-svc", &[("STATE", "Running")])
-        .assert_table_row("existing", &[("STATE", "Running")])
-        .assert_table_row_count(2);
-
-    let pid_new = out.pid_from_table_row("new-svc");
-    let pid_existing = out.pid_from_table_row("existing");
-    assert!(
-        pid_is_alive(pid_new),
-        "new-svc PID {pid_new} should be alive"
-    );
-    assert!(
-        pid_is_alive(pid_existing),
-        "existing PID {pid_existing} should be alive"
-    );
-}
-
-#[test]
-fn test_cli_reload_remove_process() {
-    let env = TestEnv::new()
-        .with_config("keeper", test_helpers::sleep_config_yaml())
-        .with_config("doomed", test_helpers::sleep_config_yaml())
-        .start();
-
-    env.daemon().wait_for_log_default("[keeper] spawned");
-    env.daemon().wait_for_log_default("[doomed] spawned");
-
-    let doomed_pid = env.cli(&["list"]).pid_from_table_row("doomed");
-
-    std::fs::remove_file(env.config_dir().join("doomed.yaml"))
-        .expect("failed to remove doomed.yaml");
-
-    env.cli(&["reload"])
-        .assert_success()
-        .assert_field("Removed", "doomed");
-
-    assert!(
-        wait_for_pid_gone(doomed_pid, Duration::from_secs(5)),
-        "removed process PID {doomed_pid} should be gone"
-    );
-
-    env.cli(&["list"])
-        .assert_success()
-        .assert_table_row_count(1)
-        .assert_table_row("keeper", &[("STATE", "Running")]);
-}
-
-#[test]
-fn test_cli_reload_modify_process() {
-    let env = TestEnv::new()
-        .with_config("svc", test_helpers::sleep_config_yaml())
-        .start();
-
-    env.daemon().wait_for_log_default("[svc] spawned");
-
-    let old_pid = env.cli(&["list"]).pid_from_table_row("svc");
-
-    let (cmd, args) = dd_procmgrd::test_helpers::sleep_cmd(600);
-    write_config(
-        env.config_dir(),
-        "svc",
-        &test_helpers::cmd_yaml(cmd, &args, ""),
-    );
-
-    env.cli(&["reload"])
-        .assert_success()
-        .assert_field("Modified", "svc");
-
-    assert!(
-        env.daemon()
-            .wait_for_log_count("[svc] spawned", 2, Duration::from_secs(10)),
-        "svc should have been respawned after modify"
-    );
-
-    assert!(
-        wait_for_pid_gone(old_pid, Duration::from_secs(5)),
-        "old PID {old_pid} should be gone after modify+reload"
-    );
-
-    let new_pid = env.cli(&["list"]).pid_from_table_row("svc");
-    assert!(pid_is_alive(new_pid), "new PID {new_pid} should be alive");
-    assert_ne!(old_pid, new_pid, "PID should change after modify+reload");
-}
-
-#[test]
-fn test_cli_reload_add_and_remove() {
-    let env = TestEnv::new()
-        .with_config("old", test_helpers::sleep_config_yaml())
-        .start();
-
-    env.daemon().wait_for_log_default("[old] spawned");
-
-    let old_pid = env.cli(&["list"]).pid_from_table_row("old");
-
-    std::fs::remove_file(env.config_dir().join("old.yaml")).expect("failed to remove old.yaml");
-    write_config(env.config_dir(), "new", test_helpers::sleep_config_yaml());
-
-    let out = env.cli(&["reload"]);
-    out.assert_success()
-        .assert_field("Added", "new")
-        .assert_field("Removed", "old");
-
-    assert!(
-        wait_for_pid_gone(old_pid, Duration::from_secs(5)),
-        "old PID {old_pid} should be gone after removal"
-    );
-
-    env.daemon().wait_for_log_default("[new] spawned");
-
-    let new_pid = env.cli(&["list"]).pid_from_table_row("new");
-    assert!(pid_is_alive(new_pid), "new PID {new_pid} should be alive");
+        .assert_field("Added", "sleeper_idle")
+        .assert_field("Removed", "sleeper");
 }
 
 #[test]
@@ -1156,48 +1157,6 @@ fn test_cli_reload_json() {
 
     assert!(json["removed"].as_array().expect("array").is_empty());
     assert!(json["modified"].as_array().expect("array").is_empty());
-}
-
-#[test]
-fn test_cli_reload_new_process_starts() {
-    let env = TestEnv::new().start();
-
-    write_config(env.config_dir(), "late", test_helpers::sleep_config_yaml());
-
-    env.cli(&["reload"]).assert_success();
-    env.daemon().wait_for_log_default("[late] spawned");
-
-    let out = env.cli(&["list"]);
-    out.assert_success()
-        .assert_table_row("late", &[("STATE", "Running")]);
-
-    let pid = out.pid_from_table_row("late");
-    assert!(pid_is_alive(pid), "PID {pid} should be alive");
-}
-
-#[test]
-fn test_cli_reload_removed_process_stopped() {
-    let env = TestEnv::new()
-        .with_config("ephemeral", test_helpers::sleep_config_yaml())
-        .start();
-
-    env.daemon().wait_for_log_default("[ephemeral] spawned");
-
-    let pid = env.cli(&["list"]).pid_from_table_row("ephemeral");
-
-    std::fs::remove_file(env.config_dir().join("ephemeral.yaml"))
-        .expect("failed to remove ephemeral.yaml");
-
-    env.cli(&["reload"]).assert_success();
-
-    assert!(
-        wait_for_pid_gone(pid, Duration::from_secs(5)),
-        "removed process PID {pid} should be gone"
-    );
-
-    env.cli(&["list"])
-        .assert_success()
-        .assert_stdout_contains("No processes");
 }
 
 #[test]
@@ -1306,31 +1265,6 @@ fn test_cli_stop_start_then_kill_restarts_on_failure() {
         json[0]["restart_count"].as_u64().unwrap() >= 1,
         "restart_count should reflect the crash restart"
     );
-}
-
-#[test]
-fn test_cli_reload_then_start() {
-    let env = TestEnv::new().start();
-
-    write_config(
-        env.config_dir(),
-        "late",
-        &test_helpers::sleep_config_with("auto_start: false\n"),
-    );
-
-    env.cli(&["reload"])
-        .assert_success()
-        .assert_field("Added", "late");
-
-    env.cli(&["list"])
-        .assert_success()
-        .assert_table_row("late", &[("STATE", "Created"), ("PID", "-")]);
-
-    env.cli(&["start", "late"]).assert_success();
-    env.daemon().wait_for_log_default("[late] spawned");
-
-    let pid = env.cli(&["list"]).pid_from_table_row("late");
-    assert!(pid_is_alive(pid), "PID {pid} should be alive");
 }
 
 #[test]

--- a/pkg/procmgr/rust/tests/e2e.rs
+++ b/pkg/procmgr/rust/tests/e2e.rs
@@ -450,16 +450,27 @@ fn test_cli_list_terminal_table_fields() {
     procmgr.assert_process_state_within("exit_ok", ProcessExpect::Exited);
     procmgr.assert_process_state_within("exit_fail", ProcessExpect::Failed);
 
+    let python = test_helpers::python_exe();
     procmgr
         .cli(&["list"])
         .assert_success()
         .assert_table_row(
             "exit_ok",
-            &[("STATE", "Exited"), ("PID", "-"), ("LAST EXIT", "exit 0")],
+            &[
+                ("STATE", "Exited"),
+                ("PID", "-"),
+                ("LAST EXIT", "exit 0"),
+                ("COMMAND", &python),
+            ],
         )
         .assert_table_row(
             "exit_fail",
-            &[("STATE", "Failed"), ("PID", "-"), ("LAST EXIT", "exit 1")],
+            &[
+                ("STATE", "Failed"),
+                ("PID", "-"),
+                ("LAST EXIT", "exit 1"),
+                ("COMMAND", &python),
+            ],
         )
         .assert_table_row_count(2);
 }

--- a/pkg/procmgr/rust/tests/e2e.rs
+++ b/pkg/procmgr/rust/tests/e2e.rs
@@ -442,6 +442,29 @@ fn test_cli_config_with_runtime_processes() {
 }
 
 #[test]
+fn test_cli_list_terminal_table_fields() {
+    let procmgr = TestEnv::new()
+        .with_process("exit_ok")
+        .with_process("exit_fail")
+        .start();
+    procmgr.assert_process_state_within("exit_ok", ProcessExpect::Exited);
+    procmgr.assert_process_state_within("exit_fail", ProcessExpect::Failed);
+
+    procmgr
+        .cli(&["list"])
+        .assert_success()
+        .assert_table_row(
+            "exit_ok",
+            &[("STATE", "Exited"), ("PID", "-"), ("LAST EXIT", "exit 0")],
+        )
+        .assert_table_row(
+            "exit_fail",
+            &[("STATE", "Failed"), ("PID", "-"), ("LAST EXIT", "exit 1")],
+        )
+        .assert_table_row_count(2);
+}
+
+#[test]
 fn test_cli_list_json() {
     let env = TestEnv::new()
         .with_config("sleeper", test_helpers::sleep_config_yaml())

--- a/pkg/procmgr/rust/tests/fixtures/BUILD.bazel
+++ b/pkg/procmgr/rust/tests/fixtures/BUILD.bazel
@@ -7,10 +7,12 @@ filegroup(
         "//pkg/procmgr/rust/tests/fixtures/condition_blocked",
         "//pkg/procmgr/rust/tests/fixtures/exit_fail",
         "//pkg/procmgr/rust/tests/fixtures/exit_ok",
+        "//pkg/procmgr/rust/tests/fixtures/full",
         "//pkg/procmgr/rust/tests/fixtures/invalid_syntax",
         "//pkg/procmgr/rust/tests/fixtures/missing_binary",
         "//pkg/procmgr/rust/tests/fixtures/sleeper",
         "//pkg/procmgr/rust/tests/fixtures/sleeper_idle",
+        "//pkg/procmgr/rust/tests/fixtures/sleeper_long",
     ],
     visibility = ["//pkg/procmgr/rust:__pkg__"],
 )

--- a/pkg/procmgr/rust/tests/fixtures/full/BUILD.bazel
+++ b/pkg/procmgr/rust/tests/fixtures/full/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "full",
+    srcs = glob(["*"]),
+    visibility = ["//pkg/procmgr/rust/tests/fixtures:__pkg__"],
+)

--- a/pkg/procmgr/rust/tests/fixtures/full/full.py
+++ b/pkg/procmgr/rust/tests/fixtures/full/full.py
@@ -1,0 +1,5 @@
+"""Long-running process for procmgr e2e tests."""
+
+import time
+
+time.sleep(300)

--- a/pkg/procmgr/rust/tests/fixtures/full/full.yaml
+++ b/pkg/procmgr/rust/tests/fixtures/full/full.yaml
@@ -1,0 +1,10 @@
+command: {{python}}
+args:
+  - {{script}}
+description: a test process
+working_dir: {{root}}
+env:
+  MY_VAR: hello
+restart: always
+after:
+  - other

--- a/pkg/procmgr/rust/tests/fixtures/sleeper_long/BUILD.bazel
+++ b/pkg/procmgr/rust/tests/fixtures/sleeper_long/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "sleeper_long",
+    srcs = glob(["*"]),
+    visibility = ["//pkg/procmgr/rust/tests/fixtures:__pkg__"],
+)

--- a/pkg/procmgr/rust/tests/fixtures/sleeper_long/sleeper_long.py
+++ b/pkg/procmgr/rust/tests/fixtures/sleeper_long/sleeper_long.py
@@ -1,0 +1,5 @@
+"""Longer-running process for procmgr reload-modify e2e tests."""
+
+import time
+
+time.sleep(600)

--- a/pkg/procmgr/rust/tests/fixtures/sleeper_long/sleeper_long.yaml
+++ b/pkg/procmgr/rust/tests/fixtures/sleeper_long/sleeper_long.yaml
@@ -1,0 +1,3 @@
+command: {{python}}
+args:
+  - {{script}}

--- a/pkg/procmgr/rust/tests/helpers/mod.rs
+++ b/pkg/procmgr/rust/tests/helpers/mod.rs
@@ -8,6 +8,7 @@ use nix::sys::signal::{self, Signal};
 #[cfg(unix)]
 use nix::unistd::Pid;
 use serde::Deserialize;
+use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
@@ -52,6 +53,263 @@ pub struct ProcessSnapshot {
     pub restart_count: u64,
     pub last_exit_code: Option<i32>,
     pub last_signal: Option<i32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct ReloadSnapshot {
+    added: Vec<String>,
+    removed: Vec<String>,
+    modified: Vec<String>,
+    unchanged: Vec<String>,
+}
+
+/// Unset list fields are not checked. An empty vec requires the list to be empty.
+/// A non-empty vec requires every name to appear in the list.
+#[derive(Debug, Clone, Default)]
+pub struct ReloadExpect {
+    pub added: Option<Vec<String>>,
+    pub removed: Option<Vec<String>>,
+    pub modified: Option<Vec<String>>,
+    pub unchanged: Option<Vec<String>>,
+    /// Running processes whose PID must not change across reload.
+    pub preserve_running_pids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReloadList {
+    Added,
+    Removed,
+    Modified,
+    Unchanged,
+}
+
+impl ReloadList {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Added => "added",
+            Self::Removed => "removed",
+            Self::Modified => "modified",
+            Self::Unchanged => "unchanged",
+        }
+    }
+
+    fn names(self, snapshot: &ReloadSnapshot) -> &[String] {
+        match self {
+            Self::Added => &snapshot.added,
+            Self::Removed => &snapshot.removed,
+            Self::Modified => &snapshot.modified,
+            Self::Unchanged => &snapshot.unchanged,
+        }
+    }
+}
+
+impl ReloadSnapshot {
+    fn assert_matches(&self, expected: &ReloadExpect) {
+        Self::assert_list_expect(self, ReloadList::Added, &expected.added);
+        Self::assert_list_expect(self, ReloadList::Removed, &expected.removed);
+        Self::assert_list_expect(self, ReloadList::Modified, &expected.modified);
+        Self::assert_list_expect(self, ReloadList::Unchanged, &expected.unchanged);
+    }
+
+    fn assert_list_expect(
+        snapshot: &ReloadSnapshot,
+        list: ReloadList,
+        expected: &Option<Vec<String>>,
+    ) {
+        let Some(expected) = expected else {
+            return;
+        };
+        let actual = list.names(snapshot);
+        if expected.is_empty() {
+            assert!(
+                actual.is_empty(),
+                "expected reload {} to be empty, got {snapshot:?}",
+                list.label()
+            );
+            return;
+        }
+        for name in expected {
+            assert!(
+                actual.iter().any(|n| n == name),
+                "expected '{name}' in reload {}, got {snapshot:?}",
+                list.label()
+            );
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+struct DescribeSnapshot {
+    pub uuid: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    pub state: String,
+    pub pid: u64,
+    #[serde(default)]
+    pub profile: String,
+    #[serde(default)]
+    pub user: String,
+    pub command: String,
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub working_dir: String,
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+    #[serde(default)]
+    pub restart_policy: String,
+    pub restart_count: u64,
+    pub last_exit_code: Option<i32>,
+    pub last_signal: Option<i32>,
+    pub auto_start: bool,
+    #[serde(default)]
+    pub stdout: String,
+    #[serde(default)]
+    pub stderr: String,
+    #[serde(default)]
+    pub condition_path_exists: String,
+    #[serde(default)]
+    pub after: Vec<String>,
+    #[serde(default)]
+    pub before: Vec<String>,
+    #[serde(default)]
+    pub runtime_user: String,
+}
+
+/// Unset fields are not checked (same pattern as ReloadExpect / StatusProcessesCount).
+#[derive(Debug, Clone, Default)]
+pub struct DescribeExpect {
+    pub name: Option<String>,
+    pub state: Option<String>,
+    pub uuid: Option<String>,
+    pub pid: Option<u64>,
+    pub command: Option<String>,
+    pub args: Option<Vec<String>>,
+    pub description: Option<String>,
+    pub working_dir: Option<String>,
+    pub restart_policy: Option<String>,
+    pub auto_start: Option<bool>,
+    pub restart_count: Option<u64>,
+    pub last_exit_code: Option<Option<i32>>,
+    pub env_contains: Option<BTreeMap<String, String>>,
+    pub after: Option<Vec<String>>,
+    pub has_uuid: Option<bool>,
+    pub has_stdout_path: Option<bool>,
+    pub has_stderr_path: Option<bool>,
+    pub pid_alive: Option<bool>,
+}
+
+impl DescribeSnapshot {
+    fn assert_matches(&self, expected: &DescribeExpect) {
+        assert_describe_field("name", &self.name, &expected.name, self);
+        assert_describe_field("state", &self.state, &expected.state, self);
+        assert_describe_field("uuid", &self.uuid, &expected.uuid, self);
+        assert_describe_field("pid", &self.pid, &expected.pid, self);
+        assert_describe_field("command", &self.command, &expected.command, self);
+        assert_describe_field("args", &self.args, &expected.args, self);
+        assert_describe_field(
+            "description",
+            &self.description,
+            &expected.description,
+            self,
+        );
+        assert_describe_field(
+            "working_dir",
+            &self.working_dir,
+            &expected.working_dir,
+            self,
+        );
+        assert_describe_field(
+            "restart_policy",
+            &self.restart_policy,
+            &expected.restart_policy,
+            self,
+        );
+        assert_describe_field("auto_start", &self.auto_start, &expected.auto_start, self);
+        assert_describe_field(
+            "restart_count",
+            &self.restart_count,
+            &expected.restart_count,
+            self,
+        );
+        assert_describe_field(
+            "last_exit_code",
+            &self.last_exit_code,
+            &expected.last_exit_code,
+            self,
+        );
+        if let Some(expected_env) = &expected.env_contains {
+            for (key, value) in expected_env {
+                assert_eq!(
+                    self.env.get(key),
+                    Some(value),
+                    "describe env[{key}]: expected {value:?}, got {:?}\nfull: {self:?}",
+                    self.env.get(key)
+                );
+            }
+        }
+        if let Some(expected_after) = &expected.after {
+            if expected_after.is_empty() {
+                assert!(
+                    self.after.is_empty(),
+                    "expected describe after to be empty, got {self:?}"
+                );
+            } else {
+                for name in expected_after {
+                    assert!(
+                        self.after.iter().any(|n| n == name),
+                        "expected '{name}' in describe after, got {self:?}"
+                    );
+                }
+            }
+        }
+        assert_describe_present("uuid", &self.uuid, expected.has_uuid, self);
+        assert_describe_present("stdout", &self.stdout, expected.has_stdout_path, self);
+        assert_describe_present("stderr", &self.stderr, expected.has_stderr_path, self);
+        if let Some(expected_alive) = expected.pid_alive {
+            let alive = self.pid > 0 && pid_is_alive(self.pid as u32);
+            assert_eq!(
+                alive,
+                expected_alive,
+                "describe pid_alive: expected {expected_alive}, pid {} alive={}\nfull: {self:?}",
+                self.pid,
+                pid_is_alive(self.pid as u32)
+            );
+        }
+    }
+}
+
+fn assert_describe_field<T: PartialEq + std::fmt::Debug>(
+    field: &str,
+    actual: &T,
+    expected: &Option<T>,
+    snapshot: &DescribeSnapshot,
+) {
+    if let Some(expected) = expected {
+        assert_eq!(
+            actual, expected,
+            "describe {field}: expected {expected:?}, got {actual:?}\nfull: {snapshot:?}"
+        );
+    }
+}
+
+fn assert_describe_present(
+    field: &str,
+    actual: &str,
+    expected: Option<bool>,
+    snapshot: &DescribeSnapshot,
+) {
+    match expected {
+        Some(true) => assert!(
+            !actual.is_empty(),
+            "describe {field} should be present, got {snapshot:?}"
+        ),
+        Some(false) => assert!(
+            actual.is_empty(),
+            "describe {field} should be empty, got {snapshot:?}"
+        ),
+        None => {}
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -599,19 +857,19 @@ fn extract_column(row: &str, col_idx: usize, columns: &[(&str, usize)]) -> Strin
 // ---------------------------------------------------------------------------
 
 /// Runs dd-procmgr CLI commands against a daemon socket.
-pub struct CliRunner {
+struct CliRunner {
     socket_path: PathBuf,
 }
 
 impl CliRunner {
-    pub fn new(socket_path: &Path) -> Self {
+    fn new(socket_path: &Path) -> Self {
         Self {
             socket_path: socket_path.to_path_buf(),
         }
     }
 
     /// Run a dd-procmgr command and capture output.
-    pub fn run(&self, args: &[&str]) -> CliOutput {
+    fn run(&self, args: &[&str]) -> CliOutput {
         let bin = env!("CARGO_BIN_EXE_dd-procmgr");
         let output = Command::new(bin)
             .arg("--socket")
@@ -673,7 +931,22 @@ impl TestEnv {
         self
     }
 
-    fn env_root(&self) -> &Path {
+    pub fn install_fixture(&self, name: &str) {
+        install_process_fixture(self.env_root(), &self.config_dir, name);
+    }
+
+    /// Render `fixture` into `{name}.yaml` (simulates operator replacing a process file).
+    pub fn overwrite_with_fixture(&self, name: &str, fixture: &str) {
+        install_process_fixture_as(self.env_root(), &self.config_dir, fixture, name);
+    }
+
+    pub fn remove_process_yaml(&self, name: &str) {
+        let path = self.config_dir.join(format!("{name}.yaml"));
+        std::fs::remove_file(&path)
+            .unwrap_or_else(|e| panic!("failed to remove {}: {e}", path.display()));
+    }
+
+    pub fn env_root(&self) -> &Path {
         self._dir.path()
     }
 
@@ -883,6 +1156,71 @@ impl TestEnv {
             .unwrap_or_else(|e| panic!("expected stop of '{name}' to succeed: {e}"));
     }
 
+    fn reload(&self) -> Result<ReloadSnapshot, String> {
+        let out = self.cli(&["reload", "--json"]);
+        if !out.status.success() {
+            return Err(format!(
+                "reload --json failed (exit {:?})\nstdout: {}\nstderr: {}",
+                out.status.code(),
+                out.stdout,
+                out.stderr,
+            ));
+        }
+        serde_json::from_str(&out.stdout)
+            .map_err(|e| format!("failed to parse reload JSON: {e}\nstdout: {}", out.stdout))
+    }
+
+    fn assert_reload(&self) -> ReloadSnapshot {
+        self.reload()
+            .unwrap_or_else(|e| panic!("expected reload to succeed: {e}"))
+    }
+
+    pub fn assert_reload_matches(&self, expected: ReloadExpect) {
+        let pids_before: Vec<(&str, u64)> = expected
+            .preserve_running_pids
+            .iter()
+            .map(|name| (name.as_str(), self.require_process_pid(name)))
+            .collect();
+        self.assert_reload().assert_matches(&expected);
+        for (name, pid_before) in pids_before {
+            self.assert_process_running(name);
+            assert_eq!(
+                self.require_process_pid(name),
+                pid_before,
+                "unchanged reload should not respawn {name}"
+            );
+        }
+    }
+
+    fn require_process_pid(&self, name: &str) -> u64 {
+        self.find_process(name)
+            .unwrap_or_else(|e| panic!("{e}"))
+            .pid
+    }
+
+    fn describe(&self, name_or_uuid: &str) -> Result<DescribeSnapshot, String> {
+        let out = self.cli(&["describe", "--json", name_or_uuid]);
+        if !out.status.success() {
+            return Err(format!(
+                "describe --json {name_or_uuid} failed (exit {:?})\nstdout: {}\nstderr: {}",
+                out.status.code(),
+                out.stdout,
+                out.stderr,
+            ));
+        }
+        serde_json::from_str(&out.stdout)
+            .map_err(|e| format!("failed to parse describe JSON: {e}\nstdout: {}", out.stdout))
+    }
+
+    fn assert_describe(&self, name_or_uuid: &str) -> DescribeSnapshot {
+        self.describe(name_or_uuid)
+            .unwrap_or_else(|e| panic!("expected describe of '{name_or_uuid}' to succeed: {e}"))
+    }
+
+    pub fn assert_describe_matches(&self, name_or_uuid: &str, expected: DescribeExpect) {
+        self.assert_describe(name_or_uuid).assert_matches(&expected);
+    }
+
     fn format_wait_failure(&self, last_err: String) -> String {
         let logs = self
             .daemon
@@ -1027,7 +1365,7 @@ impl TestEnv {
         self.assert_daemon_log_line_contains(&[&prefix, path]);
     }
 
-    pub fn assert_process_pid_alive(&self, name: &str) {
+    fn assert_process_pid_alive(&self, name: &str) {
         let process = self.find_process(name).unwrap_or_else(|e| panic!("{e}"));
         let pid = process.pid as u32;
         assert!(
@@ -1038,6 +1376,20 @@ impl TestEnv {
             pid_is_alive(pid),
             "PID {pid} for process '{name}' should be alive"
         );
+    }
+
+    pub fn assert_pid_gone(&self, pid: u64) {
+        assert!(
+            wait_for_pid_gone(pid as u32, DEFAULT_TIMEOUT),
+            "PID {pid} should be gone"
+        );
+    }
+
+    pub fn assert_process_pid_changed(&self, name: &str, old_pid: u64) {
+        self.assert_pid_gone(old_pid);
+        self.assert_process_running(name);
+        let new_pid = self.require_process_pid(name);
+        assert_ne!(old_pid, new_pid, "PID should change for {name}");
     }
 
     /// Create a sleep process via CLI with optional extra args
@@ -1150,8 +1502,17 @@ fn fixtures_root() -> PathBuf {
 }
 
 fn install_process_fixture(env_root: &Path, config_dir: &Path, name: &str) {
-    let bundle = fixtures_root().join(name);
-    let yaml_src = bundle.join(format!("{name}.yaml"));
+    install_process_fixture_as(env_root, config_dir, name, name);
+}
+
+fn install_process_fixture_as(
+    env_root: &Path,
+    config_dir: &Path,
+    fixture: &str,
+    process_name: &str,
+) {
+    let bundle = fixtures_root().join(fixture);
+    let yaml_src = bundle.join(format!("{fixture}.yaml"));
     assert!(
         yaml_src.is_file(),
         "fixture yaml not found: {}",
@@ -1162,8 +1523,8 @@ fn install_process_fixture(env_root: &Path, config_dir: &Path, name: &str) {
     std::fs::create_dir_all(&scripts_dir)
         .unwrap_or_else(|e| panic!("failed to create {}: {e}", scripts_dir.display()));
 
-    let script_path = scripts_dir.join(format!("{name}.py"));
-    let py_src = bundle.join(format!("{name}.py"));
+    let script_path = scripts_dir.join(format!("{fixture}.py"));
+    let py_src = bundle.join(format!("{fixture}.py"));
     if py_src.is_file() {
         std::fs::copy(&py_src, &script_path).unwrap_or_else(|e| {
             panic!(
@@ -1178,12 +1539,12 @@ fn install_process_fixture(env_root: &Path, config_dir: &Path, name: &str) {
         .unwrap_or_else(|e| panic!("failed to read fixture yaml {}: {e}", yaml_src.display()));
     let rendered = render_fixture_yaml(
         &template,
-        name,
+        fixture,
         env_root,
         config_dir,
         py_src.is_file().then_some(script_path.as_path()),
     );
-    write_config(config_dir, name, &rendered);
+    write_config(config_dir, process_name, &rendered);
 }
 
 fn render_fixture_yaml(

--- a/pkg/procmgr/rust/tests/helpers/mod.rs
+++ b/pkg/procmgr/rust/tests/helpers/mod.rs
@@ -982,6 +982,27 @@ impl TestEnv {
         );
     }
 
+    pub fn assert_list_empty(&self) {
+        let processes = self
+            .list_processes()
+            .unwrap_or_else(|e| panic!("failed to list processes: {e}"));
+        assert!(
+            processes.is_empty(),
+            "expected empty catalog, got {processes:?}"
+        );
+    }
+
+    pub fn assert_list_len(&self, expected: usize) {
+        let processes = self
+            .list_processes()
+            .unwrap_or_else(|e| panic!("failed to list processes: {e}"));
+        assert_eq!(
+            processes.len(),
+            expected,
+            "expected {expected} process(es) in catalog, got {processes:?}"
+        );
+    }
+
     pub fn assert_daemon_log_line_contains(&self, patterns: &[&str]) {
         assert!(
             self.daemon()

--- a/pkg/procmgr/rust/tests/helpers/mod.rs
+++ b/pkg/procmgr/rust/tests/helpers/mod.rs
@@ -972,6 +972,15 @@ impl TestEnv {
         );
     }
 
+    pub fn assert_process_last_exit_code(&self, name: &str, code: i32) {
+        let process = self.find_process(name).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(
+            process.last_exit_code,
+            Some(code),
+            "process '{name}' last_exit_code: expected {code}, got {process:?}"
+        );
+    }
+
     pub fn assert_process_absent(&self, name: &str) {
         let processes = self
             .list_processes()

--- a/pkg/procmgr/rust/tests/helpers/mod.rs
+++ b/pkg/procmgr/rust/tests/helpers/mod.rs
@@ -973,7 +973,7 @@ impl TestEnv {
     }
 
     pub fn assert_process_last_exit_code(&self, name: &str, code: i32) {
-        let process = self.find_process(name).unwrap_or_else(|e| panic!("{e}"));
+        let process = self.find_process(name).unwrap();
         assert_eq!(
             process.last_exit_code,
             Some(code),
@@ -992,9 +992,7 @@ impl TestEnv {
     }
 
     pub fn assert_list_empty(&self) {
-        let processes = self
-            .list_processes()
-            .unwrap_or_else(|e| panic!("failed to list processes: {e}"));
+        let processes = self.list_processes().expect("failed to list processes");
         assert!(
             processes.is_empty(),
             "expected empty catalog, got {processes:?}"
@@ -1002,9 +1000,7 @@ impl TestEnv {
     }
 
     pub fn assert_list_len(&self, expected: usize) {
-        let processes = self
-            .list_processes()
-            .unwrap_or_else(|e| panic!("failed to list processes: {e}"));
+        let processes = self.list_processes().expect("failed to list processes");
         assert_eq!(
             processes.len(),
             expected,


### PR DESCRIPTION
### What does this PR do?

Extends the procmgr TestEnv harness with charter tests that assert catalog contents through the TestEnv API instead of CLI list output. Adds minimal list assertion helpers and removes redundant legacy list behavior tests. CLI JSON contract tests are unchanged.

Test-only change; no product or daemon code.

### Motivation

Continue migrating procmgr e2e coverage onto TestEnv so tests express intent (catalog state) without depending on CLI formatting or log scraping.

### Describe how you validated your changes

Ran the procmgr e2e suite locally with `cargo test`, plus `cargo fmt` and `cargo clippy`.

### Additional Notes

Stacks on `jose/procmgr-testenv-process-control`. Follow-ups: reload charter (PR4), describe migration (PR5), restart/burst charter (PR6).