### PR TITLE
[CWS-6885] Expose the IMDS AWS access key ID as a SECL field

### DIFF
--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -310,6 +310,9 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
 | [`process.argv0`](#common-process-argv0-doc) | First argument of the process |
 | [`process.auid`](#common-credentials-auid-doc) | Login UID of the process |
+| [`process.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
+| [`process.aws_security_credentials.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`process.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | the security credentials type |
 | [`process.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
 | [`process.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
 | [`process.caps_attempted`](#common-process-caps_attempted-doc) | Bitmask of the capabilities that the process attempted to use |
@@ -806,6 +809,9 @@ A process was executed (does not trigger on fork syscalls).
 | [`exec.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
 | [`exec.argv0`](#common-process-argv0-doc) | First argument of the process |
 | [`exec.auid`](#common-credentials-auid-doc) | Login UID of the process |
+| [`exec.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
+| [`exec.aws_security_credentials.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`exec.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | the security credentials type |
 | [`exec.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
 | [`exec.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
 | [`exec.caps_attempted`](#common-process-caps_attempted-doc) | Bitmask of the capabilities that the process attempted to use |
@@ -934,6 +940,9 @@ A process was terminated
 | [`exit.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
 | [`exit.argv0`](#common-process-argv0-doc) | First argument of the process |
 | [`exit.auid`](#common-credentials-auid-doc) | Login UID of the process |
+| [`exit.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
+| [`exit.aws_security_credentials.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`exit.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | the security credentials type |
 | [`exit.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
 | [`exit.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
 | [`exit.caps_attempted`](#common-process-caps_attempted-doc) | Bitmask of the capabilities that the process attempted to use |
@@ -1049,8 +1058,8 @@ An IMDS event was captured
 | Property | Definition |
 | -------- | ------------- |
 | [`imds.aws.is_imds_v2`](#imds-aws-is_imds_v2-doc) | a boolean which specifies if the IMDS event follows IMDSv1 or IMDSv2 conventions |
-| [`imds.aws.security_credentials.access_key_id`](#imds-aws-security_credentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
-| [`imds.aws.security_credentials.type`](#imds-aws-security_credentials-type-doc) | the security credentials type |
+| [`imds.aws.security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
+| [`imds.aws.security_credentials.type`](#common-awssecuritycredentials-type-doc) | the security credentials type |
 | [`imds.cloud_provider`](#imds-cloud_provider-doc) | the intended cloud provider of the IMDS event |
 | [`imds.host`](#imds-host-doc) | the host of the HTTP protocol |
 | [`imds.server`](#imds-server-doc) | the server header of a response |
@@ -1516,6 +1525,9 @@ A ptrace command was executed
 | [`ptrace.tracee.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
 | [`ptrace.tracee.argv0`](#common-process-argv0-doc) | First argument of the process |
 | [`ptrace.tracee.auid`](#common-credentials-auid-doc) | Login UID of the process |
+| [`ptrace.tracee.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
+| [`ptrace.tracee.aws_security_credentials.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`ptrace.tracee.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | the security credentials type |
 | [`ptrace.tracee.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
 | [`ptrace.tracee.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
 | [`ptrace.tracee.caps_attempted`](#common-process-caps_attempted-doc) | Bitmask of the capabilities that the process attempted to use |
@@ -2025,6 +2037,9 @@ A setrlimit command was executed
 | [`setrlimit.target.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
 | [`setrlimit.target.argv0`](#common-process-argv0-doc) | First argument of the process |
 | [`setrlimit.target.auid`](#common-credentials-auid-doc) | Login UID of the process |
+| [`setrlimit.target.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
+| [`setrlimit.target.aws_security_credentials.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`setrlimit.target.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | the security credentials type |
 | [`setrlimit.target.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
 | [`setrlimit.target.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
 | [`setrlimit.target.caps_attempted`](#common-process-caps_attempted-doc) | Bitmask of the capabilities that the process attempted to use |
@@ -2439,6 +2454,9 @@ A signal was sent
 | [`signal.target.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
 | [`signal.target.argv0`](#common-process-argv0-doc) | First argument of the process |
 | [`signal.target.auid`](#common-credentials-auid-doc) | Login UID of the process |
+| [`signal.target.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
+| [`signal.target.aws_security_credentials.length`](#common-string-length-doc) | Length of the corresponding element |
+| [`signal.target.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | the security credentials type |
 | [`signal.target.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
 | [`signal.target.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
 | [`signal.target.caps_attempted`](#common-process-caps_attempted-doc) | Bitmask of the capabilities that the process attempted to use |
@@ -2807,6 +2825,15 @@ Change file access/modification times
 
 
 ## Attributes documentation
+
+
+### `*.access_key_id` {#common-awssecuritycredentials-access_key_id-doc}
+Type: string
+
+Definition: the access key ID of the security credentials in the IMDS answer
+
+`*.access_key_id` has 7 possible prefixes:
+`exec.aws_security_credentials` `exit.aws_security_credentials` `imds.aws.security_credentials` `process.aws_security_credentials` `ptrace.tracee.aws_security_credentials` `setrlimit.target.aws_security_credentials` `signal.target.aws_security_credentials`
 
 
 ### `*.args` {#common-process-args-doc}
@@ -3371,8 +3398,8 @@ Type: int
 
 Definition: Length of the corresponding element
 
-`*.length` has 100 possible prefixes:
-`accept.addr.hostname` `cgroup_write.file.name` `cgroup_write.file.path` `chdir.file.name` `chdir.file.path` `chmod.file.name` `chmod.file.path` `chown.file.name` `chown.file.path` `connect.addr.hostname` `dns.question.name` `exec.file.name` `exec.file.path` `exec.interpreter.file.name` `exec.interpreter.file.path` `exit.file.name` `exit.file.path` `exit.interpreter.file.name` `exit.interpreter.file.path` `link.file.destination.name` `link.file.destination.path` `link.file.name` `link.file.path` `load_module.file.name` `load_module.file.path` `mkdir.file.name` `mkdir.file.path` `mmap.file.name` `mmap.file.path` `network_flow_monitor.flows` `open.file.name` `open.file.path` `process.ancestors` `process.ancestors.file.name` `process.ancestors.file.path` `process.ancestors.interpreter.file.name` `process.ancestors.interpreter.file.path` `process.file.name` `process.file.path` `process.interpreter.file.name` `process.interpreter.file.path` `process.parent.file.name` `process.parent.file.path` `process.parent.interpreter.file.name` `process.parent.interpreter.file.path` `ptrace.tracee.ancestors` `ptrace.tracee.ancestors.file.name` `ptrace.tracee.ancestors.file.path` `ptrace.tracee.ancestors.interpreter.file.name` `ptrace.tracee.ancestors.interpreter.file.path` `ptrace.tracee.file.name` `ptrace.tracee.file.path` `ptrace.tracee.interpreter.file.name` `ptrace.tracee.interpreter.file.path` `ptrace.tracee.parent.file.name` `ptrace.tracee.parent.file.path` `ptrace.tracee.parent.interpreter.file.name` `ptrace.tracee.parent.interpreter.file.path` `removexattr.file.name` `removexattr.file.path` `rename.file.destination.name` `rename.file.destination.path` `rename.file.name` `rename.file.path` `rmdir.file.name` `rmdir.file.path` `setrlimit.target.ancestors` `setrlimit.target.ancestors.file.name` `setrlimit.target.ancestors.file.path` `setrlimit.target.ancestors.interpreter.file.name` `setrlimit.target.ancestors.interpreter.file.path` `setrlimit.target.file.name` `setrlimit.target.file.path` `setrlimit.target.interpreter.file.name` `setrlimit.target.interpreter.file.path` `setrlimit.target.parent.file.name` `setrlimit.target.parent.file.path` `setrlimit.target.parent.interpreter.file.name` `setrlimit.target.parent.interpreter.file.path` `setxattr.file.name` `setxattr.file.path` `signal.target.ancestors` `signal.target.ancestors.file.name` `signal.target.ancestors.file.path` `signal.target.ancestors.interpreter.file.name` `signal.target.ancestors.interpreter.file.path` `signal.target.file.name` `signal.target.file.path` `signal.target.interpreter.file.name` `signal.target.interpreter.file.path` `signal.target.parent.file.name` `signal.target.parent.file.path` `signal.target.parent.interpreter.file.name` `signal.target.parent.interpreter.file.path` `splice.file.name` `splice.file.path` `unlink.file.name` `unlink.file.path` `utimes.file.name` `utimes.file.path`
+`*.length` has 106 possible prefixes:
+`accept.addr.hostname` `cgroup_write.file.name` `cgroup_write.file.path` `chdir.file.name` `chdir.file.path` `chmod.file.name` `chmod.file.path` `chown.file.name` `chown.file.path` `connect.addr.hostname` `dns.question.name` `exec.aws_security_credentials` `exec.file.name` `exec.file.path` `exec.interpreter.file.name` `exec.interpreter.file.path` `exit.aws_security_credentials` `exit.file.name` `exit.file.path` `exit.interpreter.file.name` `exit.interpreter.file.path` `link.file.destination.name` `link.file.destination.path` `link.file.name` `link.file.path` `load_module.file.name` `load_module.file.path` `mkdir.file.name` `mkdir.file.path` `mmap.file.name` `mmap.file.path` `network_flow_monitor.flows` `open.file.name` `open.file.path` `process.ancestors` `process.ancestors.file.name` `process.ancestors.file.path` `process.ancestors.interpreter.file.name` `process.ancestors.interpreter.file.path` `process.aws_security_credentials` `process.file.name` `process.file.path` `process.interpreter.file.name` `process.interpreter.file.path` `process.parent.file.name` `process.parent.file.path` `process.parent.interpreter.file.name` `process.parent.interpreter.file.path` `ptrace.tracee.ancestors` `ptrace.tracee.ancestors.file.name` `ptrace.tracee.ancestors.file.path` `ptrace.tracee.ancestors.interpreter.file.name` `ptrace.tracee.ancestors.interpreter.file.path` `ptrace.tracee.aws_security_credentials` `ptrace.tracee.file.name` `ptrace.tracee.file.path` `ptrace.tracee.interpreter.file.name` `ptrace.tracee.interpreter.file.path` `ptrace.tracee.parent.file.name` `ptrace.tracee.parent.file.path` `ptrace.tracee.parent.interpreter.file.name` `ptrace.tracee.parent.interpreter.file.path` `removexattr.file.name` `removexattr.file.path` `rename.file.destination.name` `rename.file.destination.path` `rename.file.name` `rename.file.path` `rmdir.file.name` `rmdir.file.path` `setrlimit.target.ancestors` `setrlimit.target.ancestors.file.name` `setrlimit.target.ancestors.file.path` `setrlimit.target.ancestors.interpreter.file.name` `setrlimit.target.ancestors.interpreter.file.path` `setrlimit.target.aws_security_credentials` `setrlimit.target.file.name` `setrlimit.target.file.path` `setrlimit.target.interpreter.file.name` `setrlimit.target.interpreter.file.path` `setrlimit.target.parent.file.name` `setrlimit.target.parent.file.path` `setrlimit.target.parent.interpreter.file.name` `setrlimit.target.parent.interpreter.file.path` `setxattr.file.name` `setxattr.file.path` `signal.target.ancestors` `signal.target.ancestors.file.name` `signal.target.ancestors.file.path` `signal.target.ancestors.interpreter.file.name` `signal.target.ancestors.interpreter.file.path` `signal.target.aws_security_credentials` `signal.target.file.name` `signal.target.file.path` `signal.target.interpreter.file.name` `signal.target.interpreter.file.path` `signal.target.parent.file.name` `signal.target.parent.file.path` `signal.target.parent.interpreter.file.name` `signal.target.parent.interpreter.file.path` `splice.file.name` `splice.file.path` `unlink.file.name` `unlink.file.path` `utimes.file.name` `utimes.file.path`
 
 
 ### `*.mntns` {#common-pidcontext-mntns-doc}
@@ -3738,6 +3765,15 @@ Definition: Name of the TTY associated with the process
 
 `*.tty_name` has 14 possible prefixes:
 `exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `setrlimit.target` `setrlimit.target.ancestors` `setrlimit.target.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.type` {#common-awssecuritycredentials-type-doc}
+Type: string
+
+Definition: the security credentials type
+
+`*.type` has 7 possible prefixes:
+`exec.aws_security_credentials` `exit.aws_security_credentials` `imds.aws.security_credentials` `process.aws_security_credentials` `ptrace.tracee.aws_security_credentials` `setrlimit.target.aws_security_credentials` `signal.target.aws_security_credentials`
 
 
 ### `*.type` {#common-networkcontext-type-doc}
@@ -4291,20 +4327,6 @@ Definition: Exit code of the process or number of the signal that caused the pro
 Type: bool
 
 Definition: a boolean which specifies if the IMDS event follows IMDSv1 or IMDSv2 conventions
-
-
-
-### `imds.aws.security_credentials.access_key_id` {#imds-aws-security_credentials-access_key_id-doc}
-Type: string
-
-Definition: the access key ID of the security credentials in the IMDS answer
-
-
-
-### `imds.aws.security_credentials.type` {#imds-aws-security_credentials-type-doc}
-Type: string
-
-Definition: the security credentials type
 
 
 

--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -1049,6 +1049,7 @@ An IMDS event was captured
 | Property | Definition |
 | -------- | ------------- |
 | [`imds.aws.is_imds_v2`](#imds-aws-is_imds_v2-doc) | a boolean which specifies if the IMDS event follows IMDSv1 or IMDSv2 conventions |
+| [`imds.aws.security_credentials.access_key_id`](#imds-aws-security_credentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
 | [`imds.aws.security_credentials.type`](#imds-aws-security_credentials-type-doc) | the security credentials type |
 | [`imds.cloud_provider`](#imds-cloud_provider-doc) | the intended cloud provider of the IMDS event |
 | [`imds.host`](#imds-host-doc) | the host of the HTTP protocol |
@@ -4290,6 +4291,13 @@ Definition: Exit code of the process or number of the signal that caused the pro
 Type: bool
 
 Definition: a boolean which specifies if the IMDS event follows IMDSv1 or IMDSv2 conventions
+
+
+
+### `imds.aws.security_credentials.access_key_id` {#imds-aws-security_credentials-access_key_id-doc}
+Type: string
+
+Definition: the access key ID of the security credentials in the IMDS answer
 
 
 

--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -310,9 +310,9 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
 | [`process.argv0`](#common-process-argv0-doc) | First argument of the process |
 | [`process.auid`](#common-credentials-auid-doc) | Login UID of the process |
-| [`process.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
+| [`process.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | The access key ID of the security credentials in the IMDS answer |
 | [`process.aws_security_credentials.length`](#common-string-length-doc) | Length of the corresponding element |
-| [`process.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | the security credentials type |
+| [`process.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | The security credentials type |
 | [`process.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
 | [`process.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
 | [`process.caps_attempted`](#common-process-caps_attempted-doc) | Bitmask of the capabilities that the process attempted to use |
@@ -809,9 +809,9 @@ A process was executed (does not trigger on fork syscalls).
 | [`exec.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
 | [`exec.argv0`](#common-process-argv0-doc) | First argument of the process |
 | [`exec.auid`](#common-credentials-auid-doc) | Login UID of the process |
-| [`exec.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
+| [`exec.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | The access key ID of the security credentials in the IMDS answer |
 | [`exec.aws_security_credentials.length`](#common-string-length-doc) | Length of the corresponding element |
-| [`exec.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | the security credentials type |
+| [`exec.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | The security credentials type |
 | [`exec.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
 | [`exec.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
 | [`exec.caps_attempted`](#common-process-caps_attempted-doc) | Bitmask of the capabilities that the process attempted to use |
@@ -940,9 +940,9 @@ A process was terminated
 | [`exit.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
 | [`exit.argv0`](#common-process-argv0-doc) | First argument of the process |
 | [`exit.auid`](#common-credentials-auid-doc) | Login UID of the process |
-| [`exit.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
+| [`exit.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | The access key ID of the security credentials in the IMDS answer |
 | [`exit.aws_security_credentials.length`](#common-string-length-doc) | Length of the corresponding element |
-| [`exit.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | the security credentials type |
+| [`exit.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | The security credentials type |
 | [`exit.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
 | [`exit.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
 | [`exit.caps_attempted`](#common-process-caps_attempted-doc) | Bitmask of the capabilities that the process attempted to use |
@@ -1058,8 +1058,8 @@ An IMDS event was captured
 | Property | Definition |
 | -------- | ------------- |
 | [`imds.aws.is_imds_v2`](#imds-aws-is_imds_v2-doc) | a boolean which specifies if the IMDS event follows IMDSv1 or IMDSv2 conventions |
-| [`imds.aws.security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
-| [`imds.aws.security_credentials.type`](#common-awssecuritycredentials-type-doc) | the security credentials type |
+| [`imds.aws.security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | The access key ID of the security credentials in the IMDS answer |
+| [`imds.aws.security_credentials.type`](#common-awssecuritycredentials-type-doc) | The security credentials type |
 | [`imds.cloud_provider`](#imds-cloud_provider-doc) | the intended cloud provider of the IMDS event |
 | [`imds.host`](#imds-host-doc) | the host of the HTTP protocol |
 | [`imds.server`](#imds-server-doc) | the server header of a response |
@@ -1525,9 +1525,9 @@ A ptrace command was executed
 | [`ptrace.tracee.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
 | [`ptrace.tracee.argv0`](#common-process-argv0-doc) | First argument of the process |
 | [`ptrace.tracee.auid`](#common-credentials-auid-doc) | Login UID of the process |
-| [`ptrace.tracee.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
+| [`ptrace.tracee.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | The access key ID of the security credentials in the IMDS answer |
 | [`ptrace.tracee.aws_security_credentials.length`](#common-string-length-doc) | Length of the corresponding element |
-| [`ptrace.tracee.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | the security credentials type |
+| [`ptrace.tracee.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | The security credentials type |
 | [`ptrace.tracee.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
 | [`ptrace.tracee.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
 | [`ptrace.tracee.caps_attempted`](#common-process-caps_attempted-doc) | Bitmask of the capabilities that the process attempted to use |
@@ -2037,9 +2037,9 @@ A setrlimit command was executed
 | [`setrlimit.target.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
 | [`setrlimit.target.argv0`](#common-process-argv0-doc) | First argument of the process |
 | [`setrlimit.target.auid`](#common-credentials-auid-doc) | Login UID of the process |
-| [`setrlimit.target.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
+| [`setrlimit.target.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | The access key ID of the security credentials in the IMDS answer |
 | [`setrlimit.target.aws_security_credentials.length`](#common-string-length-doc) | Length of the corresponding element |
-| [`setrlimit.target.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | the security credentials type |
+| [`setrlimit.target.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | The security credentials type |
 | [`setrlimit.target.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
 | [`setrlimit.target.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
 | [`setrlimit.target.caps_attempted`](#common-process-caps_attempted-doc) | Bitmask of the capabilities that the process attempted to use |
@@ -2454,9 +2454,9 @@ A signal was sent
 | [`signal.target.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
 | [`signal.target.argv0`](#common-process-argv0-doc) | First argument of the process |
 | [`signal.target.auid`](#common-credentials-auid-doc) | Login UID of the process |
-| [`signal.target.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | the access key ID of the security credentials in the IMDS answer |
+| [`signal.target.aws_security_credentials.access_key_id`](#common-awssecuritycredentials-access_key_id-doc) | The access key ID of the security credentials in the IMDS answer |
 | [`signal.target.aws_security_credentials.length`](#common-string-length-doc) | Length of the corresponding element |
-| [`signal.target.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | the security credentials type |
+| [`signal.target.aws_security_credentials.type`](#common-awssecuritycredentials-type-doc) | The security credentials type |
 | [`signal.target.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
 | [`signal.target.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
 | [`signal.target.caps_attempted`](#common-process-caps_attempted-doc) | Bitmask of the capabilities that the process attempted to use |
@@ -2830,7 +2830,7 @@ Change file access/modification times
 ### `*.access_key_id` {#common-awssecuritycredentials-access_key_id-doc}
 Type: string
 
-Definition: the access key ID of the security credentials in the IMDS answer
+Definition: The access key ID of the security credentials in the IMDS answer
 
 `*.access_key_id` has 7 possible prefixes:
 `exec.aws_security_credentials` `exit.aws_security_credentials` `imds.aws.security_credentials` `process.aws_security_credentials` `ptrace.tracee.aws_security_credentials` `setrlimit.target.aws_security_credentials` `signal.target.aws_security_credentials`
@@ -3770,7 +3770,7 @@ Definition: Name of the TTY associated with the process
 ### `*.type` {#common-awssecuritycredentials-type-doc}
 Type: string
 
-Definition: the security credentials type
+Definition: The security credentials type
 
 `*.type` has 7 possible prefixes:
 `exec.aws_security_credentials` `exit.aws_security_credentials` `imds.aws.security_credentials` `process.aws_security_credentials` `ptrace.tracee.aws_security_credentials` `setrlimit.target.aws_security_credentials` `signal.target.aws_security_credentials`

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -3964,6 +3964,11 @@
           "property_doc_link": "imds-aws-is_imds_v2-doc"
         },
         {
+          "name": "imds.aws.security_credentials.access_key_id",
+          "definition": "the access key ID of the security credentials in the IMDS answer",
+          "property_doc_link": "imds-aws-security_credentials-access_key_id-doc"
+        },
+        {
           "name": "imds.aws.security_credentials.type",
           "definition": "the security credentials type",
           "property_doc_link": "imds-aws-security_credentials-type-doc"
@@ -16029,6 +16034,18 @@
       "definition": "a boolean which specifies if the IMDS event follows IMDSv1 or IMDSv2 conventions",
       "prefixes": [
         "imds.aws"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "imds.aws.security_credentials.access_key_id",
+      "link": "imds-aws-security_credentials-access_key_id-doc",
+      "type": "string",
+      "definition": "the access key ID of the security credentials in the IMDS answer",
+      "prefixes": [
+        "imds.aws.security_credentials"
       ],
       "constants": "",
       "constants_link": "",

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -654,7 +654,7 @@
         },
         {
           "name": "process.aws_security_credentials.access_key_id",
-          "definition": "the access key ID of the security credentials in the IMDS answer",
+          "definition": "The access key ID of the security credentials in the IMDS answer",
           "property_doc_link": "common-awssecuritycredentials-access_key_id-doc"
         },
         {
@@ -664,7 +664,7 @@
         },
         {
           "name": "process.aws_security_credentials.type",
-          "definition": "the security credentials type",
+          "definition": "The security credentials type",
           "property_doc_link": "common-awssecuritycredentials-type-doc"
         },
         {
@@ -2817,7 +2817,7 @@
         },
         {
           "name": "exec.aws_security_credentials.access_key_id",
-          "definition": "the access key ID of the security credentials in the IMDS answer",
+          "definition": "The access key ID of the security credentials in the IMDS answer",
           "property_doc_link": "common-awssecuritycredentials-access_key_id-doc"
         },
         {
@@ -2827,7 +2827,7 @@
         },
         {
           "name": "exec.aws_security_credentials.type",
-          "definition": "the security credentials type",
+          "definition": "The security credentials type",
           "property_doc_link": "common-awssecuritycredentials-type-doc"
         },
         {
@@ -3446,7 +3446,7 @@
         },
         {
           "name": "exit.aws_security_credentials.access_key_id",
-          "definition": "the access key ID of the security credentials in the IMDS answer",
+          "definition": "The access key ID of the security credentials in the IMDS answer",
           "property_doc_link": "common-awssecuritycredentials-access_key_id-doc"
         },
         {
@@ -3456,7 +3456,7 @@
         },
         {
           "name": "exit.aws_security_credentials.type",
-          "definition": "the security credentials type",
+          "definition": "The security credentials type",
           "property_doc_link": "common-awssecuritycredentials-type-doc"
         },
         {
@@ -4010,12 +4010,12 @@
         },
         {
           "name": "imds.aws.security_credentials.access_key_id",
-          "definition": "the access key ID of the security credentials in the IMDS answer",
+          "definition": "The access key ID of the security credentials in the IMDS answer",
           "property_doc_link": "common-awssecuritycredentials-access_key_id-doc"
         },
         {
           "name": "imds.aws.security_credentials.type",
-          "definition": "the security credentials type",
+          "definition": "The security credentials type",
           "property_doc_link": "common-awssecuritycredentials-type-doc"
         },
         {
@@ -6049,7 +6049,7 @@
         },
         {
           "name": "ptrace.tracee.aws_security_credentials.access_key_id",
-          "definition": "the access key ID of the security credentials in the IMDS answer",
+          "definition": "The access key ID of the security credentials in the IMDS answer",
           "property_doc_link": "common-awssecuritycredentials-access_key_id-doc"
         },
         {
@@ -6059,7 +6059,7 @@
         },
         {
           "name": "ptrace.tracee.aws_security_credentials.type",
-          "definition": "the security credentials type",
+          "definition": "The security credentials type",
           "property_doc_link": "common-awssecuritycredentials-type-doc"
         },
         {
@@ -8453,7 +8453,7 @@
         },
         {
           "name": "setrlimit.target.aws_security_credentials.access_key_id",
-          "definition": "the access key ID of the security credentials in the IMDS answer",
+          "definition": "The access key ID of the security credentials in the IMDS answer",
           "property_doc_link": "common-awssecuritycredentials-access_key_id-doc"
         },
         {
@@ -8463,7 +8463,7 @@
         },
         {
           "name": "setrlimit.target.aws_security_credentials.type",
-          "definition": "the security credentials type",
+          "definition": "The security credentials type",
           "property_doc_link": "common-awssecuritycredentials-type-doc"
         },
         {
@@ -10434,7 +10434,7 @@
         },
         {
           "name": "signal.target.aws_security_credentials.access_key_id",
-          "definition": "the access key ID of the security credentials in the IMDS answer",
+          "definition": "The access key ID of the security credentials in the IMDS answer",
           "property_doc_link": "common-awssecuritycredentials-access_key_id-doc"
         },
         {
@@ -10444,7 +10444,7 @@
         },
         {
           "name": "signal.target.aws_security_credentials.type",
-          "definition": "the security credentials type",
+          "definition": "The security credentials type",
           "property_doc_link": "common-awssecuritycredentials-type-doc"
         },
         {
@@ -12124,7 +12124,7 @@
       "name": "*.access_key_id",
       "link": "common-awssecuritycredentials-access_key_id-doc",
       "type": "string",
-      "definition": "the access key ID of the security credentials in the IMDS answer",
+      "definition": "The access key ID of the security credentials in the IMDS answer",
       "prefixes": [
         "exec.aws_security_credentials",
         "exit.aws_security_credentials",
@@ -15206,7 +15206,7 @@
       "name": "*.type",
       "link": "common-awssecuritycredentials-type-doc",
       "type": "string",
-      "definition": "the security credentials type",
+      "definition": "The security credentials type",
       "prefixes": [
         "exec.aws_security_credentials",
         "exit.aws_security_credentials",

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -653,6 +653,21 @@
           "property_doc_link": "common-credentials-auid-doc"
         },
         {
+          "name": "process.aws_security_credentials.access_key_id",
+          "definition": "the access key ID of the security credentials in the IMDS answer",
+          "property_doc_link": "common-awssecuritycredentials-access_key_id-doc"
+        },
+        {
+          "name": "process.aws_security_credentials.length",
+          "definition": "Length of the corresponding element",
+          "property_doc_link": "common-string-length-doc"
+        },
+        {
+          "name": "process.aws_security_credentials.type",
+          "definition": "the security credentials type",
+          "property_doc_link": "common-awssecuritycredentials-type-doc"
+        },
+        {
           "name": "process.cap_effective",
           "definition": "Effective capability set of the process",
           "property_doc_link": "common-credentials-cap_effective-doc"
@@ -2801,6 +2816,21 @@
           "property_doc_link": "common-credentials-auid-doc"
         },
         {
+          "name": "exec.aws_security_credentials.access_key_id",
+          "definition": "the access key ID of the security credentials in the IMDS answer",
+          "property_doc_link": "common-awssecuritycredentials-access_key_id-doc"
+        },
+        {
+          "name": "exec.aws_security_credentials.length",
+          "definition": "Length of the corresponding element",
+          "property_doc_link": "common-string-length-doc"
+        },
+        {
+          "name": "exec.aws_security_credentials.type",
+          "definition": "the security credentials type",
+          "property_doc_link": "common-awssecuritycredentials-type-doc"
+        },
+        {
           "name": "exec.cap_effective",
           "definition": "Effective capability set of the process",
           "property_doc_link": "common-credentials-cap_effective-doc"
@@ -3415,6 +3445,21 @@
           "property_doc_link": "common-credentials-auid-doc"
         },
         {
+          "name": "exit.aws_security_credentials.access_key_id",
+          "definition": "the access key ID of the security credentials in the IMDS answer",
+          "property_doc_link": "common-awssecuritycredentials-access_key_id-doc"
+        },
+        {
+          "name": "exit.aws_security_credentials.length",
+          "definition": "Length of the corresponding element",
+          "property_doc_link": "common-string-length-doc"
+        },
+        {
+          "name": "exit.aws_security_credentials.type",
+          "definition": "the security credentials type",
+          "property_doc_link": "common-awssecuritycredentials-type-doc"
+        },
+        {
           "name": "exit.cap_effective",
           "definition": "Effective capability set of the process",
           "property_doc_link": "common-credentials-cap_effective-doc"
@@ -3966,12 +4011,12 @@
         {
           "name": "imds.aws.security_credentials.access_key_id",
           "definition": "the access key ID of the security credentials in the IMDS answer",
-          "property_doc_link": "imds-aws-security_credentials-access_key_id-doc"
+          "property_doc_link": "common-awssecuritycredentials-access_key_id-doc"
         },
         {
           "name": "imds.aws.security_credentials.type",
           "definition": "the security credentials type",
-          "property_doc_link": "imds-aws-security_credentials-type-doc"
+          "property_doc_link": "common-awssecuritycredentials-type-doc"
         },
         {
           "name": "imds.cloud_provider",
@@ -6001,6 +6046,21 @@
           "name": "ptrace.tracee.auid",
           "definition": "Login UID of the process",
           "property_doc_link": "common-credentials-auid-doc"
+        },
+        {
+          "name": "ptrace.tracee.aws_security_credentials.access_key_id",
+          "definition": "the access key ID of the security credentials in the IMDS answer",
+          "property_doc_link": "common-awssecuritycredentials-access_key_id-doc"
+        },
+        {
+          "name": "ptrace.tracee.aws_security_credentials.length",
+          "definition": "Length of the corresponding element",
+          "property_doc_link": "common-string-length-doc"
+        },
+        {
+          "name": "ptrace.tracee.aws_security_credentials.type",
+          "definition": "the security credentials type",
+          "property_doc_link": "common-awssecuritycredentials-type-doc"
         },
         {
           "name": "ptrace.tracee.cap_effective",
@@ -8392,6 +8452,21 @@
           "property_doc_link": "common-credentials-auid-doc"
         },
         {
+          "name": "setrlimit.target.aws_security_credentials.access_key_id",
+          "definition": "the access key ID of the security credentials in the IMDS answer",
+          "property_doc_link": "common-awssecuritycredentials-access_key_id-doc"
+        },
+        {
+          "name": "setrlimit.target.aws_security_credentials.length",
+          "definition": "Length of the corresponding element",
+          "property_doc_link": "common-string-length-doc"
+        },
+        {
+          "name": "setrlimit.target.aws_security_credentials.type",
+          "definition": "the security credentials type",
+          "property_doc_link": "common-awssecuritycredentials-type-doc"
+        },
+        {
           "name": "setrlimit.target.cap_effective",
           "definition": "Effective capability set of the process",
           "property_doc_link": "common-credentials-cap_effective-doc"
@@ -10358,6 +10433,21 @@
           "property_doc_link": "common-credentials-auid-doc"
         },
         {
+          "name": "signal.target.aws_security_credentials.access_key_id",
+          "definition": "the access key ID of the security credentials in the IMDS answer",
+          "property_doc_link": "common-awssecuritycredentials-access_key_id-doc"
+        },
+        {
+          "name": "signal.target.aws_security_credentials.length",
+          "definition": "Length of the corresponding element",
+          "property_doc_link": "common-string-length-doc"
+        },
+        {
+          "name": "signal.target.aws_security_credentials.type",
+          "definition": "the security credentials type",
+          "property_doc_link": "common-awssecuritycredentials-type-doc"
+        },
+        {
           "name": "signal.target.cap_effective",
           "definition": "Effective capability set of the process",
           "property_doc_link": "common-credentials-cap_effective-doc"
@@ -12031,6 +12121,24 @@
   ],
   "properties_doc": [
     {
+      "name": "*.access_key_id",
+      "link": "common-awssecuritycredentials-access_key_id-doc",
+      "type": "string",
+      "definition": "the access key ID of the security credentials in the IMDS answer",
+      "prefixes": [
+        "exec.aws_security_credentials",
+        "exit.aws_security_credentials",
+        "imds.aws.security_credentials",
+        "process.aws_security_credentials",
+        "ptrace.tracee.aws_security_credentials",
+        "setrlimit.target.aws_security_credentials",
+        "signal.target.aws_security_credentials"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
       "name": "*.args",
       "link": "common-process-args-doc",
       "type": "string",
@@ -13635,10 +13743,12 @@
         "chown.file.path",
         "connect.addr.hostname",
         "dns.question.name",
+        "exec.aws_security_credentials",
         "exec.file.name",
         "exec.file.path",
         "exec.interpreter.file.name",
         "exec.interpreter.file.path",
+        "exit.aws_security_credentials",
         "exit.file.name",
         "exit.file.path",
         "exit.interpreter.file.name",
@@ -13661,6 +13771,7 @@
         "process.ancestors.file.path",
         "process.ancestors.interpreter.file.name",
         "process.ancestors.interpreter.file.path",
+        "process.aws_security_credentials",
         "process.file.name",
         "process.file.path",
         "process.interpreter.file.name",
@@ -13674,6 +13785,7 @@
         "ptrace.tracee.ancestors.file.path",
         "ptrace.tracee.ancestors.interpreter.file.name",
         "ptrace.tracee.ancestors.interpreter.file.path",
+        "ptrace.tracee.aws_security_credentials",
         "ptrace.tracee.file.name",
         "ptrace.tracee.file.path",
         "ptrace.tracee.interpreter.file.name",
@@ -13695,6 +13807,7 @@
         "setrlimit.target.ancestors.file.path",
         "setrlimit.target.ancestors.interpreter.file.name",
         "setrlimit.target.ancestors.interpreter.file.path",
+        "setrlimit.target.aws_security_credentials",
         "setrlimit.target.file.name",
         "setrlimit.target.file.path",
         "setrlimit.target.interpreter.file.name",
@@ -13710,6 +13823,7 @@
         "signal.target.ancestors.file.path",
         "signal.target.ancestors.interpreter.file.name",
         "signal.target.ancestors.interpreter.file.path",
+        "signal.target.aws_security_credentials",
         "signal.target.file.name",
         "signal.target.file.path",
         "signal.target.interpreter.file.name",
@@ -15090,6 +15204,24 @@
     },
     {
       "name": "*.type",
+      "link": "common-awssecuritycredentials-type-doc",
+      "type": "string",
+      "definition": "the security credentials type",
+      "prefixes": [
+        "exec.aws_security_credentials",
+        "exit.aws_security_credentials",
+        "imds.aws.security_credentials",
+        "process.aws_security_credentials",
+        "ptrace.tracee.aws_security_credentials",
+        "setrlimit.target.aws_security_credentials",
+        "signal.target.aws_security_credentials"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.type",
       "link": "common-networkcontext-type-doc",
       "type": "int",
       "definition": "Type of the network packet",
@@ -16034,30 +16166,6 @@
       "definition": "a boolean which specifies if the IMDS event follows IMDSv1 or IMDSv2 conventions",
       "prefixes": [
         "imds.aws"
-      ],
-      "constants": "",
-      "constants_link": "",
-      "examples": []
-    },
-    {
-      "name": "imds.aws.security_credentials.access_key_id",
-      "link": "imds-aws-security_credentials-access_key_id-doc",
-      "type": "string",
-      "definition": "the access key ID of the security credentials in the IMDS answer",
-      "prefixes": [
-        "imds.aws.security_credentials"
-      ],
-      "constants": "",
-      "constants_link": "",
-      "examples": []
-    },
-    {
-      "name": "imds.aws.security_credentials.type",
-      "link": "imds-aws-security_credentials-type-doc",
-      "type": "string",
-      "definition": "the security credentials type",
-      "prefixes": [
-        "imds.aws.security_credentials"
       ],
       "constants": "",
       "constants_link": "",

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -2214,6 +2214,73 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "exec.aws_security_credentials.access_key_id":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &AWSSecurityCredentialsIterator{Root: ev.Exec.Process.AWSSecurityCredentials}
+				if regID != "" {
+					value := iterator.At(ctx, regID, ctx.Registers[regID])
+					if value == nil {
+						return nil
+					}
+					element := *value
+					result := element.AccessKeyID
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Exec.Process.AWSSecurityCredentials", ctx, nil, func(ev *Event, current *AWSSecurityCredentials) string {
+					return current.AccessKeyID
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "exec.aws_security_credentials.length":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				iterator := &AWSSecurityCredentialsIterator{}
+				return iterator.Len(ctx)
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "exec.aws_security_credentials.type":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &AWSSecurityCredentialsIterator{Root: ev.Exec.Process.AWSSecurityCredentials}
+				if regID != "" {
+					value := iterator.At(ctx, regID, ctx.Registers[regID])
+					if value == nil {
+						return nil
+					}
+					element := *value
+					result := element.Type
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Exec.Process.AWSSecurityCredentials", ctx, nil, func(ev *Event, current *AWSSecurityCredentials) string {
+					return current.Type
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "exec.cap_effective":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3703,6 +3770,73 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "exit.aws_security_credentials.access_key_id":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &AWSSecurityCredentialsIterator{Root: ev.Exit.Process.AWSSecurityCredentials}
+				if regID != "" {
+					value := iterator.At(ctx, regID, ctx.Registers[regID])
+					if value == nil {
+						return nil
+					}
+					element := *value
+					result := element.AccessKeyID
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Exit.Process.AWSSecurityCredentials", ctx, nil, func(ev *Event, current *AWSSecurityCredentials) string {
+					return current.AccessKeyID
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "exit.aws_security_credentials.length":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				iterator := &AWSSecurityCredentialsIterator{}
+				return iterator.Len(ctx)
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "exit.aws_security_credentials.type":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &AWSSecurityCredentialsIterator{Root: ev.Exit.Process.AWSSecurityCredentials}
+				if regID != "" {
+					value := iterator.At(ctx, regID, ctx.Registers[regID])
+					if value == nil {
+						return nil
+					}
+					element := *value
+					result := element.Type
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Exit.Process.AWSSecurityCredentials", ctx, nil, func(ev *Event, current *AWSSecurityCredentials) string {
+					return current.Type
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
 	case "exit.cap_effective":
@@ -11637,6 +11771,73 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "process.aws_security_credentials.access_key_id":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &AWSSecurityCredentialsIterator{Root: ev.BaseEvent.ProcessContext.Process.AWSSecurityCredentials}
+				if regID != "" {
+					value := iterator.At(ctx, regID, ctx.Registers[regID])
+					if value == nil {
+						return nil
+					}
+					element := *value
+					result := element.AccessKeyID
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Process.AWSSecurityCredentials", ctx, nil, func(ev *Event, current *AWSSecurityCredentials) string {
+					return current.AccessKeyID
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.aws_security_credentials.length":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				iterator := &AWSSecurityCredentialsIterator{}
+				return iterator.Len(ctx)
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.aws_security_credentials.type":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &AWSSecurityCredentialsIterator{Root: ev.BaseEvent.ProcessContext.Process.AWSSecurityCredentials}
+				if regID != "" {
+					value := iterator.At(ctx, regID, ctx.Registers[regID])
+					if value == nil {
+						return nil
+					}
+					element := *value
+					result := element.Type
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Process.AWSSecurityCredentials", ctx, nil, func(ev *Event, current *AWSSecurityCredentials) string {
+					return current.Type
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "process.cap_effective":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -18110,6 +18311,73 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.aws_security_credentials.access_key_id":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &AWSSecurityCredentialsIterator{Root: ev.PTrace.Tracee.Process.AWSSecurityCredentials}
+				if regID != "" {
+					value := iterator.At(ctx, regID, ctx.Registers[regID])
+					if value == nil {
+						return nil
+					}
+					element := *value
+					result := element.AccessKeyID
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Process.AWSSecurityCredentials", ctx, nil, func(ev *Event, current *AWSSecurityCredentials) string {
+					return current.AccessKeyID
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.aws_security_credentials.length":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				iterator := &AWSSecurityCredentialsIterator{}
+				return iterator.Len(ctx)
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.aws_security_credentials.type":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &AWSSecurityCredentialsIterator{Root: ev.PTrace.Tracee.Process.AWSSecurityCredentials}
+				if regID != "" {
+					value := iterator.At(ctx, regID, ctx.Registers[regID])
+					if value == nil {
+						return nil
+					}
+					element := *value
+					result := element.Type
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Process.AWSSecurityCredentials", ctx, nil, func(ev *Event, current *AWSSecurityCredentials) string {
+					return current.Type
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
 	case "ptrace.tracee.cap_effective":
@@ -26015,6 +26283,73 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.aws_security_credentials.access_key_id":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &AWSSecurityCredentialsIterator{Root: ev.Setrlimit.Target.Process.AWSSecurityCredentials}
+				if regID != "" {
+					value := iterator.At(ctx, regID, ctx.Registers[regID])
+					if value == nil {
+						return nil
+					}
+					element := *value
+					result := element.AccessKeyID
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Process.AWSSecurityCredentials", ctx, nil, func(ev *Event, current *AWSSecurityCredentials) string {
+					return current.AccessKeyID
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.aws_security_credentials.length":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				iterator := &AWSSecurityCredentialsIterator{}
+				return iterator.Len(ctx)
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.aws_security_credentials.type":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &AWSSecurityCredentialsIterator{Root: ev.Setrlimit.Target.Process.AWSSecurityCredentials}
+				if regID != "" {
+					value := iterator.At(ctx, regID, ctx.Registers[regID])
+					if value == nil {
+						return nil
+					}
+					element := *value
+					result := element.Type
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Process.AWSSecurityCredentials", ctx, nil, func(ev *Event, current *AWSSecurityCredentials) string {
+					return current.Type
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.cap_effective":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -33012,6 +33347,73 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.aws_security_credentials.access_key_id":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &AWSSecurityCredentialsIterator{Root: ev.Signal.Target.Process.AWSSecurityCredentials}
+				if regID != "" {
+					value := iterator.At(ctx, regID, ctx.Registers[regID])
+					if value == nil {
+						return nil
+					}
+					element := *value
+					result := element.AccessKeyID
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Process.AWSSecurityCredentials", ctx, nil, func(ev *Event, current *AWSSecurityCredentials) string {
+					return current.AccessKeyID
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.aws_security_credentials.length":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				iterator := &AWSSecurityCredentialsIterator{}
+				return iterator.Len(ctx)
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.aws_security_credentials.type":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &AWSSecurityCredentialsIterator{Root: ev.Signal.Target.Process.AWSSecurityCredentials}
+				if regID != "" {
+					value := iterator.At(ctx, regID, ctx.Registers[regID])
+					if value == nil {
+						return nil
+					}
+					element := *value
+					result := element.Type
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Process.AWSSecurityCredentials", ctx, nil, func(ev *Event, current *AWSSecurityCredentials) string {
+					return current.Type
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.cap_effective":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -37416,6 +37818,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"exec.argv",
 		"exec.argv0",
 		"exec.auid",
+		"exec.aws_security_credentials.access_key_id",
+		"exec.aws_security_credentials.length",
+		"exec.aws_security_credentials.type",
 		"exec.cap_effective",
 		"exec.cap_permitted",
 		"exec.caps_attempted",
@@ -37537,6 +37942,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"exit.argv",
 		"exit.argv0",
 		"exit.auid",
+		"exit.aws_security_credentials.access_key_id",
+		"exit.aws_security_credentials.length",
+		"exit.aws_security_credentials.type",
 		"exit.cap_effective",
 		"exit.cap_permitted",
 		"exit.caps_attempted",
@@ -38031,6 +38439,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.argv",
 		"process.argv0",
 		"process.auid",
+		"process.aws_security_credentials.access_key_id",
+		"process.aws_security_credentials.length",
+		"process.aws_security_credentials.type",
 		"process.cap_effective",
 		"process.cap_permitted",
 		"process.caps_attempted",
@@ -38370,6 +38781,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.argv",
 		"ptrace.tracee.argv0",
 		"ptrace.tracee.auid",
+		"ptrace.tracee.aws_security_credentials.access_key_id",
+		"ptrace.tracee.aws_security_credentials.length",
+		"ptrace.tracee.aws_security_credentials.type",
 		"ptrace.tracee.cap_effective",
 		"ptrace.tracee.cap_permitted",
 		"ptrace.tracee.caps_attempted",
@@ -38837,6 +39251,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.argv",
 		"setrlimit.target.argv0",
 		"setrlimit.target.auid",
+		"setrlimit.target.aws_security_credentials.access_key_id",
+		"setrlimit.target.aws_security_credentials.length",
+		"setrlimit.target.aws_security_credentials.type",
 		"setrlimit.target.cap_effective",
 		"setrlimit.target.cap_permitted",
 		"setrlimit.target.caps_attempted",
@@ -39223,6 +39640,9 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.argv",
 		"signal.target.argv0",
 		"signal.target.auid",
+		"signal.target.aws_security_credentials.access_key_id",
+		"signal.target.aws_security_credentials.length",
+		"signal.target.aws_security_credentials.type",
 		"signal.target.cap_effective",
 		"signal.target.cap_permitted",
 		"signal.target.caps_attempted",
@@ -39937,6 +40357,12 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exec", reflect.String, "string", false, nil
 	case "exec.auid":
 		return "exec", reflect.Int, "int", false, nil
+	case "exec.aws_security_credentials.access_key_id":
+		return "exec", reflect.String, "string", false, nil
+	case "exec.aws_security_credentials.length":
+		return "exec", reflect.Int, "int", false, nil
+	case "exec.aws_security_credentials.type":
+		return "exec", reflect.String, "string", false, nil
 	case "exec.cap_effective":
 		return "exec", reflect.Int, "int", false, nil
 	case "exec.cap_permitted":
@@ -40179,6 +40605,12 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exit", reflect.String, "string", false, nil
 	case "exit.auid":
 		return "exit", reflect.Int, "int", false, nil
+	case "exit.aws_security_credentials.access_key_id":
+		return "exit", reflect.String, "string", false, nil
+	case "exit.aws_security_credentials.length":
+		return "exit", reflect.Int, "int", false, nil
+	case "exit.aws_security_credentials.type":
+		return "exit", reflect.String, "string", false, nil
 	case "exit.cap_effective":
 		return "exit", reflect.Int, "int", false, nil
 	case "exit.cap_permitted":
@@ -41167,6 +41599,12 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.String, "string", false, nil
 	case "process.auid":
 		return "", reflect.Int, "int", false, nil
+	case "process.aws_security_credentials.access_key_id":
+		return "", reflect.String, "string", false, nil
+	case "process.aws_security_credentials.length":
+		return "", reflect.Int, "int", false, nil
+	case "process.aws_security_credentials.type":
+		return "", reflect.String, "string", false, nil
 	case "process.cap_effective":
 		return "", reflect.Int, "int", false, nil
 	case "process.cap_permitted":
@@ -41845,6 +42283,12 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.String, "string", false, nil
 	case "ptrace.tracee.auid":
 		return "ptrace", reflect.Int, "int", false, nil
+	case "ptrace.tracee.aws_security_credentials.access_key_id":
+		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.aws_security_credentials.length":
+		return "ptrace", reflect.Int, "int", false, nil
+	case "ptrace.tracee.aws_security_credentials.type":
+		return "ptrace", reflect.String, "string", false, nil
 	case "ptrace.tracee.cap_effective":
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.cap_permitted":
@@ -42779,6 +43223,12 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.String, "string", false, nil
 	case "setrlimit.target.auid":
 		return "setrlimit", reflect.Int, "int", false, nil
+	case "setrlimit.target.aws_security_credentials.access_key_id":
+		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.aws_security_credentials.length":
+		return "setrlimit", reflect.Int, "int", false, nil
+	case "setrlimit.target.aws_security_credentials.type":
+		return "setrlimit", reflect.String, "string", false, nil
 	case "setrlimit.target.cap_effective":
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.cap_permitted":
@@ -43551,6 +44001,12 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.String, "string", false, nil
 	case "signal.target.auid":
 		return "signal", reflect.Int, "int", false, nil
+	case "signal.target.aws_security_credentials.access_key_id":
+		return "signal", reflect.String, "string", false, nil
+	case "signal.target.aws_security_credentials.length":
+		return "signal", reflect.Int, "int", false, nil
+	case "signal.target.aws_security_credentials.type":
+		return "signal", reflect.String, "string", false, nil
 	case "signal.target.cap_effective":
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.cap_permitted":
@@ -44626,6 +45082,18 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("exec.argv0", &ev.Exec.Process.Argv0, value)
 	case "exec.auid":
 		return ev.setUint32FieldValue("exec.auid", &ev.Exec.Process.Credentials.AUID, value)
+	case "exec.aws_security_credentials.access_key_id":
+		if len(ev.Exec.Process.AWSSecurityCredentials) == 0 {
+			ev.Exec.Process.AWSSecurityCredentials = append(ev.Exec.Process.AWSSecurityCredentials, AWSSecurityCredentials{})
+		}
+		return ev.setStringFieldValue("exec.aws_security_credentials.access_key_id", &ev.Exec.Process.AWSSecurityCredentials[0].AccessKeyID, value)
+	case "exec.aws_security_credentials.length":
+		return &eval.ErrFieldReadOnly{Field: "exec.aws_security_credentials.length"}
+	case "exec.aws_security_credentials.type":
+		if len(ev.Exec.Process.AWSSecurityCredentials) == 0 {
+			ev.Exec.Process.AWSSecurityCredentials = append(ev.Exec.Process.AWSSecurityCredentials, AWSSecurityCredentials{})
+		}
+		return ev.setStringFieldValue("exec.aws_security_credentials.type", &ev.Exec.Process.AWSSecurityCredentials[0].Type, value)
 	case "exec.cap_effective":
 		return ev.setUint64FieldValue("exec.cap_effective", &ev.Exec.Process.Credentials.CapEffective, value)
 	case "exec.cap_permitted":
@@ -44983,6 +45451,18 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("exit.argv0", &ev.Exit.Process.Argv0, value)
 	case "exit.auid":
 		return ev.setUint32FieldValue("exit.auid", &ev.Exit.Process.Credentials.AUID, value)
+	case "exit.aws_security_credentials.access_key_id":
+		if len(ev.Exit.Process.AWSSecurityCredentials) == 0 {
+			ev.Exit.Process.AWSSecurityCredentials = append(ev.Exit.Process.AWSSecurityCredentials, AWSSecurityCredentials{})
+		}
+		return ev.setStringFieldValue("exit.aws_security_credentials.access_key_id", &ev.Exit.Process.AWSSecurityCredentials[0].AccessKeyID, value)
+	case "exit.aws_security_credentials.length":
+		return &eval.ErrFieldReadOnly{Field: "exit.aws_security_credentials.length"}
+	case "exit.aws_security_credentials.type":
+		if len(ev.Exit.Process.AWSSecurityCredentials) == 0 {
+			ev.Exit.Process.AWSSecurityCredentials = append(ev.Exit.Process.AWSSecurityCredentials, AWSSecurityCredentials{})
+		}
+		return ev.setStringFieldValue("exit.aws_security_credentials.type", &ev.Exit.Process.AWSSecurityCredentials[0].Type, value)
 	case "exit.cap_effective":
 		return ev.setUint64FieldValue("exit.cap_effective", &ev.Exit.Process.Credentials.CapEffective, value)
 	case "exit.cap_permitted":
@@ -46267,6 +46747,18 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("process.argv0", &ev.BaseEvent.ProcessContext.Process.Argv0, value)
 	case "process.auid":
 		return ev.setUint32FieldValue("process.auid", &ev.BaseEvent.ProcessContext.Process.Credentials.AUID, value)
+	case "process.aws_security_credentials.access_key_id":
+		if len(ev.BaseEvent.ProcessContext.Process.AWSSecurityCredentials) == 0 {
+			ev.BaseEvent.ProcessContext.Process.AWSSecurityCredentials = append(ev.BaseEvent.ProcessContext.Process.AWSSecurityCredentials, AWSSecurityCredentials{})
+		}
+		return ev.setStringFieldValue("process.aws_security_credentials.access_key_id", &ev.BaseEvent.ProcessContext.Process.AWSSecurityCredentials[0].AccessKeyID, value)
+	case "process.aws_security_credentials.length":
+		return &eval.ErrFieldReadOnly{Field: "process.aws_security_credentials.length"}
+	case "process.aws_security_credentials.type":
+		if len(ev.BaseEvent.ProcessContext.Process.AWSSecurityCredentials) == 0 {
+			ev.BaseEvent.ProcessContext.Process.AWSSecurityCredentials = append(ev.BaseEvent.ProcessContext.Process.AWSSecurityCredentials, AWSSecurityCredentials{})
+		}
+		return ev.setStringFieldValue("process.aws_security_credentials.type", &ev.BaseEvent.ProcessContext.Process.AWSSecurityCredentials[0].Type, value)
 	case "process.cap_effective":
 		return ev.setUint64FieldValue("process.cap_effective", &ev.BaseEvent.ProcessContext.Process.Credentials.CapEffective, value)
 	case "process.cap_permitted":
@@ -47290,6 +47782,18 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("ptrace.tracee.argv0", &ev.PTrace.Tracee.Process.Argv0, value)
 	case "ptrace.tracee.auid":
 		return ev.setUint32FieldValue("ptrace.tracee.auid", &ev.PTrace.Tracee.Process.Credentials.AUID, value)
+	case "ptrace.tracee.aws_security_credentials.access_key_id":
+		if len(ev.PTrace.Tracee.Process.AWSSecurityCredentials) == 0 {
+			ev.PTrace.Tracee.Process.AWSSecurityCredentials = append(ev.PTrace.Tracee.Process.AWSSecurityCredentials, AWSSecurityCredentials{})
+		}
+		return ev.setStringFieldValue("ptrace.tracee.aws_security_credentials.access_key_id", &ev.PTrace.Tracee.Process.AWSSecurityCredentials[0].AccessKeyID, value)
+	case "ptrace.tracee.aws_security_credentials.length":
+		return &eval.ErrFieldReadOnly{Field: "ptrace.tracee.aws_security_credentials.length"}
+	case "ptrace.tracee.aws_security_credentials.type":
+		if len(ev.PTrace.Tracee.Process.AWSSecurityCredentials) == 0 {
+			ev.PTrace.Tracee.Process.AWSSecurityCredentials = append(ev.PTrace.Tracee.Process.AWSSecurityCredentials, AWSSecurityCredentials{})
+		}
+		return ev.setStringFieldValue("ptrace.tracee.aws_security_credentials.type", &ev.PTrace.Tracee.Process.AWSSecurityCredentials[0].Type, value)
 	case "ptrace.tracee.cap_effective":
 		return ev.setUint64FieldValue("ptrace.tracee.cap_effective", &ev.PTrace.Tracee.Process.Credentials.CapEffective, value)
 	case "ptrace.tracee.cap_permitted":
@@ -49268,6 +49772,27 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
 		return ev.setUint32FieldValue("setrlimit.target.auid", &ev.Setrlimit.Target.Process.Credentials.AUID, value)
+	case "setrlimit.target.aws_security_credentials.access_key_id":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if len(ev.Setrlimit.Target.Process.AWSSecurityCredentials) == 0 {
+			ev.Setrlimit.Target.Process.AWSSecurityCredentials = append(ev.Setrlimit.Target.Process.AWSSecurityCredentials, AWSSecurityCredentials{})
+		}
+		return ev.setStringFieldValue("setrlimit.target.aws_security_credentials.access_key_id", &ev.Setrlimit.Target.Process.AWSSecurityCredentials[0].AccessKeyID, value)
+	case "setrlimit.target.aws_security_credentials.length":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return &eval.ErrFieldReadOnly{Field: "setrlimit.target.aws_security_credentials.length"}
+	case "setrlimit.target.aws_security_credentials.type":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if len(ev.Setrlimit.Target.Process.AWSSecurityCredentials) == 0 {
+			ev.Setrlimit.Target.Process.AWSSecurityCredentials = append(ev.Setrlimit.Target.Process.AWSSecurityCredentials, AWSSecurityCredentials{})
+		}
+		return ev.setStringFieldValue("setrlimit.target.aws_security_credentials.type", &ev.Setrlimit.Target.Process.AWSSecurityCredentials[0].Type, value)
 	case "setrlimit.target.cap_effective":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -52081,6 +52606,27 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target = &ProcessContext{}
 		}
 		return ev.setUint32FieldValue("signal.target.auid", &ev.Signal.Target.Process.Credentials.AUID, value)
+	case "signal.target.aws_security_credentials.access_key_id":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if len(ev.Signal.Target.Process.AWSSecurityCredentials) == 0 {
+			ev.Signal.Target.Process.AWSSecurityCredentials = append(ev.Signal.Target.Process.AWSSecurityCredentials, AWSSecurityCredentials{})
+		}
+		return ev.setStringFieldValue("signal.target.aws_security_credentials.access_key_id", &ev.Signal.Target.Process.AWSSecurityCredentials[0].AccessKeyID, value)
+	case "signal.target.aws_security_credentials.length":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return &eval.ErrFieldReadOnly{Field: "signal.target.aws_security_credentials.length"}
+	case "signal.target.aws_security_credentials.type":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if len(ev.Signal.Target.Process.AWSSecurityCredentials) == 0 {
+			ev.Signal.Target.Process.AWSSecurityCredentials = append(ev.Signal.Target.Process.AWSSecurityCredentials, AWSSecurityCredentials{})
+		}
+		return ev.setStringFieldValue("signal.target.aws_security_credentials.type", &ev.Signal.Target.Process.AWSSecurityCredentials[0].Type, value)
 	case "signal.target.cap_effective":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -5053,6 +5053,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "imds.aws.security_credentials.access_key_id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.IMDS.AWS.SecurityCredentials.AccessKeyID
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "imds.aws.security_credentials.type":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -37634,6 +37645,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"exit.user_session.ssh_public_key",
 		"exit.user_session.ssh_session_id",
 		"imds.aws.is_imds_v2",
+		"imds.aws.security_credentials.access_key_id",
 		"imds.aws.security_credentials.type",
 		"imds.cloud_provider",
 		"imds.host",
@@ -40383,6 +40395,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exit", reflect.Int, "int", false, nil
 	case "imds.aws.is_imds_v2":
 		return "imds", reflect.Bool, "bool", false, nil
+	case "imds.aws.security_credentials.access_key_id":
+		return "imds", reflect.String, "string", false, nil
 	case "imds.aws.security_credentials.type":
 		return "imds", reflect.String, "string", false, nil
 	case "imds.cloud_provider":
@@ -45300,6 +45314,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setUint64FieldValue("exit.user_session.ssh_session_id", &ev.Exit.Process.UserSession.SSHSessionContext.SSHSessionID, value)
 	case "imds.aws.is_imds_v2":
 		return ev.setBoolFieldValue("imds.aws.is_imds_v2", &ev.IMDS.AWS.IsIMDSv2, value)
+	case "imds.aws.security_credentials.access_key_id":
+		return ev.setStringFieldValue("imds.aws.security_credentials.access_key_id", &ev.IMDS.AWS.SecurityCredentials.AccessKeyID, value)
 	case "imds.aws.security_credentials.type":
 		return ev.setStringFieldValue("imds.aws.security_credentials.type", &ev.IMDS.AWS.SecurityCredentials.Type, value)
 	case "imds.cloud_provider":

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -745,8 +745,8 @@ type AWSIMDSEvent struct {
 // AWSSecurityCredentials is used to parse the fields that are none to be free of credentials or secrets
 type AWSSecurityCredentials struct {
 	Code        string    `field:"-" json:"Code"`
-	Type        string    `field:"type" json:"Type"` // SECLDoc[type] Definition:`the security credentials type`
-	AccessKeyID string    `field:"-" json:"AccessKeyId"`
+	Type        string    `field:"type" json:"Type"`                 // SECLDoc[type] Definition:`the security credentials type`
+	AccessKeyID string    `field:"access_key_id" json:"AccessKeyId"` // SECLDoc[access_key_id] Definition:`the access key ID of the security credentials in the IMDS answer`
 	LastUpdated string    `field:"-" json:"LastUpdated"`
 	Expiration  time.Time `field:"-"`
 

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -745,8 +745,8 @@ type AWSIMDSEvent struct {
 // AWSSecurityCredentials is used to parse the fields that are none to be free of credentials or secrets
 type AWSSecurityCredentials struct {
 	Code        string    `field:"-" json:"Code"`
-	Type        string    `field:"type" json:"Type"`                 // SECLDoc[type] Definition:`the security credentials type`
-	AccessKeyID string    `field:"access_key_id" json:"AccessKeyId"` // SECLDoc[access_key_id] Definition:`the access key ID of the security credentials in the IMDS answer`
+	Type        string    `field:"type" json:"Type"`                 // SECLDoc[type] Definition:`The security credentials type`
+	AccessKeyID string    `field:"access_key_id" json:"AccessKeyId"` // SECLDoc[access_key_id] Definition:`The access key ID of the security credentials in the IMDS answer`
 	LastUpdated string    `field:"-" json:"LastUpdated"`
 	Expiration  time.Time `field:"-"`
 

--- a/pkg/security/secl/model/model_test.go
+++ b/pkg/security/secl/model/model_test.go
@@ -242,3 +242,52 @@ func TestSetFieldValue(t *testing.T) {
 		}
 	}
 }
+
+func TestProcessAWSSecurityCredentials(t *testing.T) {
+	mod := &Model{}
+
+	evaluateStrings := func(t *testing.T, event *Event, field string) []string {
+		t.Helper()
+
+		evaluator, err := mod.GetEvaluator(field, "", 0)
+		if err != nil {
+			t.Fatalf("failed to get an evaluator for %s: %v", field, err)
+		}
+
+		arrayEvaluator, ok := evaluator.(*eval.StringArrayEvaluator)
+		if !ok {
+			t.Fatalf("%s should evaluate to a string array, got %T", field, evaluator)
+		}
+
+		values, ok := arrayEvaluator.Eval(eval.NewContext(event)).([]string)
+		if !ok {
+			t.Fatalf("%s should evaluate to a string array", field)
+		}
+		return values
+	}
+
+	t.Run("no-credentials", func(t *testing.T) {
+		event := NewFakeEvent()
+
+		if values := evaluateStrings(t, event, "process.aws_security_credentials.access_key_id"); len(values) != 0 {
+			t.Errorf("expected no access key ID, got %v", values)
+		}
+	})
+
+	t.Run("every-resolved-credential", func(t *testing.T) {
+		event := NewFakeEvent()
+		event.ProcessContext.Process.AWSSecurityCredentials = []AWSSecurityCredentials{
+			{Type: "AWS-HMAC", AccessKeyID: "ASIAIOSFODNN7EXAMPLE"},
+			{Type: "AWS-HMAC", AccessKeyID: "ASIAROTATEDKEY000000"},
+		}
+
+		values := evaluateStrings(t, event, "process.aws_security_credentials.access_key_id")
+		if !reflect.DeepEqual(values, []string{"ASIAIOSFODNN7EXAMPLE", "ASIAROTATEDKEY000000"}) {
+			t.Errorf("expected every access key ID the process resolved, got %v", values)
+		}
+
+		if values := evaluateStrings(t, event, "process.aws_security_credentials.type"); !reflect.DeepEqual(values, []string{"AWS-HMAC", "AWS-HMAC"}) {
+			t.Errorf("unexpected credentials types: %v", values)
+		}
+	})
+}

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -430,7 +430,7 @@ type Process struct {
 
 	UserSession UserSessionContext `field:"user_session"` // SECLDoc[user_session] Definition:`User Session context of this process`
 
-	AWSSecurityCredentials []AWSSecurityCredentials `field:"-"`
+	AWSSecurityCredentials []AWSSecurityCredentials `field:"aws_security_credentials,iterator:AWSSecurityCredentialsIterator,opts:exposed_at_event_root_only"` // AWS security credentials this process resolved from IMDS; only exposed at the root of a process context, the accessors generator keeps a single iterator per field so it cannot be nested under the ancestors one
 
 	Tracer Tracer `field:"-"`
 
@@ -1046,6 +1046,54 @@ type NetworkFlowMonitorEvent struct {
 	Device     NetworkDeviceContext `field:"device"` // network device on which the network flows were captured
 	FlowsCount uint64               `field:"-"`
 	Flows      []Flow               `field:"flows,iterator:FlowsIterator"` // list of captured flows
+}
+
+// AWSSecurityCredentialsIterator defines an iterator of the AWS security credentials of a process
+type AWSSecurityCredentialsIterator struct {
+	Root []AWSSecurityCredentials
+	prev int
+}
+
+// Front returns the first element
+func (it *AWSSecurityCredentialsIterator) Front(_ *eval.Context) *AWSSecurityCredentials {
+	if len(it.Root) == 0 {
+		return nil
+	}
+
+	it.prev = 0
+	return &it.Root[0]
+}
+
+// Next returns the next element
+func (it *AWSSecurityCredentialsIterator) Next(_ *eval.Context) *AWSSecurityCredentials {
+	if len(it.Root) > it.prev+1 {
+		it.prev++
+		return &it.Root[it.prev]
+	}
+	return nil
+}
+
+// At returns the element at the given position
+func (it *AWSSecurityCredentialsIterator) At(ctx *eval.Context, regID eval.RegisterID, pos int) *AWSSecurityCredentials {
+	if entry := ctx.RegisterCache[regID]; entry != nil && entry.Pos == pos {
+		return entry.Value.(*AWSSecurityCredentials)
+	}
+
+	if len(it.Root) > pos {
+		creds := &it.Root[pos]
+		ctx.RegisterCache[regID] = &eval.RegisterCacheEntry{
+			Pos:   pos,
+			Value: creds,
+		}
+		return creds
+	}
+
+	return nil
+}
+
+// Len returns the len
+func (it *AWSSecurityCredentialsIterator) Len(_ *eval.Context) int {
+	return len(it.Root)
 }
 
 // FlowsIterator defines an iterator of flows

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -745,8 +745,8 @@ type AWSIMDSEvent struct {
 // AWSSecurityCredentials is used to parse the fields that are none to be free of credentials or secrets
 type AWSSecurityCredentials struct {
 	Code        string    `field:"-" json:"Code"`
-	Type        string    `field:"type" json:"Type"` // SECLDoc[type] Definition:`the security credentials type`
-	AccessKeyID string    `field:"-" json:"AccessKeyId"`
+	Type        string    `field:"type" json:"Type"`                 // SECLDoc[type] Definition:`the security credentials type`
+	AccessKeyID string    `field:"access_key_id" json:"AccessKeyId"` // SECLDoc[access_key_id] Definition:`the access key ID of the security credentials in the IMDS answer`
 	LastUpdated string    `field:"-" json:"LastUpdated"`
 	Expiration  time.Time `field:"-"`
 

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -745,8 +745,8 @@ type AWSIMDSEvent struct {
 // AWSSecurityCredentials is used to parse the fields that are none to be free of credentials or secrets
 type AWSSecurityCredentials struct {
 	Code        string    `field:"-" json:"Code"`
-	Type        string    `field:"type" json:"Type"`                 // SECLDoc[type] Definition:`the security credentials type`
-	AccessKeyID string    `field:"access_key_id" json:"AccessKeyId"` // SECLDoc[access_key_id] Definition:`the access key ID of the security credentials in the IMDS answer`
+	Type        string    `field:"type" json:"Type"`                 // SECLDoc[type] Definition:`The security credentials type`
+	AccessKeyID string    `field:"access_key_id" json:"AccessKeyId"` // SECLDoc[access_key_id] Definition:`The access key ID of the security credentials in the IMDS answer`
 	LastUpdated string    `field:"-" json:"LastUpdated"`
 	Expiration  time.Time `field:"-"`
 

--- a/pkg/security/tests/imds_test.go
+++ b/pkg/security/tests/imds_test.go
@@ -272,7 +272,7 @@ func TestAWSIMDSv2Response(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_rule_aws_imds_v2_response",
-			Expression: fmt.Sprintf(`imds.aws.is_imds_v2 == true && imds.type == "response" && imds.aws.security_credentials.type == "%s" && process.file.name == "%s"`, testutils.AWSSecurityCredentialsTypeTestValue, path.Base(executable)),
+			Expression: fmt.Sprintf(`imds.aws.is_imds_v2 == true && imds.type == "response" && imds.aws.security_credentials.type == "%s" && imds.aws.security_credentials.access_key_id == "%s" && process.file.name == "%s"`, testutils.AWSSecurityCredentialsTypeTestValue, testutils.AWSSecurityCredentialsAccessKeyIDTestValue, path.Base(executable)),
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

Makes the AWS access key ID that a workload resolves from IMDS usable from an agent rule.

### Motivation

Being able to write a rule that matches on any IMDS version and request type, but only in the context of AWS IMDS, e.g. `imds.aws.security_credentials.access_key_id != ""`

### Describe how you validated your changes

Extended the existing IMDS response functional test so its rule matches on the new field, which exercises it through rule evaluation rather than only asserting on the parsed event.

### Additional Notes
