### PR TITLE
cluster-agent: add `--enable-bazel` flag

### DIFF
--- a/cmd/cluster-agent-cloudfoundry/BUILD.bazel
+++ b/cmd/cluster-agent-cloudfoundry/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_go//go:def.bzl", "go_library")
 load("//bazel/rules/go:go_binary.bzl", "dd_agent_go_binary")
-load("//tasks:build_tags.bzl", "CLUSTER_AGENT_TAGS")
+load("//tasks:build_tags.bzl", "CLUSTER_AGENT_CLOUDFOUNDRY_TAGS")
 
 go_library(
     name = "cluster-agent-cloudfoundry_lib",
@@ -105,7 +105,7 @@ go_library(
 dd_agent_go_binary(
     name = "cluster-agent-cloudfoundry",
     embed = [":cluster-agent-cloudfoundry_lib"],
-    gotags = CLUSTER_AGENT_TAGS,
+    gotags = CLUSTER_AGENT_CLOUDFOUNDRY_TAGS,
     target_compatible_with = ["@platforms//os:linux"],  # keep
     visibility = ["//visibility:public"],
 )

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -36,6 +36,7 @@ def build(
     skip_assets=False,
     policies_version=None,
     force_policies_clone=True,
+    enable_bazel=False,
 ):
     """
     Build Cluster Agent
@@ -43,6 +44,12 @@ def build(
      Example invokation:
         dda inv cluster-agent.build
     """
+    if enable_bazel:
+        if race:
+            raise NotImplementedError("--enable-bazel does not support --race.")
+        if build_include is not None or build_exclude is not None:
+            raise NotImplementedError("--enable-bazel does not support --build-include/--build-exclude.")
+
     build_common(
         ctx,
         BIN_PATH,
@@ -55,6 +62,7 @@ def build(
         development,
         skip_assets,
         cover=os.getenv("E2E_COVERAGE_PIPELINE") == "true",
+        enable_bazel=enable_bazel,
     )
 
     if policies_version is None:

--- a/tasks/cluster_agent_cloudfoundry.py
+++ b/tasks/cluster_agent_cloudfoundry.py
@@ -14,13 +14,28 @@ BIN_PATH = os.path.join(".", "bin", "datadog-cluster-agent-cloudfoundry")
 
 
 @task
-def build(ctx, rebuild=False, build_include=None, build_exclude=None, race=False, development=True, skip_assets=False):
+def build(
+    ctx,
+    rebuild=False,
+    build_include=None,
+    build_exclude=None,
+    race=False,
+    development=True,
+    skip_assets=False,
+    enable_bazel=False,
+):
     """
     Build Cluster Agent for Cloud Foundry
 
      Example invokation:
         dda inv cluster-agent-cloudfoundry.build
     """
+    if enable_bazel:
+        if race:
+            raise NotImplementedError("--enable-bazel does not support --race.")
+        if build_include is not None or build_exclude is not None:
+            raise NotImplementedError("--enable-bazel does not support --build-include/--build-exclude.")
+
     build_common(
         ctx,
         BIN_PATH,
@@ -34,6 +49,7 @@ def build(ctx, rebuild=False, build_include=None, build_exclude=None, race=False
         race,
         development,
         skip_assets,
+        enable_bazel=enable_bazel,
     )
 
 

--- a/tasks/cluster_agent_helpers.py
+++ b/tasks/cluster_agent_helpers.py
@@ -5,6 +5,7 @@ Common utilities for building Cluster Agent variants
 import os
 import shutil
 
+from tasks.libs.build.bazel import build_binary_with_bazel
 from tasks.libs.common.go import go_build
 from tasks.libs.common.utils import REPO_PATH, bin_name, get_build_flags, get_version
 from tasks.schema.generate import compress as schema_compress
@@ -31,30 +32,36 @@ def build_common(
     skip_assets,
     go_mod="readonly",
     cover=False,
+    enable_bazel=False,
 ):
     """
     Build Cluster Agent
     """
 
-    # We rely on the go libs embedded in the debian stretch image to build dynamically
-    ldflags, gcflags, env = get_build_flags(ctx, static=False)
-
     schema_compress(ctx)
 
-    go_build(
-        ctx,
-        f"{REPO_PATH}/cmd/cluster-agent{bin_suffix}",
-        mod=go_mod,
-        race=race,
-        rebuild=rebuild,
-        gcflags=gcflags,
-        ldflags=ldflags,
-        build_tags=build_tags,
-        bin_path=os.path.join(bin_path, bin_name(f"datadog-cluster-agent{bin_suffix}")),
-        env=env,
-        check_deadcode=os.getenv("DEPLOY_AGENT") == "true",
-        coverage=cover,
-    )
+    agent_bin = os.path.join(bin_path, bin_name(f"datadog-cluster-agent{bin_suffix}"))
+
+    if enable_bazel:
+        build_binary_with_bazel(f"//cmd/cluster-agent{bin_suffix}", bin_path=agent_bin)
+    else:
+        # We rely on the go libs embedded in the debian stretch image to build dynamically
+        ldflags, gcflags, env = get_build_flags(ctx, static=False)
+
+        go_build(
+            ctx,
+            f"{REPO_PATH}/cmd/cluster-agent{bin_suffix}",
+            mod=go_mod,
+            race=race,
+            rebuild=rebuild,
+            gcflags=gcflags,
+            ldflags=ldflags,
+            build_tags=build_tags,
+            bin_path=agent_bin,
+            env=env,
+            check_deadcode=os.getenv("DEPLOY_AGENT") == "true",
+            coverage=cover,
+        )
 
     # Render the configuration file template. The cluster-agent and the
     # cloudfoundry variant only ship on linux, so we always target linux


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Allow the cluster-agent to be built with bazel locally

### Motivation

Allow developers to try out the bazel build as we continue to work on migrating them to bazel

### Describe how you validated your changes

Local builds, this isn't wired in the CI yet

### Additional Notes
