### PR TITLE
[PROF-12409] Use FQDN for profiling intake URLs

### DIFF
--- a/comp/trace/config/impl/config_test.go
+++ b/comp/trace/config/impl/config_test.go
@@ -543,6 +543,55 @@ func TestSite(t *testing.T) {
 	}
 }
 
+func TestProfilingURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "default site",
+			expected: "https://intake.profile.datadoghq.com./api/v2/profile",
+		},
+		{
+			name:     "configured Datadog site",
+			settings: map[string]interface{}{"site": "datadoghq.eu"},
+			expected: "https://intake.profile.datadoghq.eu./api/v2/profile",
+		},
+		{
+			name: "FQDN conversion disabled",
+			settings: map[string]interface{}{
+				"site":                         "datadoghq.eu",
+				"convert_dd_site_fqdn.enabled": false,
+			},
+			expected: "https://intake.profile.datadoghq.eu/api/v2/profile",
+		},
+		{
+			name:     "custom site",
+			settings: map[string]interface{}{"site": "example.com"},
+			expected: "https://intake.profile.example.com/api/v2/profile",
+		},
+		{
+			name: "explicit profiling URL",
+			settings: map[string]interface{}{
+				"site":                        "datadoghq.eu",
+				"apm_config.profiling_dd_url": "https://profiles.example.com/custom/path",
+			},
+			expected: "https://profiles.example.com/custom/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := buildConfigComponentFromOverrides(t, true, tt.settings)
+			cfg := config.Object()
+
+			require.NotNil(t, cfg)
+			assert.Equal(t, tt.expected, cfg.ProfilingProxy.DDURL)
+		})
+	}
+}
+
 func TestDefaultConfig(t *testing.T) {
 	config := buildConfigComponent(t, true)
 	cfg := config.Object()

--- a/comp/trace/config/impl/setup.go
+++ b/comp/trace/config/impl/setup.go
@@ -646,6 +646,10 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if k := "apm_config.profiling_dd_url"; core.IsConfigured(k) {
 		c.ProfilingProxy.DDURL = core.GetString(k)
 	}
+	if c.ProfilingProxy.DDURL == "" {
+		// Resolve the implicit URL here to keep config dependencies out of pkg/trace.
+		c.ProfilingProxy.DDURL = utils.BuildURLWithPrefix(config.ProfilingEndpointPrefix, c.Site) + config.ProfilingEndpointPath
+	}
 	if k := "apm_config.profiling_additional_endpoints"; core.IsConfigured(k) {
 		c.ProfilingProxy.AdditionalEndpoints = core.GetStringMapStringSlice(k)
 	}

--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -29,9 +29,9 @@ import (
 
 const (
 	// profilingURLTemplate specifies the template for obtaining the profiling URL along with the site.
-	profilingURLTemplate = "https://intake.profile.%s/api/v2/profile"
+	profilingURLTemplate = config.ProfilingEndpointPrefix + "%s" + config.ProfilingEndpointPath
 	// profilingURLDefault specifies the default intake API URL.
-	profilingURLDefault = "https://intake.profile.datadoghq.com/api/v2/profile"
+	profilingURLDefault = config.ProfilingEndpointPrefix + "datadoghq.com" + config.ProfilingEndpointPath
 	// profilingV1EndpointSuffix suffix identifying a user-configured V1 endpoint
 	profilingV1EndpointSuffix = "v1/input"
 )
@@ -91,6 +91,8 @@ func mainProfilingURL(conf *config.AgentConfig) string {
 		}
 		return v
 	}
+	// The component config loader resolves DDURL. Keep the Site/default fallback
+	// for standalone pkg/trace callers that construct AgentConfig directly.
 	if conf.Site != "" {
 		return fmt.Sprintf(profilingURLTemplate, conf.Site)
 	}

--- a/pkg/trace/config/BUILD.bazel
+++ b/pkg/trace/config/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "client.go",
         "config.go",
+        "endpoints.go",
         "mock_remote_client.go",
         "peer_tags.go",
     ],

--- a/pkg/trace/config/endpoints.go
+++ b/pkg/trace/config/endpoints.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package config
+
+const (
+	// ProfilingEndpointPrefix is the URL prefix for the profiling intake.
+	ProfilingEndpointPrefix = "https://intake.profile."
+	// ProfilingEndpointPath is the API path for the profiling intake.
+	ProfilingEndpointPath = "/api/v2/profile"
+)


### PR DESCRIPTION
### What does this PR do?

Resolve site-derived profiling intake URLs through the shared `BuildURLWithPrefix` helper while loading the trace-agent configuration. This adds the trailing DNS dot for known Datadog sites when `convert_dd_site_fqdn.enabled` is enabled.

Explicit `apm_config.profiling_dd_url` values, custom sites, and profiling additional endpoints remain unchanged. The resolution stays in `comp/trace/config`, which already depends on `pkg/config/utils`, rather than reintroducing that dependency into the standalone `pkg/trace` module.

### Motivation

Fix [PROF-12409](https://datadoghq.atlassian.net/browse/PROF-12409). Using an absolute/FQDN intake hostname avoids unnecessary DNS lookups against the search domains from `/etc/resolv.conf`, particularly in Kubernetes environments using `ndots:5`.

### Describe how you validated your changes

- `dda inv test --targets=./comp/trace/config/impl --test-run-name=TestProfilingURL`
- `dda inv test --targets=./comp/trace/config/impl` (228 tests passed)
- `git diff --check`

### Additional Notes

No release note: this is an internal DNS-resolution efficiency fix with no user-facing configuration or API change.


[PROF-12409]: https://datadoghq.atlassian.net/browse/PROF-12409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ