### PR TITLE
Fix NCM check interval defaults.

### DIFF
--- a/pkg/networkconfigmanagement/config/config.go
+++ b/pkg/networkconfigmanagement/config/config.go
@@ -119,8 +119,8 @@ func NewNcmCheckContext(rawInstance integration.Data, rawInitConfig integration.
 
 	// Build the final context to send out
 	ncc := &NcmCheckContext{
-		MinCollectionInterval:      time.Duration(initConfig.MinCollectionInterval) * time.Second,
-		InventoryReportMaxInterval: time.Duration(initConfig.InventoryReportMaxInterval) * time.Second,
+		MinCollectionInterval:      initConfig.MinCollectionInterval,
+		InventoryReportMaxInterval: initConfig.InventoryReportMaxInterval,
 		Device:                     &deviceInstance,
 	}
 	return ncc, nil
@@ -173,10 +173,20 @@ func (ic *InitConfig) applyDefaults() {
 	if ic.MinCollectionInterval <= 0 {
 		log.Debugf("No or invalid min_collection_interval specified in init config, applying default: %d", defaultCheckInterval)
 		ic.MinCollectionInterval = defaultCheckInterval // Default to 15 minutes
+	} else if ic.MinCollectionInterval < time.Millisecond {
+		// go-yaml parses a plain int (e.g. "30") as "30ns"; we want plain ints
+		// to be seconds. We assume that any time frame less than a millisecond
+		// was entered without units and parsed as nanoseconds.
+		ic.MinCollectionInterval *= time.Second
 	}
 	if ic.InventoryReportMaxInterval <= 0 {
 		log.Debugf("No or invalid inventory_report_max_interval specified in init config, applying default: %s", defaultInventoryReportMaxInterval)
 		ic.InventoryReportMaxInterval = defaultInventoryReportMaxInterval
+	} else if ic.InventoryReportMaxInterval < time.Millisecond {
+		// go-yaml parses a plain int (e.g. "30") as "30ns"; we want plain ints
+		// to be seconds. We assume that any time frame less than a millisecond
+		// was entered without units and parsed as nanoseconds.
+		ic.InventoryReportMaxInterval *= time.Second
 	}
 }
 

--- a/pkg/networkconfigmanagement/config/config_test.go
+++ b/pkg/networkconfigmanagement/config/config_test.go
@@ -377,3 +377,132 @@ auth:
 		})
 	}
 }
+
+func TestParsingMinCollectionIntervalFromYAML(t *testing.T) {
+	var tests = []struct {
+		name     string
+		interval string
+		expected time.Duration
+	}{
+		{
+			name:     "duration string with units",
+			interval: "1m30s",
+			expected: 90 * time.Second,
+		},
+		{
+			name:     "duration string without units",
+			interval: "60",
+			expected: 60 * time.Second,
+		},
+		{
+			name:     "duration string with only seconds unit",
+			interval: "45s",
+			expected: 45 * time.Second,
+		},
+		{
+			name:     "upper boundary for conversion",
+			interval: "999999",
+			expected: 999999 * time.Second,
+		},
+		{
+			name:     "upper boundary for conversion",
+			interval: "1000000",
+			expected: time.Millisecond,
+		},
+		{
+			name:     "negative duration string",
+			interval: "-30s",
+			expected: defaultCheckInterval, // should fall back to default on error
+		},
+	}
+
+	var newConfigs = func(interval string) ([]byte, []byte) {
+		initConfig := `
+namespace: default
+min_collection_interval: ` + interval + `
+ssh:
+  insecure_skip_verify: true
+`
+		instanceConfig := `
+ip_address: 192.168.0.1
+auth:
+  password: 'password'
+  username: 'admin'
+`
+		return []byte(initConfig), []byte(instanceConfig)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initConfig, instanceConfig := newConfigs(tt.interval)
+			cfg, err := NewNcmCheckContext(instanceConfig, initConfig)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, cfg.MinCollectionInterval)
+		})
+	}
+}
+
+func TestParsingInventoryReportMaxIntervalFromYAML(t *testing.T) {
+	var tests = []struct {
+		name     string
+		interval string
+		expected time.Duration
+	}{
+		{
+			name:     "duration string with units",
+			interval: "1m30s",
+			expected: 90 * time.Second,
+		},
+		{
+			name:     "duration string without units",
+			interval: "60",
+			expected: 60 * time.Second,
+		},
+		{
+			name:     "duration string with only seconds unit",
+			interval: "45s",
+			expected: 45 * time.Second,
+		},
+		{
+			name:     "upper boundary for conversion",
+			interval: "999999",
+			expected: 999999 * time.Second,
+		},
+		{
+			name:     "upper boundary for conversion",
+			interval: "1000000",
+			expected: time.Millisecond,
+		},
+		{
+			name:     "negative duration string",
+			interval: "-30s",
+			expected: defaultInventoryReportMaxInterval, // should fall back to default on error
+		},
+	}
+
+	var newConfigs = func(interval string) ([]byte, []byte) {
+		initConfig := `
+namespace: default
+min_collection_interval: 60
+inventory_report_max_interval: ` + interval + `
+ssh:
+  insecure_skip_verify: true
+`
+		instanceConfig := `
+ip_address: 192.168.0.1
+auth:
+  password: 'password'
+  username: 'admin'
+`
+		return []byte(initConfig), []byte(instanceConfig)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initConfig, instanceConfig := newConfigs(tt.interval)
+			cfg, err := NewNcmCheckContext(instanceConfig, initConfig)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, cfg.InventoryReportMaxInterval)
+		})
+	}
+}

--- a/releasenotes/notes/fix-ncm-default-check-intervals-63b50229db22df4b.yaml
+++ b/releasenotes/notes/fix-ncm-default-check-intervals-63b50229db22df4b.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    NCM check frequency will no longer default to a negative number; config
+    values expressed as integers instead of durations (e.g. "5" instead of "30s"
+    or "10m") will be parsed as seconds instead of nanoseconds.


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where two default intervals are ridiculous.

### Motivation

Two fields that used to be integers in seconds were converted to time.Durations at some point, but we accidentally left in some code that multiplies them by `time.Second`. The result would've been that the default check interval for NCM was about 285 centuries, but actually this overflows and becomes about -123 years (which means the check doesn't get scheduled).

To keep backwards compatibility with cases where the check interval or inventory report interval had previously been specified in seconds (which now gets parsed as nanoseconds by go-yaml), I added a check that will interpret any interval shorter than a millisecond as being a number of seconds instead.
 
### Describe how you validated your changes

I ran the agent locally and confirmed that the values were set correctly.

### Additional Notes

Rather than doing the <millisecond check I would prefer to use a custom YAML unmarshaller, but unfortunately go's type system is awful and there doesn't appear to be a way to do this without a lot of explicit type conversion.