### PR TITLE
[SYNTH-28969] Forward Synthetics run type to Network Path results

### DIFF
--- a/comp/syntheticstestscheduler/common/data.go
+++ b/comp/syntheticstestscheduler/common/data.go
@@ -74,9 +74,17 @@ func (i ICMPConfigRequest) GetSubType() payload.Protocol {
 	return payload.ProtocolICMP
 }
 
-// RunTypeScheduled is the value of SyntheticsTestConfig.RunType for scheduled
-// tests. Used to identify tests that should be cached for fallback execution.
-const RunTypeScheduled = "scheduled"
+const (
+	// RunTypeScheduled is the value of SyntheticsTestConfig.RunType for scheduled
+	// tests. Used to identify tests that should be cached for fallback execution.
+	RunTypeScheduled = "scheduled"
+	// RunTypeFast is the value of SyntheticsTestConfig.RunType for fast tests.
+	RunTypeFast = "fast"
+	// RunTypeCI is the value of SyntheticsTestConfig.RunType for CI tests.
+	RunTypeCI = "ci"
+	// RunTypeTriggered is the value of SyntheticsTestConfig.RunType for triggered tests.
+	RunTypeTriggered = "triggered"
+)
 
 // SyntheticsTestConfig represents the whole config of a network test.
 type SyntheticsTestConfig struct {

--- a/comp/syntheticstestscheduler/common/data_test.go
+++ b/comp/syntheticstestscheduler/common/data_test.go
@@ -145,7 +145,7 @@ func TestSyntheticsTestConfig_UnmarshalJSON_AllFields(t *testing.T) {
 		"org_id": 101,
 		"main_dc": "eu-west-1",
 		"public_id": "pub-12345",
-		"run_type": "on-demand",
+		"run_type": "triggered",
 		"tick_every": 60
 	}`
 
@@ -167,7 +167,7 @@ func TestSyntheticsTestConfig_UnmarshalJSON_AllFields(t *testing.T) {
 		OrgID:    101,
 		MainDC:   "eu-west-1",
 		PublicID: "pub-12345",
-		RunType:  "on-demand",
+		RunType:  RunTypeTriggered,
 		Interval: 60,
 		Config: struct {
 			Assertions []Assertion   `json:"assertions"`

--- a/comp/syntheticstestscheduler/impl/syntheticstestscheduler_test.go
+++ b/comp/syntheticstestscheduler/impl/syntheticstestscheduler_test.go
@@ -97,13 +97,13 @@ func Test_SyntheticsTestScheduler_Processing(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name: "one test provided",
+			name: "CI test emits a triggered Network Path result",
 			testJSON: `{
 					"version":1,"type":"network","subtype":"TCP",
 					"config":{"assertions":[],"request":{"host":"example.com","port":443,"tcp_method":"SYN","probe_count":3,"traceroute_count":1,"max_ttl":30,"timeout":5,"source_service":"frontend","destination_service":"backend"}},
-					"org_id":12345,"main_dc":"us1.staging.dog","public_id":"puf-9fm-c89","run_type":"scheduled"
+					"org_id":12345,"main_dc":"us1.staging.dog","public_id":"puf-9fm-c89","run_type":"ci"
 				}`,
-			expectedEventJSON: `{"location":{"id":"agent:test-hostname"},"_dd":{},"result":{"id":"4907739274636687553","initialId":"4907739274636687553","testFinishedAt":1756901488592,"testStartedAt":1756901488591,"testTriggeredAt":1756901488589,"assertions":[],"failure":null,"duration":1,"config":{"assertions":[],"request":{"destinationService":"backend","port":443,"maxTtl":30,"host":"example.com","tracerouteQueries":1,"e2eQueries":3,"sourceService":"frontend","timeout":5,"tcpMethod":"SYN"}},"netstats":{"packetsSent":0,"packetsReceived":0,"packetLossPercentage":0,"jitter":null,"latency":null,"hops":{"avg":0,"min":0,"max":0}},"netpath":{"timestamp":1756901488592,"agent_version":"","namespace":"","test_config_id":"puf-9fm-c89","test_result_id":"4907739274636687553","test_run_id":"test-run-id-111-example.com","origin":"synthetics","test_run_type":"scheduled","source_product":"synthetics","collector_type":"agent","protocol":"TCP","source":{"name":"test-hostname","display_name":"test-hostname","hostname":"test-hostname"},"destination":{"hostname":"example.com","port":443},"traceroute":{"runs":[{"run_id":"1","source":{"ip_address":"","port":0},"destination":{"ip_address":"","port":0},"hops":[{"ttl":0,"ip_address":"1.1.1.1","reachable":false},{"ttl":0,"ip_address":"1.1.1.2","reachable":false}]}],"hop_count":{"avg":0,"min":0,"max":0}},"e2e_probe":{"rtts":null,"packets_sent":0,"packets_received":0,"packet_loss_percentage":0,"jitter":0,"rtt":{"avg":0,"min":0,"max":0}}},"status":"passed","runType":"scheduled"},"test":{"id":"puf-9fm-c89","subType":"tcp","type":"network","version":1},"v":1}`,
+			expectedEventJSON: `{"location":{"id":"agent:test-hostname"},"_dd":{},"result":{"id":"4907739274636687553","initialId":"4907739274636687553","testFinishedAt":1756901488591,"testStartedAt":1756901488590,"testTriggeredAt":1756901488589,"assertions":[],"failure":null,"duration":1,"config":{"assertions":[],"request":{"destinationService":"backend","port":443,"maxTtl":30,"host":"example.com","tracerouteQueries":1,"e2eQueries":3,"sourceService":"frontend","timeout":5,"tcpMethod":"SYN"}},"netstats":{"packetsSent":0,"packetsReceived":0,"packetLossPercentage":0,"jitter":null,"latency":null,"hops":{"avg":0,"min":0,"max":0}},"netpath":{"timestamp":1756901488591,"agent_version":"","namespace":"","test_config_id":"puf-9fm-c89","test_result_id":"4907739274636687553","test_run_id":"test-run-id-111-example.com","origin":"synthetics","test_run_type":"triggered","source_product":"synthetics","collector_type":"agent","protocol":"TCP","source":{"name":"test-hostname","display_name":"test-hostname","hostname":"test-hostname"},"destination":{"hostname":"example.com","port":443},"traceroute":{"runs":[{"run_id":"1","source":{"ip_address":"","port":0},"destination":{"ip_address":"","port":0},"hops":[{"ttl":0,"ip_address":"1.1.1.1","reachable":false},{"ttl":0,"ip_address":"1.1.1.2","reachable":false}]}],"hop_count":{"avg":0,"min":0,"max":0}},"e2e_probe":{"rtts":null,"packets_sent":0,"packets_received":0,"packet_loss_percentage":0,"jitter":0,"rtt":{"avg":0,"min":0,"max":0}}},"status":"passed","runType":"ci"},"test":{"id":"puf-9fm-c89","subType":"tcp","type":"network","version":1},"v":1}`,
 			expectedRunTraceroute: func(_ context.Context, cfg config.Config) (payload.NetworkPath, error) {
 				return payload.NetworkPath{
 					TestRunID:   "test-run-id-111-" + cfg.DestHostname,
@@ -122,6 +122,7 @@ func Test_SyntheticsTestScheduler_Processing(t *testing.T) {
 			},
 		},
 	}
+
 	configs := &schedulerConfigs{
 		workers:                    6,
 		flushInterval:              100 * time.Millisecond,

--- a/comp/syntheticstestscheduler/impl/worker.go
+++ b/comp/syntheticstestscheduler/impl/worker.go
@@ -409,7 +409,10 @@ func (s *syntheticsTestScheduler) networkPathToTestResult(w *workerResult) (*com
 	w.tracerouteResult.TestConfigID = w.testCfg.cfg.PublicID
 	w.tracerouteResult.TestResultID = testResultID
 	w.tracerouteResult.Origin = payload.PathOriginSynthetics
-	w.tracerouteResult.TestRunType = payload.TestRunTypeScheduled
+	w.tracerouteResult.TestRunType = payload.TestRunType(w.testCfg.cfg.RunType)
+	if w.testCfg.cfg.RunType == common.RunTypeCI {
+		w.tracerouteResult.TestRunType = payload.TestRunTypeTriggered
+	}
 	w.tracerouteResult.SourceProduct = payload.SourceProductSynthetics
 	w.tracerouteResult.CollectorType = payload.CollectorTypeAgent
 	w.tracerouteResult.Timestamp = w.finishedAt.UnixMilli()

--- a/comp/syntheticstestscheduler/impl/worker_test.go
+++ b/comp/syntheticstestscheduler/impl/worker_test.go
@@ -575,7 +575,7 @@ func TestNetworkPathToTestResult_UsesRequestResultIDAndMapsCIRunType(t *testing.
 		{name: "scheduled", runType: common.RunTypeScheduled, expected: payload.TestRunTypeScheduled},
 		{name: "triggered", runType: common.RunTypeTriggered, expected: payload.TestRunTypeTriggered},
 		{name: "fast", runType: common.RunTypeFast, expected: payload.TestRunType(common.RunTypeFast)},
-		{name: "CI", runType: common.RunTypeCI, expected: payload.TestRunTypeTriggered},
+		{name: "ci", runType: common.RunTypeCI, expected: payload.TestRunTypeTriggered},
 	}
 
 	for _, tt := range testCases {

--- a/comp/syntheticstestscheduler/impl/worker_test.go
+++ b/comp/syntheticstestscheduler/impl/worker_test.go
@@ -480,6 +480,10 @@ func TestNetworkPathToTestResult(t *testing.T) {
 		},
 	}
 
+	for i := range tests {
+		tests[i].worker.testCfg.cfg.RunType = string(payload.TestRunTypeScheduled)
+	}
+
 	sched := &syntheticsTestScheduler{
 		generateTestResultID: func(func(rand io.Reader, max *big.Int) (n *big.Int, err error)) (string, error) {
 			return "test-result-id-123", nil
@@ -525,7 +529,7 @@ func TestNetworkPathToTestResult(t *testing.T) {
 	}
 }
 
-func TestNetworkPathToTestResult_UsesBackendResultID(t *testing.T) {
+func TestNetworkPathToTestResult_UsesRequestResultIDAndMapsCIRunType(t *testing.T) {
 	src := "frontend"
 	dst := "backend"
 	icmpTTL := 5
@@ -540,8 +544,9 @@ func TestNetworkPathToTestResult_UsesBackendResultID(t *testing.T) {
 	worker := workerResult{
 		testCfg: SyntheticsTestCtx{
 			cfg: common.SyntheticsTestConfig{
-				PublicID: "pub-on-demand",
+				PublicID: "pub-triggered",
 				ResultID: "backend-result-id",
+				RunType:  string(payload.TestRunTypeTriggered),
 				Type:     "network",
 				Config: struct {
 					Assertions []common.Assertion   `json:"assertions"`
@@ -562,9 +567,27 @@ func TestNetworkPathToTestResult_UsesBackendResultID(t *testing.T) {
 		hostname: "agent-host",
 	}
 
-	got, err := sched.networkPathToTestResult(&worker)
-	require.NoError(t, err)
-	require.Equal(t, "backend-result-id", got.Result.ID)
+	testCases := []struct {
+		name     string
+		runType  string
+		expected payload.TestRunType
+	}{
+		{name: "scheduled", runType: common.RunTypeScheduled, expected: payload.TestRunTypeScheduled},
+		{name: "triggered", runType: common.RunTypeTriggered, expected: payload.TestRunTypeTriggered},
+		{name: "fast", runType: common.RunTypeFast, expected: payload.TestRunType(common.RunTypeFast)},
+		{name: "CI", runType: common.RunTypeCI, expected: payload.TestRunTypeTriggered},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			worker.testCfg.cfg.RunType = tt.runType
+
+			got, err := sched.networkPathToTestResult(&worker)
+			require.NoError(t, err)
+			require.Equal(t, "backend-result-id", got.Result.ID)
+			require.Equal(t, tt.expected, got.Result.Netpath.TestRunType)
+		})
+	}
 }
 
 func TestNetworkPathToTestResult_Namespace(t *testing.T) {


### PR DESCRIPTION
## Summary
- preserve the Synthetics request `run_type` in the Network Path payload
- map `ci` to the Network Path `triggered` value
- cover `scheduled`, `fast`, `triggered`, and `ci` requests

The [dd-source run-type definitions](https://github.com/ddoghq/dd-source/blob/d9d20e14e14d95c27da5bd5972072f6f8e3028b2/domains/synthetics/shared/libs/go/model/check.go#L24-L29) list these request values. The [Agent-location serializer](https://github.com/DataDog/dd-source/blob/main/domains/synthetics/shared/libs/propagation/internal/on-demand/model/agent.go#L114) writes the value to the Agent request.

## Testing
- `bazel --batch test //comp/syntheticstestscheduler/impl:impl_test`

[Jira: SYNTH-28969](https://datadoghq.atlassian.net/browse/SYNTH-28969)