### PR TITLE
PROF-XXXXX: resolve dda version automatically

### DIFF
--- a/tools/host-profiler/Dockerfile
+++ b/tools/host-profiler/Dockerfile
@@ -1,9 +1,10 @@
 FROM debian:trixie-slim AS dda
-ARG DDA_VERSION=v0.29.0
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     rm -rf /var/lib/apt/lists/*
+COPY .dda/version /tmp/dda.version
 RUN ARCH=$(dpkg --print-architecture) && \
+    DDA_VERSION="v$(cat /tmp/dda.version)" && \
     if [ "$ARCH" = "amd64" ]; then DDA_ARCH="x86_64"; \
     elif [ "$ARCH" = "arm64" ]; then DDA_ARCH="aarch64"; fi && \
     curl -fsSL --retry 4 "https://github.com/DataDog/datadog-agent-dev/releases/download/${DDA_VERSION}/dda-${DDA_ARCH}-unknown-linux-gnu.tar.gz" \


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

This PR resolves `DDA_VERSION` directly from `.dda/version` when testing locally with Docker.

### Motivation

I encountered the following error when setting up a new workspace:
```
host-profiler git:(main) ✗ docker-compose logs host-profiler -f      

host-profiler-1 | Repo requires at least dda version 0.38.0 but 0.29.0 is installed.
host-profiler-1 | Run the following command:
host-profiler-1 | dda self update
```

Since the Docker setup is used for local testing, resolving the version directly from the existing `.dda/version` file avoids having to bump the value manually.

### Describe how you validated your changes

Tested locally.

### Additional Notes