### PR TITLE
[CWS-6671] Report rule error when capabilities monitoring is disabled

### DIFF
--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -17,7 +17,7 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"go.uber.org/atomic"
 
-	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
@@ -467,6 +467,11 @@ func (p *Probe) IsNetworkRawPacketEnabled() bool {
 // IsNetworkFlowMonitorEnabled returns whether the network flow monitor is enabled
 func (p *Probe) IsNetworkFlowMonitorEnabled() bool {
 	return p.IsNetworkEnabled() && p.Config.Probe.NetworkFlowMonitorEnabled
+}
+
+// IsCapabilitiesMonitoringEnabled returns whether capabilities monitoring is enabled
+func (p *Probe) IsCapabilitiesMonitoringEnabled() bool {
+	return p.Config.Probe.CapabilitiesMonitoringEnabled
 }
 
 // IsActivityDumpEnabled returns whether activity dump is enabled

--- a/pkg/security/probe/probe_others.go
+++ b/pkg/security/probe/probe_others.go
@@ -104,6 +104,11 @@ func (p *Probe) IsNetworkFlowMonitorEnabled() bool {
 	return p.IsNetworkEnabled() && p.Config.Probe.NetworkFlowMonitorEnabled
 }
 
+// IsCapabilitiesMonitoringEnabled returns whether capabilities monitoring is enabled
+func (p *Probe) IsCapabilitiesMonitoringEnabled() bool {
+	return p.Config.Probe.CapabilitiesMonitoringEnabled
+}
+
 // IsActivityDumpEnabled returns whether activity dump is enabled
 func (p *Probe) IsActivityDumpEnabled() bool {
 	return p.Config.RuntimeSecurity.ActivityDumpEnabled

--- a/pkg/security/rules/BUILD.bazel
+++ b/pkg/security/rules/BUILD.bazel
@@ -53,6 +53,7 @@ dd_agent_go_test(
         "//pkg/security/config",
         "//pkg/security/metrics",
         "//pkg/security/probe",
+        "//pkg/security/probe/config",
         "//pkg/security/secl/compiler/eval",
         "//pkg/security/secl/model",
         "//pkg/security/secl/rules",

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -678,7 +678,12 @@ func (e *RuleEngine) getEventTypeEnabled() map[eval.EventType]bool {
 
 			if eventTypes, exists := categories[category]; exists {
 				for _, eventType := range eventTypes {
-					enabled[eventType] = true
+					switch eventType {
+					case model.CapabilitiesEventType.String():
+						enabled[eventType] = e.probe.IsCapabilitiesMonitoringEnabled()
+					default:
+						enabled[eventType] = true
+					}
 				}
 			}
 		}

--- a/pkg/security/rules/engine_test.go
+++ b/pkg/security/rules/engine_test.go
@@ -7,6 +7,7 @@
 package rules
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -17,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
+	pconfig "github.com/DataDog/datadog-agent/pkg/security/probe/config"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -112,5 +114,34 @@ func TestRuleEngineNoMatchMetric(t *testing.T) {
 		assert.Equal(t, int64(1), matched[0].val)
 		assert.Contains(t, matched[0].tags, "event_type:exec")
 		assert.Contains(t, matched[0].tags, "category:"+model.GetEventTypeCategory("exec").String())
+	}
+}
+
+func TestRuleEngineCapabilitiesEventTypeEnabled(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("the capabilities event type is only available on Linux")
+	}
+
+	tests := []struct {
+		name                  string
+		capsMonitoringEnabled bool
+	}{
+		{name: "caps monitoring enabled", capsMonitoringEnabled: true},
+		{name: "caps monitoring disabled", capsMonitoringEnabled: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine := &RuleEngine{
+				config: &config.RuntimeSecurityConfig{RuntimeEnabled: true},
+				probe: &probe.Probe{
+					Config: &config.Config{
+						Probe: &pconfig.Config{CapabilitiesMonitoringEnabled: tt.capsMonitoringEnabled},
+					},
+				},
+			}
+
+			assert.Equal(t, tt.capsMonitoringEnabled, engine.getEventTypeEnabled()[model.CapabilitiesEventType.String()])
+		})
 	}
 }

--- a/pkg/security/rules/monitor/policy_monitor_test.go
+++ b/pkg/security/rules/monitor/policy_monitor_test.go
@@ -34,6 +34,7 @@ type testCase struct {
 	policies             []*testPolicy
 	expectedPolicyStates []*PolicyState
 	model                *model.Model
+	eventTypeEnabled     map[eval.EventType]bool
 }
 
 func TestPolicyMonitorPolicyState(t *testing.T) {
@@ -1645,6 +1646,55 @@ func TestPolicyMonitorPolicyState(t *testing.T) {
 	if runtime.GOOS == "linux" {
 		testCases = append(testCases, []*testCase{
 			{
+				name: "rule targeting an event type disabled by its feature flag",
+				eventTypeEnabled: map[eval.EventType]bool{
+					model.ExecEventType.String():         true,
+					model.CapabilitiesEventType.String(): false,
+				},
+				policies: []*testPolicy{
+					{
+						info: rules.PolicyInfo{
+							Name:   "Policy A",
+							Source: "test",
+						},
+						def: rules.PolicyDef{
+							Rules: []*rules.RuleDefinition{
+								{
+									ID:         "rule_a",
+									Expression: `exec.file.path == "/etc/foo/bar"`,
+								},
+								{
+									ID:         "rule_b",
+									Expression: `capabilities.used > 0`,
+								},
+							},
+						},
+					},
+				},
+				expectedPolicyStates: []*PolicyState{
+					{
+						PolicyMetadata: PolicyMetadata{
+							Name:   "Policy A",
+							Source: "test",
+						},
+						Status: PolicyStatusPartiallyLoaded,
+						Rules: []*RuleState{
+							{
+								ID:         "rule_a",
+								Expression: `exec.file.path == "/etc/foo/bar"`,
+								Status:     "loaded",
+							},
+							{
+								ID:         "rule_b",
+								Expression: `capabilities.used > 0`,
+								Status:     string(rules.EventTypeNotEnabledErrType),
+								Message:    rules.ErrEventTypeNotEnabled.Error(),
+							},
+						},
+					},
+				},
+			},
+			{
 				name: "policy with os filters",
 				policies: []*testPolicy{
 					{
@@ -1780,7 +1830,6 @@ func TestPolicyMonitorPolicyState(t *testing.T) {
 	eventCtor := func() eval.Event {
 		return &model.Event{}
 	}
-	ruleOpts, evalOpts := rules.NewBothOpts(map[eval.EventType]bool{"*": true})
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1788,6 +1837,11 @@ func TestPolicyMonitorPolicyState(t *testing.T) {
 			if m == nil {
 				m = &model.Model{}
 			}
+			eventTypeEnabled := tc.eventTypeEnabled
+			if eventTypeEnabled == nil {
+				eventTypeEnabled = map[eval.EventType]bool{"*": true}
+			}
+			ruleOpts, evalOpts := rules.NewBothOpts(eventTypeEnabled)
 			rs := rules.NewRuleSet(m, eventCtor, ruleOpts, evalOpts)
 			loader := rules.NewPolicyLoader(newTestPolicyProvider(tc.policies...))
 			filteredRules, errs := rs.LoadPolicies(loader, rules.PolicyLoaderOpts{MacroFilters: macroFilters, RuleFilters: ruleFilters})


### PR DESCRIPTION
### What does this PR do?

Do not silently load capabilities rules when the feature is disabled.

The capabilities event type was enabled in the rule set regardless of the capabilities monitoring configuration, so rules relying on it were reported as loaded even though no probe was attached to collect the corresponding events.

### Motivation

Fix status reporting for capabilities rules.

### Describe how you validated your changes

Added two new unit tests.

### Additional Notes
