### PR TITLE
fix(ipc): skip bearer token for unauthenticated debug endpoints

### DIFF
--- a/cmd/agent/subcommands/diagnose/BUILD.bazel
+++ b/cmd/agent/subcommands/diagnose/BUILD.bazel
@@ -57,6 +57,7 @@ dd_agent_go_test(
         "//pkg/config/mock",
         "//pkg/util/fxutil",
         "@com_github_spf13_cobra//:cobra",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/cmd/agent/subcommands/diagnose/BUILD.bazel
+++ b/cmd/agent/subcommands/diagnose/BUILD.bazel
@@ -57,7 +57,6 @@ dd_agent_go_test(
         "//pkg/config/mock",
         "//pkg/util/fxutil",
         "@com_github_spf13_cobra//:cobra",
-        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/cmd/agent/subcommands/diagnose/BUILD.bazel
+++ b/cmd/agent/subcommands/diagnose/BUILD.bazel
@@ -53,8 +53,11 @@ dd_agent_go_test(
     deps = [
         "//cmd/agent/command",
         "//comp/core",
+        "//comp/core/ipc/mock",
+        "//pkg/config/mock",
         "//pkg/util/fxutil",
         "@com_github_spf13_cobra//:cobra",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -542,7 +542,7 @@ func printAgentFullTelemetry(config config.Component, client ipc.HTTPClient) err
 		return err
 	}
 	addr := net.JoinHostPort(ipcAddress, config.GetString("expvar_port"))
-	r, err := client.Get(fmt.Sprintf("http://%s/telemetry", addr))
+	r, err := client.Get(fmt.Sprintf("http://%s/telemetry", addr), ipchttp.WithNoAuthToken)
 	if err != nil {
 		return fmt.Errorf("error getting full telemetry payload: %w", err)
 	}

--- a/cmd/agent/subcommands/diagnose/command_test.go
+++ b/cmd/agent/subcommands/diagnose/command_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
@@ -168,9 +169,8 @@ func TestShowHealthIssuesCommand(t *testing.T) {
 
 // Verifies the bearer token does not leak to the unauthenticated /telemetry endpoint.
 func TestPrintAgentFullTelemetryNoBearer(t *testing.T) {
-	var capturedAuth string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedAuth = r.Header.Get("Authorization")
+		assert.Empty(t, r.Header.Get("Authorization"), "Bearer token must not be sent to unauthenticated telemetry endpoint")
 		fmt.Fprint(w, "telemetry")
 	}))
 	defer ts.Close()
@@ -184,5 +184,4 @@ func TestPrintAgentFullTelemetryNoBearer(t *testing.T) {
 	ipcComp := ipcmock.New(t)
 	err = printAgentFullTelemetry(cfg, ipcComp.GetClient())
 	require.NoError(t, err)
-	require.Empty(t, capturedAuth, "Bearer token must not be sent to unauthenticated telemetry endpoint")
 }

--- a/cmd/agent/subcommands/diagnose/command_test.go
+++ b/cmd/agent/subcommands/diagnose/command_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
@@ -185,5 +184,5 @@ func TestPrintAgentFullTelemetryNoBearer(t *testing.T) {
 	ipcComp := ipcmock.New(t)
 	err = printAgentFullTelemetry(cfg, ipcComp.GetClient())
 	require.NoError(t, err)
-	assert.Empty(t, capturedAuth, "Bearer token must not be sent to unauthenticated telemetry endpoint")
+	require.Empty(t, capturedAuth, "Bearer token must not be sent to unauthenticated telemetry endpoint")
 }

--- a/cmd/agent/subcommands/diagnose/command_test.go
+++ b/cmd/agent/subcommands/diagnose/command_test.go
@@ -6,15 +6,22 @@
 package diagnose
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
+	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -158,4 +165,25 @@ func TestShowHealthIssuesCommand(t *testing.T) {
 		[]string{"diagnose", "show-metadata", "health-issues"},
 		printHealthPlatformIssues,
 		func(_ core.BundleParams) {})
+}
+
+// Verifies the bearer token does not leak to the unauthenticated /telemetry endpoint.
+func TestPrintAgentFullTelemetryNoBearer(t *testing.T) {
+	var capturedAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		fmt.Fprint(w, "telemetry")
+	}))
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+
+	cfg := configmock.New(t)
+	cfg.SetInTest("expvar_port", u.Port())
+
+	ipcComp := ipcmock.New(t)
+	err = printAgentFullTelemetry(cfg, ipcComp.GetClient())
+	require.NoError(t, err)
+	assert.Empty(t, capturedAuth, "Bearer token must not be sent to unauthenticated telemetry endpoint")
 }

--- a/comp/core/ipc/def/component.go
+++ b/comp/core/ipc/def/component.go
@@ -34,7 +34,8 @@ type Component interface {
 // RequestParams is a struct that contains the parameters for a request
 type RequestParams struct {
 	*http.Request
-	Timeout time.Duration
+	Timeout     time.Duration
+	NoAuthToken bool
 }
 
 // RequestOption allows to specify custom behavior for requests

--- a/comp/core/ipc/httphelpers/client.go
+++ b/comp/core/ipc/httphelpers/client.go
@@ -182,7 +182,9 @@ func (s *ipcClient) do(req *http.Request, contentType string, onChunk func([]byt
 	client.Timeout = params.Timeout
 
 	req.Header.Set("Content-Type", contentType)
-	req.Header.Set("Authorization", "Bearer "+s.authToken)
+	if !params.NoAuthToken {
+		req.Header.Set("Authorization", "Bearer "+s.authToken)
+	}
 
 	r, err := client.Do(req)
 
@@ -294,6 +296,12 @@ func WithCloseConnection(req *ipc.RequestParams) {
 // WithLeaveConnectionOpen is a request option that leaves the connection open after the request
 func WithLeaveConnectionOpen(req *ipc.RequestParams) {
 	req.Close = false
+}
+
+// WithNoAuthToken skips attaching the IPC bearer token to the request.
+// Use for plain HTTP endpoints (expvar, pprof, /telemetry) that do not verify the token.
+func WithNoAuthToken(req *ipc.RequestParams) {
+	req.NoAuthToken = true
 }
 
 // WithContext is a request option that sets the context for the request

--- a/comp/core/ipc/httphelpers/client.go
+++ b/comp/core/ipc/httphelpers/client.go
@@ -182,7 +182,10 @@ func (s *ipcClient) do(req *http.Request, contentType string, onChunk func([]byt
 	client.Timeout = params.Timeout
 
 	req.Header.Set("Content-Type", contentType)
-	if !params.NoAuthToken {
+	if params.NoAuthToken {
+		// Ensure no Authorization is sent, even if the caller pre-set the header.
+		req.Header.Del("Authorization")
+	} else {
 		req.Header.Set("Authorization", "Bearer "+s.authToken)
 	}
 

--- a/comp/core/ipc/httphelpers/client_test.go
+++ b/comp/core/ipc/httphelpers/client_test.go
@@ -464,3 +464,15 @@ func TestIPCEndpointErrorMap(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, err.Error(), "something went wrong")
 }
+
+// Verifies WithNoAuthToken prevents the IPC client from attaching the bearer token.
+func TestWithNoAuthToken(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		require.Empty(t, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}
+	client, ts := getMockServerAndConfig(t, http.HandlerFunc(handler), testToken)
+
+	_, err := client.Get(ts.URL, WithNoAuthToken)
+	require.NoError(t, err)
+}

--- a/comp/core/profiler/impl/profiler.go
+++ b/comp/core/profiler/impl/profiler.go
@@ -81,7 +81,7 @@ func (p profiler) ReadProfileData(seconds int, logFunc func(log string, params .
 			endpoint.Scheme = "https"
 		}
 		return func(path string) ([]byte, error) {
-			return p.ipcClient.Get(endpoint.String()+path, ipchttp.WithLeaveConnectionOpen)
+			return p.ipcClient.Get(endpoint.String()+path, ipchttp.WithLeaveConnectionOpen, ipchttp.WithNoAuthToken)
 		}
 	}
 
@@ -223,7 +223,7 @@ func (p profiler) fillFlare(_ context.Context, fb flaretypes.FlareBuilder) error
 	// goroutines, and gracefully produces no file when the agent is unreachable
 	// (e.g. local flare mode) instead of capturing the CLI's own goroutines.
 	pprofURL := "http://127.0.0.1:" + strconv.Itoa(p.cfg.GetInt("expvar_port")) + "/debug/pprof/goroutine?debug=2"
-	if data, err := p.ipcClient.Get(pprofURL, ipchttp.WithLeaveConnectionOpen); err == nil {
+	if data, err := p.ipcClient.Get(pprofURL, ipchttp.WithLeaveConnectionOpen, ipchttp.WithNoAuthToken); err == nil {
 		fb.AddFile("go-routine-dump.log", data) //nolint:errcheck
 	}
 

--- a/comp/core/profiler/impl/profiler_test.go
+++ b/comp/core/profiler/impl/profiler_test.go
@@ -6,6 +6,9 @@
 package profilerimpl
 
 import (
+	"context"
+	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"runtime"
@@ -87,6 +90,33 @@ func getProfiler(t testing.TB, overrideSysProbe map[string]interface{}) profiler
 	)
 
 	return deps.Comp.(profiler)
+}
+
+// Verifies the bearer token does not leak to the unauthenticated pprof endpoint (RC flare goroutine dump).
+func TestFillFlareGoRoutineDumpNoBearer(t *testing.T) {
+	var capturedAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		fmt.Fprint(w, "goroutine dump")
+	}))
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+
+	mockConfig := configmock.New(t)
+	mockConfig.SetInTest("expvar_port", u.Port())
+
+	ipcComp := ipcmock.New(t)
+	p := profiler{
+		cfg:       mockConfig,
+		ipcClient: ipcComp.GetClient(),
+	}
+
+	fb := helpers.NewFlareBuilderMockWithArgs(t, false, types.FlareArgs{})
+	err = p.fillFlare(context.Background(), fb)
+	require.NoError(t, err)
+	assert.Empty(t, capturedAuth, "Bearer token must not be sent to unauthenticated pprof endpoint")
 }
 
 func TestProfileSetting(t *testing.T) {

--- a/comp/core/profiler/impl/profiler_test.go
+++ b/comp/core/profiler/impl/profiler_test.go
@@ -94,9 +94,8 @@ func getProfiler(t testing.TB, overrideSysProbe map[string]interface{}) profiler
 
 // Verifies the bearer token does not leak to the unauthenticated pprof endpoint (RC flare goroutine dump).
 func TestFillFlareGoRoutineDumpNoBearer(t *testing.T) {
-	var capturedAuth string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedAuth = r.Header.Get("Authorization")
+		assert.Empty(t, r.Header.Get("Authorization"), "Bearer token must not be sent to unauthenticated pprof endpoint")
 		fmt.Fprint(w, "goroutine dump")
 	}))
 	defer ts.Close()
@@ -116,7 +115,6 @@ func TestFillFlareGoRoutineDumpNoBearer(t *testing.T) {
 	fb := helpers.NewFlareBuilderMockWithArgs(t, false, types.FlareArgs{})
 	err = p.fillFlare(context.Background(), fb)
 	require.NoError(t, err)
-	assert.Empty(t, capturedAuth, "Bearer token must not be sent to unauthenticated pprof endpoint")
 }
 
 func TestProfileSetting(t *testing.T) {

--- a/pkg/cli/subcommands/dcaflare/BUILD.bazel
+++ b/pkg/cli/subcommands/dcaflare/BUILD.bazel
@@ -45,6 +45,7 @@ dd_agent_go_test(
     include_default = False,
     deps = select({
         "@rules_go//go/platform:aix": [
+            "//comp/core/ipc/mock",
             "//pkg/config/mock",
             "//pkg/config/model",
             "//pkg/util/defaultpaths",
@@ -54,6 +55,7 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:android": [
+            "//comp/core/ipc/mock",
             "//pkg/config/mock",
             "//pkg/config/model",
             "//pkg/util/defaultpaths",
@@ -63,6 +65,7 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:darwin": [
+            "//comp/core/ipc/mock",
             "//pkg/config/mock",
             "//pkg/config/model",
             "//pkg/util/defaultpaths",
@@ -72,6 +75,7 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:dragonfly": [
+            "//comp/core/ipc/mock",
             "//pkg/config/mock",
             "//pkg/config/model",
             "//pkg/util/defaultpaths",
@@ -81,6 +85,7 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:freebsd": [
+            "//comp/core/ipc/mock",
             "//pkg/config/mock",
             "//pkg/config/model",
             "//pkg/util/defaultpaths",
@@ -90,6 +95,7 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:illumos": [
+            "//comp/core/ipc/mock",
             "//pkg/config/mock",
             "//pkg/config/model",
             "//pkg/util/defaultpaths",
@@ -99,6 +105,7 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:ios": [
+            "//comp/core/ipc/mock",
             "//pkg/config/mock",
             "//pkg/config/model",
             "//pkg/util/defaultpaths",
@@ -108,6 +115,7 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:js": [
+            "//comp/core/ipc/mock",
             "//pkg/config/mock",
             "//pkg/config/model",
             "//pkg/util/defaultpaths",
@@ -117,6 +125,7 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:linux": [
+            "//comp/core/ipc/mock",
             "//pkg/config/mock",
             "//pkg/config/model",
             "//pkg/util/defaultpaths",
@@ -126,6 +135,7 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:netbsd": [
+            "//comp/core/ipc/mock",
             "//pkg/config/mock",
             "//pkg/config/model",
             "//pkg/util/defaultpaths",
@@ -135,6 +145,7 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:openbsd": [
+            "//comp/core/ipc/mock",
             "//pkg/config/mock",
             "//pkg/config/model",
             "//pkg/util/defaultpaths",
@@ -144,6 +155,7 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:osx": [
+            "//comp/core/ipc/mock",
             "//pkg/config/mock",
             "//pkg/config/model",
             "//pkg/util/defaultpaths",
@@ -153,6 +165,7 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:plan9": [
+            "//comp/core/ipc/mock",
             "//pkg/config/mock",
             "//pkg/config/model",
             "//pkg/util/defaultpaths",
@@ -162,6 +175,7 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:qnx": [
+            "//comp/core/ipc/mock",
             "//pkg/config/mock",
             "//pkg/config/model",
             "//pkg/util/defaultpaths",
@@ -171,6 +185,7 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:solaris": [
+            "//comp/core/ipc/mock",
             "//pkg/config/mock",
             "//pkg/config/model",
             "//pkg/util/defaultpaths",

--- a/pkg/cli/subcommands/dcaflare/command.go
+++ b/pkg/cli/subcommands/dcaflare/command.go
@@ -142,7 +142,7 @@ func readProfileData(client ipc.HTTPClient, seconds int) (clusterAgentFlare.Prof
 			URL:  pprofURL + "/block",
 		},
 	} {
-		b, err := client.Get(prof.URL, ipchttp.WithLeaveConnectionOpen)
+		b, err := client.Get(prof.URL, ipchttp.WithLeaveConnectionOpen, ipchttp.WithNoAuthToken)
 		if err != nil {
 			return pdata, err
 		}

--- a/pkg/cli/subcommands/dcaflare/command_test.go
+++ b/pkg/cli/subcommands/dcaflare/command_test.go
@@ -8,12 +8,18 @@
 package dcaflare
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
@@ -45,4 +51,27 @@ func TestCommand(t *testing.T) {
 		[]string{"flare"},
 		run,
 		func() {})
+}
+
+// Verifies the bearer token does not leak to the unauthenticated DCA pprof endpoint (DCA flare).
+func TestReadProfileDataNoBearer(t *testing.T) {
+	var capturedAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		fmt.Fprint(w, "pprof data")
+	}))
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(u.Port())
+	require.NoError(t, err)
+
+	cfg := configmock.New(t)
+	cfg.SetInTest("expvar_port", port)
+
+	ipcComp := ipcmock.New(t)
+	_, err = readProfileData(ipcComp.GetClient(), 1)
+	require.NoError(t, err)
+	assert.Empty(t, capturedAuth, "Bearer token must not be sent to unauthenticated DCA pprof endpoint")
 }

--- a/pkg/cli/subcommands/dcaflare/command_test.go
+++ b/pkg/cli/subcommands/dcaflare/command_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strconv"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -64,11 +63,9 @@ func TestReadProfileDataNoBearer(t *testing.T) {
 
 	u, err := url.Parse(ts.URL)
 	require.NoError(t, err)
-	port, err := strconv.Atoi(u.Port())
-	require.NoError(t, err)
 
 	cfg := configmock.New(t)
-	cfg.SetInTest("expvar_port", port)
+	cfg.SetInTest("expvar_port", u.Port())
 
 	ipcComp := ipcmock.New(t)
 	_, err = readProfileData(ipcComp.GetClient(), 1)

--- a/pkg/cli/subcommands/dcaflare/command_test.go
+++ b/pkg/cli/subcommands/dcaflare/command_test.go
@@ -54,9 +54,8 @@ func TestCommand(t *testing.T) {
 
 // Verifies the bearer token does not leak to the unauthenticated DCA pprof endpoint (DCA flare).
 func TestReadProfileDataNoBearer(t *testing.T) {
-	var capturedAuth string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedAuth = r.Header.Get("Authorization")
+		assert.Empty(t, r.Header.Get("Authorization"), "Bearer token must not be sent to unauthenticated DCA pprof endpoint")
 		fmt.Fprint(w, "pprof data")
 	}))
 	defer ts.Close()
@@ -70,5 +69,4 @@ func TestReadProfileDataNoBearer(t *testing.T) {
 	ipcComp := ipcmock.New(t)
 	_, err = readProfileData(ipcComp.GetClient(), 1)
 	require.NoError(t, err)
-	assert.Empty(t, capturedAuth, "Bearer token must not be sent to unauthenticated DCA pprof endpoint")
 }

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -442,7 +442,7 @@ func (r *RemoteFlareProvider) getHTTPCallContent(url string) ([]byte, error) {
 		return nil, err
 	}
 
-	resp, err := r.IPC.GetClient().Do(req.WithContext(ctx))
+	resp, err := r.IPC.GetClient().Do(req.WithContext(ctx), ipchttp.WithNoAuthToken)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -60,6 +61,29 @@ func TestGoRoutines(t *testing.T) {
 	content, err := remoteProvider.getHTTPCallContent(ts.URL)
 	require.NoError(t, err)
 	assert.Equal(t, expected, string(content))
+}
+
+// Verifies the bearer token does not leak to the unauthenticated pprof endpoint (CLI flare goroutine dump).
+func TestGetGoRoutineDumpNoBearer(t *testing.T) {
+	var capturedAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		fmt.Fprint(w, "goroutine dump")
+	}))
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+
+	cfg := configmock.New(t)
+	cfg.SetInTest("expvar_port", u.Port())
+
+	ipcComp := ipcmock.New(t)
+	remoteProvider := RemoteFlareProvider{IPC: ipcComp}
+
+	_, err = remoteProvider.GetGoRoutineDump()
+	require.NoError(t, err)
+	assert.Empty(t, capturedAuth, "Bearer token must not be sent to unauthenticated pprof endpoint")
 }
 
 func createTestFile(t *testing.T, filename string) string {

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -65,9 +65,8 @@ func TestGoRoutines(t *testing.T) {
 
 // Verifies the bearer token does not leak to the unauthenticated pprof endpoint (CLI flare goroutine dump).
 func TestGetGoRoutineDumpNoBearer(t *testing.T) {
-	var capturedAuth string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedAuth = r.Header.Get("Authorization")
+		assert.Empty(t, r.Header.Get("Authorization"), "Bearer token must not be sent to unauthenticated pprof endpoint")
 		fmt.Fprint(w, "goroutine dump")
 	}))
 	defer ts.Close()
@@ -83,7 +82,6 @@ func TestGetGoRoutineDumpNoBearer(t *testing.T) {
 
 	_, err = remoteProvider.GetGoRoutineDump()
 	require.NoError(t, err)
-	assert.Empty(t, capturedAuth, "Bearer token must not be sent to unauthenticated pprof endpoint")
 }
 
 func createTestFile(t *testing.T, filename string) string {


### PR DESCRIPTION
## What does this PR do?

Adds a `WithNoAuthToken` option to the IPC HTTP client, and applies it at 5 call sites that fetch from unauthenticated debug endpoints (`/debug/pprof/*` and `/telemetry`).

## Motivation

Security fix. The IPC HTTP client attaches `Authorization: Bearer <token>` to every outgoing request. Several flare and diagnose paths use this client to fetch from the agent's unauthenticated debug endpoints, unnecessarily exposing the bearer token.

Affected paths (all now fixed):
- CLI flare goroutine dump: `pkg/flare/archive.go`
- RC flare goroutine dump: `comp/core/profiler/impl/profiler.go`
- RC and CLI flare pprof profiles for core-agent, security-agent, process-agent, and trace-agent: `comp/core/profiler/impl/profiler.go`
- DCA flare pprof profiles: `pkg/cli/subcommands/dcaflare/command.go`
- `agent diagnose show-metadata agent-full-telemetry`: `cmd/agent/subcommands/diagnose/command.go`

## Describe how you validated your changes

- Added a unit test for the new `WithNoAuthToken` option.
- Added a per-caller test for each fixed path, asserting no `Authorization` header is sent.
- Verified each per-caller test fails when the fix is removed from the corresponding call site.
- All existing tests still pass; behaviour is unchanged for callers that do not pass the new option.

## Additional Notes
