### PR TITLE
[Backport 7.83.x] [ABLD-536] Bazelify `golangci-lint` usage (#55405)

### DIFF
--- a/.github/actions/bazel-cache/action.yml
+++ b/.github/actions/bazel-cache/action.yml
@@ -20,5 +20,6 @@ runs:
         path: |
           .cache/bazel/*/cache
           .cache/go
+          .cache/golangci-lint
           .cache/ms-go
           .cache/pip

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -985,6 +985,8 @@ workflow:
   - changes:
       paths:
         - .gitlab/test/e2e/e2e.yml
+        - bazel/rules/go_shim/**/* # Runs bazelified Go tools
+        - internal/tools/**/* # Go tools: golangci-lint, etc. (incident-59251/59255/59256/59257/59258)
         - test/e2e-framework/**/*
         - test/new-e2e/go.mod
         - flakes.yaml

--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -28,6 +28,7 @@
       paths:
         - .cache/bazel/*/cache
         - .cache/go
+        - .cache/golangci-lint
         - .cache/ms-go
         - .cache/pip
       policy: pull$BAZEL_CACHE_POLICY_SUFFIX

--- a/.gitlab/build/lint/cross.yml
+++ b/.gitlab/build/lint/cross.yml
@@ -5,7 +5,7 @@
 
 .cross_lint:
   stage: lint
-  extends: .linux_x64
+  extends: [.linux_x64, .bazel:defs:cache:progressive]
   needs: ["go_deps", "go_tools_deps"]
   variables:
     FLAVORS: "--flavor base"

--- a/.gitlab/build/lint/linux.yml
+++ b/.gitlab/build/lint/linux.yml
@@ -5,6 +5,7 @@
   - dda inv -- -e linter.go --cpus $KUBERNETES_CPU_REQUEST --debug $FLAVORS $EXTRA_OPTS
 
 .linux_lint:
+  extends: .bazel:defs:cache:progressive
   stage: lint
   needs: ["go_deps", "go_tools_deps"]
   variables:

--- a/.vscode/settings.json.template
+++ b/.vscode/settings.json.template
@@ -1,9 +1,18 @@
 {{
     "go.buildTags": "{build_tags}",
     "go.testTags": "{build_tags}",
-    "go.lintTool": "golangci-lint",
+    "go.lintTool": "bazelisk",
     "go.buildFlags": ["-buildvcs=false"],
     "go.lintFlags": [
+        "run",
+        "//internal/tools:golangci-lint",
+        "--",
+        "run",
+        "--issues-exit-code=0",
+        "--output.text.print-issued-lines=false",
+        "--show-stats=false",
+        "--output.text.path=stdout",
+        "--path-mode=abs",
         "--build-tags",
         "{build_tags}"
     ],

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -302,7 +302,7 @@
         "recordedInputs": [
           "FILE:@@//.bazelversion 1b9487d55bea47fea50d226cc9c53bc548877ad2a318bac8fbc8b320f429e5c5",
           "FILE:@@//tools/bazel f5a8a2f4756b38cd2967fa1b609c85628e3222fae35b2eae1ae4a2525d1c40c6",
-          "FILE:@@//tools/bazel.bat 19e3adf0b4c589672602f0a74f65db364d081ca9a0f2b34e32b2e45449d25ddd",
+          "FILE:@@//tools/bazel.bat 2cadc4dd0b8c1864824b496b9c3f587f9419d786a8486c7b16a77aca9dd34880",
           "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
         ],
         "generatedRepoSpecs": {}

--- a/bazel/rules/go_shim/BUILD.bazel
+++ b/bazel/rules/go_shim/BUILD.bazel
@@ -1,0 +1,7 @@
+exports_files(
+    [
+        "template.bat",
+        "template.sh",
+    ],
+    visibility = ["//visibility:private"],
+)

--- a/bazel/rules/go_shim/defs.bzl
+++ b/bazel/rules/go_shim/defs.bzl
@@ -1,0 +1,51 @@
+"""Shim to run a tool with the hermetic Go SDK's `go` first in $PATH, from the current working directory.
+
+A (thin) wrapper is unavoidable because prepending to the inherited PATH cannot be expressed declaratively.
+The SDK's `go` is used over @rules_go//go, because the latter changes the current directory again, breaking subcommands.
+
+References:
+- https://github.com/bazel-contrib/bazel-lib/blob/main/lib/private/bats.bzl (is_windows)
+- https://github.com/bazel-contrib/rules_multitool/blob/main/multitool/private/run_in.bzl (template)
+"""
+
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+_GO_TOOLCHAIN = "@rules_go//go:toolchain"
+
+def _impl(ctx):
+    sdk = ctx.toolchains[_GO_TOOLCHAIN].sdk
+    go_dir = paths.dirname(sdk.go.short_path)
+    goroot = paths.dirname(sdk.root_file.short_path)
+    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
+    template = ctx.file._template_bat if is_windows else ctx.file._template_sh
+    tool = ctx.executable.tool.short_path
+    wrapper = ctx.actions.declare_file("{}.{}".format(ctx.label.name, template.extension))
+    ctx.actions.expand_template(
+        is_executable = True,
+        output = wrapper,
+        substitutions = {
+            "{{go_dir}}": go_dir.replace("/", "\\") if is_windows else go_dir,
+            "{{goroot}}": goroot.replace("/", "\\") if is_windows else goroot,
+            "{{tool}}": tool.replace("/", "\\") if is_windows else tool,
+        },
+        template = template,
+    )
+    return [DefaultInfo(
+        executable = wrapper,
+        runfiles = ctx.runfiles(
+            [sdk.go],
+            transitive_files = depset(transitive = [sdk.headers, sdk.libs, sdk.srcs, sdk.tools]),
+        ).merge(ctx.attr.tool[DefaultInfo].default_runfiles),
+    )]
+
+go_shim = rule(
+    implementation = _impl,
+    attrs = {
+        "_template_bat": attr.label(allow_single_file = True, default = ":template.bat"),
+        "_template_sh": attr.label(allow_single_file = True, default = ":template.sh"),
+        "_windows_constraint": attr.label(default = "@platforms//os:windows"),
+        "tool": attr.label(cfg = "exec", executable = True, mandatory = True),
+    },
+    executable = True,
+    toolchains = [_GO_TOOLCHAIN],
+)

--- a/bazel/rules/go_shim/template.bat
+++ b/bazel/rules/go_shim/template.bat
@@ -1,0 +1,9 @@
+@echo off
+
+set "GOROOT=%cd%\{{goroot}}"
+set "GOTOOLCHAIN=local"
+set "PATH=%cd%\{{go_dir}};%PATH%"
+set "tool=%cd%\{{tool}}"
+
+cd /d "%BUILD_WORKING_DIRECTORY%" || exit /b
+"%tool%" %*

--- a/bazel/rules/go_shim/template.sh
+++ b/bazel/rules/go_shim/template.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$BUILD_WORKING_DIRECTORY"
+GOROOT="$OLDPWD/{{goroot}}" GOTOOLCHAIN=local PATH="$OLDPWD/{{go_dir}}:$PATH" exec "$OLDPWD/{{tool}}" "$@"

--- a/internal/tools/BUILD.bazel
+++ b/internal/tools/BUILD.bazel
@@ -1,4 +1,6 @@
-# Tools-only module (//go:build tools tracker for `go install` dependencies).
-# No Bazel targets are generated; the empty BUILD.bazel keeps bazelify_go_work
-# happy without compiling anything.
-# gazelle:ignore
+load("//bazel/rules/go_shim:defs.bzl", "go_shim")
+
+go_shim(
+    name = "golangci-lint",
+    tool = "@com_github_golangci_golangci_lint_v2//cmd/golangci-lint",
+)

--- a/tasks/devcontainer.py
+++ b/tasks/devcontainer.py
@@ -127,9 +127,21 @@ def setup(
                 # they are intentionally left unset here.
                 "go.buildTags": local_build_tags,
                 "go.testTags": local_build_tags,
-                "go.lintTool": "golangci-lint",
+                "go.lintTool": "bazelisk",
                 "go.lintOnSave": "package",
                 "go.lintFlags": [
+                    "run",
+                    "//internal/tools:golangci-lint",
+                    "--",
+                    # add vscode-go default args, see:
+                    # https://github.com/golang/vscode-go/blob/master/extension/src/diagnostics/goLint.ts#L122-L163
+                    "run",
+                    "--issues-exit-code=0",
+                    "--output.text.print-issued-lines=false",
+                    "--show-stats=false",
+                    "--output.text.path=stdout",
+                    "--path-mode=abs",
+                    # then our own
                     "--build-tags",
                     local_build_tags,
                 ],

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -76,21 +76,32 @@ def run_golangci_lint(
         include_python="python" in tags,
     )
 
-    verbosity = "-v" if verbose else ""
-    concurrency_arg = "" if concurrency is None else f"--concurrency {concurrency}"
     tags_arg = ",".join(sorted(set(tags)))
     timeout_arg_value = "25m0s" if not timeout else f"{timeout}m0s"
     # Compose the targets string for the command
-    targets_rec = [f"{target}/..." if not target.endswith("/...") else target for target in targets]
-    targets_str = " ".join(targets_rec if recursive else targets)
-    cmd = (
-        f'golangci-lint run {verbosity} --timeout {timeout_arg_value} {concurrency_arg} '
-        f'--build-tags "{tags_arg}" --path-prefix "{base_path}" {golangci_lint_kwargs} {targets_str}'
-    )
+    target_patterns = [t if t.endswith("/...") else f"{t}/..." for t in targets] if recursive else targets
+    targets_str = " ".join(target_patterns)
+    cmd = ["run"]
+    if verbose:
+        cmd.append("-v")
+    cmd += ["--timeout", timeout_arg_value]
+    if concurrency is not None:
+        cmd += ["--concurrency", str(concurrency)]
+    cmd += ["--build-tags", tags_arg, "--path-prefix", base_path] + golangci_lint_kwargs.split() + target_patterns
     if not headless_mode:
         print(f"running golangci-lint on: {targets_str}")
     result, time_result = TimedOperationResult.run(
-        lambda: ctx.run(cmd, env=env, warn=True), "golangci-lint", f"Lint {targets_str}"
+        lambda: bazel(
+            ctx,
+            "run",
+            *(f"--run_env={k}={v}" for k, v in env.items()),
+            "//internal/tools:golangci-lint",
+            "--",
+            *cmd,
+            ignore_errors=True,
+        ),
+        "golangci-lint",
+        f"Lint {targets_str}",
     )
     return [result], [time_result]
 

--- a/tasks/install_tasks.py
+++ b/tasks/install_tasks.py
@@ -15,7 +15,6 @@ TOOL_LIST = [
     'github.com/bazelbuild/bazelisk',
     'github.com/frapposelli/wwhrd',
     'github.com/go-enry/go-license-detector/v4/cmd/license-detector',
-    'github.com/golangci/golangci-lint/v2/cmd/golangci-lint',
     'github.com/goware/modvendor',
     'gotest.tools/gotestsum',
     'github.com/vektra/mockery/v3',

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -12,6 +12,7 @@ from typing import IO, NamedTuple
 
 from invoke import Exit
 from invoke.context import Context
+from invoke.runners import Result
 
 from tasks.libs.common.color import color_message
 from tasks.libs.common.utils import get_repo_root
@@ -97,17 +98,14 @@ def bazel(
     ctx: Context,
     *args: str,
     capture_output: bool = False,
-    capture_stderr: bool = False,
     ignore_errors: bool = False,
     input_stream: IO[str] | bool = False,
     sudo: bool = False,
-) -> str:
+) -> str | Result:
     """Execute a bazel command.
 
     capture_output: capture stdout.
-    capture_stderr: also capture stderr and append it to the returned string.
-        Use this when Bazel writes important output (e.g.  test results) to stderr
-        and the caller needs to process it.
+    ignore_errors: do not fail fast, but instead return the raw `Result`, whether the Bazel command succeeded or not.
     """
 
     if not (bazelisk := shutil.which("bazelisk")):  # `/usr/bin/bazel` may otherwise take precedence in DD Workspaces
@@ -120,21 +118,14 @@ def bazel(
     # In every other libray, that would be called capture, and the
     # act of capturing it would hide it from the user.
     # https://docs.pyinvoke.org/en/stable/api/runners.html#invoke.runners.Runner.run
-    if capture_output and capture_stderr:
-        kwargs["hide"] = "both"
-    elif capture_output:
+    if capture_output:
         kwargs["hide"] = "out"
-    elif capture_stderr:
-        kwargs["hide"] = "err"
     elif not sudo and sys.stdout.isatty() and sys.platform != "win32":
         kwargs["pty"] = True
     result = ctx.run(cmdline, echo=False, in_stream=input_stream, warn=ignore_errors, **kwargs)
-    captured = []
-    if capture_output and result.ok:
-        captured.append(result.stdout)
-    if capture_stderr:
-        captured.append(result.stderr)
-    return "".join(captured)
+    if ignore_errors:
+        return result
+    return result.stdout if capture_output else ""
 
 
 def _insert_omnibazel_flags(args: tuple[str, ...]) -> tuple[str, ...]:

--- a/tasks/libs/common/check_tools_version.py
+++ b/tasks/libs/common/check_tools_version.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import sys
 
 from invoke import Context, Exit
@@ -10,7 +9,6 @@ from tasks.libs.common.utils import gitlab_section
 
 # VPATH as in version path
 GO_VPATH = ".go-version"
-GOLANGCI_LINT_VPATH = "internal/tools/go.mod"
 
 
 def expected_go_repo_v() -> str:
@@ -29,28 +27,6 @@ def current_go_v(ctx: Context) -> str:
     return ctx.run(cmd, hide=True).stdout.split(' ')[2][2:]
 
 
-def expected_golangci_lint_repo_v(ctx: Context) -> str:
-    """
-    Returns the installed golangci-lint version by parsing the internal/tools/go.mod file.
-    """
-    mod_name = "github.com/golangci/golangci-lint/v2"
-    go_mod_json = json.loads(ctx.run(f"go mod edit -json {GOLANGCI_LINT_VPATH}", hide=True).stdout)
-    for mod in go_mod_json['Require']:
-        if mod['Path'] == mod_name:
-            return mod['Version'].lstrip('v')
-    return ""
-
-
-def current_golangci_lint_v(ctx: Context, debug: bool = False) -> str:
-    """
-    Returns the current user golangci-lint version by running golangci-lint --version
-    """
-    debug_flag = "--debug" if debug else ""
-    cmd = f"golangci-lint version {debug_flag}"
-    version_output = ctx.run(cmd, hide=True).stdout
-    return version_output if debug else version_output.split(' ')[3]
-
-
 def check_tools_version(ctx: Context, tools_list: list[str], debug: bool = False) -> bool:
     """
     Check that each installed tool in tools_list is the version expected for the repo.
@@ -63,13 +39,6 @@ def check_tools_version(ctx: Context, tools_list: list[str], debug: bool = False
             'debug': '' if not debug else current_go_v(ctx),
             'exit_on_error': False,
             'error_msg': "Warning: If you have linter errors it might be due to version mismatches.",
-        },
-        'golangci-lint': {
-            'current_v': current_golangci_lint_v(ctx),
-            'expected_v': expected_golangci_lint_repo_v(ctx),
-            'debug': '' if not debug else current_golangci_lint_v(ctx, debug=debug),
-            'exit_on_error': True,
-            'error_msg': "Error: The golanci-lint version you are using is not the correct one. Please run dda inv -e setup to install the correct version.",
         },
     }
     for tool in tools_list:

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -93,14 +93,14 @@ def go(
     Args:
         timeout: Number of minutes after which the linter should time out.
         headless_mode: Allows you to output the result in a single json file.
-        debug: prints the go version and the golangci-lint debug information to help debugging lint discrepancies between versions.
+        debug: prints the go version to help debugging lint discrepancies between versions.
 
     Example invokation:
         $ dda inv linter.go --targets=./pkg/collector/check,./pkg/aggregator
         $ dda inv linter.go --module=.
     """
 
-    check_tools_version(ctx, ['golangci-lint', 'go'], debug=debug)
+    check_tools_version(ctx, ['go'], debug=debug)
 
     modules, flavor = process_input_args(
         ctx,

--- a/tasks/unit_tests/libs/build/bazel_tests.py
+++ b/tasks/unit_tests/libs/build/bazel_tests.py
@@ -29,22 +29,11 @@ class TestBazel(unittest.TestCase):
         self.assertEqual(bazel(self._ctx(), "info", capture_output=True), "out\n")
 
     @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
-    def test_capture_stderr(self, _):
-        self.assertEqual(bazel(self._ctx(), "info", capture_stderr=True), "err\n")
-
-    @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
-    def test_capture_both(self, _):
-        self.assertEqual(bazel(self._ctx(), "info", capture_output=True, capture_stderr=True), "out\nerr\n")
-
-    @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
-    def test_ignore_errors_captures_output_on_success(self, _):
-        self.assertEqual(bazel(self._ctx(), "info", ignore_errors=True, capture_output=True), "out\n")
-
-    @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
-    def test_ignore_errors_only_captures_stderr_on_failure(self, _):
-        self.assertEqual(
-            bazel(self._ctx(exit=1), "info", ignore_errors=True, capture_output=True, capture_stderr=True), "err\n"
-        )
+    def test_ignore_errors_returns_raw_result(self, _):
+        res = bazel(self._ctx(exit=1), "info", ignore_errors=True, capture_output=True)
+        self.assertFalse(res.ok)
+        self.assertEqual(res.stdout, "out\n")
+        self.assertEqual(res.stderr, "err\n")
 
     @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
     def test_input_stream_disabled_by_default(self, _):

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -30,6 +30,7 @@ if defined XDG_CACHE_HOME (
     exit /b 2
   )
   set "GOCACHE=!XDG_CACHE_HOME!\go-build"
+  set "GOLANGCI_LINT_CACHE=!XDG_CACHE_HOME!\golangci-lint"
   set "GOMODCACHE=!XDG_CACHE_HOME!\go\mod"
   set "PIP_CACHE_DIR=!XDG_CACHE_HOME!\pip"
   :: https://github.com/bazelbuild/bazel/issues/27808


### PR DESCRIPTION
Backport d88f9b6a2451a488f8192ccb1475a714d28a5f21 from #55405.

 ___

### What does this PR do?
Wrap `golangci-lint` in a `go_shim` target and route `run_golangci_lint` through `bazel run //internal/tools:golangci-lint` instead of a `go install`-ed, PATH-resolved binary, and drop it from `install-tools`'s `TOOL_LIST` - therefore contributing [ABLD-536](https://datadoghq.atlassian.net/browse/ABLD-536).

Wire `golangci-lint`'s own analysis cache into the existing cache setup:
- `.linux_lint` and `.cross_lint` now extend `.bazel:defs:cache:progressive`,
- `.cache/golangci-lint` joins `bazel_cache`'s persisted paths,
- `tools/bazel.bat` sets `GOLANGCI_LINT_CACHE` alongside its `GOCACHE`/`GOMODCACHE` siblings.

Since jobs now reach `golangci-lint` through `bazel run` (cached binary), vestigial `go_tools_deps[_arm64]` are removed from:
- `.cross_lint`,
- `.linux_lint`,
- `.new_e2e_template`,
- `.tests_linux_ebpf`,
- `lint_linux-arm64`,
- `tests_ebpf_arm64`,
- the `e2e` jobs that spell out their own `needs`:
  - `new-e2e-base[-coverage]`,
  - `new-e2e-otel`,
  - `*-init` jobs.

### Motivation
`golangci-lint`'s version drift was tracked only by `check_tools_version.py` running `golangci-lint version` against `internal/tools/go.mod`, the same "tracked by a runtime version check" shape `gotestsum` had before #54107.

Unlike most other `TOOL_LIST` entries, it gates nearly every lint job, so a wrong-version or wrong-arch binary has a broader blast radius.

`golangci-lint`'s own cache is ~500M against a ~50G `GOCACHE` and ~100G Bazel disk cache, so persisting it costs nothing meaningful in GitLab's S3-backed cache transfer time or storage.

### Describe how you validated your changes
Ran a full, untargeted `dda inv linter.go` (every module) 5 times to validate at CI scale and characterize the cache stack:
1. 1140.6s cold,
2. 1043.4s after rebasing onto a different branch with many changes,
3. 12.6s full hit,
4. 341.9s after clearing only `golangci-lint`'s own cache,
5. 11.8s on a repeat full hit.

### Additional Notes
Adopting `nogo` [instead](https://github.com/bazel-contrib/rules_go/blob/master/go/nogo.rst#should-i-use-nogo-or-golangci-lint), as already flagged as a TODO in `deps/go.MODULE.bazel`, is a separate, larger decision left for its own follow-up.

[ABLD-536]: https://datadoghq.atlassian.net/browse/ABLD-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ