### PR TITLE
feat(config-files-discovery): collect PostgreSQL configuration files

### DIFF
--- a/comp/core/configfilesdiscovery/impl/collectors/postgres.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/postgres.go
@@ -8,13 +8,20 @@ package collectors
 import (
 	"context"
 	"fmt"
+	"path"
 	"regexp"
+	"strings"
 
+	"github.com/DataDog/agent-payload/v5/agentdiscovery"
 	configfilesdiscoveryimpl "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // PostgresIntegrationName is the Autodiscovery check name for PostgreSQL.
-const PostgresIntegrationName = "postgres"
+const (
+	PostgresIntegrationName     = "postgres"
+	postgresConfigPayloadFormat = agentdiscovery.AgentDiscoveryConfigFilePayloadFormat_PAYLOAD_FORMAT_PROPERTIES
+)
 
 type postgresConfigCollector struct{}
 
@@ -64,30 +71,176 @@ var postgresBitnamiEnvDeny = regexp.MustCompile(
 )
 
 // NewPostgres returns a collector that reads selected, non-secret PostgreSQL
-// environment variables. It does not read postgresql.conf; config-file
-// collection is intentionally out of scope.
+// environment variables and the main PostgreSQL configuration file.
 func NewPostgres() configfilesdiscoveryimpl.ConfigCollector {
 	return postgresConfigCollector{}
 }
 
-// CanCollectFromProcess always returns false: this collector has no
-// process-command-line-based collection to retry.
-func (postgresConfigCollector) CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline) bool {
-	return false
+// CanCollectFromProcess returns whether the process command line identifies a
+// PostgreSQL server. Its main config file is selected by an explicit command
+// line option or by PGDATA.
+func (postgresConfigCollector) CanCollectFromProcess(commandline configfilesdiscoveryimpl.TargetCommandline) bool {
+	return postgresMatchesCommandline(commandline.Args)
 }
 
 func (postgresConfigCollector) Collect(ctx context.Context, reader configfilesdiscoveryimpl.ConfigReader) (configfilesdiscoveryimpl.CollectedConfig, error) {
-	envVars, err := readEnvVars(ctx, reader, includePostgresEnvVar)
-	if err != nil {
-		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read postgres env vars: %w", err)
-	}
-	if len(envVars) == 0 {
-		return configfilesdiscoveryimpl.CollectedConfig{}, nil
+	envVars, envErr := readEnvVars(ctx, reader, includePostgresEnvVar)
+	if envErr != nil {
+		log.Debugf("config files discovery skipped postgres env var collection: %v", envErr)
+		envVars = nil
 	}
 
+	fallbackConfigArg := postgresFallbackConfigArg(envVars)
+	file, ok, err := readConfigFile(
+		ctx,
+		reader,
+		postgresGetConfigArgFromCommandline,
+		postgresMatchesCommandline,
+		fallbackConfigArg,
+	)
+	if err != nil {
+		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("collect postgres config file: %w", err)
+	}
+	if !ok {
+		// Without a config file, env vars are the only PostgreSQL config source.
+		// Return the error so the scheduler retries.
+		if envErr != nil {
+			return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read postgres env vars: %w", envErr)
+		}
+		if len(envVars) == 0 {
+			log.Debugf("config files discovery skipped postgres config collection: no config file or selected env vars detected")
+			return configfilesdiscoveryimpl.CollectedConfig{}, nil
+		}
+
+		log.Debugf("config files discovery collected postgres env vars without a config file")
+		return configfilesdiscoveryimpl.CollectedConfig{EnvVars: envVars}, nil
+	}
+
+	file.PayloadFormat = postgresConfigPayloadFormat
 	return configfilesdiscoveryimpl.CollectedConfig{
-		EnvVars: envVars,
+		ConfigFiles: []configfilesdiscoveryimpl.ConfigFile{file},
+		EnvVars:     envVars,
 	}, nil
+}
+
+// postgresFallbackConfigArg returns a config file path only for image
+// conventions that expose one explicitly. PostgreSQL's PGDATA is a config
+// directory, whereas Bitnami keeps its main configuration file separately.
+func postgresFallbackConfigArg(envVars []configfilesdiscoveryimpl.ConfigEnvVar) string {
+	var pgData string
+	for _, envVar := range envVars {
+		switch envVar.Name {
+		case "POSTGRESQL_CONF_FILE":
+			return envVar.Value
+		case "PGDATA":
+			pgData = envVar.Value
+		}
+	}
+	if pgData == "" {
+		return ""
+	}
+	return path.Join(pgData, "postgresql.conf")
+}
+
+// postgresGetConfigArgFromCommandline returns the main PostgreSQL config file
+// specified by the server command. An explicit config_file takes precedence
+// over -D because PostgreSQL permits the config file to live elsewhere.
+func postgresGetConfigArgFromCommandline(args []string) (string, bool) {
+	postgresArgs, ok := postgresGetArgs(unwrapShellCommandline(args))
+	if !ok {
+		return "", false
+	}
+
+	if configPath, found := postgresGetExplicitConfigArg(postgresArgs); found {
+		return configPath, true
+	}
+	return postgresGetDataDirConfigArg(postgresArgs)
+}
+
+func postgresMatchesCommandline(args []string) bool {
+	_, ok := postgresGetArgs(unwrapShellCommandline(args))
+	return ok
+}
+
+func postgresGetArgs(args []string) ([]string, bool) {
+	if len(args) == 0 {
+		return nil, false
+	}
+	if path.Base(args[0]) == "postgres" {
+		return args[1:], true
+	}
+	// Docker's official PostgreSQL image keeps docker-entrypoint.sh as the
+	// container command and passes postgres as its first argument.
+	if len(args) > 1 && path.Base(args[0]) == "docker-entrypoint.sh" && path.Base(args[1]) == "postgres" {
+		return args[2:], true
+	}
+	return nil, false
+}
+
+func postgresGetExplicitConfigArg(args []string) (string, bool) {
+	var configPath string
+	foundConfigPath := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		var value string
+		directPath := false
+		switch {
+		case arg == "-c" && i+1 < len(args):
+			i++
+			value = args[i]
+		case strings.HasPrefix(arg, "-c"):
+			value = strings.TrimPrefix(arg, "-c")
+		case arg == "--config-file" && i+1 < len(args):
+			i++
+			value = args[i]
+			directPath = true
+		case strings.HasPrefix(arg, "--config-file="):
+			value = strings.TrimPrefix(arg, "--config-file=")
+			directPath = true
+		case strings.HasPrefix(arg, "--config_file="):
+			value = strings.TrimPrefix(arg, "--config_file=")
+			directPath = true
+		default:
+			continue
+		}
+
+		if !directPath {
+			name, path, found := strings.Cut(value, "=")
+			if !found || (name != "config_file" && name != "config-file") {
+				continue
+			}
+			value = path
+		}
+
+		configPath = value
+		foundConfigPath = true
+	}
+	return configPath, foundConfigPath
+}
+
+func postgresGetDataDirConfigArg(args []string) (string, bool) {
+	var dataDir string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		var value string
+		switch {
+		case arg == "-D" && i+1 < len(args):
+			i++
+			value = args[i]
+		case strings.HasPrefix(arg, "-D"):
+			value = strings.TrimPrefix(arg, "-D")
+		default:
+			continue
+		}
+		if value == "" {
+			return "", true
+		}
+		dataDir = value
+	}
+	if dataDir == "" {
+		return "", false
+	}
+	return path.Join(dataDir, "postgresql.conf"), true
 }
 
 func includePostgresEnvVar(name string) bool {

--- a/comp/core/configfilesdiscovery/impl/collectors/postgres_test.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/postgres_test.go
@@ -103,6 +103,12 @@ func TestPostgresCollectorCollectsEnvVars(t *testing.T) {
 			"POSTGRESQL_PASSWORD":            "must-not-be-forwarded",
 			"UNREQUESTED":                    "value",
 		},
+		files: map[string]configfilesdiscoveryimpl.ConfigFile{
+			"/opt/bitnami/postgresql/conf/postgresql.conf": {
+				Path:    "/opt/bitnami/postgresql/conf/postgresql.conf",
+				Content: []byte("max_connections = 200\nshared_preload_libraries = 'pg_stat_statements'\n"),
+			},
+		},
 	}
 	collector := NewPostgres()
 
@@ -126,7 +132,12 @@ func TestPostgresCollectorCollectsEnvVars(t *testing.T) {
 		{Name: "POSTGRES_PORT_NUMBER", Value: "5432"},
 		{Name: "POSTGRES_USER", Value: "app"},
 	}, collected.EnvVars)
-	assert.Empty(t, collected.ConfigFiles)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, configfilesdiscoveryimpl.ConfigFile{
+		Path:          "/opt/bitnami/postgresql/conf/postgresql.conf",
+		Content:       []byte("max_connections = 200\nshared_preload_libraries = 'pg_stat_statements'\n"),
+		PayloadFormat: postgresConfigPayloadFormat,
+	}, collected.ConfigFiles[0])
 }
 
 func TestPostgresCollectorSkipsWhenNoSelectedEnvVars(t *testing.T) {
@@ -153,17 +164,135 @@ func TestPostgresCollectorReturnsEnvVarErrors(t *testing.T) {
 	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
 }
 
-func TestPostgresCollectorCanCollectFromProcessAlwaysFalse(t *testing.T) {
+func TestPostgresCollectorReadsDetectedConfigWhenEnvVarsFail(t *testing.T) {
+	const configPath = "/etc/postgresql/postgresql.conf"
+	reader := &postgresCollectorTestReader{
+		readEnvVarsErr: errors.New("env unavailable"),
+		commandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres", "-c", "config_file=" + configPath},
+		},
+		files: map[string]configfilesdiscoveryimpl.ConfigFile{
+			configPath: {Path: configPath, Content: []byte("max_connections = 200\n")},
+		},
+	}
+
+	collected, err := NewPostgres().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{configPath}, reader.readFileCalls)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigFile{{
+		Path:          configPath,
+		Content:       []byte("max_connections = 200\n"),
+		PayloadFormat: postgresConfigPayloadFormat,
+	}}, collected.ConfigFiles)
+	assert.Empty(t, collected.EnvVars)
+}
+
+func TestPostgresCollectorReadsExplicitConfigAfterDockerEntrypoint(t *testing.T) {
+	const explicitConfigPath = "/etc/postgresql/custom.conf"
+	const fallbackConfigPath = "/var/lib/postgresql/data/postgresql.conf"
+	reader := &postgresCollectorTestReader{
+		env: map[string]string{
+			"PGDATA": "/var/lib/postgresql/data",
+		},
+		commandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/usr/local/bin/docker-entrypoint.sh", "postgres", "-c", "config_file=" + explicitConfigPath},
+		},
+		files: map[string]configfilesdiscoveryimpl.ConfigFile{
+			explicitConfigPath: {Path: explicitConfigPath, Content: []byte("max_connections = 200\n")},
+			fallbackConfigPath: {Path: fallbackConfigPath, Content: []byte("max_connections = 100\n")},
+		},
+	}
+
+	collected, err := NewPostgres().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{explicitConfigPath}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, explicitConfigPath, collected.ConfigFiles[0].Path)
+}
+
+func TestPostgresCollectorSkipsClientCommandline(t *testing.T) {
+	const backupConfigPath = "/backup/postgresql.conf"
+	reader := &postgresCollectorTestReader{
+		commandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"pg_basebackup", "-U", "postgres", "-D", "/backup"},
+		},
+		files: map[string]configfilesdiscoveryimpl.ConfigFile{
+			backupConfigPath: {Path: backupConfigPath, Content: []byte("max_connections = 200\n")},
+		},
+	}
+
+	collected, err := NewPostgres().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, collected)
+	assert.Empty(t, reader.readFileCalls)
+}
+
+func TestPostgresCollectorCanCollectFromProcess(t *testing.T) {
 	collector := postgresConfigCollector{}
-	assert.False(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{
+	assert.True(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{
+		Args: []string{"postgres"},
+	}))
+	assert.True(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{
 		Args: []string{"postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"},
 	}))
+	assert.True(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{
+		Args: []string{"docker-entrypoint.sh", "postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"},
+	}))
+	assert.False(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{
+		Args: []string{"pg_basebackup", "-U", "postgres", "-D", "/backup"},
+	}))
 	assert.False(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{}))
+}
+
+func TestPostgresGetConfigArgFromCommandline(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantPath string
+		wantOK   bool
+	}{
+		{name: "explicit config file", args: []string{"postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"}, wantPath: "/etc/postgresql/postgresql.conf", wantOK: true},
+		{name: "long explicit config file", args: []string{"postgres", "--config-file=/etc/postgresql/postgresql.conf"}, wantPath: "/etc/postgresql/postgresql.conf", wantOK: true},
+		{name: "last explicit config file wins", args: []string{"postgres", "-c", "config_file=/one/postgresql.conf", "-c", "config_file=/two/postgresql.conf"}, wantPath: "/two/postgresql.conf", wantOK: true},
+		{name: "data directory", args: []string{"postgres", "-D", "/var/lib/postgresql/data"}, wantPath: "/var/lib/postgresql/data/postgresql.conf", wantOK: true},
+		{name: "attached data directory", args: []string{"postgres", "-D/var/lib/postgresql/data"}, wantPath: "/var/lib/postgresql/data/postgresql.conf", wantOK: true},
+		{name: "last data directory wins", args: []string{"postgres", "-D", "/one", "-D", "/two"}, wantPath: "/two/postgresql.conf", wantOK: true},
+		{name: "explicit config file wins over data directory", args: []string{"postgres", "-D", "/var/lib/postgresql/data", "-c", "config_file=/etc/postgresql/postgresql.conf"}, wantPath: "/etc/postgresql/postgresql.conf", wantOK: true},
+		{name: "shell wrapper", args: []string{"/bin/sh", "-c", "postgres -D /var/lib/postgresql/data"}, wantPath: "/var/lib/postgresql/data/postgresql.conf", wantOK: true},
+		{name: "official docker entrypoint", args: []string{"docker-entrypoint.sh", "postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"}, wantPath: "/etc/postgresql/postgresql.conf", wantOK: true},
+		{name: "client command with postgres user", args: []string{"pg_basebackup", "-U", "postgres", "-D", "/backup"}},
+		{name: "no path", args: []string{"postgres"}},
+		{name: "non postgres command", args: []string{"redis-server", "/etc/redis/redis.conf"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, ok := postgresGetConfigArgFromCommandline(tt.args)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantPath, path)
+		})
+	}
+}
+
+func TestPostgresFallbackConfigArg(t *testing.T) {
+	assert.Equal(t, "/opt/bitnami/postgresql/conf/postgresql.conf", postgresFallbackConfigArg([]configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "PGDATA", Value: "/var/lib/postgresql/data"},
+		{Name: "POSTGRESQL_CONF_FILE", Value: "/opt/bitnami/postgresql/conf/postgresql.conf"},
+	}))
+	assert.Equal(t, "/var/lib/postgresql/data/postgresql.conf", postgresFallbackConfigArg([]configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "PGDATA", Value: "/var/lib/postgresql/data"},
+	}))
 }
 
 type postgresCollectorTestReader struct {
 	env            map[string]string
 	readEnvVarsErr error
+	commandline    configfilesdiscoveryimpl.TargetCommandline
+	files          map[string]configfilesdiscoveryimpl.ConfigFile
+	readFileCalls  []string
 }
 
 func (r *postgresCollectorTestReader) Runtime() configfilesdiscoveryimpl.RuntimeType {
@@ -172,8 +301,12 @@ func (r *postgresCollectorTestReader) Runtime() configfilesdiscoveryimpl.Runtime
 
 func (r *postgresCollectorTestReader) Close() {}
 
-func (r *postgresCollectorTestReader) ReadFile(context.Context, string) (configfilesdiscoveryimpl.ConfigFile, error) {
-	return configfilesdiscoveryimpl.ConfigFile{}, errors.New("not implemented")
+func (r *postgresCollectorTestReader) ReadFile(_ context.Context, path string) (configfilesdiscoveryimpl.ConfigFile, error) {
+	r.readFileCalls = append(r.readFileCalls, path)
+	if file, found := r.files[path]; found {
+		return file, nil
+	}
+	return configfilesdiscoveryimpl.ConfigFile{}, errors.New("not found")
 }
 
 func (r *postgresCollectorTestReader) ReadEnvVars(_ context.Context, predicate configfilesdiscoveryimpl.ConfigEnvVarPredicate) (map[string]string, error) {
@@ -195,7 +328,7 @@ func (r *postgresCollectorTestReader) ReadEnvVars(_ context.Context, predicate c
 }
 
 func (r *postgresCollectorTestReader) ReadRuntimeCommandline(context.Context) (configfilesdiscoveryimpl.TargetCommandline, error) {
-	return configfilesdiscoveryimpl.TargetCommandline{}, nil
+	return r.commandline, nil
 }
 
 func (r *postgresCollectorTestReader) ReadLiveProcessCommandlines(context.Context) []configfilesdiscoveryimpl.TargetCommandline {

--- a/test/new-e2e/tests/discovery/configfilesdiscovery_docker_test.go
+++ b/test/new-e2e/tests/discovery/configfilesdiscovery_docker_test.go
@@ -67,6 +67,8 @@ const (
 const (
 	postgresConfigDir       = "/tmp/configfilesdiscovery-postgres"
 	postgresContainerName   = "postgres-configfilesdiscovery"
+	postgresConfigPath      = "/var/lib/postgresql/data/configfilesdiscovery/postgresql.conf"
+	postgresInitScriptName  = "10-add-config.sh"
 	postgresIntegrationName = "postgres"
 	postgresDBName          = "configfilesdiscovery"
 	postgresUser            = "configfilesdiscovery"
@@ -91,6 +93,16 @@ const redisDefaultConfig = `port 6379
 appendonly no
 maxmemory-policy allkeys-lru
 # configfilesdiscovery-default-e2e-sentinel
+`
+
+const postgresInitScript = `#!/bin/sh
+set -eu
+
+cat >> "$PGDATA/postgresql.conf" <<'EOF'
+max_connections = 200
+cluster_name = 'configfilesdiscovery-postgres-e2e'
+log_line_prefix = '%m [%p] '
+EOF
 `
 
 const redisExplicitStartScript = `#!/bin/sh
@@ -165,8 +177,9 @@ func TestConfigFilesDiscoveryDockerSuite(t *testing.T) {
 		dockeragentparams.WithExtraComposeManifest("configfilesdiscovery-kafka", pulumi.String(kafkaCompose)),
 		dockeragentparams.WithExtraComposeManifest("configfilesdiscovery-postgres", pulumi.String(postgresCompose)),
 		dockeragentparams.WithEnvironmentVariables(pulumi.StringMap{
-			"CONFIG_FILES_DISCOVERY_REDIS_CONFIG_DIR": pulumi.String(redisConfigDir),
-			"CONFIG_FILES_DISCOVERY_KAFKA_CONFIG_DIR": pulumi.String(kafkaConfigDir),
+			"CONFIG_FILES_DISCOVERY_REDIS_CONFIG_DIR":    pulumi.String(redisConfigDir),
+			"CONFIG_FILES_DISCOVERY_KAFKA_CONFIG_DIR":    pulumi.String(kafkaConfigDir),
+			"CONFIG_FILES_DISCOVERY_POSTGRES_CONFIG_DIR": pulumi.String(postgresConfigDir),
 		}),
 	}
 
@@ -174,6 +187,7 @@ func TestConfigFilesDiscoveryDockerSuite(t *testing.T) {
 		awsdocker.WithRunOptions(
 			scendocker.WithPreAgentInstallHook(createConfigFilesDiscoveryRedisConfig),
 			scendocker.WithPreAgentInstallHook(createConfigFilesDiscoveryKafkaConfig),
+			scendocker.WithPreAgentInstallHook(createConfigFilesDiscoveryPostgresConfig),
 			scendocker.WithAgentOptions(agentOpts...),
 		),
 	)))
@@ -199,6 +213,14 @@ func createConfigFilesDiscoveryKafkaConfig(_ *aws.Environment, host *remote.Host
 		[]configFilesDiscoveryFixtureFile{
 			{name: kafkaStartScriptName, content: kafkaStartScript},
 		},
+	)
+}
+
+func createConfigFilesDiscoveryPostgresConfig(_ *aws.Environment, host *remote.Host) (pulumi.Resource, error) {
+	return createConfigFilesDiscoveryFixtureFiles(
+		host,
+		postgresConfigDir,
+		[]configFilesDiscoveryFixtureFile{{name: postgresInitScriptName, content: postgresInitScript}},
 	)
 }
 
@@ -352,7 +374,7 @@ func (s *configFilesDiscoveryDockerSuite) TestRedisEnvVarsDiscoveredWithoutConfi
 	}, 3*time.Minute, 10*time.Second, "timed out waiting for redis env var discovery payload")
 }
 
-func (s *configFilesDiscoveryDockerSuite) TestPostgresEnvVarsDiscovered() {
+func (s *configFilesDiscoveryDockerSuite) TestPostgresConfigFileAndEnvVarsDiscovered() {
 	t := s.T()
 	s.prepareConfigFilesDiscoveryContainers(t, configFilesDiscoveryContainerFixture{
 		integrationName: postgresIntegrationName,
@@ -374,7 +396,20 @@ func (s *configFilesDiscoveryDockerSuite) TestPostgresEnvVarsDiscovered() {
 
 		for _, payload := range postgresPayloads {
 			assertAgentDiscoveryPayload(c, payload, postgresIntegrationName)
-			assert.Empty(c, payload.ConfigFiles)
+			postgresConfigs := findConfigFilePayloads([]*aggregator.AgentDiscoveryPayload{payload}, postgresIntegrationName, postgresConfigPath)
+			if !assert.NotEmpty(c, postgresConfigs, "no postgres config file in payload %+v", payload) {
+				return
+			}
+			for _, postgresConfig := range postgresConfigs {
+				assertConfigFilePayload(c, postgresConfig, configFilePayloadExpectation{
+					integrationName: postgresIntegrationName,
+					configPath:      postgresConfigPath,
+					payloadFormat:   agentdiscovery.AgentDiscoveryConfigFilePayloadFormat_PAYLOAD_FORMAT_PROPERTIES,
+				})
+				assert.Contains(c, string(postgresConfig.config.Content), "max_connections = 200")
+				assert.Contains(c, string(postgresConfig.config.Content), "cluster_name = 'configfilesdiscovery-postgres-e2e'")
+				assert.Contains(c, string(postgresConfig.config.Content), "log_line_prefix = '%m [%p] '")
+			}
 
 			envVars := make(map[string]string, len(payload.EnvVars))
 			for _, envVar := range payload.EnvVars {
@@ -397,7 +432,7 @@ func (s *configFilesDiscoveryDockerSuite) TestPostgresEnvVarsDiscovered() {
 			assert.NotContains(c, envVars, "POSTGRESQL_PASSWORD_FILE")
 			assert.NotContains(c, envVars, "POSTGRESQL_LDAP_URL")
 		}
-	}, 3*time.Minute, 10*time.Second, "timed out waiting for postgres env var discovery payload")
+	}, 3*time.Minute, 10*time.Second, "timed out waiting for postgres config file discovery payload")
 }
 
 func (s *configFilesDiscoveryDockerSuite) TestKafkaDefaultConfigFileDiscovered() {

--- a/test/new-e2e/tests/discovery/testdata/compose/docker-compose.configfilesdiscovery-postgres.yaml
+++ b/test/new-e2e/tests/discovery/testdata/compose/docker-compose.configfilesdiscovery-postgres.yaml
@@ -38,3 +38,8 @@ services:
             ]
           }
         }
+    volumes:
+      - type: bind
+        source: ${CONFIG_FILES_DISCOVERY_POSTGRES_CONFIG_DIR}/10-add-config.sh
+        target: /docker-entrypoint-initdb.d/10-add-config.sh
+        read_only: true


### PR DESCRIPTION
### What does this PR do?

Adds collection of PostgreSQL's main configuration file to Config Files Discovery. The collector resolves an explicit configuration path from the PostgreSQL command line, falls back to `POSTGRESQL_CONF_FILE` or `PGDATA/postgresql.conf`, and forwards the selected raw file as an Agent Discovery properties payload.

### Motivation

[DSCVR-665](https://datadoghq.atlassian.net/browse/DSCVR-665)

### Describe how you validated your changes

- Add some unit test and E2E test
- Local Docker Compose with PostgreSQL, Agent, and Fake Intake: verified that the Agent Discovery payload contains the expected postgresql.conf content

### Additional Notes

The collector intentionally retrieves only the selected main file. Existing Compliance parsing code was evaluated but not reused because it uses a process-root filesystem model and produces normalized Compliance settings rather than raw container-file content. More in [DSCVR-667](https://datadoghq.atlassian.net/browse/DSCVR-667?issueKey=DSCVR-667&subProduct=jira-software) 

[DSCVR-665]: https://datadoghq.atlassian.net/browse/DSCVR-665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DSCVR-667]: https://datadoghq.atlassian.net/browse/DSCVR-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ