### PR TITLE
Remove failed to send telemetry payload 404 warnings on GovCloud sites

### DIFF
--- a/pkg/fleet/installer/telemetry/client.go
+++ b/pkg/fleet/installer/telemetry/client.go
@@ -40,6 +40,9 @@ type client struct {
 	client             httpClient
 	endpoints          []*endpoint
 	sendPayloadTimeout time.Duration
+	// siteSupportsTelemetry is false when the site has no telemetry intake backend
+	// (e.g. GovCloud), in which case payloads are dropped locally instead of being sent.
+	siteSupportsTelemetry bool
 
 	// we can pre-calculate the host payload structure at init time
 	baseEvent event
@@ -135,16 +138,17 @@ type httpClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-func newClient(httpClient httpClient, endpoints []*endpoint, service string, debug bool) *client {
+func newClient(httpClient httpClient, endpoints []*endpoint, service string, debug bool, siteSupportsTelemetry bool) *client {
 	info, err := host.Info()
 	if err != nil {
 		log.Errorf("failed to retrieve host info: %v", err)
 		info = &host.InfoStat{}
 	}
 	return &client{
-		client:             httpClient,
-		endpoints:          endpoints,
-		sendPayloadTimeout: defaultSendPayloadTimeout,
+		client:                httpClient,
+		endpoints:             endpoints,
+		sendPayloadTimeout:    defaultSendPayloadTimeout,
+		siteSupportsTelemetry: siteSupportsTelemetry,
 		baseEvent: event{
 			APIVersion: "v2",
 			DebugFlag:  debug,
@@ -209,6 +213,9 @@ func (c *client) sampleTraces(ts traces) traces {
 }
 
 func (c *client) sendPayload(requestType requestType, payload interface{}) {
+	if !c.siteSupportsTelemetry {
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), c.sendPayloadTimeout)
 	defer cancel()
 

--- a/pkg/fleet/installer/telemetry/telemetry.go
+++ b/pkg/fleet/installer/telemetry/telemetry.go
@@ -11,10 +11,12 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -25,6 +27,13 @@ const (
 	envSamplingPriority = "DATADOG_SAMPLING_PRIORITY"
 	telemetrySubdomain  = "instrumentation-telemetry-intake"
 )
+
+// reGovCloudSite matches GovCloud sites (e.g. "ddog-gov.com", "xxxx99.ddog-gov.com").
+// No instrumentation telemetry intake backend exists on GovCloud, so telemetry is
+// disabled outright for these sites rather than attempting (and failing) to send.
+// This mirrors the equivalent exclusion for the resident agent's own telemetry in
+// pkg/config/utils/telemetry.go's IsAgentTelemetryEnabled.
+var reGovCloudSite = regexp.MustCompile(`(.+\.)?ddog-gov\.com`)
 
 // Telemetry handles the telemetry for fleet components.
 type Telemetry struct {
@@ -56,8 +65,13 @@ func newTelemetry(client *http.Client, apiKey string, site string, service strin
 		env = "staging"
 	}
 
+	siteSupportsTelemetry := !reGovCloudSite.MatchString(strings.TrimSpace(site))
+	if !siteSupportsTelemetry {
+		log.Debugf("telemetry disabled: no instrumentation telemetry intake exists for GovCloud site %q", site)
+	}
+
 	return &Telemetry{
-		telemetryClient: newClient(client, []*endpoint{e}, service, site == "datad0g.com"),
+		telemetryClient: newClient(client, []*endpoint{e}, service, site == "datad0g.com", siteSupportsTelemetry),
 		done:            make(chan struct{}),
 		flushed:         make(chan struct{}),
 		env:             env,

--- a/pkg/fleet/installer/telemetry/telemetry.go
+++ b/pkg/fleet/installer/telemetry/telemetry.go
@@ -33,7 +33,12 @@ const (
 // disabled outright for these sites rather than attempting (and failing) to send.
 // This mirrors the equivalent exclusion for the resident agent's own telemetry in
 // pkg/config/utils/telemetry.go's IsAgentTelemetryEnabled.
+// Expects a normalized (lowercase, no trailing DNS root dot) site — see normalizeSite.
 var reGovCloudSite = regexp.MustCompile(`^(?:.+\.)?ddog-gov\.com$`)
+
+func normalizeSite(site string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(site)), ".")
+}
 
 // Telemetry handles the telemetry for fleet components.
 type Telemetry struct {
@@ -65,7 +70,7 @@ func newTelemetry(client *http.Client, apiKey string, site string, service strin
 		env = "staging"
 	}
 
-	siteSupportsTelemetry := !reGovCloudSite.MatchString(strings.TrimSpace(site))
+	siteSupportsTelemetry := !reGovCloudSite.MatchString(normalizeSite(site))
 	if !siteSupportsTelemetry {
 		log.Debugf("telemetry disabled: no instrumentation telemetry intake exists for GovCloud site %q", site)
 	}

--- a/pkg/fleet/installer/telemetry/telemetry.go
+++ b/pkg/fleet/installer/telemetry/telemetry.go
@@ -33,7 +33,7 @@ const (
 // disabled outright for these sites rather than attempting (and failing) to send.
 // This mirrors the equivalent exclusion for the resident agent's own telemetry in
 // pkg/config/utils/telemetry.go's IsAgentTelemetryEnabled.
-var reGovCloudSite = regexp.MustCompile(`(.+\.)?ddog-gov\.com`)
+var reGovCloudSite = regexp.MustCompile(`^(?:.+\.)?ddog-gov\.com$`)
 
 // Telemetry handles the telemetry for fleet components.
 type Telemetry struct {

--- a/pkg/fleet/installer/telemetry/telemetry_test.go
+++ b/pkg/fleet/installer/telemetry/telemetry_test.go
@@ -255,6 +255,18 @@ func TestNewTelemetry_EnabledForNonGovCloudSite(t *testing.T) {
 	}
 }
 
+// TestNewTelemetry_EnabledForSitesResemblingGovCloud guards against a regex that
+// matches "ddog-gov.com" as a substring instead of the full site name: a custom
+// site that merely contains that string (as a suffix of a longer domain, or a
+// prefix glued onto it) is not actually GovCloud and must not be silently
+// disabled.
+func TestNewTelemetry_EnabledForSitesResemblingGovCloud(t *testing.T) {
+	for _, site := range []string{"ddog-gov.com.example.com", "prefixddog-gov.com", "ddog-gov.com.evil.com", "notddog-gov.com"} {
+		telem := newTelemetry(&http.Client{}, "api", site, "test-service")
+		assert.True(t, telem.telemetryClient.siteSupportsTelemetry, "expected telemetry to be enabled for site %q", site)
+	}
+}
+
 // recordingHTTPClient is a minimal httpClient stub that records whether Do was called.
 type recordingHTTPClient struct {
 	called bool

--- a/pkg/fleet/installer/telemetry/telemetry_test.go
+++ b/pkg/fleet/installer/telemetry/telemetry_test.go
@@ -248,6 +248,25 @@ func TestNewTelemetry_DisabledForGovCloudSite(t *testing.T) {
 	}
 }
 
+// TestNewTelemetry_DisabledForGovCloudSiteCaseInsensitiveAndTrailingDot guards
+// against two valid-but-easy-to-miss DNS forms of the same GovCloud site: DNS
+// names are case-insensitive, and a trailing root dot (e.g. "ddog-gov.com.")
+// denotes the same fully-qualified domain. Both must still be detected as
+// GovCloud, matching the case-sensitive-only regex bug flagged in review.
+func TestNewTelemetry_DisabledForGovCloudSiteCaseInsensitiveAndTrailingDot(t *testing.T) {
+	for _, site := range []string{
+		"DDOG-GOV.COM",
+		"Ddog-Gov.Com",
+		"ddog-gov.com.",
+		"DDOG-GOV.COM.",
+		"XXXX99.DDOG-GOV.COM",
+		"  DDOG-GOV.COM  ",
+	} {
+		telem := newTelemetry(&http.Client{}, "api", site, "test-service")
+		assert.False(t, telem.telemetryClient.siteSupportsTelemetry, "expected telemetry to be disabled for site %q", site)
+	}
+}
+
 func TestNewTelemetry_EnabledForNonGovCloudSite(t *testing.T) {
 	for _, site := range []string{"datadoghq.com", "datadoghq.eu", "datad0g.com", ""} {
 		telem := newTelemetry(&http.Client{}, "api", site, "test-service")

--- a/pkg/fleet/installer/telemetry/telemetry_test.go
+++ b/pkg/fleet/installer/telemetry/telemetry_test.go
@@ -241,6 +241,46 @@ func TestRemapOnFlush(t *testing.T) {
 	}
 }
 
+func TestNewTelemetry_DisabledForGovCloudSite(t *testing.T) {
+	for _, site := range []string{"ddog-gov.com", "xxxx99.ddog-gov.com"} {
+		telem := newTelemetry(&http.Client{}, "api", site, "test-service")
+		assert.False(t, telem.telemetryClient.siteSupportsTelemetry, "expected telemetry to be disabled for site %q", site)
+	}
+}
+
+func TestNewTelemetry_EnabledForNonGovCloudSite(t *testing.T) {
+	for _, site := range []string{"datadoghq.com", "datadoghq.eu", "datad0g.com", ""} {
+		telem := newTelemetry(&http.Client{}, "api", site, "test-service")
+		assert.True(t, telem.telemetryClient.siteSupportsTelemetry, "expected telemetry to be enabled for site %q", site)
+	}
+}
+
+// recordingHTTPClient is a minimal httpClient stub that records whether Do was called.
+type recordingHTTPClient struct {
+	called bool
+}
+
+func (r *recordingHTTPClient) Do(*http.Request) (*http.Response, error) {
+	r.called = true
+	return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+}
+
+func TestSendPayload_SkipsHTTPCallWhenDisabledForGovCloud(t *testing.T) {
+	rec := &recordingHTTPClient{}
+	e := &endpoint{Host: "https://instrumentation-telemetry-intake.ddog-gov.com", APIKey: "api"}
+	c := newClient(rec, []*endpoint{e}, "test-service", false, false /* siteSupportsTelemetry */)
+	c.sendPayload(requestTypeLogs, LogPayload{})
+	assert.False(t, rec.called, "expected no HTTP call to be made when telemetry is disabled")
+}
+
+func TestSendPayload_MakesHTTPCallWhenEnabled(t *testing.T) {
+	rec := &recordingHTTPClient{}
+	e := &endpoint{Host: "https://instrumentation-telemetry-intake.datadoghq.com", APIKey: "api"}
+	c := newClient(rec, []*endpoint{e}, "test-service", false, true /* siteSupportsTelemetry */)
+	c.sendPayload(requestTypeLogs, LogPayload{})
+	assert.True(t, rec.called, "expected an HTTP call to be made when telemetry is enabled")
+}
+
 func TestSampling(t *testing.T) {
 	const testService = "test-service"
 	telem := newTelemetry(&http.Client{}, "api", "datad0g.com", testService)

--- a/releasenotes/notes/govcloud-installer-telemetry-404-b869f440789dd311.yaml
+++ b/releasenotes/notes/govcloud-installer-telemetry-404-b869f440789dd311.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fleet Installer: Fix an issue where the installer's telemetry client repeatedly
+    logged ``failed to send telemetry payload`` warnings with ``404 Not Found`` errors
+    on GovCloud sites (``ddog-gov.com``), since no instrumentation telemetry intake
+    exists there. Telemetry is now disabled outright for GovCloud sites, matching the
+    existing behavior of the Agent's own resident telemetry.


### PR DESCRIPTION
### What does this PR do?
Fix an issue where the installer's telemetry client repeatedly logged ``failed to send telemetry payload`` warnings with ``404 Not Found`` errors on GovCloud sites (``ddog-gov.com``), since no instrumentation telemetry intake exists there. Telemetry is now disabled outright for GovCloud sites.

### Motivation
[AGENT-16871](https://datadoghq.atlassian.net/browse/AGENT-16871)

### Describe how you validated your changes
Unit tests (`pkg/fleet/installer/telemetry`):
- `TestNewTelemetry_DisabledForGovCloudSite` - asserts telemetry is disabled for `ddog-gov.com` and a GovCloud subdomain (`xxxx99.ddog-gov.com`).
- `TestNewTelemetry_EnabledForNonGovCloudSite` - asserts telemetry stays enabled for `datadoghq.com`, `datadoghq.eu`, `datad0g.com`, and the default (empty) site.
- `TestNewTelemetry_EnabledForSitesResemblingGovCloud` - negative cases for sites that merely contain `ddog-gov.com` as a substring (`ddog-gov.com.example.com`, `prefixddog-gov.com`, `ddog-gov.com.evil.com`, `notddog-gov.com`), guarding against the unanchored-regex false positive flagged in review.
- `TestSendPayload_SkipsHTTPCallWhenDisabledForGovCloud`/`TestSendPayload_MakesHTTPCallWhenEnabled` - a recording `httpClient` stub confirms `sendPayload` makes zero HTTP calls when `siteSupportsTelemetry` is false, and still fires normally when true.

[AGENT-16871]: https://datadoghq.atlassian.net/browse/AGENT-16871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ