### PR TITLE
[ACTP] remove DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION

### DIFF
--- a/comp/privateactionrunner/fx/fx_test.go
+++ b/comp/privateactionrunner/fx/fx_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestNewKeysManagerProvidesRCListener(t *testing.T) {
-	t.Setenv("DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION", "false")
 	cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
 		privateactionrunner.PAREnabled: true,
 	})
@@ -31,7 +30,6 @@ func TestNewKeysManagerProvidesRCListener(t *testing.T) {
 }
 
 func TestNewKeysManagerDoesNotRegisterWhenPARIsDisabled(t *testing.T) {
-	t.Setenv("DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION", "false")
 	cfg := coreconfig.NewMock(t)
 
 	provides := newKeysManager(cfg)

--- a/pkg/privateactionrunner/adapters/constants/constants_adapter.go
+++ b/pkg/privateactionrunner/adapters/constants/constants_adapter.go
@@ -6,11 +6,6 @@
 package constants
 
 const (
-	// InternalSkipTaskVerificationEnvVar is an internal-only env var for tests that
-	// cannot provide Remote Config signing keys. It must not control OPMS routing.
-	// NOT intended for customer use.
-	InternalSkipTaskVerificationEnvVar = "DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION"
-
 	// InternalUseDDURLForOPMSEnvVar is an internal-only env var for tests.
 	// When set to "true", PAR sends OPMS requests to the configured dd_url.
 	// NOT intended for customer use.

--- a/pkg/privateactionrunner/task-verifier/BUILD.bazel
+++ b/pkg/privateactionrunner/task-verifier/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/privateactionrunner/adapters/config",
-        "//pkg/privateactionrunner/adapters/constants",
         "//pkg/privateactionrunner/adapters/logging",
         "//pkg/privateactionrunner/adapters/rcclient",
         "//pkg/privateactionrunner/types",
@@ -20,7 +19,6 @@ go_library(
         "//pkg/proto/pbgo/privateactionrunner/errorcode",
         "//pkg/proto/pbgo/privateactionrunner/privateactions",
         "//pkg/remoteconfig/state",
-        "//pkg/util/log",
         "@org_golang_google_protobuf//proto",
     ],
 )
@@ -30,11 +28,11 @@ dd_agent_go_test(
     srcs = ["verifier_test.go"],
     embed = [":task-verifier"],
     deps = [
+        "//pkg/privateactionrunner/adapters/config",
         "//pkg/privateactionrunner/types",
         "//pkg/proto/pbgo/privateactionrunner/privateactions",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/structpb",
     ],
 )

--- a/pkg/privateactionrunner/task-verifier/keys_manager.go
+++ b/pkg/privateactionrunner/task-verifier/keys_manager.go
@@ -14,10 +14,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"os"
 	"sync"
 
-	app "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/constants"
 	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/rcclient"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
@@ -36,16 +34,7 @@ type keysManager struct {
 	firstCallbackCompleted bool
 }
 
-// noOpKeysManager satisfies KeysManager without requiring Remote Config.
-// WaitForReady returns immediately. Used when DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION=true.
-type noOpKeysManager struct{}
-
-func (n *noOpKeysManager) Start(_ context.Context)          {}
-func (n *noOpKeysManager) GetKey(_ string) types.DecodedKey { return nil }
-func (n *noOpKeysManager) WaitForReady()                    {}
-
-// NewKeyManager returns a KeysManager appropriate for the current environment.
-// When DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION=true, a no-op manager is returned.
+// NewKeyManager returns a key manager backed by Remote Config.
 func NewKeyManager(rcClient rcclient.Client) KeysManager {
 	manager, _ := NewKeyManagerWithCallback()
 	if manager, ok := manager.(*keysManager); ok {
@@ -57,9 +46,6 @@ func NewKeyManager(rcClient rcclient.Client) KeysManager {
 // NewKeyManagerWithCallback returns a key manager and the callback to register
 // with Remote Config before its polling loop starts.
 func NewKeyManagerWithCallback() (KeysManager, UpdateCallback) {
-	if os.Getenv(app.InternalSkipTaskVerificationEnvVar) == "true" {
-		return &noOpKeysManager{}, nil
-	}
 	manager := &keysManager{
 		stopChan: make(chan bool),
 		keys:     make(map[string]types.DecodedKey),

--- a/pkg/privateactionrunner/task-verifier/verifier.go
+++ b/pkg/privateactionrunner/task-verifier/verifier.go
@@ -9,50 +9,20 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"google.golang.org/protobuf/proto"
 
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
-	app "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/constants"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
 	aperrorpb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/errorcode"
 	privateactionspb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/privateactions"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// NewTaskVerifier returns a TaskVerifier appropriate for the current environment.
-// When DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION=true, a no-op verifier is returned for e2e tests.
+// NewTaskVerifier returns a verifier for signed task envelopes.
 func NewTaskVerifier(keysManager KeysManager, cfg *config.Config) TaskVerifier {
-	if os.Getenv(app.InternalSkipTaskVerificationEnvVar) == "true" {
-		log.Warn("task verification disabled")
-		return &noOpTaskVerifier{}
-	}
 	return &signedEnvelopeTaskVerifier{keysManager: keysManager, config: cfg}
-}
-
-// noOpTaskVerifier passes tasks through without signature validation.
-// Used only when DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION=true.
-type noOpTaskVerifier struct{}
-
-func (n *noOpTaskVerifier) UnwrapTask(task *types.Task) (*types.Task, error) {
-	if task == nil || task.Data.Attributes == nil {
-		return task, nil
-	}
-
-	envelope := task.Data.Attributes.SignedEnvelope
-	if envelope == nil || len(envelope.Data) == 0 {
-		return task, nil
-	}
-
-	var pbTask privateactionspb.PrivateActionTask
-	err := proto.Unmarshal(envelope.Data, &pbTask)
-	if err != nil {
-		return nil, util.NewPARError(aperrorpb.ActionPlatformErrorCode_INTERNAL_ERROR, errors.New("failed to unmarshal task"))
-	}
-	return mapPbTaskToStruct(&pbTask), nil
 }
 
 type signedEnvelopeTaskVerifier struct {

--- a/pkg/privateactionrunner/task-verifier/verifier_test.go
+++ b/pkg/privateactionrunner/task-verifier/verifier_test.go
@@ -8,10 +8,10 @@ package taskverifier
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	privateactionspb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/privateactions"
@@ -51,46 +51,11 @@ func TestMapPbTaskToStructEmptyRemoteActionPolicyFields(t *testing.T) {
 	assert.Nil(t, got.Data.Attributes.SystemInputs)
 }
 
-func TestNoOpTaskVerifierUnwrapsSignedEnvelopeData(t *testing.T) {
-	inputs, err := structpb.NewStruct(map[string]interface{}{"command": "cat /tmp/file"})
-	require.NoError(t, err)
-	pbTask := &privateactionspb.PrivateActionTask{
-		ActionName: "runCommand",
-		BundleId:   "com.datadoghq.remoteaction.rshell",
-		TaskId:     "task-id",
-		Inputs:     inputs,
-		SystemInputs: &privateactionspb.SystemInputs{
-			Input: &privateactionspb.SystemInputs_RemoteAction{
-				RemoteAction: &privateactionspb.RemoteAction{
-					AllowedCommands: []string{"rshell:cat"},
-					AllowedPaths:    []string{"/tmp:ro"},
-					SystemServices: map[string]*structpb.ListValue{
-						"nginx.service": {
-							Values: []*structpb.Value{structpb.NewStringValue("read")},
-						},
-					},
-				},
-			},
-		},
-	}
-	signedTaskData, err := proto.Marshal(pbTask)
-	require.NoError(t, err)
-
+func TestTaskVerifierRejectsUnsignedTask(t *testing.T) {
 	task := &types.Task{}
-	task.Data.Attributes = &types.Attributes{
-		SignedEnvelope: &privateactionspb.RemoteConfigSignatureEnvelope{
-			Data: signedTaskData,
-		},
-	}
+	task.Data.Attributes = &types.Attributes{}
 
-	got, err := (&noOpTaskVerifier{}).UnwrapTask(task)
+	_, err := NewTaskVerifier(nil, &config.Config{}).UnwrapTask(task)
 
-	require.NoError(t, err)
-	assert.Equal(t, "task-id", got.Data.ID)
-	remoteAction := got.Data.Attributes.SystemInputs.GetRemoteAction()
-	require.NotNil(t, remoteAction)
-	assert.Equal(t, []string{"rshell:cat"}, remoteAction.AllowedCommands)
-	assert.Equal(t, []string{"/tmp:ro"}, remoteAction.AllowedPaths)
-	require.Contains(t, remoteAction.SystemServices, "nginx.service")
-	assert.Equal(t, []interface{}{"read"}, remoteAction.SystemServices["nginx.service"].AsSlice())
+	require.ErrorContains(t, err, "task is missing signed envelope")
 }

--- a/test/fakeintake/server/par.go
+++ b/test/fakeintake/server/par.go
@@ -149,8 +149,8 @@ func parRemoteActionFromInputs(inputs map[string]interface{}) (*privateactionspb
 	// rshell policy fields are delivered in the signed task fields in production
 	// (resolved from execution policies by the backend). The runner reads them
 	// from system_inputs.remote_action, not inputs. Surface any flat test inputs
-	// in the serialized task payload so skip-verification e2e flows behave like a
-	// real backend-signed task.
+	// in the serialized task payload so fakeintake behaves like a real
+	// backend-signed task.
 	remoteAction := &privateactionspb.RemoteAction{}
 	hasRemoteAction := false
 	if v, ok := inputs["allowedCommands"]; ok {

--- a/test/fakeintake/server/par.go
+++ b/test/fakeintake/server/par.go
@@ -149,8 +149,8 @@ func parRemoteActionFromInputs(inputs map[string]interface{}) (*privateactionspb
 	// rshell policy fields are delivered in the signed task fields in production
 	// (resolved from execution policies by the backend). The runner reads them
 	// from system_inputs.remote_action, not inputs. Surface any flat test inputs
-	// in the serialized task payload so fakeintake behaves like a real
-	// backend-signed task.
+	// in the serialized task payload so skip-verification e2e flows behave like a
+	// real backend-signed task.
 	remoteAction := &privateactionspb.RemoteAction{}
 	hasRemoteAction := false
 	if v, ok := inputs["allowedCommands"]; ok {

--- a/test/regression/cases/quality_gate_private_action_runner/experiment.yaml
+++ b/test/regression/cases/quality_gate_private_action_runner/experiment.yaml
@@ -19,9 +19,6 @@ target:
     ENTRYPOINT: privateactionrunner
     DD_API_KEY: a0000001
     DD_HOSTNAME: smp-regression
-    # This performance test has no Remote Config server, so bypass signing-key
-    # readiness while still exercising idle OPMS polling against lading.
-    DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION: "true"
     DD_INTERNAL_PAR_USE_DD_URL_FOR_OPMS: "true"
     # Expose /telemetry so SMP can capture Go runtime metrics for the runner.
     DD_INTERNAL_PAR_ENABLE_TELEMETRY: "true"


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Removes DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION

### Motivation

It is not necessary anymore, we made fake intake able to send signing keys so removing this code path as it was only meant for tests

### Describe how you validated your changes

CI is green

### Additional Notes
