### PR TITLE
trace-agent: verify Semantic Core registry content hash

### DIFF
--- a/pkg/trace/agent/normalizer_test.go
+++ b/pkg/trace/agent/normalizer_test.go
@@ -1077,7 +1077,7 @@ func TestNormalizeTraceChunkV1TraceIDLength(t *testing.T) {
 
 func TestNormalizeUsesLiveRegistry(t *testing.T) {
 	// Custom registry: ConceptDDEnv maps to "x.test.env" instead of "env".
-	customJSON := `{"version":"test","metadata":{"content_hash":"hash-a"},"concepts":{"env":{"canonical":"env","fallbacks":[{"name":"x.test.env","provider":"datadog","type":"string"}]}}}`
+	customJSON := `{"version":"test","metadata":{"content_hash":"sha256:23301ec2e06aeeaef6ae1dbbbf8d7ae47a29dd10e5cab911d12c5c81a6f5663f"},"concepts":{"env":{"canonical":"env","fallbacks":[{"name":"x.test.env","provider":"datadog","type":"string"}]}}}`
 	custom, err := semantics.NewRegistryFromJSON([]byte(customJSON))
 	require.NoError(t, err)
 	original, err := semantics.NewEmbeddedRegistry()

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -166,7 +166,7 @@ func TestEnableOPMFetchDefault(t *testing.T) {
 
 func TestConfiguredPeerTagsUsesLiveRegistry(t *testing.T) {
 	// Custom registry: ConceptPeerService maps to "x.custom.peer" instead of "peer.service".
-	customJSON := `{"version":"test","metadata":{"content_hash":"hash-a"},"concepts":{"peer.service":{"canonical":"peer.service","fallbacks":[{"name":"x.custom.peer","provider":"datadog","type":"string"}]}}}`
+	customJSON := `{"version":"test","metadata":{"content_hash":"sha256:df4ae1091ddfb8a32683b44f52afed1525573187ebf43a7f2c4f0f7a686db25d"},"concepts":{"peer.service":{"canonical":"peer.service","fallbacks":[{"name":"x.custom.peer","provider":"datadog","type":"string"}]}}}`
 	custom, err := semantics.NewRegistryFromJSON([]byte(customJSON))
 	require.NoError(t, err)
 	original, err := semantics.NewEmbeddedRegistry()

--- a/pkg/trace/info/trace_semantics_test.go
+++ b/pkg/trace/info/trace_semantics_test.go
@@ -6,6 +6,7 @@
 package info
 
 import (
+	"encoding/json"
 	"expvar"
 	"testing"
 
@@ -44,7 +45,8 @@ func TestPublishTraceSemanticsInfo_Embedded(t *testing.T) {
 func TestPublishTraceSemanticsInfo_RemoteConfig(t *testing.T) {
 	restoreEmbeddedRegistry(t)
 
-	const rcJSON = `{"version":"rc-1.0","metadata":{"content_hash":"hash-rc"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`
+	const contentHash = "sha256:a055d6c59d7d4d260cb9d0c99a29b5d894f05b8e48cf8f2ccaaa86ed956e7e73"
+	const rcJSON = `{"version":"rc-1.0","metadata":{"content_hash":"` + contentHash + `"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`
 	reg, err := semantics.NewRegistryFromJSON([]byte(rcJSON))
 	require.NoError(t, err)
 	semantics.UpdateRegistry(reg)
@@ -52,7 +54,7 @@ func TestPublishTraceSemanticsInfo_RemoteConfig(t *testing.T) {
 	info, ok := publishTraceSemanticsInfo().(TraceSemanticsInfo)
 	require.True(t, ok)
 	require.Equal(t, semantics.SourceRemoteConfig, info.Source)
-	require.Equal(t, "hash-rc", info.ContentHash)
+	require.Equal(t, contentHash, info.ContentHash)
 	require.Equal(t, "rc-1.0", info.Version)
 }
 
@@ -66,8 +68,20 @@ func TestPublishTraceSemanticsInfo_RemoteConfigMatchingEmbeddedHash(t *testing.T
 	embedded, err := semantics.NewEmbeddedRegistry()
 	require.NoError(t, err)
 
-	rcJSON := `{"version":"rc-same","metadata":{"content_hash":"` + embedded.ContentHash() + `"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`
-	reg, err := semantics.NewRegistryFromJSON([]byte(rcJSON))
+	concepts := make(map[string]any)
+	for concept, fallbacks := range embedded.GetAllEquivalences() {
+		concepts[string(concept)] = map[string]any{
+			"canonical": string(concept),
+			"fallbacks": fallbacks,
+		}
+	}
+	rcJSON, err := json.Marshal(map[string]any{
+		"version":  "rc-same",
+		"metadata": map[string]string{"content_hash": embedded.ContentHash()},
+		"concepts": concepts,
+	})
+	require.NoError(t, err)
+	reg, err := semantics.NewRegistryFromJSON(rcJSON)
 	require.NoError(t, err)
 	semantics.UpdateRegistry(reg)
 

--- a/pkg/trace/remoteconfighandler/remote_config_handler_test.go
+++ b/pkg/trace/remoteconfighandler/remote_config_handler_test.go
@@ -490,7 +490,7 @@ func TestMRFUpdateCallbackWithMultipleConfigs(t *testing.T) {
 
 // --- onSemanticCoreUpdate tests ---
 
-const semanticTestJSON = `{"version":"test-1.0","metadata":{"content_hash":"hash-a"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`
+const semanticTestJSON = `{"version":"test-1.0","metadata":{"content_hash":"sha256:a055d6c59d7d4d260cb9d0c99a29b5d894f05b8e48cf8f2ccaaa86ed956e7e73"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`
 
 // newSemanticTestHandler returns a handler with minimal sampler mocks for
 // exercising onSemanticCoreUpdate. Tests that mutate the global registry must
@@ -577,8 +577,8 @@ func TestOnSemanticCoreUpdate_MultipleValidConfigs_LastWins(t *testing.T) {
 	h := newSemanticTestHandler(t)
 
 	// Two valid configs with different version strings + content. lex-last wins.
-	cfgEarly := `{"version":"early","metadata":{"content_hash":"hash-early"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`
-	cfgLate := `{"version":"late","metadata":{"content_hash":"hash-late"},"concepts":{"http.method":{"canonical":"http.method","fallbacks":[{"name":"http.method","provider":"otel","type":"string"}]}}}`
+	cfgEarly := `{"version":"early","metadata":{"content_hash":"sha256:a055d6c59d7d4d260cb9d0c99a29b5d894f05b8e48cf8f2ccaaa86ed956e7e73"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`
+	cfgLate := `{"version":"late","metadata":{"content_hash":"sha256:de824759184887dc3a653771c8ff8c7366525dcfe3f62674cdf8747c86030ca2"},"concepts":{"http.method":{"canonical":"http.method","fallbacks":[{"name":"http.method","provider":"otel","type":"string"}]}}}`
 
 	statuses, cb := captureStatuses()
 	h.onSemanticCoreUpdate(map[string]state.RawConfig{
@@ -611,40 +611,31 @@ func TestOnSemanticCoreUpdate_AllErrors(t *testing.T) {
 	assert.Equal(t, state.ApplyStateError, statuses["datadog/2/APM_SEMANTIC_CORE_DD/b/config"].State)
 }
 
-// TestOnSemanticCoreUpdate_SameHashNoOp verifies that a second push with the
-// same metadata.content_hash as the live registry is detected as a no-op
-// (skips the UpdateRegistry call) but is still acknowledged, even when
-// Version() differs — content_hash is content-bound and version is not.
-func TestOnSemanticCoreUpdate_SameHashNoOp(t *testing.T) {
+func TestOnSemanticCoreUpdate_ContentHashMismatch(t *testing.T) {
 	restoreEmbeddedRegistry(t)
 	h := newSemanticTestHandler(t)
 
 	// Use a custom marker as the live registry so we can observe whether the
 	// second push replaced it. UpdateRegistry replaces the live one with this
 	// one carrying a sentinel concept (peer.service mapped to x.sentinel).
-	const liveJSON = `{"version":"sentinel-1.0","metadata":{"content_hash":"hash-sentinel"},"concepts":{"peer.service":{"canonical":"peer.service","fallbacks":[{"name":"x.sentinel","provider":"datadog","type":"string"}]}}}`
+	const liveJSON = `{"version":"sentinel-1.0","metadata":{"content_hash":"sha256:597496baaf43d4da37fba27d2bef7723ce971338f70b05e4d0c00a9ed7fa6517"},"concepts":{"peer.service":{"canonical":"peer.service","fallbacks":[{"name":"x.sentinel","provider":"datadog","type":"string"}]}}}`
 	liveReg, err := semantics.NewRegistryFromJSON([]byte(liveJSON))
 	require.NoError(t, err)
 	semantics.UpdateRegistry(liveReg)
 
-	// Push a payload with a DIFFERENT version but the SAME content_hash. The
-	// handler must NOT swap the registry — the sentinel concept must still be
-	// reachable after the push, even though the concepts in this payload
-	// differ (the hash is trusted, not recomputed).
-	const sameHashDifferentVersion = `{"version":"sentinel-1.1","metadata":{"content_hash":"hash-sentinel"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`
+	// Push different concepts while retaining the live registry's hash.
+	const sameHashDifferentVersion = `{"version":"sentinel-1.1","metadata":{"content_hash":"sha256:597496baaf43d4da37fba27d2bef7723ce971338f70b05e4d0c00a9ed7fa6517"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`
 	statuses, cb := captureStatuses()
 	h.onSemanticCoreUpdate(map[string]state.RawConfig{
 		"datadog/2/APM_SEMANTIC_CORE_DD/cfg/config": {Config: []byte(sameHashDifferentVersion)},
 	}, cb)
 
-	// Sentinel concept survived: the swap was skipped.
 	assert.NotNil(t, semantics.DefaultRegistry().GetAttributePrecedence(semantics.ConceptPeerService))
 	assert.Nil(t, semantics.DefaultRegistry().GetAttributePrecedence(semantics.ConceptDBStatement),
-		"db.statement must not be present — the second push was supposed to be a no-op")
+		"db.statement must not be present after a rejected update")
 	assert.Equal(t, "sentinel-1.0", semantics.DefaultRegistry().Version())
-	// Even though we skipped the swap, the cfgPath is still acknowledged: the
-	// payload was valid, we just decided we didn't need to apply it.
-	assert.Equal(t, state.ApplyStateAcknowledged, statuses["datadog/2/APM_SEMANTIC_CORE_DD/cfg/config"].State)
+	assert.Equal(t, state.ApplyStateError, statuses["datadog/2/APM_SEMANTIC_CORE_DD/cfg/config"].State)
+	assert.Contains(t, statuses["datadog/2/APM_SEMANTIC_CORE_DD/cfg/config"].Error, "content hash mismatch")
 }
 
 // TestOnSemanticCoreUpdate_EmptyUpdatesWhileEmbedded verifies that an empty

--- a/pkg/trace/semantics/mappings.json
+++ b/pkg/trace/semantics/mappings.json
@@ -989,7 +989,7 @@
     }
   },
   "metadata": {
-    "content_hash": "sha256:d2d19e7f53f8d3cb4abe235d3a83b3dcb3399cadcc21cc2ebb5d5e724143b7f3",
+    "content_hash": "sha256:684fce5096d96a4a6fa44af00b48cea4c7985ac2bcc221a4c75a26fa7af5b8b3",
     "git_commit": "a23d98a0be6355dcc72c6af771b13c8f738ff5ba",
     "timestamp": "20260630131934"
   },

--- a/pkg/trace/semantics/registry.go
+++ b/pkg/trace/semantics/registry.go
@@ -119,6 +119,10 @@ func (r *EmbeddedRegistry) loadFromJSON(data []byte) error {
 	return nil
 }
 
+// computeContentHash returns "sha256:<lowercase hex>" over the UTF-8 bytes of
+// {"concepts": <concepts>} serialized like Python json.dumps with sort_keys=True
+// and separators=(",", ":"). Object keys are sorted recursively, array order is
+// preserved, and non-ASCII runes are escaped as lowercase \uXXXX sequences.
 func computeContentHash(data []byte) (string, error) {
 	var payload struct {
 		Concepts json.RawMessage `json:"concepts"`

--- a/pkg/trace/semantics/registry.go
+++ b/pkg/trace/semantics/registry.go
@@ -6,11 +6,16 @@
 package semantics
 
 import (
+	"bytes"
+	"crypto/sha256"
 	_ "embed" //nolint:revive
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"sync/atomic"
+	"unicode/utf16"
+	"unicode/utf8"
 )
 
 //go:embed mappings.json
@@ -69,7 +74,7 @@ func UpdateRegistry(r Registry) {
 }
 
 // NewRegistryFromJSON constructs a Registry from raw JSON without affecting the live registry.
-// Returns an error if the JSON is malformed, contains no concepts, or is missing metadata.content_hash.
+// Returns an error if the JSON is malformed, contains no concepts, or has an invalid metadata.content_hash.
 func NewRegistryFromJSON(data []byte) (Registry, error) {
 	r := &EmbeddedRegistry{source: SourceRemoteConfig}
 	if err := r.loadFromJSON(data); err != nil {
@@ -98,13 +103,77 @@ func (r *EmbeddedRegistry) loadFromJSON(data []byte) error {
 	if rd.Metadata.ContentHash == "" {
 		return errors.New("registry JSON missing metadata.content_hash")
 	}
+	computedHash, err := computeContentHash(data)
+	if err != nil {
+		return fmt.Errorf("compute registry content hash: %w", err)
+	}
+	if computedHash != rd.Metadata.ContentHash {
+		return fmt.Errorf("registry content hash mismatch: declared %q, computed %q", rd.Metadata.ContentHash, computedHash)
+	}
 	r.version = rd.Version
-	r.hash = rd.Metadata.ContentHash
+	r.hash = computedHash
 	r.mappings = make(map[Concept][]TagInfo, len(rd.Concepts))
 	for conceptName, mapping := range rd.Concepts {
 		r.mappings[Concept(conceptName)] = mapping.Fallbacks
 	}
 	return nil
+}
+
+func computeContentHash(data []byte) (string, error) {
+	var payload struct {
+		Concepts json.RawMessage `json:"concepts"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return "", err
+	}
+
+	var concepts any
+	decoder := json.NewDecoder(bytes.NewReader(payload.Concepts))
+	decoder.UseNumber()
+	if err := decoder.Decode(&concepts); err != nil {
+		return "", err
+	}
+
+	canonical, err := marshalCanonicalJSON(map[string]any{"concepts": concepts})
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha256.Sum256(canonical)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func marshalCanonicalJSON(value any) ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return nil, err
+	}
+	return escapeForPythonJSON(bytes.TrimSuffix(buffer.Bytes(), []byte{'\n'})), nil
+}
+
+func escapeForPythonJSON(data []byte) []byte {
+	const hexDigits = "0123456789abcdef"
+	appendUnicodeEscape := func(dst []byte, value uint16) []byte {
+		return append(dst, '\\', 'u', hexDigits[value>>12], hexDigits[value>>8&0xf], hexDigits[value>>4&0xf], hexDigits[value&0xf])
+	}
+
+	dst := make([]byte, 0, len(data))
+	for len(data) > 0 {
+		r, size := utf8.DecodeRune(data)
+		data = data[size:]
+		if r <= 0x7e {
+			dst = append(dst, byte(r))
+		} else if r <= 0xffff {
+			dst = appendUnicodeEscape(dst, uint16(r))
+		} else {
+			high, low := utf16.EncodeRune(r)
+			dst = appendUnicodeEscape(dst, uint16(high))
+			dst = appendUnicodeEscape(dst, uint16(low))
+		}
+	}
+	return dst
 }
 
 // GetAttributePrecedence returns the ordered attribute keys for a concept.

--- a/pkg/trace/semantics/registry_update_test.go
+++ b/pkg/trace/semantics/registry_update_test.go
@@ -13,6 +13,66 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const dbStatementContentHash = "sha256:a055d6c59d7d4d260cb9d0c99a29b5d894f05b8e48cf8f2ccaaa86ed956e7e73"
+
+func TestComputeContentHash_PythonProducerFixture(t *testing.T) {
+	data := []byte(`{"version":"1.0.0","metadata":{"content_hash":"ignored"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`)
+
+	hash, err := computeContentHash(data)
+
+	require.NoError(t, err)
+	assert.Equal(t, dbStatementContentHash, hash)
+}
+
+func TestComputeContentHash_PythonStringEncoding(t *testing.T) {
+	data := []byte(`{"concepts":{"test.concept":{"canonical":"test.concept","fallbacks":[{"name":"café😀<>&\u007f","present":true,"provider":"datadog","type":"string"}]}}}`)
+
+	hash, err := computeContentHash(data)
+
+	require.NoError(t, err)
+	assert.Equal(t, "sha256:208924fbfc6e72e944566069bcf77f744af72bbea6a5f4e0158048a670297d3b", hash)
+}
+
+func TestNewRegistryFromJSON_RejectsChangedContentWithOldHash(t *testing.T) {
+	data := []byte(`{"version":"1.0.0","metadata":{"content_hash":"` + dbStatementContentHash + `"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"changed.statement","provider":"datadog","type":"string"}]}}}`)
+
+	_, err := NewRegistryFromJSON(data)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "content hash mismatch")
+}
+
+func TestNewRegistryFromJSON_AcceptsReorderedKeysAndWhitespace(t *testing.T) {
+	data := []byte(`{
+  "concepts": {
+    "db.statement": {
+      "fallbacks": [{"type": "string", "provider": "datadog", "name": "db.statement"}],
+      "canonical": "db.statement"
+    }
+  },
+  "metadata": {"content_hash": "` + dbStatementContentHash + `"},
+  "version": "1.0.0"
+}`)
+
+	r, err := NewRegistryFromJSON(data)
+
+	require.NoError(t, err)
+	assert.Equal(t, dbStatementContentHash, r.ContentHash())
+}
+
+func TestComputeContentHash_IgnoresVersionAndMetadata(t *testing.T) {
+	a := []byte(`{"version":"1.0.0","metadata":{"content_hash":"old","source":"one"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`)
+	b := []byte(`{"version":"2.0.0","metadata":{"content_hash":"new","source":"two"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`)
+
+	hashA, err := computeContentHash(a)
+	require.NoError(t, err)
+	hashB, err := computeContentHash(b)
+	require.NoError(t, err)
+
+	assert.Equal(t, dbStatementContentHash, hashA)
+	assert.Equal(t, dbStatementContentHash, hashB)
+}
+
 func TestNewRegistryFromJSON_ValidJSON(t *testing.T) {
 	r, err := NewRegistryFromJSON(mappingsJSON)
 	require.NoError(t, err)
@@ -43,7 +103,7 @@ func TestUpdateRegistry_AtomicSwap(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { UpdateRegistry(original) })
 
-	customJSON := `{"version":"test-version","metadata":{"content_hash":"hash-a"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`
+	customJSON := `{"version":"test-version","metadata":{"content_hash":"` + dbStatementContentHash + `"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`
 	custom, err := NewRegistryFromJSON([]byte(customJSON))
 	require.NoError(t, err)
 
@@ -52,25 +112,25 @@ func TestUpdateRegistry_AtomicSwap(t *testing.T) {
 }
 
 func TestRegistryEqual_SameHashDifferentVersion(t *testing.T) {
-	a, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"hash-a"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
+	a, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"` + dbStatementContentHash + `"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
 	require.NoError(t, err)
-	b, err := NewRegistryFromJSON([]byte(`{"version":"2.0.0","metadata":{"content_hash":"hash-a"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
+	b, err := NewRegistryFromJSON([]byte(`{"version":"2.0.0","metadata":{"content_hash":"` + dbStatementContentHash + `"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
 	require.NoError(t, err)
 	assert.True(t, RegistryEqual(a, b), "same content_hash means same concepts, regardless of the CI-bumped version string")
 }
 
 func TestRegistryEqual_DifferentHashSameVersion(t *testing.T) {
-	a, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"hash-a"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
+	a, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"` + dbStatementContentHash + `"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
 	require.NoError(t, err)
-	b, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"hash-b"},"concepts":{"http.method":{"canonical":"http.method","fallbacks":[{"name":"http.method","provider":"otel","type":"string"}]}}}`))
+	b, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"sha256:de824759184887dc3a653771c8ff8c7366525dcfe3f62674cdf8747c86030ca2"},"concepts":{"http.method":{"canonical":"http.method","fallbacks":[{"name":"http.method","provider":"otel","type":"string"}]}}}`))
 	require.NoError(t, err)
 	assert.False(t, RegistryEqual(a, b), "differing content_hash means the concepts changed, even if version happens to match")
 }
 
 func TestRegistryEqual_DifferentHash(t *testing.T) {
-	a, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"hash-a"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
+	a, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"` + dbStatementContentHash + `"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
 	require.NoError(t, err)
-	b, err := NewRegistryFromJSON([]byte(`{"version":"2.0.0","metadata":{"content_hash":"hash-b"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
+	b, err := NewRegistryFromJSON([]byte(`{"version":"2.0.0","metadata":{"content_hash":"sha256:de824759184887dc3a653771c8ff8c7366525dcfe3f62674cdf8747c86030ca2"},"concepts":{"http.method":{"canonical":"http.method","fallbacks":[{"name":"http.method","provider":"otel","type":"string"}]}}}`))
 	require.NoError(t, err)
 	assert.False(t, RegistryEqual(a, b))
 }

--- a/pkg/trace/stats/aggregation_test.go
+++ b/pkg/trace/stats/aggregation_test.go
@@ -492,7 +492,7 @@ func TestIsRootSpan(t *testing.T) {
 
 func TestGetStatusCodeUsesLiveRegistry(t *testing.T) {
 	// A registry where http.status_code only maps to "x.custom.status", not the standard key.
-	customJSON := `{"version":"test","metadata":{"content_hash":"hash-a"},"concepts":{"http.status_code":{"canonical":"http.status_code","fallbacks":[{"name":"x.custom.status","provider":"datadog","type":"string"}]}}}`
+	customJSON := `{"version":"test","metadata":{"content_hash":"sha256:4391229201039e3744004093d1898b4387349692080af86e4df279053c1eeaeb"},"concepts":{"http.status_code":{"canonical":"http.status_code","fallbacks":[{"name":"x.custom.status","provider":"datadog","type":"string"}]}}}`
 	custom, err := semantics.NewRegistryFromJSON([]byte(customJSON))
 	require.NoError(t, err)
 	original, err := semantics.NewEmbeddedRegistry()

--- a/pkg/trace/stats/concentrator_test.go
+++ b/pkg/trace/stats/concentrator_test.go
@@ -206,7 +206,7 @@ func TestConcentrator_PeerTagKeysFollowRegistry(t *testing.T) {
 	assert.Contains(t, originalKeys, "peer.service", "embedded registry maps peer.service concept")
 
 	// Install a registry with a different Version() and a remapped peer.service concept.
-	customJSON := `{"version":"test-custom-1","metadata":{"content_hash":"hash-a"},"concepts":{"peer.service":{"canonical":"peer.service","fallbacks":[{"name":"x.custom.peer","provider":"datadog","type":"string"}]}}}`
+	customJSON := `{"version":"test-custom-1","metadata":{"content_hash":"sha256:df4ae1091ddfb8a32683b44f52afed1525573187ebf43a7f2c4f0f7a686db25d"},"concepts":{"peer.service":{"canonical":"peer.service","fallbacks":[{"name":"x.custom.peer","provider":"datadog","type":"string"}]}}}`
 	custom, err := semantics.NewRegistryFromJSON([]byte(customJSON))
 	require.NoError(t, err)
 	semantics.UpdateRegistry(custom)


### PR DESCRIPTION
## Summary

- recompute the APM Semantic Core content hash from canonical JSON containing only concepts
- match the Python producer's recursive key sorting, compact encoding, and ASCII string escaping
- reject mismatches before registry replacement so the previous registry and peer-tag cache key remain active
- correct the embedded registry hash, which had become stale after later mapping edits

## Context

- https://app.datadoghq.com/work/COREOBS-3448

## Test plan

- GOWORK=off GOTOOLCHAIN=local go test ./semantics -count=1
- GOWORK=off GOTOOLCHAIN=local go test -tags test ./remoteconfighandler -count=1
- GOWORK=off GOTOOLCHAIN=local go vet ./semantics
- producer fixtures cover content mutation, key order and whitespace, metadata independence, Unicode escaping, and RC ApplyStateError registry preservation