### PR TITLE
fix(ci): temporarily kill earlier Bazel server in macOS jobs

### DIFF
--- a/.gitlab/.pre/common/macos.yml
+++ b/.gitlab/.pre/common/macos.yml
@@ -91,6 +91,7 @@
     - !reference [.aws_retry_config]
     # Drop GOPROXY entries not usable from macOS runners, before any go command.
     - !reference [.sanitize_goproxy]
+    - !reference [.kill_bazel_server]
     # Selecting the current Go version
     - |
       eval $(gimme $(cat .go-version))

--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -46,7 +46,7 @@
     XDG_CACHE_HOME: "$CI_PROJECT_DIR/.cache"
 
 # Temporarily kill any Bazel server running on that slot until https://github.com/bazelbuild/bazel/issues/30435 is fixed
-# in the Bazel version we use (hopefully in Bazel 9.3.0):
+# in our Bazel version, i.e. through https://github.com/bazelbuild/bazel/commit/058adaacae08166ce6e6edb0e2fdb28a67524314
 .kill_bazel_server:
   - pkill -f "output_base=$XDG_CACHE_HOME" || [ "$?" -eq 1 ]  # No processes matched
 

--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -45,10 +45,20 @@
   variables:
     XDG_CACHE_HOME: "$CI_PROJECT_DIR/.cache"
 
+# Temporarily kill any Bazel server running on that slot until https://github.com/bazelbuild/bazel/issues/30435 is fixed
+# in the Bazel version we use (hopefully in Bazel 9.3.0):
+.kill_bazel_server:
+  - pkill -f "output_base=$XDG_CACHE_HOME" || [ "$?" -eq 1 ]  # No processes matched
+
 .bazel:defs:cache:macos:
   extends: .bazel:defs
   variables:
     XDG_CACHE_HOME: "$RUNNER_TEMP_PROJECT_DIR"
+  before_script:
+    # Drop GOPROXY entries not usable from macOS runners before bazel forwards
+    # GOPROXY into its repository rules.
+    - !reference [.sanitize_goproxy]
+    - !reference [.kill_bazel_server]
 
 .bazel:defs:cache:persistent:
   extends: .bazel:defs
@@ -86,16 +96,10 @@
 .bazel:runner:macos-amd64:
   extends: .bazel:defs:cache:macos
   tags: [ "macos:sonoma-amd64", "specific:true" ]
-  # Drop GOPROXY entries not usable from macOS runners before bazel forwards
-  # GOPROXY into its repository rules.
-  before_script:
-    - !reference [.sanitize_goproxy]
 
 .bazel:runner:macos-arm64:
   extends: .bazel:defs:cache:macos
   tags: [ "macos:sonoma-arm64", "specific:true" ]
-  before_script:
-    - !reference [.sanitize_goproxy]
 
 .bazel:runner:windows-amd64:
   extends: [ .bazel:defs:cache:windows, .windows_docker_default ]

--- a/.gitlab/build/package_build/dmg.yml
+++ b/.gitlab/build/package_build/dmg.yml
@@ -71,6 +71,7 @@
     - !reference [.macos_runner_maintenance]
     - !reference [.macos_setup_cache]
     - !reference [.sanitize_goproxy]
+    - !reference [.kill_bazel_server]
     # Populate AWS_SHARED_CREDENTIALS_FILE via CI Identities (no macOS IAM instance role needed);
     # must run before build_agent_dmg.sh since Omnibus reads it for S3 cache access during the build.
     - ci-identities-gitlab-job-client assume-role


### PR DESCRIPTION
### What does this PR do?
Stop the Bazel server of a previous job of the same macOS runner slot (same `outputBase`), before every job reaching `bazel`, be it indirectly.

### Motivation
A job canceled mid-command, as the merge queue does routinely, can leave its server holding the command lock, see: bazelbuild/bazel#30435.

Bazel-powered jobs may then wait for a command that never ends, until their own job timeout, after having warned once ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1993478629)):
```
Another command (pid=41944) is running. Waiting for it to complete on the server (server_pid=1457)...
```
Upstream fixed it in bazelbuild/bazel@058adaa, on `master` only as of today, while we pin 9.2.0.

### Describe how you validated your changes
`pkill` reports the same exit codes on BSD and `procps`, so accepting only its `1` (No processes matched) holds on macOS, where CI provides the first real run.

### Additional Notes
Both `.macos_gitlab` and `.agent_dmg` reference it on their own: a `before_script` shadows the `extend`ed one.