### PR TITLE
Report DDOT process state in the installer agent state (#54982)

### DIFF
--- a/pkg/fleet/daemon/BUILD.bazel
+++ b/pkg/fleet/daemon/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "daemon",
     srcs = [
         "daemon.go",
+        "ddot_state.go",
         "local_api.go",
         "local_api_unix.go",
         "local_api_windows.go",
@@ -29,6 +30,7 @@ go_library(
         "//pkg/fleet/installer/paths",
         "//pkg/fleet/installer/repository",
         "//pkg/fleet/installer/telemetry",
+        "//pkg/procmgr/coat",
         "//pkg/proto/pbgo/core",
         "//pkg/remoteconfig/state",
         "//pkg/util/log",
@@ -48,6 +50,7 @@ dd_agent_go_test(
     name = "daemon_test",
     srcs = [
         "daemon_test.go",
+        "ddot_state_test.go",
         "local_api_test.go",
         "remote_config_test.go",
         "task_db_test.go",
@@ -58,6 +61,7 @@ dd_agent_go_test(
         "//pkg/fleet/installer/config",
         "//pkg/fleet/installer/env",
         "//pkg/fleet/installer/repository",
+        "//pkg/procmgr/coat",
         "//pkg/proto/pbgo/core",
         "//pkg/remoteconfig/state",
         "//pkg/version",

--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -36,6 +36,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/procmgr/coat"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -100,6 +101,8 @@ type daemonImpl struct {
 	gcInterval      time.Duration
 	ctx             context.Context
 	cancel          context.CancelFunc
+
+	procmgrCollector procmgrSnapshotCollector
 
 	secretsPubKey, secretsPrivKey *[32]byte
 }
@@ -166,7 +169,9 @@ func NewDaemon(hostname string, rcFetcher client.ConfigFetcher, config agentconf
 		return nil, fmt.Errorf("could not generate box key: %w", err)
 	}
 
-	return newDaemon(rc, installer, env, taskDB, refreshInterval, gcInterval, secretsPubKey, secretsPrivKey), nil
+	d := newDaemon(rc, installer, env, taskDB, refreshInterval, gcInterval, secretsPubKey, secretsPrivKey)
+	d.procmgrCollector = coat.NewCLICollector()
+	return d, nil
 }
 
 func newDaemon(rc *remoteConfig, installer func(env *env.Env) installer.Installer, env *env.Env, taskDB *taskDB, refreshInterval time.Duration, gcInterval time.Duration, secretsPubKey, secretsPrivKey *[32]byte) *daemonImpl {
@@ -811,6 +816,10 @@ func (d *daemonImpl) refreshState(ctx context.Context) {
 	runningConfigVersions := map[string]string{
 		"datadog-agent": d.env.ConfigID,
 	}
+	var ddotProcessState string
+	if _, ok := configAndPackageStates.States["datadog-agent"]; ok {
+		ddotProcessState = d.ddotProcessState(ctx)
+	}
 	var packages []*pbgo.PackageState
 	for pkg, s := range configAndPackageStates.States {
 		p := &pbgo.PackageState{
@@ -822,6 +831,11 @@ func (d *daemonImpl) refreshState(ctx context.Context) {
 			RunningVersion:          runningVersions[pkg],
 			RunningConfigVersion:    runningConfigVersions[pkg],
 			HeartbeatTimestamp:      uint64(time.Now().Unix()),
+		}
+		if pkg == "datadog-agent" {
+			p.ProcessStates = map[string]string{
+				coat.ServiceIDDDOT: ddotProcessState,
+			}
 		}
 
 		requestState, ok := tasksState[pkg]

--- a/pkg/fleet/daemon/daemon_test.go
+++ b/pkg/fleet/daemon/daemon_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/config"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
+	"github.com/DataDog/datadog-agent/pkg/procmgr/coat"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -561,6 +562,7 @@ func TestRefreshStateRunningVersions(t *testing.T) {
 	assert.Equal(t, "config-exp-1", pkg.ExperimentConfigVersion)
 	assert.Equal(t, version.AgentPackageVersion, pkg.RunningVersion, "RunningVersion should be set to AgentPackageVersion")
 	assert.Equal(t, "test-config-id-123", pkg.RunningConfigVersion, "RunningConfigVersion should be set to env.ConfigID")
+	assert.Equal(t, coat.ProcessStateUnknown, pkg.ProcessStates[coat.ServiceIDDDOT], "ddot process state should report unknown without a procmgr collector")
 	assert.Equal(t, state.SecretsPubKey, base64.StdEncoding.EncodeToString(secretsPubKey[:]))
 
 	pm.AssertExpectations(t)

--- a/pkg/fleet/daemon/ddot_state.go
+++ b/pkg/fleet/daemon/ddot_state.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package daemon
+
+import (
+	"context"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/procmgr/coat"
+)
+
+type procmgrSnapshotCollector interface {
+	Collect(ctx context.Context) coat.Snapshot
+}
+
+func (d *daemonImpl) ddotProcessState(ctx context.Context) string {
+	if d.procmgrCollector == nil {
+		return coat.ProcessStateUnknown
+	}
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	return d.procmgrCollector.Collect(ctx).ServiceProcessState(coat.ServiceIDDDOT)
+}

--- a/pkg/fleet/daemon/ddot_state_test.go
+++ b/pkg/fleet/daemon/ddot_state_test.go
@@ -1,0 +1,132 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package daemon
+
+import (
+	"context"
+	"crypto/rand"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/nacl/box"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
+	"github.com/DataDog/datadog-agent/pkg/procmgr/coat"
+)
+
+type fakeProcmgrCollector struct {
+	snapshot coat.Snapshot
+}
+
+func (f *fakeProcmgrCollector) Collect(context.Context) coat.Snapshot {
+	return f.snapshot
+}
+
+func ddotSnapshot(mode coat.ManagementMode, state string) coat.Snapshot {
+	return coat.Snapshot{
+		Daemon: coat.DaemonSnapshot{Reachable: true, Ready: true},
+		Services: []coat.ServiceSnapshot{{
+			ID:                coat.ServiceIDDDOT,
+			Installed:         mode != coat.ManagementModeNone,
+			ProcmgrConfigured: mode == coat.ManagementModeProcmgr,
+			ProcmgrState:      state,
+			ManagementMode:    mode,
+		}},
+	}
+}
+
+func TestDDOTProcessStateWithoutCollector(t *testing.T) {
+	d := &daemonImpl{}
+	assert.Equal(t, coat.ProcessStateUnknown, d.ddotProcessState(context.Background()))
+}
+
+func TestDDOTProcessStateFromCollector(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot coat.Snapshot
+		expected string
+	}{
+		{
+			name:     "procmgr running",
+			snapshot: ddotSnapshot(coat.ManagementModeProcmgr, coat.ProcessStateRunning),
+			expected: coat.ProcessStateRunning,
+		},
+		{
+			name:     "procmgr failed",
+			snapshot: ddotSnapshot(coat.ManagementModeProcmgr, coat.ProcessStateFailed),
+			expected: coat.ProcessStateFailed,
+		},
+		{
+			name:     "systemd managed",
+			snapshot: ddotSnapshot(coat.ManagementModeSystemd, coat.ProcessStateUnknown),
+			expected: coat.ProcessStateRunning,
+		},
+		{
+			name:     "not installed",
+			snapshot: ddotSnapshot(coat.ManagementModeNone, coat.ProcessStateUnknown),
+			expected: coat.ProcessStateNotInstalled,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := &daemonImpl{procmgrCollector: &fakeProcmgrCollector{snapshot: test.snapshot}}
+			assert.Equal(t, test.expected, d.ddotProcessState(context.Background()))
+		})
+	}
+}
+
+func TestRefreshStateReportsDDOTProcessState(t *testing.T) {
+	pm := &testPackageManager{}
+	pm.On("AvailableDiskSpace").Return(uint64(1000000000), nil)
+	pm.On("ConfigAndPackageStates", mock.Anything).Return(&repository.PackageStates{
+		States: map[string]repository.State{
+			"datadog-agent":      {Stable: "7.50.0"},
+			"datadog-apm-inject": {Stable: "0.20.0"},
+		},
+		ConfigStates: map[string]repository.State{},
+	}, nil)
+	rcc := newTestRemoteConfigClient(t)
+	taskDB, err := newTaskDB(filepath.Join(t.TempDir(), "tasks.db"))
+	require.NoError(t, err)
+	defer taskDB.Close()
+	secretsPubKey, secretsPrivKey, err := box.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	daemon := newDaemon(
+		&remoteConfig{client: rcc},
+		func(_ *env.Env) installer.Installer { return pm },
+		&env.Env{RemoteUpdates: true},
+		taskDB,
+		30*time.Second,
+		1*time.Hour,
+		secretsPubKey,
+		secretsPrivKey,
+	)
+	daemon.procmgrCollector = &fakeProcmgrCollector{
+		snapshot: ddotSnapshot(coat.ManagementModeProcmgr, coat.ProcessStateRunning),
+	}
+	daemon.refreshState(context.Background())
+
+	state := rcc.GetInstallerState()
+	require.NotNil(t, state)
+	require.Len(t, state.Packages, 2)
+	for _, pkg := range state.Packages {
+		if pkg.Package == "datadog-agent" {
+			assert.Equal(t, coat.ProcessStateRunning, pkg.ProcessStates[coat.ServiceIDDDOT])
+			continue
+		}
+		assert.Empty(t, pkg.ProcessStates, "DDOT state must only be reported on the agent package")
+	}
+
+	pm.AssertExpectations(t)
+}

--- a/pkg/fleet/daemon/local_api_test.go
+++ b/pkg/fleet/daemon/local_api_test.go
@@ -135,7 +135,8 @@ func TestAPIStatus(t *testing.T) {
 	remoteConfigState := &pbgo.ClientUpdater{
 		Packages: []*pbgo.PackageState{
 			{
-				Package: "test-package",
+				Package:       "test-package",
+				ProcessStates: map[string]string{"ddot": "running"},
 				Task: &pbgo.PackageStateTask{
 					State: pbgo.TaskState_DONE,
 				},

--- a/pkg/fleet/installer/commands/status.go
+++ b/pkg/fleet/installer/commands/status.go
@@ -131,6 +131,7 @@ type remoteConfigPackageState struct {
 	Task                    *remoteConfigPackageTask `json:"task,omitempty"`
 	StableConfigVersion     string                   `json:"stable_config_version,omitempty"`
 	ExperimentConfigVersion string                   `json:"experiment_config_version,omitempty"`
+	ProcessStates           map[string]string        `json:"process_states,omitempty"`
 }
 
 type remoteConfigPackageTask struct {

--- a/pkg/fleet/installer/commands/status.tmpl
+++ b/pkg/fleet/installer/commands/status.tmpl
@@ -16,6 +16,9 @@ Packages installed:
       ExperimentVersion: {{ $remoteConfig.ExperimentVersion }}
       StableConfigVersion: {{ $remoteConfig.StableConfigVersion }}
       ExperimentConfigVersion: {{ $remoteConfig.ExperimentConfigVersion }}
+      {{- range $service, $state := $remoteConfig.ProcessStates }}
+      ProcessState[{{ $service }}]: {{ $state }}
+      {{- end }}
       Task:
         {{- if $remoteConfig.Task }}
         Id: {{ $remoteConfig.Task.ID }}

--- a/pkg/procmgr/coat/BUILD.bazel
+++ b/pkg/procmgr/coat/BUILD.bazel
@@ -5,6 +5,9 @@ go_library(
     name = "coat",
     srcs = [
         "client.go",
+        "client_cli.go",
+        "client_cli_unix.go",
+        "client_cli_windows.go",
         "client_grpc.go",
         "client_grpc_unix.go",
         "client_grpc_windows.go",
@@ -14,6 +17,7 @@ go_library(
         "collector_windows.go",
         "paths_notwindows.go",
         "paths_windows.go",
+        "process_state.go",
         "reporter.go",
         "services.go",
         "snapshot.go",
@@ -115,10 +119,12 @@ go_library(
 
 dd_agent_go_test(
     name = "coat_test",
-    srcs = ["collector_test.go"],
+    srcs = [
+        "collector_test.go",
+        "process_state_test.go",
+    ],
     embed = [":coat"],
     deps = [
-        "//pkg/proto/pbgo/procmgr",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/procmgr/coat/client_cli.go
+++ b/pkg/procmgr/coat/client_cli.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package coat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type cliClient struct {
+	cli string
+}
+
+func newCLIClient(installRoot string) Client {
+	return &cliClient{cli: procmgrCLIPath(installRoot)}
+}
+
+func (c *cliClient) Connect(_ context.Context) (ProcmgrSession, error) {
+	if _, err := os.Stat(c.cli); err != nil {
+		return nil, err
+	}
+	return &cliSession{cli: c.cli}, nil
+}
+
+type cliSession struct {
+	cli string
+}
+
+func (s *cliSession) Status(ctx context.Context) (DaemonSnapshot, error) {
+	out, err := runProcmgrCLI(ctx, s.cli, "status", "--json")
+	if err != nil {
+		return DaemonSnapshot{}, err
+	}
+	var resp struct {
+		Ready            bool   `json:"ready"`
+		RunningProcesses uint32 `json:"running_processes"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return DaemonSnapshot{}, fmt.Errorf("parse dd-procmgr status output: %w", err)
+	}
+	return DaemonSnapshot{Reachable: true, Ready: resp.Ready, RunningProcesses: resp.RunningProcesses}, nil
+}
+
+func (s *cliSession) List(ctx context.Context) (map[string]ProcessSnapshot, error) {
+	out, err := runProcmgrCLI(ctx, s.cli, "list", "--json")
+	if err != nil {
+		return nil, err
+	}
+	var items []struct {
+		Name  string `json:"name"`
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(out, &items); err != nil {
+		return nil, fmt.Errorf("parse dd-procmgr list output: %w", err)
+	}
+	processes := make(map[string]ProcessSnapshot, len(items))
+	for _, item := range items {
+		processes[item.Name] = ProcessSnapshot{Name: item.Name, State: parseProcmgrState(item.State)}
+	}
+	return processes, nil
+}
+
+func (s *cliSession) Disconnect() error {
+	return nil
+}
+
+func runProcmgrCLI(ctx context.Context, cli string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, cli, args...)
+	if err := runAsDDAgent(cmd); err != nil {
+		return nil, fmt.Errorf("dd-procmgr %s: %w", strings.Join(args, " "), err)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if strings.Contains(msg, "failed to connect to") {
+			return nil, fmt.Errorf("dd-procmgr %s: %w: %s", strings.Join(args, " "), os.ErrNotExist, msg)
+		}
+		return nil, fmt.Errorf("dd-procmgr %s: %w: %s", strings.Join(args, " "), err, msg)
+	}
+	return stdout.Bytes(), nil
+}

--- a/pkg/procmgr/coat/client_cli_unix.go
+++ b/pkg/procmgr/coat/client_cli_unix.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build !windows
+
+package coat
+
+import (
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
+)
+
+func procmgrCLIPath(_ string) string {
+	return filepath.Join(defaultpaths.GetEmbeddedBinPath(), "dd-procmgr")
+}
+
+func runAsDDAgent(cmd *exec.Cmd) error {
+	if os.Geteuid() != 0 {
+		return nil
+	}
+	ddAgent, err := user.Lookup("dd-agent")
+	if err != nil {
+		return err
+	}
+	uid, err := strconv.ParseUint(ddAgent.Uid, 10, 32)
+	if err != nil {
+		return err
+	}
+	gid, err := strconv.ParseUint(ddAgent.Gid, 10, 32)
+	if err != nil {
+		return err
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}}
+	return nil
+}

--- a/pkg/procmgr/coat/client_cli_windows.go
+++ b/pkg/procmgr/coat/client_cli_windows.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build windows
+
+package coat
+
+import (
+	"os/exec"
+	"path/filepath"
+)
+
+func procmgrCLIPath(installRoot string) string {
+	return filepath.Join(installRoot, "bin", "agent", "dd-procmgr.exe")
+}
+
+func runAsDDAgent(_ *exec.Cmd) error {
+	return nil
+}

--- a/pkg/procmgr/coat/client_grpc.go
+++ b/pkg/procmgr/coat/client_grpc.go
@@ -69,7 +69,7 @@ func processesFromListResponse(resp *pb.ListResponse) map[string]ProcessSnapshot
 	for _, proc := range resp.GetProcesses() {
 		processes[proc.GetName()] = ProcessSnapshot{
 			Name:  proc.GetName(),
-			State: proc.GetState(),
+			State: parseProcmgrState(proc.GetState().String()),
 		}
 	}
 	return processes

--- a/pkg/procmgr/coat/collector.go
+++ b/pkg/procmgr/coat/collector.go
@@ -29,6 +29,14 @@ func NewCollector() *Collector {
 	return NewCollectorWithClient(installRoot, newDefaultClient())
 }
 
+// NewCLICollector creates a collector using the dd-procmgr CLI instead of dialing gRPC directly,
+// so binaries that only need this collector (e.g. datadog-installer) don't link
+// google.golang.org/grpc or the generated procmgr protobuf stubs.
+func NewCLICollector() *Collector {
+	installRoot := agentInstallRoot()
+	return NewCollectorWithClient(installRoot, newCLIClient(installRoot))
+}
+
 // NewCollectorWithClient creates a collector with a custom install root and procmgr client.
 func NewCollectorWithClient(installRoot string, client Client) *Collector {
 	return &Collector{
@@ -110,6 +118,7 @@ func (c *Collector) collectService(ctx context.Context, service MigratableServic
 	status := ServiceSnapshot{
 		ID:             service.ID,
 		ManagementMode: ManagementModeNone,
+		ProcmgrState:   ProcessStateUnknown,
 	}
 
 	for _, marker := range installMarkerPaths(c.installRoot, service) {

--- a/pkg/procmgr/coat/collector_test.go
+++ b/pkg/procmgr/coat/collector_test.go
@@ -14,8 +14,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/procmgr"
 )
 
 type mockClient struct {
@@ -127,7 +125,7 @@ func TestCollectServiceProcmgrRunning(t *testing.T) {
 	collector := NewCollectorWithClient(root, &mockClient{
 		daemon: DaemonSnapshot{Reachable: true, Ready: true, RunningProcesses: 1},
 		processes: map[string]ProcessSnapshot{
-			"datadog-agent-ddot": {Name: "datadog-agent-ddot", State: pb.ProcessState_RUNNING},
+			"datadog-agent-ddot": {Name: "datadog-agent-ddot", State: ProcessStateRunning},
 		},
 	})
 
@@ -137,7 +135,7 @@ func TestCollectServiceProcmgrRunning(t *testing.T) {
 	assert.Equal(t, "ddot", service.ID)
 	assert.True(t, service.Installed)
 	assert.True(t, service.ProcmgrConfigured)
-	assert.Equal(t, pb.ProcessState_RUNNING, service.ProcmgrState)
+	assert.Equal(t, ProcessStateRunning, service.ProcmgrState)
 	assert.Equal(t, ManagementModeProcmgr, service.ManagementMode)
 	assert.True(t, snapshot.Daemon.Reachable)
 	assert.True(t, snapshot.Daemon.Ready)
@@ -161,7 +159,7 @@ func TestCollectADPProcmgrRunning(t *testing.T) {
 	collector := NewCollectorWithClient(root, &mockClient{
 		daemon: DaemonSnapshot{Reachable: true, Ready: true, RunningProcesses: 1},
 		processes: map[string]ProcessSnapshot{
-			"datadog-agent-data-plane": {Name: "datadog-agent-data-plane", State: pb.ProcessState_RUNNING},
+			"datadog-agent-data-plane": {Name: "datadog-agent-data-plane", State: ProcessStateRunning},
 		},
 	})
 
@@ -171,7 +169,7 @@ func TestCollectADPProcmgrRunning(t *testing.T) {
 	assert.Equal(t, "agent-data-plane", service.ID)
 	assert.True(t, service.Installed)
 	assert.True(t, service.ProcmgrConfigured)
-	assert.Equal(t, pb.ProcessState_RUNNING, service.ProcmgrState)
+	assert.Equal(t, ProcessStateRunning, service.ProcmgrState)
 	assert.Equal(t, ManagementModeProcmgr, service.ManagementMode)
 }
 
@@ -180,7 +178,7 @@ func TestCollectServiceProcmgrNotRunningStillManaged(t *testing.T) {
 
 	collector := NewCollectorWithClient(root, &mockClient{
 		processes: map[string]ProcessSnapshot{
-			"datadog-agent-ddot": {Name: "datadog-agent-ddot", State: pb.ProcessState_STARTING},
+			"datadog-agent-ddot": {Name: "datadog-agent-ddot", State: ProcessStateStarting},
 		},
 	})
 
@@ -188,7 +186,7 @@ func TestCollectServiceProcmgrNotRunningStillManaged(t *testing.T) {
 
 	service := serviceSnapshotByID(t, snapshot, "ddot")
 	assert.Equal(t, ManagementModeProcmgr, service.ManagementMode)
-	assert.Equal(t, pb.ProcessState_STARTING, service.ProcmgrState)
+	assert.Equal(t, ProcessStateStarting, service.ProcmgrState)
 }
 
 func TestCollectNoProcmgrNoLegacy(t *testing.T) {
@@ -202,7 +200,7 @@ func TestCollectNoProcmgrNoLegacy(t *testing.T) {
 	assert.False(t, service.Installed)
 	assert.False(t, service.ProcmgrConfigured)
 	assert.Equal(t, ManagementModeNone, service.ManagementMode)
-	assert.Equal(t, pb.ProcessState_UNKNOWN, service.ProcmgrState)
+	assert.Equal(t, ProcessStateUnknown, service.ProcmgrState)
 }
 
 func TestCollectInstallMarkerAbsent(t *testing.T) {
@@ -252,7 +250,7 @@ func TestCollectDaemonUnreachable(t *testing.T) {
 	collector := NewCollectorWithClient(root, &mockClient{
 		daemonErr: errors.New("dial failed"),
 		processes: map[string]ProcessSnapshot{
-			"datadog-agent-ddot": {Name: "datadog-agent-ddot", State: pb.ProcessState_RUNNING},
+			"datadog-agent-ddot": {Name: "datadog-agent-ddot", State: ProcessStateRunning},
 		},
 	})
 
@@ -263,7 +261,7 @@ func TestCollectDaemonUnreachable(t *testing.T) {
 	service := serviceSnapshotByID(t, snapshot, "ddot")
 	assert.Equal(t, ManagementModeNone, service.ManagementMode,
 		"daemon failure prevents listing processes")
-	assert.Equal(t, pb.ProcessState_UNKNOWN, service.ProcmgrState)
+	assert.Equal(t, ProcessStateUnknown, service.ProcmgrState)
 }
 
 func TestCollectDaemonReachableListFails(t *testing.T) {
@@ -272,7 +270,7 @@ func TestCollectDaemonReachableListFails(t *testing.T) {
 	collector := NewCollectorWithClient(root, &mockClient{
 		daemon:    DaemonSnapshot{Reachable: true, Ready: true, RunningProcesses: 1},
 		listErr:   errors.New("list failed"),
-		processes: map[string]ProcessSnapshot{"datadog-agent-ddot": {Name: "datadog-agent-ddot", State: pb.ProcessState_RUNNING}},
+		processes: map[string]ProcessSnapshot{"datadog-agent-ddot": {Name: "datadog-agent-ddot", State: ProcessStateRunning}},
 	})
 
 	snapshot := collector.Collect(context.Background())
@@ -281,5 +279,5 @@ func TestCollectDaemonReachableListFails(t *testing.T) {
 	assert.True(t, snapshot.Daemon.Ready)
 	service := serviceSnapshotByID(t, snapshot, "ddot")
 	assert.Equal(t, ManagementModeNone, service.ManagementMode)
-	assert.Equal(t, pb.ProcessState_UNKNOWN, service.ProcmgrState)
+	assert.Equal(t, ProcessStateUnknown, service.ProcmgrState)
 }

--- a/pkg/procmgr/coat/process_state.go
+++ b/pkg/procmgr/coat/process_state.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package coat
+
+import "strings"
+
+// ServiceIDDDOT is the service ID of the DDOT extension in the migratable service catalog.
+const ServiceIDDDOT = "ddot"
+
+const (
+	ProcessStateNotInstalled = "not_installed"
+	ProcessStateUnknown      = "unknown"
+	ProcessStateCreated      = "created"
+	ProcessStateStarting     = "starting"
+	ProcessStateRunning      = "running"
+	ProcessStateStopping     = "stopping"
+	ProcessStateStopped      = "stopped"
+	ProcessStateCrashed      = "crashed"
+	ProcessStateExited       = "exited"
+	ProcessStateFailed       = "failed"
+)
+
+func (s Snapshot) ServiceProcessState(id string) string {
+	for _, service := range s.Services {
+		if service.ID != id {
+			continue
+		}
+		switch service.ManagementMode {
+		case ManagementModeProcmgr:
+			return service.ProcmgrState
+		case ManagementModeSystemd, ManagementModeWindowsService:
+			// These modes are only set when the unit or service is active.
+			return ProcessStateRunning
+		}
+		if !service.Installed && !service.ProcmgrConfigured {
+			return ProcessStateNotInstalled
+		}
+		if service.ProcmgrConfigured && !s.Daemon.Reachable {
+			return ProcessStateUnknown
+		}
+		return ProcessStateStopped
+	}
+	return ProcessStateUnknown
+}
+
+// parseProcmgrState normalizes a process state name reported by either transport into a
+// ProcessState* constant: the gRPC client reports pb.ProcessState.String() (e.g. "RUNNING"),
+// while the dd-procmgr CLI reports state_name() (e.g. "Running").
+func parseProcmgrState(name string) string {
+	switch strings.ToUpper(name) {
+	case "CREATED":
+		return ProcessStateCreated
+	case "STARTING":
+		return ProcessStateStarting
+	case "RUNNING":
+		return ProcessStateRunning
+	case "STOPPING":
+		return ProcessStateStopping
+	case "STOPPED":
+		return ProcessStateStopped
+	case "CRASHED":
+		return ProcessStateCrashed
+	case "EXITED":
+		return ProcessStateExited
+	case "FAILED":
+		return ProcessStateFailed
+	default:
+		return ProcessStateUnknown
+	}
+}

--- a/pkg/procmgr/coat/process_state_test.go
+++ b/pkg/procmgr/coat/process_state_test.go
@@ -1,0 +1,165 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package coat
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceProcessStateProcmgrManaged(t *testing.T) {
+	states := []string{
+		ProcessStateUnknown,
+		ProcessStateCreated,
+		ProcessStateStarting,
+		ProcessStateRunning,
+		ProcessStateStopping,
+		ProcessStateStopped,
+		ProcessStateCrashed,
+		ProcessStateExited,
+		ProcessStateFailed,
+	}
+
+	for _, expected := range states {
+		t.Run(expected, func(t *testing.T) {
+			snapshot := Snapshot{
+				Daemon: DaemonSnapshot{Reachable: true, Ready: true},
+				Services: []ServiceSnapshot{{
+					ID:                ServiceIDDDOT,
+					Installed:         true,
+					ProcmgrConfigured: true,
+					ProcmgrState:      expected,
+					ManagementMode:    ManagementModeProcmgr,
+				}},
+			}
+			assert.Equal(t, expected, snapshot.ServiceProcessState(ServiceIDDDOT))
+		})
+	}
+}
+
+func TestParseProcmgrState(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"RUNNING", ProcessStateRunning},
+		{"Running", ProcessStateRunning},
+		{"FAILED", ProcessStateFailed},
+		{"Failed", ProcessStateFailed},
+		{"CREATED", ProcessStateCreated},
+		{"STARTING", ProcessStateStarting},
+		{"STOPPING", ProcessStateStopping},
+		{"STOPPED", ProcessStateStopped},
+		{"CRASHED", ProcessStateCrashed},
+		{"EXITED", ProcessStateExited},
+		{"UNKNOWN", ProcessStateUnknown},
+		{"garbage", ProcessStateUnknown},
+		{"", ProcessStateUnknown},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, parseProcmgrState(test.name))
+		})
+	}
+}
+
+func TestServiceProcessStateLegacySupervisors(t *testing.T) {
+	for _, mode := range []ManagementMode{ManagementModeSystemd, ManagementModeWindowsService} {
+		t.Run(string(mode), func(t *testing.T) {
+			snapshot := Snapshot{
+				Services: []ServiceSnapshot{{
+					ID:             ServiceIDDDOT,
+					Installed:      true,
+					ManagementMode: mode,
+				}},
+			}
+			assert.Equal(t, ProcessStateRunning, snapshot.ServiceProcessState(ServiceIDDDOT))
+		})
+	}
+}
+
+func TestServiceProcessStateNotInstalled(t *testing.T) {
+	snapshot := Snapshot{
+		Daemon: DaemonSnapshot{Reachable: true, Ready: true},
+		Services: []ServiceSnapshot{{
+			ID:             ServiceIDDDOT,
+			ManagementMode: ManagementModeNone,
+		}},
+	}
+	assert.Equal(t, ProcessStateNotInstalled, snapshot.ServiceProcessState(ServiceIDDDOT))
+}
+
+func TestServiceProcessStateProcmgrUnreachable(t *testing.T) {
+	snapshot := Snapshot{
+		Daemon: DaemonSnapshot{},
+		Services: []ServiceSnapshot{{
+			ID:                ServiceIDDDOT,
+			Installed:         true,
+			ProcmgrConfigured: true,
+			ManagementMode:    ManagementModeNone,
+		}},
+	}
+	assert.Equal(t, ProcessStateUnknown, snapshot.ServiceProcessState(ServiceIDDDOT))
+}
+
+func TestServiceProcessStateInstalledWithoutSupervisor(t *testing.T) {
+	snapshot := Snapshot{
+		Daemon: DaemonSnapshot{Reachable: true, Ready: true},
+		Services: []ServiceSnapshot{{
+			ID:                ServiceIDDDOT,
+			Installed:         true,
+			ProcmgrConfigured: true,
+			ManagementMode:    ManagementModeNone,
+		}},
+	}
+	assert.Equal(t, ProcessStateStopped, snapshot.ServiceProcessState(ServiceIDDDOT))
+}
+
+func TestServiceProcessStateUnknownService(t *testing.T) {
+	snapshot := Snapshot{
+		Services: []ServiceSnapshot{{ID: ServiceIDDDOT, ManagementMode: ManagementModeProcmgr}},
+	}
+	assert.Equal(t, ProcessStateUnknown, snapshot.ServiceProcessState("not-a-service"))
+}
+
+func TestCollectServiceProcessStateRunning(t *testing.T) {
+	root := setupDDOTInstallFixture(t)
+
+	collector := NewCollectorWithClient(root, &mockClient{
+		daemon: DaemonSnapshot{Reachable: true, Ready: true, RunningProcesses: 1},
+		processes: map[string]ProcessSnapshot{
+			"datadog-agent-ddot": {Name: "datadog-agent-ddot", State: ProcessStateRunning},
+		},
+	})
+
+	snapshot := collector.Collect(context.Background())
+
+	assert.Equal(t, ProcessStateRunning, snapshot.ServiceProcessState(ServiceIDDDOT))
+}
+
+func TestCollectServiceProcessStateDaemonUnreachable(t *testing.T) {
+	root := setupDDOTInstallFixture(t)
+
+	collector := NewCollectorWithClient(root, &mockClient{connectErr: os.ErrNotExist})
+
+	snapshot := collector.Collect(context.Background())
+
+	assert.Equal(t, ProcessStateUnknown, snapshot.ServiceProcessState(ServiceIDDDOT))
+}
+
+func TestCollectServiceProcessStateNotInstalled(t *testing.T) {
+	collector := NewCollectorWithClient(t.TempDir(), &mockClient{
+		daemon: DaemonSnapshot{Reachable: true, Ready: true},
+	})
+
+	snapshot := collector.Collect(context.Background())
+
+	assert.Equal(t, ProcessStateNotInstalled, snapshot.ServiceProcessState(ServiceIDDDOT))
+}

--- a/pkg/procmgr/coat/reporter.go
+++ b/pkg/procmgr/coat/reporter.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/procmgr"
 )
 
 const reportInterval = 5 * time.Minute
@@ -101,7 +100,7 @@ func report(ctx context.Context, g gauges, collector *Collector) {
 
 		setBoolGauge(g.serviceInstalled, service.Installed, service.ID)
 		setBoolGauge(g.serviceProcmgrConfigured, service.ProcmgrConfigured, service.ID)
-		setBoolGauge(g.processRunning, service.ProcmgrState == pb.ProcessState_RUNNING, spec.ProcmgrProcessName)
+		setBoolGauge(g.processRunning, service.ProcmgrState == ProcessStateRunning, spec.ProcmgrProcessName)
 
 		// Do not emit management_mode=none on platforms where we never classify
 		// systemd/SCM/procmgr (e.g. macOS); avoids polluting COAT adoption metrics.

--- a/pkg/procmgr/coat/snapshot.go
+++ b/pkg/procmgr/coat/snapshot.go
@@ -9,8 +9,6 @@ package coat
 import (
 	"os"
 	"runtime"
-
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/procmgr"
 )
 
 const (
@@ -47,8 +45,9 @@ type DaemonSnapshot struct {
 
 // ProcessSnapshot captures a single managed process reported by dd-procmgrd.
 type ProcessSnapshot struct {
-	Name  string
-	State pb.ProcessState
+	Name string
+	// State is one of the ProcessState* constants, already normalized by the client.
+	State string
 }
 
 // ServiceSnapshot captures install and supervision state for a migratable agent service.
@@ -56,8 +55,9 @@ type ServiceSnapshot struct {
 	ID                string
 	Installed         bool
 	ProcmgrConfigured bool
-	ProcmgrState      pb.ProcessState
-	ManagementMode    ManagementMode
+	// ProcmgrState is one of the ProcessState* constants, already normalized by the client.
+	ProcmgrState   string
+	ManagementMode ManagementMode
 }
 
 // Snapshot aggregates procmgr daemon and per-service supervision state.

--- a/pkg/proto/datadog/remoteconfig/remoteconfig.proto
+++ b/pkg/proto/datadog/remoteconfig/remoteconfig.proto
@@ -131,6 +131,7 @@ message PackageState {
   string running_config_version = 14;
   uint64 heartbeat_timestamp = 15;
   float  completion = 16;
+  map<string, string> process_states = 17;
 }
 
 message PackageStateTask {

--- a/pkg/proto/pbgo/core/remoteconfig.pb.go
+++ b/pkg/proto/pbgo/core/remoteconfig.pb.go
@@ -1238,6 +1238,7 @@ type PackageState struct {
 	RunningConfigVersion    string                 `protobuf:"bytes,14,opt,name=running_config_version,json=runningConfigVersion,proto3" json:"running_config_version,omitempty"`
 	HeartbeatTimestamp      uint64                 `protobuf:"varint,15,opt,name=heartbeat_timestamp,json=heartbeatTimestamp,proto3" json:"heartbeat_timestamp,omitempty"`
 	Completion              float32                `protobuf:"fixed32,16,opt,name=completion,proto3" json:"completion,omitempty"`
+	ProcessStates           map[string]string      `protobuf:"bytes,17,rep,name=process_states,json=processStates,proto3" json:"process_states,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -1340,6 +1341,13 @@ func (x *PackageState) GetCompletion() float32 {
 		return x.Completion
 	}
 	return 0
+}
+
+func (x *PackageState) GetProcessStates() map[string]string {
+	if x != nil {
+		return x.ProcessStates
+	}
+	return nil
 }
 
 type PackageStateTask struct {
@@ -2357,7 +2365,7 @@ type ConfigSubscriptionState_TrackedClient struct {
 
 func (x *ConfigSubscriptionState_TrackedClient) Reset() {
 	*x = ConfigSubscriptionState_TrackedClient{}
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[33]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2369,7 +2377,7 @@ func (x *ConfigSubscriptionState_TrackedClient) String() string {
 func (*ConfigSubscriptionState_TrackedClient) ProtoMessage() {}
 
 func (x *ConfigSubscriptionState_TrackedClient) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[33]
+	mi := &file_datadog_remoteconfig_remoteconfig_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2502,7 +2510,7 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\x04tags\x18\x01 \x03(\tR\x04tags\x128\n" +
 	"\bpackages\x18\x02 \x03(\v2\x1c.datadog.config.PackageStateR\bpackages\x120\n" +
 	"\x14available_disk_space\x18\x03 \x01(\x04R\x12availableDiskSpace\x12&\n" +
-	"\x0fsecrets_pub_key\x18\x04 \x01(\tR\rsecretsPubKey\"\xf8\x03\n" +
+	"\x0fsecrets_pub_key\x18\x04 \x01(\tR\rsecretsPubKey\"\x92\x05\n" +
 	"\fPackageState\x12\x18\n" +
 	"\apackage\x18\x01 \x01(\tR\apackage\x12%\n" +
 	"\x0estable_version\x18\x02 \x01(\tR\rstableVersion\x12-\n" +
@@ -2515,7 +2523,11 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\x13heartbeat_timestamp\x18\x0f \x01(\x04R\x12heartbeatTimestamp\x12\x1e\n" +
 	"\n" +
 	"completion\x18\x10 \x01(\x02R\n" +
-	"completionJ\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
+	"completion\x12V\n" +
+	"\x0eprocess_states\x18\x11 \x03(\v2/.datadog.config.PackageState.ProcessStatesEntryR\rprocessStates\x1a@\n" +
+	"\x12ProcessStatesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
 	"J\x04\b\n" +
 	"\x10\v\"\x84\x01\n" +
 	"\x10PackageStateTask\x12\x0e\n" +
@@ -2634,7 +2646,7 @@ func file_datadog_remoteconfig_remoteconfig_proto_rawDescGZIP() []byte {
 }
 
 var file_datadog_remoteconfig_remoteconfig_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_datadog_remoteconfig_remoteconfig_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_datadog_remoteconfig_remoteconfig_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_datadog_remoteconfig_remoteconfig_proto_goTypes = []any{
 	(TaskState)(0),                                // 0: datadog.config.TaskState
 	(ConfigSubscriptionProducts)(0),               // 1: datadog.config.ConfigSubscriptionProducts
@@ -2670,10 +2682,11 @@ var file_datadog_remoteconfig_remoteconfig_proto_goTypes = []any{
 	(*ResetStateConfigResponse)(nil),              // 31: datadog.config.ResetStateConfigResponse
 	(*TracerPredicateV1)(nil),                     // 32: datadog.config.TracerPredicateV1
 	(*TracerPredicates)(nil),                      // 33: datadog.config.TracerPredicates
-	nil,                                           // 34: datadog.config.GetStateConfigResponse.ConfigStateEntry
-	nil,                                           // 35: datadog.config.GetStateConfigResponse.DirectorStateEntry
-	nil,                                           // 36: datadog.config.GetStateConfigResponse.TargetFilenamesEntry
-	(*ConfigSubscriptionState_TrackedClient)(nil), // 37: datadog.config.ConfigSubscriptionState.TrackedClient
+	nil,                                           // 34: datadog.config.PackageState.ProcessStatesEntry
+	nil,                                           // 35: datadog.config.GetStateConfigResponse.ConfigStateEntry
+	nil,                                           // 36: datadog.config.GetStateConfigResponse.DirectorStateEntry
+	nil,                                           // 37: datadog.config.GetStateConfigResponse.TargetFilenamesEntry
+	(*ConfigSubscriptionState_TrackedClient)(nil), // 38: datadog.config.ConfigSubscriptionState.TrackedClient
 }
 var file_datadog_remoteconfig_remoteconfig_proto_depIdxs = []int32{
 	7,  // 0: datadog.config.ConfigMetas.roots:type_name -> datadog.config.TopMeta
@@ -2695,33 +2708,34 @@ var file_datadog_remoteconfig_remoteconfig_proto_depIdxs = []int32{
 	16, // 16: datadog.config.Client.client_updater:type_name -> datadog.config.ClientUpdater
 	17, // 17: datadog.config.ClientUpdater.packages:type_name -> datadog.config.PackageState
 	18, // 18: datadog.config.PackageState.task:type_name -> datadog.config.PackageStateTask
-	0,  // 19: datadog.config.PackageStateTask.state:type_name -> datadog.config.TaskState
-	19, // 20: datadog.config.PackageStateTask.error:type_name -> datadog.config.TaskError
-	20, // 21: datadog.config.ClientState.config_states:type_name -> datadog.config.ConfigState
-	22, // 22: datadog.config.TargetFileMeta.hashes:type_name -> datadog.config.TargetFileHash
-	3,  // 23: datadog.config.ConfigSubscriptionRequest.action:type_name -> datadog.config.ConfigSubscriptionRequest.Action
-	1,  // 24: datadog.config.ConfigSubscriptionRequest.products:type_name -> datadog.config.ConfigSubscriptionProducts
-	13, // 25: datadog.config.ConfigSubscriptionResponse.client:type_name -> datadog.config.Client
-	8,  // 26: datadog.config.ConfigSubscriptionResponse.target_files:type_name -> datadog.config.File
-	13, // 27: datadog.config.ClientGetConfigsRequest.client:type_name -> datadog.config.Client
-	23, // 28: datadog.config.ClientGetConfigsRequest.cached_target_files:type_name -> datadog.config.TargetFileMeta
-	8,  // 29: datadog.config.ClientGetConfigsResponse.target_files:type_name -> datadog.config.File
-	2,  // 30: datadog.config.ClientGetConfigsResponse.config_status:type_name -> datadog.config.ConfigStatus
-	34, // 31: datadog.config.GetStateConfigResponse.config_state:type_name -> datadog.config.GetStateConfigResponse.ConfigStateEntry
-	35, // 32: datadog.config.GetStateConfigResponse.director_state:type_name -> datadog.config.GetStateConfigResponse.DirectorStateEntry
-	36, // 33: datadog.config.GetStateConfigResponse.target_filenames:type_name -> datadog.config.GetStateConfigResponse.TargetFilenamesEntry
-	13, // 34: datadog.config.GetStateConfigResponse.active_clients:type_name -> datadog.config.Client
-	30, // 35: datadog.config.GetStateConfigResponse.config_subscription_states:type_name -> datadog.config.ConfigSubscriptionState
-	37, // 36: datadog.config.ConfigSubscriptionState.tracked_clients:type_name -> datadog.config.ConfigSubscriptionState.TrackedClient
-	32, // 37: datadog.config.TracerPredicates.tracer_predicates_v1:type_name -> datadog.config.TracerPredicateV1
-	28, // 38: datadog.config.GetStateConfigResponse.ConfigStateEntry.value:type_name -> datadog.config.FileMetaState
-	28, // 39: datadog.config.GetStateConfigResponse.DirectorStateEntry.value:type_name -> datadog.config.FileMetaState
-	1,  // 40: datadog.config.ConfigSubscriptionState.TrackedClient.products:type_name -> datadog.config.ConfigSubscriptionProducts
-	41, // [41:41] is the sub-list for method output_type
-	41, // [41:41] is the sub-list for method input_type
-	41, // [41:41] is the sub-list for extension type_name
-	41, // [41:41] is the sub-list for extension extendee
-	0,  // [0:41] is the sub-list for field type_name
+	34, // 19: datadog.config.PackageState.process_states:type_name -> datadog.config.PackageState.ProcessStatesEntry
+	0,  // 20: datadog.config.PackageStateTask.state:type_name -> datadog.config.TaskState
+	19, // 21: datadog.config.PackageStateTask.error:type_name -> datadog.config.TaskError
+	20, // 22: datadog.config.ClientState.config_states:type_name -> datadog.config.ConfigState
+	22, // 23: datadog.config.TargetFileMeta.hashes:type_name -> datadog.config.TargetFileHash
+	3,  // 24: datadog.config.ConfigSubscriptionRequest.action:type_name -> datadog.config.ConfigSubscriptionRequest.Action
+	1,  // 25: datadog.config.ConfigSubscriptionRequest.products:type_name -> datadog.config.ConfigSubscriptionProducts
+	13, // 26: datadog.config.ConfigSubscriptionResponse.client:type_name -> datadog.config.Client
+	8,  // 27: datadog.config.ConfigSubscriptionResponse.target_files:type_name -> datadog.config.File
+	13, // 28: datadog.config.ClientGetConfigsRequest.client:type_name -> datadog.config.Client
+	23, // 29: datadog.config.ClientGetConfigsRequest.cached_target_files:type_name -> datadog.config.TargetFileMeta
+	8,  // 30: datadog.config.ClientGetConfigsResponse.target_files:type_name -> datadog.config.File
+	2,  // 31: datadog.config.ClientGetConfigsResponse.config_status:type_name -> datadog.config.ConfigStatus
+	35, // 32: datadog.config.GetStateConfigResponse.config_state:type_name -> datadog.config.GetStateConfigResponse.ConfigStateEntry
+	36, // 33: datadog.config.GetStateConfigResponse.director_state:type_name -> datadog.config.GetStateConfigResponse.DirectorStateEntry
+	37, // 34: datadog.config.GetStateConfigResponse.target_filenames:type_name -> datadog.config.GetStateConfigResponse.TargetFilenamesEntry
+	13, // 35: datadog.config.GetStateConfigResponse.active_clients:type_name -> datadog.config.Client
+	30, // 36: datadog.config.GetStateConfigResponse.config_subscription_states:type_name -> datadog.config.ConfigSubscriptionState
+	38, // 37: datadog.config.ConfigSubscriptionState.tracked_clients:type_name -> datadog.config.ConfigSubscriptionState.TrackedClient
+	32, // 38: datadog.config.TracerPredicates.tracer_predicates_v1:type_name -> datadog.config.TracerPredicateV1
+	28, // 39: datadog.config.GetStateConfigResponse.ConfigStateEntry.value:type_name -> datadog.config.FileMetaState
+	28, // 40: datadog.config.GetStateConfigResponse.DirectorStateEntry.value:type_name -> datadog.config.FileMetaState
+	1,  // 41: datadog.config.ConfigSubscriptionState.TrackedClient.products:type_name -> datadog.config.ConfigSubscriptionProducts
+	42, // [42:42] is the sub-list for method output_type
+	42, // [42:42] is the sub-list for method input_type
+	42, // [42:42] is the sub-list for extension type_name
+	42, // [42:42] is the sub-list for extension extendee
+	0,  // [0:42] is the sub-list for field type_name
 }
 
 func init() { file_datadog_remoteconfig_remoteconfig_proto_init() }
@@ -2735,7 +2749,7 @@ func file_datadog_remoteconfig_remoteconfig_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_remoteconfig_remoteconfig_proto_rawDesc), len(file_datadog_remoteconfig_remoteconfig_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   34,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/proto/pbgo/core/remoteconfig_gen.go
+++ b/pkg/proto/pbgo/core/remoteconfig_gen.go
@@ -3874,9 +3874,9 @@ func (z OrgStatusResponse) Msgsize() (s int) {
 // MarshalMsg implements msgp.Marshaler
 func (z *PackageState) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 10
+	// map header, size 11
 	// string "Package"
-	o = append(o, 0x8a, 0xa7, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65)
+	o = append(o, 0x8b, 0xa7, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65)
 	o = msgp.AppendString(o, z.Package)
 	// string "StableVersion"
 	o = append(o, 0xad, 0x53, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e)
@@ -3913,6 +3913,13 @@ func (z *PackageState) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Completion"
 	o = append(o, 0xaa, 0x43, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x69, 0x6f, 0x6e)
 	o = msgp.AppendFloat32(o, z.Completion)
+	// string "ProcessStates"
+	o = append(o, 0xad, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x53, 0x74, 0x61, 0x74, 0x65, 0x73)
+	o = msgp.AppendMapHeader(o, uint32(len(z.ProcessStates)))
+	for za0001, za0002 := range z.ProcessStates {
+		o = msgp.AppendString(o, za0001)
+		o = msgp.AppendString(o, za0002)
+	}
 	return
 }
 
@@ -4005,6 +4012,34 @@ func (z *PackageState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "Completion")
 				return
 			}
+		case "ProcessStates":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "ProcessStates")
+				return
+			}
+			if z.ProcessStates == nil {
+				z.ProcessStates = make(map[string]string, zb0002)
+			} else if len(z.ProcessStates) > 0 {
+				clear(z.ProcessStates)
+			}
+			for zb0002 > 0 {
+				var za0002 string
+				zb0002--
+				var za0001 string
+				za0001, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ProcessStates")
+					return
+				}
+				za0002, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "ProcessStates", za0001)
+					return
+				}
+				z.ProcessStates[za0001] = za0002
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -4025,7 +4060,13 @@ func (z *PackageState) Msgsize() (s int) {
 	} else {
 		s += z.Task.Msgsize()
 	}
-	s += 20 + msgp.StringPrefixSize + len(z.StableConfigVersion) + 24 + msgp.StringPrefixSize + len(z.ExperimentConfigVersion) + 15 + msgp.StringPrefixSize + len(z.RunningVersion) + 21 + msgp.StringPrefixSize + len(z.RunningConfigVersion) + 19 + msgp.Uint64Size + 11 + msgp.Float32Size
+	s += 20 + msgp.StringPrefixSize + len(z.StableConfigVersion) + 24 + msgp.StringPrefixSize + len(z.ExperimentConfigVersion) + 15 + msgp.StringPrefixSize + len(z.RunningVersion) + 21 + msgp.StringPrefixSize + len(z.RunningConfigVersion) + 19 + msgp.Uint64Size + 11 + msgp.Float32Size + 14 + msgp.MapHeaderSize
+	if z.ProcessStates != nil {
+		for za0001, za0002 := range z.ProcessStates {
+			_ = za0002
+			s += msgp.StringPrefixSize + len(za0001) + msgp.StringPrefixSize + len(za0002)
+		}
+	}
 	return
 }
 

--- a/releasenotes/notes/installer-report-ddot-process-state-eae9a02967eb14b6.yaml
+++ b/releasenotes/notes/installer-report-ddot-process-state-eae9a02967eb14b6.yaml
@@ -1,0 +1,8 @@
+---
+other:
+  - |
+    The fleet installer daemon now reports the DDOT (OpenTelemetry Collector) process state
+    as part of the agent state sent to Datadog, so DDOT version and configuration updates
+    can be monitored. The state is read from the process manager when it supervises DDOT,
+    and from systemd or the Windows service manager otherwise. It is also visible in the
+    output of ``datadog-installer status``.

--- a/test/new-e2e/tests/fleet/backend/backend.go
+++ b/test/new-e2e/tests/fleet/backend/backend.go
@@ -39,11 +39,12 @@ type RemoteConfigState struct {
 
 // RemoteConfigStatePackage is the state of a package in the remote config.
 type RemoteConfigStatePackage struct {
-	Package                 string `json:"package"`
-	StableVersion           string `json:"stable_version"`
-	ExperimentVersion       string `json:"experiment_version"`
-	StableConfigVersion     string `json:"stable_config_version"`
-	ExperimentConfigVersion string `json:"experiment_config_version"`
+	Package                 string            `json:"package"`
+	StableVersion           string            `json:"stable_version"`
+	ExperimentVersion       string            `json:"experiment_version"`
+	StableConfigVersion     string            `json:"stable_config_version"`
+	ExperimentConfigVersion string            `json:"experiment_config_version"`
+	ProcessStates           map[string]string `json:"process_states"`
 }
 
 // Backend is the fake fleet backend.

--- a/test/new-e2e/tests/fleet/config_test.go
+++ b/test/new-e2e/tests/fleet/config_test.go
@@ -610,6 +610,80 @@ func (s *configSuite) TestDDOTConfigBadConfigRollsBack() {
 	verifyDDOTRunning(s.T(), s.Agent)
 }
 
+// A failing DDOT does not end the experiment on its own: the core agent does not read
+// otel-config.yaml so the experiment agent stays healthy, and dd-procmgrd keeps retrying its child
+// forever rather than giving up. The reported DDOT process state is therefore the only signal that
+// tells the backend this experiment must not be promoted.
+func (s *configSuite) TestDDOTConfigFailureReportsFailedAndReverts() {
+	if s.Env().RemoteHost.OSFamily != e2eos.LinuxFamily {
+		s.T().Skip("DDOT runs under dd-procmgrd with a separate experiment config directory only on Linux")
+	}
+
+	s.Agent.MustInstall()
+	defer s.Agent.MustUninstall()
+
+	s.Installer.MustInstallExtension(getAgentPackageURL(s.T(), ""), "ddot")
+	defer func() { _, _ = s.Installer.RemoveExtension("datadog-agent", "ddot") }()
+
+	verifyDDOTRunning(s.T(), s.Agent)
+	s.assertCollectorConfigPath(false)
+	s.assertReportedDDOTProcessState("running")
+
+	stableConfigBefore := s.readActiveOTelConfig(false)
+	stateBefore, err := s.Backend.RemoteConfigStatusPackage("datadog-agent")
+	s.Require().NoError(err)
+
+	err = s.Backend.StartConfigExperiment(backend.ConfigOperations{
+		DeploymentID:   "ddot-config-broken-revert",
+		FileOperations: []backend.FileOperation{{FileOperationType: backend.FileOperationMergePatch, FilePath: "/otel-config.yaml", Patch: []byte(ddotBrokenPatch)}},
+	}, nil)
+	s.Require().NoError(err)
+
+	s.Require().Contains(s.readActiveOTelConfig(true), "not-a-valid-verbosity")
+	s.Require().EventuallyWithT(func(c *assert.CollectT) {
+		status, err := s.Agent.Status()
+		assert.NoError(c, err)
+		assert.True(c, status.OtelAgent.Error != "" || status.OtelAgent.AgentVersion == "",
+			"DDOT should be unhealthy while running the broken experiment config")
+	}, 2*time.Minute, 5*time.Second)
+
+	s.assertReportedDDOTProcessState("failed")
+
+	stateFailed, err := s.Backend.RemoteConfigStatusPackage("datadog-agent")
+	s.Require().NoError(err)
+	s.Require().NotEmpty(stateFailed.ExperimentConfigVersion, "the host should still be in experiment")
+	s.Require().NotContains(s.readActiveOTelConfig(false), "not-a-valid-verbosity",
+		"the broken config must never reach the stable configuration")
+
+	err = s.Backend.StopConfigExperiment()
+	s.Require().NoError(err)
+
+	stateReverted, err := s.Backend.RemoteConfigStatusPackage("datadog-agent")
+	s.Require().NoError(err)
+	s.Require().Empty(stateReverted.ExperimentConfigVersion,
+		"experiment_config_version should be cleared by the revert")
+	s.Require().Equal(stateBefore.StableConfigVersion, stateReverted.StableConfigVersion,
+		"stable_config_version should be unchanged: the experiment was never promoted")
+	s.Require().Equal(stableConfigBefore, s.readActiveOTelConfig(false),
+		"the stable otel-config.yaml should be restored")
+	verifyDDOTRunning(s.T(), s.Agent)
+	s.assertCollectorConfigPath(false)
+	s.assertReportedDDOTProcessState("running")
+}
+
+// assertReportedDDOTProcessState waits for the DDOT process state the installer daemon reports to
+// the backend as part of the datadog-agent package state to reach want. The daemon refreshes that
+// state every installer.refresh_interval (30s), so this polls well past one refresh.
+func (s *configSuite) assertReportedDDOTProcessState(want string) {
+	s.Require().EventuallyWithT(func(c *assert.CollectT) {
+		state, err := s.Backend.RemoteConfigStatusPackage("datadog-agent")
+		if !assert.NoError(c, err) {
+			return
+		}
+		assert.Equal(c, want, state.ProcessStates["ddot"])
+	}, 3*time.Minute, 10*time.Second)
+}
+
 // readActiveOTelConfig returns the contents of the otel-config.yaml the collector is (or will be)
 // running. On Linux the experiment config lives in a separate directory (/etc/datadog-agent-exp);
 // on Windows config experiments are applied in place to the stable data directory (the -exp


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/DataDog/datadog-agent/pull/54982 in 7.83
This PR modify the agent reported state to allow backend to gate the ddot update by a healthy ddot process.

### Motivation

Have this process state in 7.83 to be able to GA the ddot config update with auto-rollback and minimize the number of version where ddot update is possible while breaking ddot process

### Describe how you validated your changes

### Additional Notes
](https://github.com/DataDog/datadog-agent/pull/54982)