### PR TITLE
[incident-60025] fix(ci): make `go_tools_deps` track actual `TOOL_LIST`

### DIFF
--- a/.gitlab/.pre/deps_fetch/deps_fetch.yml
+++ b/.gitlab/.pre/deps_fetch/deps_fetch.yml
@@ -96,6 +96,7 @@ go_tools_deps:
   extends: .cache
   tags: ["arch:amd64", "specific:true"]
   script:
+    # ⚠ When adjusting the script's logic, please bump the `cache:key:prefix` value below to invalidate the cache!
     - if [ -f go_tools_bin.tar.zst ] && [ -f modcache_tools.tar.zst ]; then exit 0; fi
     - dda inv -- -e install-tools
     # Exclude datadog-package binary from the cache: it's already installed on all images and they don't have the same glibc version
@@ -116,7 +117,7 @@ go_tools_deps:
         files:
           - ./**/go.mod
           - tasks/install_tasks.py  # TOOL_LIST
-        prefix: "go_tools_deps_modcache_zstd"
+        prefix: go_tools_deps_v2
       paths:
         - go_tools_bin.tar.zst
         - modcache_tools.tar.zst
@@ -125,6 +126,7 @@ go_tools_deps_arm64:
   extends: .cache
   tags: ["arch:arm64", "specific:true"]
   script:
+    # ⚠ When adjusting the script's logic, please bump the `cache:key:prefix` value below to invalidate the cache!
     - if [ -f go_tools_bin_arm64.tar.zst ] && [ -f modcache_tools_arm64.tar.zst ]; then exit 0; fi
     - dda inv -- -e install-tools
     # Exclude datadog-package binary from the cache: it's already installed on all images and they don't have the same glibc version
@@ -145,7 +147,7 @@ go_tools_deps_arm64:
         files:
           - ./**/go.mod
           - tasks/install_tasks.py  # TOOL_LIST
-        prefix: "go_tools_deps_modcache_arm64_zstd"
+        prefix: go_tools_deps_arm64_v2
       paths:
         - go_tools_bin_arm64.tar.zst
         - modcache_tools_arm64.tar.zst

--- a/.gitlab/.pre/deps_fetch/deps_fetch.yml
+++ b/.gitlab/.pre/deps_fetch/deps_fetch.yml
@@ -16,7 +16,7 @@
   - mkdir -p $GOPATH/pkg/mod/cache && zstd -dc modcache.tar.zst | tar xf - -C $GOPATH/pkg/mod/cache
   - rm -f modcache.tar.zst
 
-.retrieve_linux_go_tools_deps: 
+.retrieve_linux_go_tools_deps:
   - |
     go_bin="$(go env GOBIN)"
     if [ -z "$go_bin" ]; then
@@ -115,7 +115,7 @@ go_tools_deps:
     - key:
         files:
           - ./**/go.mod
-          - .gitlab/.pre/deps_fetch/deps_fetch.yml
+          - tasks/install_tasks.py  # TOOL_LIST
         prefix: "go_tools_deps_modcache_zstd"
       paths:
         - go_tools_bin.tar.zst
@@ -144,7 +144,7 @@ go_tools_deps_arm64:
     - key:
         files:
           - ./**/go.mod
-          - .gitlab/.pre/deps_fetch/deps_fetch.yml
+          - tasks/install_tasks.py  # TOOL_LIST
         prefix: "go_tools_deps_modcache_arm64_zstd"
       paths:
         - go_tools_bin_arm64.tar.zst


### PR DESCRIPTION
### What does this PR do?
Point `go_tools_deps`'/`go_tools_deps_arm64`'s cache key at `tasks/install_tasks.py` (where `TOOL_LIST` lives) instead of `deps_fetch.yml` (this job's own script).

### Motivation
[#incident-60025](https://dd.enterprise.slack.com/archives/C0BTM7DAXAT).

`cache:key:files` caps at 2 paths (GitLab limitation), and `go.mod` is meant to cover tool version drift, hence the original choice of `deps_fetch.yml` as the second path.

But `go.mod` does not list **which tools** get installed, so adding or removing a tool from `TOOL_LIST` never busted the cache, and a stale tarball built under an older `TOOL_LIST` gets replayed indefinitely.

Caught via the tentative 7.83.x backport of golangci-lint's bazelification (#55661): golangci-lint's removal from `TOOL_LIST` there didn't bust `go_tools_deps`' cache, and separately its tarball already lacked a working `gotestsum`, going unnoticed because 7.83.x rarely runs the full e2e matrix that would exercise it.