### PR TITLE
fix(ci): Use bazel --batch for e2e test runs to avoid orphaned servers on cancellation

### DIFF
--- a/.gitlab/test/e2e/e2e_templates.yml
+++ b/.gitlab/test/e2e/e2e_templates.yml
@@ -99,6 +99,9 @@
     E2E_PREBUILD_S3_URI: "$S3_PERMANENT_ARTIFACTS_URI/e2e-pre-build/$CI_PIPELINE_ID"
     MAX_RETRIES_FLAG: "" # Empty by default, can be set to `--max-retries=3` for example to retry failed tests
     REMOTE_STACK_CLEANING: "true"
+    # A normal GitLab cancellation runs after_script. Keep an explicit budget for the
+    # stackcleaner request and the existing test-report and coverage uploads below.
+    RUNNER_AFTER_SCRIPT_TIMEOUT: 5m
   script:
     - export IS_DEV_BRANCH="$(dda inv -- -e pipeline.is-dev-branch)"
     - DYNAMIC_TESTS_BREAKGLASS=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $DYNAMIC_TESTS_BREAKGLASS value) || exit $?; export DYNAMIC_TESTS_BREAKGLASS
@@ -110,6 +113,14 @@
     - export E2E_IMAGE_PULL_PASSWORD=$(aws ecr get-login-password),$E2E_GCP_IMAGE_PULL_PASSWORD
     - dda inv -- -e new-e2e-tests.run $DYNAMIC_TESTS_FLAG $PRE_BUILT_BINARIES_FLAG $MAX_RETRIES_FLAG --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --result-json $E2E_RESULT_JSON --targets $TARGETS --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
   after_script:
+    - |
+      if [ "$CI_JOB_STATUS" = "canceled" ]; then
+        # after_script runs in a fresh shell, so restore the profile exported in before_script.
+        export AWS_PROFILE=agent-qa-ci
+        STACK_REGEX="^ci-${CI_JOB_ID}-${CI_PROJECT_ID}-.*$"
+        dda inv -- -e new-e2e-tests.cleanup-remote-stacks --stack-regex "$STACK_REGEX" || \
+          echo "WARNING: failed to submit canceled job stacks to stackcleaner"
+      fi
     - CODECOV_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $CODECOV token) || exit $?; export CODECOV_TOKEN
     - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "junit-${CI_JOB_ID}.tgz" "$E2E_RESULT_JSON"
     - |

--- a/.gitlab/test/e2e/e2e_templates.yml
+++ b/.gitlab/test/e2e/e2e_templates.yml
@@ -115,6 +115,9 @@
   after_script:
     - |
       if [ "$CI_JOB_STATUS" = "canceled" ]; then
+        # New E2E tests use Bazel batch mode so cancellation terminates the test process.
+        # Shut down any server left by an earlier Bazel command before cleaning stacks.
+        bazelisk shutdown || echo "WARNING: failed to stop Bazel before stack cleanup"
         # after_script runs in a fresh shell, so restore the profile exported in before_script.
         export AWS_PROFILE=agent-qa-ci
         STACK_REGEX="^ci-${CI_JOB_ID}-${CI_PROJECT_ID}-.*$"

--- a/.gitlab/test/e2e/e2e_templates.yml
+++ b/.gitlab/test/e2e/e2e_templates.yml
@@ -111,13 +111,43 @@
       fi
     # E2E_IMAGE_PULL_PASSWORD is a comma-separated list of passwords for the different registries
     - export E2E_IMAGE_PULL_PASSWORD=$(aws ecr get-login-password),$E2E_GCP_IMAGE_PULL_PASSWORD
-    - dda inv -- -e new-e2e-tests.run $DYNAMIC_TESTS_FLAG $PRE_BUILT_BINARIES_FLAG $MAX_RETRIES_FLAG --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --result-json $E2E_RESULT_JSON --targets $TARGETS --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
+    - |
+      # Run E2E tests in a dedicated process group. GitLab cancellation terminates
+      # this shell before after_script starts, so keep the group ID for after_script.
+      E2E_PROCESS_GROUP_FILE="$CI_PROJECT_DIR/.e2e-process-group"
+      setsid dda inv -- -e new-e2e-tests.run $DYNAMIC_TESTS_FLAG $PRE_BUILT_BINARIES_FLAG $MAX_RETRIES_FLAG --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --result-json $E2E_RESULT_JSON --targets $TARGETS --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH &
+      E2E_PROCESS_GROUP=$!
+      echo "$E2E_PROCESS_GROUP" > "$E2E_PROCESS_GROUP_FILE"
+      if wait "$E2E_PROCESS_GROUP"; then
+        E2E_EXIT_CODE=0
+      else
+        E2E_EXIT_CODE=$?
+      fi
+      rm -f "$E2E_PROCESS_GROUP_FILE"
+      exit "$E2E_EXIT_CODE"
   after_script:
     - |
       if [ "$CI_JOB_STATUS" = "canceled" ]; then
-        # New E2E tests use Bazel batch mode so cancellation terminates the test process.
-        # Shut down any server left by an earlier Bazel command before cleaning stacks.
-        bazelisk shutdown || echo "WARNING: failed to stop Bazel before stack cleanup"
+        E2E_PROCESS_GROUP_FILE="$CI_PROJECT_DIR/.e2e-process-group"
+        if [ -f "$E2E_PROCESS_GROUP_FILE" ]; then
+          E2E_PROCESS_GROUP=$(cat "$E2E_PROCESS_GROUP_FILE")
+          if [[ "$E2E_PROCESS_GROUP" =~ ^[0-9]+$ ]]; then
+            echo "Stopping canceled E2E process group $E2E_PROCESS_GROUP"
+            kill -TERM -- "-$E2E_PROCESS_GROUP" 2>/dev/null || true
+            for _ in {1..10}; do
+              if ! kill -0 -- "-$E2E_PROCESS_GROUP" 2>/dev/null; then
+                break
+              fi
+              sleep 1
+            done
+            if kill -0 -- "-$E2E_PROCESS_GROUP" 2>/dev/null; then
+              echo "E2E process group did not stop after 10 seconds; killing it"
+              kill -KILL -- "-$E2E_PROCESS_GROUP" 2>/dev/null || true
+            fi
+          else
+            echo "WARNING: invalid E2E process group: $E2E_PROCESS_GROUP"
+          fi
+        fi
         # after_script runs in a fresh shell, so restore the profile exported in before_script.
         export AWS_PROFILE=agent-qa-ci
         STACK_REGEX="^ci-${CI_JOB_ID}-${CI_PROJECT_ID}-.*$"

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -406,6 +406,7 @@ def test_flavor(
     recursive: bool = True,
     exclude_packages: set[str] | None = None,
     skip_tests_covered_by_bazel: bool = False,
+    bazel_batch: bool = False,
 ):
     """
     Runs unit tests for given flavor, build tags, and modules.
@@ -489,6 +490,7 @@ def test_flavor(
                 )
             else:
                 res = bazel(
+                    *(["--batch"] if bazel_batch else []),
                     "run",
                     "//internal/tools:gotestsum",
                     "--",

--- a/tasks/libs/pipeline/tools.py
+++ b/tasks/libs/pipeline/tools.py
@@ -123,9 +123,9 @@ def cancel_pipelines_with_confirmation(repo: Project, pipelines: list[ProjectPip
 def gracefully_cancel_pipeline(repo: Project, pipeline: ProjectPipeline, force_cancel_stages):
     """
     Gracefully cancel pipeline
-    - Cancel all the jobs that did not start to run yet
+    - Cancel all queued and running jobs
     - Do not cancel jobs containing 'cleanup' in their name
-    - Jobs in the stages specified in 'force_cancel_stages' variables will always be canceled even if running
+    - Jobs in the stages specified in 'force_cancel_stages' variables will always be canceled
     - Do not cancel jobs in the no_cancel_override list
     """
 
@@ -141,7 +141,7 @@ def gracefully_cancel_pipeline(repo: Project, pipeline: ProjectPipeline, force_c
             continue
 
         if job.stage in force_cancel_stages or (
-            job.status not in ["running", "canceled", "success", "manual"] and "cleanup" not in job.name
+            job.status not in ["canceled", "success", "manual"] and "cleanup" not in job.name
         ):
             repo.jobs.get(job.id, lazy=True).cancel()
 

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -1160,19 +1160,26 @@ def cleanup_remote_stacks(ctx, stack_regex):
     with multiprocessing.Pool(len(to_delete_stacks)) as pool:
         destroy_func = destroy_remote_stack_api if remote_stack_cleaning else destroy_remote_stack_local
         res = pool.map(destroy_func, to_delete_stacks)
-        destroyed_stack = set()
+        successful_stack = set()
         failed_stack = set()
         for exit_code, stdout, stderr, stack in res:
             if exit_code != 0:
                 failed_stack.add(stack)
             else:
-                destroyed_stack.add(stack)
-            print(f"Stack {stack}: {stdout} {stderr}")
+                successful_stack.add(stack)
+            if stdout or stderr:
+                print(f"Stack {stack}: {stdout} {stderr}".rstrip())
 
-    for stack in destroyed_stack:
-        print(f"Stack {stack} destroyed successfully")
+    for stack in successful_stack:
+        if remote_stack_cleaning:
+            print(f"Stack {stack} cleanup request submitted successfully")
+        else:
+            print(f"Stack {stack} destroyed successfully")
     for stack in failed_stack:
-        print(f"Failed to destroy stack {stack}")
+        if remote_stack_cleaning:
+            print(f"Failed to submit cleanup request for stack {stack}")
+        else:
+            print(f"Failed to destroy stack {stack}")
 
 
 def post_process_output(path: str, test_depth: int = 1) -> list[tuple[str, str, list[str]]]:

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -871,6 +871,9 @@ def run(
             result_junit=partial_result_junit,
             result_json=partial_result_json,
             recursive=recursive,
+            # A Bazel server outlives the canceled GitLab shell and may continue
+            # provisioning E2E resources while after_script tries to clean them.
+            bazel_batch=running_in_ci(),
         )
         if test_res is None:
             ctx.run("datadog-ci tag --level job --tags 'e2e.skipped_all_tests:true'")
@@ -946,6 +949,7 @@ def run(
             env=env_vars,
             result_junit="",  # No need to store JUnit results for teardown-only runs
             result_json="",  # No need to store results for teardown-only runs
+            bazel_batch=running_in_ci(),
         )
 
     # Merge all the partial result JSON files into the final result JSON

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -122,7 +122,7 @@ def auto_cancel_previous_pipelines(ctx):
     ]
 
     for pipeline in older_pipelines:
-        print(f'Gracefully canceling jobs that are not canceled on pipeline {pipeline.id} ({pipeline.web_url})')
+        print(f'Canceling eligible jobs on older pipeline {pipeline.id} ({pipeline.web_url})')
         gracefully_cancel_pipeline(repo, pipeline, force_cancel_stages=force_cancel_stages)
 
 

--- a/tasks/tools/e2e_stacks.py
+++ b/tasks/tools/e2e_stacks.py
@@ -24,7 +24,7 @@ def destroy_remote_stack_api(stack: str, ctx: Context | None = None):
             "stackcleaner/stack",
             env="prod",
             ty="stackcleaner_workflow_request",
-            attrs=f"stack_name={stack},job_name={os.environ['CI_JOB_NAME']},job_id={os.environ['CI_JOB_ID']},pipeline_id={os.environ['CI_PIPELINE_ID']},ref={os.environ['CI_COMMIT_REF_NAME']},ignore_lock=bool:true,ignore_not_found=bool:true",
+            attrs=f"stack_name={stack},job_name={os.environ['CI_JOB_NAME']},job_id={os.environ['CI_JOB_ID']},pipeline_id={os.environ['CI_PIPELINE_ID']},ref={os.environ['CI_COMMIT_REF_NAME']},ignore_lock=bool:true,ignore_not_found=bool:true,cancel_first=bool:true",
             timeout=10,
             ignore_timeout_error=True,
         )
@@ -32,4 +32,4 @@ def destroy_remote_stack_api(stack: str, ctx: Context | None = None):
         exit_code = 1
         stderr = str(e)
 
-    return exit_code, f"Failed to destroy stack {stack} using the API", stderr, stack
+    return exit_code, "Stack cleanup request submitted to stackcleaner" if exit_code == 0 else "", stderr, stack

--- a/tasks/unit_tests/e2e_stacks_tests.py
+++ b/tasks/unit_tests/e2e_stacks_tests.py
@@ -1,0 +1,67 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tasks.new_e2e_tests import cleanup_remote_stacks
+from tasks.tools.e2e_stacks import destroy_remote_stack_api
+
+
+class TestDestroyRemoteStackApi(unittest.TestCase):
+    @patch.dict(
+        os.environ,
+        {
+            "CI_JOB_NAME": "new-e2e-job",
+            "CI_JOB_ID": "123",
+            "CI_PIPELINE_ID": "456",
+            "CI_COMMIT_REF_NAME": "test-branch",
+        },
+    )
+    @patch("tasks.tools.e2e_stacks.run")
+    def test_submits_cleanup_with_cancel_first(self, run_mock):
+        stack = "organization/e2eci/ci-123-4670-e2e-suite"
+
+        exit_code, stdout, stderr, returned_stack = destroy_remote_stack_api(stack, MagicMock())
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout, "Stack cleanup request submitted to stackcleaner")
+        self.assertEqual(stderr, "")
+        self.assertEqual(returned_stack, stack)
+        self.assertIn("cancel_first=bool:true", run_mock.call_args.kwargs["attrs"])
+
+    @patch.dict(
+        os.environ,
+        {
+            "CI_JOB_NAME": "new-e2e-job",
+            "CI_JOB_ID": "123",
+            "CI_PIPELINE_ID": "456",
+            "CI_COMMIT_REF_NAME": "test-branch",
+        },
+    )
+    @patch("tasks.tools.e2e_stacks.run", side_effect=RuntimeError("request failed"))
+    def test_reports_submission_failure(self, _run_mock):
+        stack = "organization/e2eci/ci-123-4670-e2e-suite"
+
+        exit_code, stdout, stderr, returned_stack = destroy_remote_stack_api(stack, MagicMock())
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout, "")
+        self.assertEqual(stderr, "request failed")
+        self.assertEqual(returned_stack, stack)
+
+
+class TestCleanupRemoteStacks(unittest.TestCase):
+    @patch.dict(os.environ, {"REMOTE_STACK_CLEANING": "true"})
+    @patch("tasks.new_e2e_tests.list_stacks")
+    @patch("tasks.new_e2e_tests.multiprocessing.Pool")
+    @patch("builtins.print")
+    def test_reports_remote_cleanup_as_submitted(self, print_mock, pool_mock, list_stacks_mock):
+        stack = "organization/e2eci/ci-123-4670-e2e-suite"
+        list_stacks_mock.return_value = [{"name": stack}]
+        pool_mock.return_value.__enter__.return_value.map.return_value = [
+            (0, "Stack cleanup request submitted to stackcleaner", "", stack)
+        ]
+
+        cleanup_remote_stacks.body(MagicMock(), r"^ci-123-4670-.*$")
+
+        print_mock.assert_any_call(f"Stack {stack} cleanup request submitted successfully")
+        self.assertNotIn(f"Stack {stack} destroyed successfully", [call.args[0] for call in print_mock.call_args_list])

--- a/tasks/unit_tests/pipeline_lib_tests.py
+++ b/tasks/unit_tests/pipeline_lib_tests.py
@@ -1,10 +1,12 @@
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from gitlab.v4.objects import ProjectJob
 
 from tasks.libs.pipeline import notifications
 from tasks.libs.pipeline.data import get_job_failure_context, get_jobs_skipped_on_pr
+from tasks.libs.pipeline.tools import gracefully_cancel_pipeline
 from tasks.libs.types.types import FailedJobReason, FailedJobType
 
 
@@ -17,6 +19,27 @@ class TestLoadAndValidate(unittest.TestCase):
         # Assert that a couple of expected entries are there, including one that uses DEFAULT_SLACK_PROJECT
         self.assertEqual(notifications.GITHUB_SLACK_MAP['@datadog/agent-community-eng'], "#datadog-agent-pipelines")
         self.assertEqual(notifications.GITHUB_SLACK_MAP['@datadog/agent-devx'], "#agent-devx-ops")
+
+
+class TestGracefullyCancelPipeline(unittest.TestCase):
+    def test_cancels_queued_and_running_jobs_except_cleanup_and_allowlisted_jobs(self):
+        jobs = [
+            SimpleNamespace(id=1, name='pending-job', stage='test', status='pending'),
+            SimpleNamespace(id=2, name='running-job', stage='test', status='running'),
+            SimpleNamespace(id=3, name='new-e2e-cleanup-on-failure', stage='.post', status='running'),
+            SimpleNamespace(id=4, name='dev_deploy-host-profiler-devtest', stage='deploy', status='running'),
+            SimpleNamespace(id=5, name='successful-job', stage='test', status='success'),
+            SimpleNamespace(id=6, name='manual-job', stage='test', status='manual'),
+        ]
+        pipeline = MagicMock()
+        pipeline.jobs.list.return_value = jobs
+        repo = MagicMock()
+
+        gracefully_cancel_pipeline(repo, pipeline, force_cancel_stages=[])
+
+        self.assertEqual([call.args[0] for call in repo.jobs.get.call_args_list], [1, 2])
+        self.assertTrue(all(call.kwargs == {'lazy': True} for call in repo.jobs.get.call_args_list))
+        self.assertEqual(repo.jobs.get.return_value.cancel.call_count, 2)
 
 
 class TestFailedJobs(unittest.TestCase):


### PR DESCRIPTION
### What does this PR do?
Reintroduces the `bazel_batch` option (split out of #54809 per [review feedback](https://github.com/DataDog/datadog-agent/pull/54809#discussion_r3893423869)) that runs the `new-e2e-tests.run` Bazel invocation with `--batch`, so no persistent Bazel server survives a canceled job and keeps touching E2E infra while `after_script` is running cleanup.

### Motivation
Without `--batch`, a Bazel server can outlive the canceled GitLab shell and continue provisioning/using E2E resources while `after_script` tries to clean them up.

`--batch` disables Bazel's client/server model entirely, so every `bazel run //internal/tools:gotestsum` invocation pays the full cold analysis cost instead of reusing a warm server. Since `new-e2e-tests.run` calls this twice per job (main run + teardown-only run) and this affects every `new-e2e-*` job in CI, this is blocked until we have a narrower fix.

Tracking:
- https://github.com/bazelbuild/bazel/issues/30435 (root-cause livelock when a client disconnects mid-cancellation)
- https://github.com/bazelbuild/bazel/pull/30929 (upstream fix proposed by @rdesgroppes)
- Régis has a workaround in place in the meantime; this PR should stay draft/blocked until we land that or the upstream fix.

### Describe how you validated your changes
Same validation as #54809 (cancellation cleanup was manually verified there); this PR only reintroduces the `--batch` flag on top.

### Additional Notes
Depends on #54809 (based on that branch).