### PR TITLE
Move compile of nosys.so out of the cluster-agent dockerfile.

### DIFF
--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -435,9 +435,8 @@ docker_build_agent7_fips_full_arm64:
     - mv -vf $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector $ARTIFACTS_BUILD_CONTEXT/
     - mv -vf $CWS_INSTRUMENTATION_BINARIES_DIR $ARTIFACTS_BUILD_CONTEXT/
     # Build nosys.so from the agent image's nosys-seccomp stage and extract it as a
-    # standalone artifact, instead of duplicating the gcc/libseccomp-dev toolchain
-    # stage inside this image (see PR review on #55669). Cached via registry so
-    # this only actually compiles when nosys.c/nosys.sym or the base image change.
+    # standalone artifact.
+    # Cached via registry so so we only compile when nosys.c/nosys.sym or the base image change.
     - |
       NOSYS_CACHE_REF="registry.ddbuild.io/ci/datadog-agent/nosys-seccomp:cache-${ARCH}"
       NOSYS_CACHE_FROM="--cache-from type=registry,ref=${NOSYS_CACHE_REF}"

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -434,7 +434,14 @@ docker_build_agent7_fips_full_arm64:
     - mv -vf $CLUSTER_AGENT_BINARIES_DIR/datadog-cluster-agent $ARTIFACTS_BUILD_CONTEXT/
     - mv -vf $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector $ARTIFACTS_BUILD_CONTEXT/
     - mv -vf $CWS_INSTRUMENTATION_BINARIES_DIR $ARTIFACTS_BUILD_CONTEXT/
-    - mv -vf Dockerfiles/agent/nosys-seccomp $BUILD_CONTEXT/
+    # Build nosys.so from the agent image's nosys-seccomp stage and extract it as a
+    # standalone artifact, instead of duplicating the gcc/libseccomp-dev toolchain
+    # stage inside this image (see PR review on #55669).
+    - |
+      docker buildx build --target nosys-artifact --platform linux/$ARCH \
+        --build-arg CI --build-arg BASE_IMAGE_REGISTRY \
+        --output type=local,dest=${ARTIFACTS_BUILD_CONTEXT} \
+        --file Dockerfiles/agent/Dockerfile Dockerfiles/agent
     - mkdir -p ${BUILD_CONTEXT}/private-action-runner
     - cp -v pkg/privateactionrunner/autoconnections/conf/script-config.yaml ${BUILD_CONTEXT}/private-action-runner/
 

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -436,10 +436,21 @@ docker_build_agent7_fips_full_arm64:
     - mv -vf $CWS_INSTRUMENTATION_BINARIES_DIR $ARTIFACTS_BUILD_CONTEXT/
     # Build nosys.so from the agent image's nosys-seccomp stage and extract it as a
     # standalone artifact, instead of duplicating the gcc/libseccomp-dev toolchain
-    # stage inside this image (see PR review on #55669).
+    # stage inside this image (see PR review on #55669). Cached via registry so
+    # this only actually compiles when nosys.c/nosys.sym or the base image change.
     - |
+      NOSYS_CACHE_REF="registry.ddbuild.io/ci/datadog-agent/nosys-seccomp:cache-${ARCH}"
+      NOSYS_CACHE_FROM="--cache-from type=registry,ref=${NOSYS_CACHE_REF}"
+      NOSYS_CACHE_TO=""
+      if [[ "$DEPLOY_AGENT" == "true" ]]; then
+        NOSYS_CACHE_FROM=""
+      fi
+      if [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" || "$BUCKET_BRANCH" == "nightly" ]]; then
+        NOSYS_CACHE_TO="--cache-to type=registry,ref=${NOSYS_CACHE_REF},mode=max"
+      fi
       docker buildx build --target nosys-artifact --platform linux/$ARCH \
         --build-arg CI --build-arg BASE_IMAGE_REGISTRY \
+        ${NOSYS_CACHE_FROM} ${NOSYS_CACHE_TO} \
         --output type=local,dest=${ARTIFACTS_BUILD_CONTEXT} \
         --file Dockerfiles/agent/Dockerfile Dockerfiles/agent
     - mkdir -p ${BUILD_CONTEXT}/private-action-runner

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -52,10 +52,8 @@ COPY nosys-seccomp/nosys.c   /tmp/nosys.c
 COPY nosys-seccomp/nosys.sym /tmp/nosys.sym
 RUN gcc -pipe -Wall -Wextra -O2 -shared -fPIC -Wl,--version-script=/tmp/nosys.sym -o /tmp/nosys.so /tmp/nosys.c  -lseccomp
 
-# Target used to extract nosys.so as a standalone build artifact (via
-# `docker buildx build --target nosys-artifact --output type=local,...`),
-# so other images (e.g. cluster-agent) can consume it without rebuilding
-# their own gcc/libseccomp-dev toolchain stage.
+# Target to extract nosys.so as a standalone build artifact so other
+# images (e.g. cluster-agent) can consume it without rebuilding.
 FROM scratch AS nosys-artifact
 COPY --from=nosys-seccomp /tmp/nosys.so /nosys.so
 

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -52,6 +52,13 @@ COPY nosys-seccomp/nosys.c   /tmp/nosys.c
 COPY nosys-seccomp/nosys.sym /tmp/nosys.sym
 RUN gcc -pipe -Wall -Wextra -O2 -shared -fPIC -Wl,--version-script=/tmp/nosys.sym -o /tmp/nosys.so /tmp/nosys.c  -lseccomp
 
+# Target used to extract nosys.so as a standalone build artifact (via
+# `docker buildx build --target nosys-artifact --output type=local,...`),
+# so other images (e.g. cluster-agent) can consume it without rebuilding
+# their own gcc/libseccomp-dev toolchain stage.
+FROM scratch AS nosys-artifact
+COPY --from=nosys-seccomp /tmp/nosys.so /nosys.so
+
 FROM baseimage AS extract-base
 RUN apt update && apt install --no-install-recommends -y curl ca-certificates maven xz-utils
 

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -22,7 +22,7 @@ RUN if [ "$CI" = "true" ]; then \
         /etc/apt/sources.list.d/ubuntu.sources; \
     fi; \
     fi
-RUN apt update && apt install --no-install-recommends -y gcc libc6-dev libseccomp-dev
+RUN apt-get update && apt install --no-install-recommends -y gcc libc6-dev libseccomp-dev
 COPY nosys-seccomp/nosys.c   /tmp/nosys.c
 COPY nosys-seccomp/nosys.sym /tmp/nosys.sym
 RUN gcc -pipe -Wall -Wextra -O2 -shared -fPIC -Wl,--version-script=/tmp/nosys.sym -o /tmp/nosys.so /tmp/nosys.c -lseccomp
@@ -82,9 +82,8 @@ ENV PATH="/opt/datadog-agent/bin/:$PATH" \
 #  same time for speed.
 # For agent install and operation: ca-certificates, tzdata, adduser
 # For TSE operations: curl
-RUN apt-get update \
-    && apt full-upgrade -y \
-    && apt-get install --no-install-recommends -y ca-certificates curl libseccomp2 tzdata adduser\
+RUN apt full-upgrade -y \
+    && apt-get install --no-install-recommends -y ca-certificates curl libseccomp2 tzdata adduser \
     && rm -rf \
       /var/cache/debconf/*-old \
       /var/lib/apt/lists/* \

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -62,7 +62,7 @@ ENV PATH="/opt/datadog-agent/bin/:$PATH" \
 #  same time for speed.
 # For agent install and operation: ca-certificates, tzdata, adduser
 # For TSE operations: curl
-RUN apt full-upgrade -y \
+RUN apt-get update && apt full-upgrade -y \
     && apt-get install --no-install-recommends -y ca-certificates curl libseccomp2 tzdata adduser \
     && rm -rf \
       /var/cache/debconf/*-old \

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -2,30 +2,10 @@ ARG BASE_IMAGE_UBUNTU_VERSION=24.04
 ARG BASE_IMAGE_UBUNTU_NAME=noble
 ARG BASE_IMAGE_REGISTRY=docker.io
 
-FROM ${BASE_IMAGE_REGISTRY}/ubuntu:$BASE_IMAGE_UBUNTU_VERSION AS nosys-seccomp
-ARG CI
-ENV DEBIAN_FRONTEND=noninteractive
-RUN if [ "$CI" = "true" ]; then \
-    printf 'Acquire::Retries "1";\nAcquire::http::Timeout "10";\nAcquire::https::Timeout "10";\n' > /etc/apt/apt.conf.d/99datadog-mirror-resilience && \
-    printf 'http://us-east-1.ec2.archive.ubuntu.com/ubuntu\nhttp://archive.ubuntu.com/ubuntu\nhttp://mirror.leaseweb.net/ubuntu\n' > /etc/apt/mirrorlist.main && \
-    printf 'http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\nhttp://ports.ubuntu.com/ubuntu-ports\nhttp://mirror.leaseweb.net/ubuntu-ports\n' > /etc/apt/mirrorlist.ports && \
-    if [ -f /etc/apt/sources.list ]; then \
-      sed -i -e 's#http://archive.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
-             -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
-             -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' /etc/apt/sources.list; \
-    fi && \
-    if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
-      sed -i -E \
-        -e 's#^(URIs:[[:space:]]+)https?://[a-z0-9.-]*archive\.ubuntu\.com/ubuntu/?[[:space:]]*$#\1http://us-east-1.ec2.archive.ubuntu.com/ubuntu http://archive.ubuntu.com/ubuntu http://mirror.leaseweb.net/ubuntu#' \
-        -e 's#^(URIs:[[:space:]]+)https?://security\.ubuntu\.com/ubuntu/?[[:space:]]*$#\1http://us-east-1.ec2.archive.ubuntu.com/ubuntu http://archive.ubuntu.com/ubuntu http://mirror.leaseweb.net/ubuntu#' \
-        -e 's#^(URIs:[[:space:]]+)https?://[a-z0-9.-]*ports\.ubuntu\.com/ubuntu-ports/?[[:space:]]*$#\1http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports http://ports.ubuntu.com/ubuntu-ports http://mirror.leaseweb.net/ubuntu-ports#' \
-        /etc/apt/sources.list.d/ubuntu.sources; \
-    fi; \
-    fi
-RUN apt-get update && apt install --no-install-recommends -y gcc libc6-dev libseccomp-dev
-COPY nosys-seccomp/nosys.c   /tmp/nosys.c
-COPY nosys-seccomp/nosys.sym /tmp/nosys.sym
-RUN gcc -pipe -Wall -Wextra -O2 -shared -fPIC -Wl,--version-script=/tmp/nosys.sym -o /tmp/nosys.so /tmp/nosys.c -lseccomp
+# nosys.so is no longer built here. It's compiled from Dockerfiles/agent's
+# nosys-seccomp stage and handed in via the `artifacts` build context (see
+# .docker_build_cluster_agent in .gitlab/deploy/container_build/docker_linux.yml),
+# so this image doesn't need its own gcc/libseccomp-dev toolchain stage.
 
 FROM ${BASE_IMAGE_REGISTRY}/ubuntu:$BASE_IMAGE_UBUNTU_VERSION AS release-base
 ARG BASE_IMAGE_UBUNTU_VERSION=24.04
@@ -149,7 +129,7 @@ RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agen
     && chmod u=r,g=r,o= /etc/datadog-agent/private-action-runner/*
 
 # Ensure the glibc doesn't try to call syscalls that may not be supported
-COPY --from=nosys-seccomp /tmp/nosys.so /lib/x86_64-linux-gnu/nosys.so
+COPY --from=artifacts nosys.so /lib/x86_64-linux-gnu/nosys.so
 ENV LD_PRELOAD=/lib/x86_64-linux-gnu/nosys.so
 
 # Incompatible with the custom metrics API on port 443


### PR DESCRIPTION
Move build of nosys.so out of cluster-agent build into a cached artifact

### What does this PR do?

Moves the build of nosys.so from the cluster-agent docker file into a distinct buildx job.

### Motivation

I noticed a double apt-get update in the cluster agent built while looking at CI logs and wondering why we are wasting time.


### Describe how you validated your changes
CI
