### PR TITLE
trace/semantics: invalidate derived state on a local fingerprint, not content_hash

### DIFF
--- a/pkg/trace/config/peer_tags.go
+++ b/pkg/trace/config/peer_tags.go
@@ -33,14 +33,14 @@ var peerTagConcepts = []semantics.Concept{
 }
 
 // PeerTagsCache is a snapshot of the peer-tag attribute key set together with
-// the semantic registry content hash it was derived from. Callers that need
+// the semantic registry fingerprint it was derived from. Callers that need
 // to avoid recomputing on every read (e.g. the Concentrator's hot path)
-// should hold a *PeerTagsCache and compare its ContentHash against
-// semantics.DefaultRegistry().ContentHash() to decide when to rebuild via
+// should hold a *PeerTagsCache and compare its Fingerprint against
+// semantics.DefaultRegistry().Fingerprint() to decide when to rebuild via
 // AgentConfig.PeerTagsCache.
 type PeerTagsCache struct {
-	// ContentHash is the registry content hash that Keys was derived from.
-	ContentHash string
+	// Fingerprint is the registry identity that Keys was derived from.
+	Fingerprint string
 	// Keys is the sorted, deduped peer-tag attribute key set, or nil if
 	// PeerTagsAggregation is disabled on the AgentConfig.
 	Keys []string
@@ -48,11 +48,11 @@ type PeerTagsCache struct {
 
 // PeerTagsCache builds and returns a fresh PeerTagsCache snapshot from the
 // live semantic registry combined with the operator-configured PeerTags.
-// The returned ContentHash is the registry's ContentHash() at the time of the call.
+// The returned Fingerprint is the registry's Fingerprint() at the time of the call.
 // Returns a snapshot with nil Keys when PeerTagsAggregation is disabled.
 func (c *AgentConfig) PeerTagsCache() *PeerTagsCache {
 	r := semantics.DefaultRegistry()
-	cache := &PeerTagsCache{ContentHash: r.ContentHash()}
+	cache := &PeerTagsCache{Fingerprint: r.Fingerprint()}
 	if !c.PeerTagsAggregation {
 		return cache
 	}

--- a/pkg/trace/remoteconfighandler/remote_config_handler.go
+++ b/pkg/trace/remoteconfighandler/remote_config_handler.go
@@ -321,9 +321,12 @@ func (h *RemoteConfigHandler) onSemanticCoreUpdate(
 			pkglog.Errorf("semantic-core RC: failed to load embedded registry while reverting: %v", err)
 			return
 		}
-		if !semantics.RegistryEqual(embedded, semantics.DefaultRegistry()) {
+		live := semantics.DefaultRegistry()
+		if semantics.RegistryEqual(embedded, live) {
+			pkglog.Debug("semantic-core RC: embedded content already matches the live registry; nothing was swapped and the live registry source is unchanged")
+		} else {
 			semantics.UpdateRegistry(embedded)
-			pkglog.Infof("semantic-core RC: empty payload received; reverted to embedded registry content_hash=%s", embedded.ContentHash())
+			pkglog.Infof("semantic-core RC: empty payload received; reverted to embedded registry: content_hash=%s, version=%s, source=%s", embedded.ContentHash(), embedded.Version(), embedded.Source())
 		}
 		return
 	}
@@ -355,15 +358,15 @@ func (h *RemoteConfigHandler) onSemanticCoreUpdate(
 	}
 
 	if chosen != nil {
-		if semantics.RegistryEqual(chosen, semantics.DefaultRegistry()) {
-			// Same registry fingerprint as the one already live: skip the swap.
-			// Downstream consumers detect registry replacement themselves by
-			// comparing the live registry's fingerprint against their own cached
-			// state, so we don't need to notify them explicitly.
-			pkglog.Debugf("semantic-core RC payload %s matches the live registry mappings; no-op", chosenPath)
+		live := semantics.DefaultRegistry()
+		if semantics.RegistryEqual(chosen, live) {
+			pkglog.Debugf("semantic-core RC payload %s carries the same content as the live registry; it was accepted but not swapped, and the live registry source is unchanged", chosenPath)
 		} else {
+			// Downstream consumers invalidate derived state by comparing against
+			// the live registry's fingerprint rather than by being notified of a
+			// registry replacement.
 			semantics.UpdateRegistry(chosen)
-			pkglog.Infof("semantic-core registry updated via RC: content_hash=%s, cfgPath=%s", chosen.ContentHash(), chosenPath)
+			pkglog.Infof("semantic-core registry updated via RC: content_hash=%s, version=%s, source=%s, cfgPath=%s", chosen.ContentHash(), chosen.Version(), chosen.Source(), chosenPath)
 		}
 	}
 

--- a/pkg/trace/remoteconfighandler/remote_config_handler.go
+++ b/pkg/trace/remoteconfighandler/remote_config_handler.go
@@ -356,11 +356,11 @@ func (h *RemoteConfigHandler) onSemanticCoreUpdate(
 
 	if chosen != nil {
 		if semantics.RegistryEqual(chosen, semantics.DefaultRegistry()) {
-			// Same registry content_hash as the one already live: skip the swap.
+			// Same registry fingerprint as the one already live: skip the swap.
 			// Downstream consumers detect registry replacement themselves by
-			// comparing the live registry's content_hash against their own cached
+			// comparing the live registry's fingerprint against their own cached
 			// state, so we don't need to notify them explicitly.
-			pkglog.Debugf("semantic-core RC payload %s matches the live registry content_hash; no-op", chosenPath)
+			pkglog.Debugf("semantic-core RC payload %s matches the live registry mappings; no-op", chosenPath)
 		} else {
 			semantics.UpdateRegistry(chosen)
 			pkglog.Infof("semantic-core registry updated via RC: content_hash=%s, cfgPath=%s", chosen.ContentHash(), chosenPath)

--- a/pkg/trace/remoteconfighandler/remote_config_handler_test.go
+++ b/pkg/trace/remoteconfighandler/remote_config_handler_test.go
@@ -515,6 +515,31 @@ func captureStatuses() (map[string]state.ApplyStatus, func(string, state.ApplySt
 	return got, cb
 }
 
+func registryPayloadWithMappings(t *testing.T, r semantics.Registry, version, contentHash string) []byte {
+	t.Helper()
+	concepts := make(map[string]semantics.ConceptMapping)
+	for concept, fallbacks := range r.GetAllEquivalences() {
+		concepts[string(concept)] = semantics.ConceptMapping{
+			Canonical: string(concept),
+			Fallbacks: fallbacks,
+		}
+	}
+	payload, err := json.Marshal(map[string]any{
+		"version":  version,
+		"metadata": map[string]string{"content_hash": contentHash},
+		"concepts": concepts,
+	})
+	require.NoError(t, err)
+	return payload
+}
+
+type registryWithSource struct {
+	semantics.Registry
+	source string
+}
+
+func (r *registryWithSource) Source() string { return r.source }
+
 func TestOnSemanticCoreUpdate_ValidConfig(t *testing.T) {
 	restoreEmbeddedRegistry(t)
 	h := newSemanticTestHandler(t)
@@ -526,6 +551,44 @@ func TestOnSemanticCoreUpdate_ValidConfig(t *testing.T) {
 
 	assert.Equal(t, "test-1.0", semantics.DefaultRegistry().Version())
 	assert.Equal(t, state.ApplyStateAcknowledged, statuses["datadog/2/APM_SEMANTIC_CORE_DD/cfgA/config"].State)
+}
+
+func TestOnSemanticCoreUpdate_ByteIdenticalPayloadKeepsLiveRegistryAndSource(t *testing.T) {
+	restoreEmbeddedRegistry(t)
+	h := newSemanticTestHandler(t)
+
+	payload := []byte(semanticTestJSON)
+	live, err := semantics.NewRegistryFromJSON(payload)
+	require.NoError(t, err)
+	semantics.UpdateRegistry(live)
+	require.Equal(t, semantics.SourceRemoteConfig, live.Source())
+
+	statuses, cb := captureStatuses()
+	const cfgPath = "datadog/2/APM_SEMANTIC_CORE_DD/cfg/config"
+	h.onSemanticCoreUpdate(map[string]state.RawConfig{
+		cfgPath: {Config: payload},
+	}, cb)
+
+	assert.Equal(t, state.ApplyStateAcknowledged, statuses[cfgPath].State)
+	assert.Same(t, live, semantics.DefaultRegistry(), "a byte-identical refresh must not replace the live registry")
+	assert.Equal(t, semantics.SourceRemoteConfig, semantics.DefaultRegistry().Source(), "source is not part of registry identity")
+}
+
+func TestOnSemanticCoreUpdate_UntargetingIdenticalEmbeddedPayloadKeepsLiveRegistryAndSource(t *testing.T) {
+	restoreEmbeddedRegistry(t)
+	h := newSemanticTestHandler(t)
+
+	embedded, err := semantics.NewEmbeddedRegistry()
+	require.NoError(t, err)
+	live := &registryWithSource{Registry: embedded, source: semantics.SourceRemoteConfig}
+	semantics.UpdateRegistry(live)
+
+	called := 0
+	h.onSemanticCoreUpdate(map[string]state.RawConfig{}, func(string, state.ApplyStatus) { called++ })
+
+	assert.Same(t, live, semantics.DefaultRegistry(), "untargeting must not replace a registry built from the embedded payload bytes")
+	assert.Equal(t, semantics.SourceRemoteConfig, semantics.DefaultRegistry().Source(), "source is not part of registry identity")
+	assert.Equal(t, 0, called)
 }
 
 func TestOnSemanticCoreUpdate_MalformedJSON(t *testing.T) {
@@ -638,10 +701,10 @@ func TestOnSemanticCoreUpdate_SameHashChangedMappingsApplied(t *testing.T) {
 	assert.Equal(t, state.ApplyStateAcknowledged, statuses["datadog/2/APM_SEMANTIC_CORE_DD/cfg/config"].State)
 }
 
-// TestOnSemanticCoreUpdate_DifferentMetadataSameMappingsNoOp verifies the
+// TestOnSemanticCoreUpdate_DifferentMetadataSameMappingsPublished verifies the
 // converse of TestOnSemanticCoreUpdate_SameHashChangedMappingsApplied: changed
-// producer metadata cannot force a swap when the parsed mappings are identical.
-func TestOnSemanticCoreUpdate_DifferentMetadataSameMappingsNoOp(t *testing.T) {
+// producer metadata is published even when the parsed mappings are identical.
+func TestOnSemanticCoreUpdate_DifferentMetadataSameMappingsPublished(t *testing.T) {
 	restoreEmbeddedRegistry(t)
 	h := newSemanticTestHandler(t)
 
@@ -657,8 +720,61 @@ func TestOnSemanticCoreUpdate_DifferentMetadataSameMappingsNoOp(t *testing.T) {
 		cfgPath: {Config: []byte(differentMetadataSameMappings)},
 	}, cb)
 
-	assert.Same(t, liveRegistry, semantics.DefaultRegistry(), "identical parsed mappings must not replace the live registry")
+	live := semantics.DefaultRegistry()
+	assert.Equal(t, "sentinel-2.0", live.Version())
+	assert.Equal(t, "hash-new", live.ContentHash())
+	assert.Equal(t, semantics.SourceRemoteConfig, live.Source())
 	assert.Equal(t, state.ApplyStateAcknowledged, statuses[cfgPath].State)
+}
+
+// TestOnSemanticCoreUpdate_EmbeddedMappingsPublishedFromRemoteConfig protects
+// the embedded-to-remote-config provenance transition when mappings are equal.
+func TestOnSemanticCoreUpdate_EmbeddedMappingsPublishedFromRemoteConfig(t *testing.T) {
+	restoreEmbeddedRegistry(t)
+	h := newSemanticTestHandler(t)
+	embedded, err := semantics.NewEmbeddedRegistry()
+	require.NoError(t, err)
+	semantics.UpdateRegistry(embedded)
+
+	const cfgPath = "datadog/2/APM_SEMANTIC_CORE_DD/cfg/config"
+	statuses, cb := captureStatuses()
+	h.onSemanticCoreUpdate(map[string]state.RawConfig{
+		cfgPath: {Config: registryPayloadWithMappings(t, embedded, "remote-embedded", "remote-embedded-hash")},
+	}, cb)
+
+	live := semantics.DefaultRegistry()
+	assert.NotEqual(t, embedded.Fingerprint(), live.Fingerprint(), "the remote payload carries a different version and therefore different bytes")
+	assert.Equal(t, "remote-embedded", live.Version())
+	assert.Equal(t, "remote-embedded-hash", live.ContentHash())
+	assert.Equal(t, semantics.SourceRemoteConfig, live.Source())
+	assert.Equal(t, state.ApplyStateAcknowledged, statuses[cfgPath].State)
+}
+
+// TestOnSemanticCoreUpdate_EmbeddedMappingsRevertSourceAfterUntargeting protects
+// the remote-config-to-embedded provenance transition when mappings are equal.
+func TestOnSemanticCoreUpdate_EmbeddedMappingsRevertSourceAfterUntargeting(t *testing.T) {
+	restoreEmbeddedRegistry(t)
+	h := newSemanticTestHandler(t)
+	embedded, err := semantics.NewEmbeddedRegistry()
+	require.NoError(t, err)
+	semantics.UpdateRegistry(embedded)
+
+	const cfgPath = "datadog/2/APM_SEMANTIC_CORE_DD/cfg/config"
+	_, cb := captureStatuses()
+	h.onSemanticCoreUpdate(map[string]state.RawConfig{
+		cfgPath: {Config: registryPayloadWithMappings(t, embedded, "remote-embedded", "remote-embedded-hash")},
+	}, cb)
+	require.Equal(t, semantics.SourceRemoteConfig, semantics.DefaultRegistry().Source())
+
+	called := 0
+	h.onSemanticCoreUpdate(map[string]state.RawConfig{}, func(string, state.ApplyStatus) { called++ })
+
+	live := semantics.DefaultRegistry()
+	assert.True(t, semantics.RegistryEqual(embedded, live))
+	assert.Equal(t, semantics.SourceEmbedded, live.Source())
+	assert.Equal(t, embedded.Version(), live.Version())
+	assert.Equal(t, embedded.ContentHash(), live.ContentHash())
+	assert.Equal(t, 0, called)
 }
 
 // TestOnSemanticCoreUpdate_EmptyUpdatesWhileEmbedded verifies that an empty

--- a/pkg/trace/remoteconfighandler/remote_config_handler_test.go
+++ b/pkg/trace/remoteconfighandler/remote_config_handler_test.go
@@ -611,11 +611,9 @@ func TestOnSemanticCoreUpdate_AllErrors(t *testing.T) {
 	assert.Equal(t, state.ApplyStateError, statuses["datadog/2/APM_SEMANTIC_CORE_DD/b/config"].State)
 }
 
-// TestOnSemanticCoreUpdate_SameHashNoOp verifies that a second push with the
-// same metadata.content_hash as the live registry is detected as a no-op
-// (skips the UpdateRegistry call) but is still acknowledged, even when
-// Version() differs — content_hash is content-bound and version is not.
-func TestOnSemanticCoreUpdate_SameHashNoOp(t *testing.T) {
+// TestOnSemanticCoreUpdate_SameHashChangedMappingsApplied verifies that a
+// producer-declared hash cannot hide changed parsed mappings.
+func TestOnSemanticCoreUpdate_SameHashChangedMappingsApplied(t *testing.T) {
 	restoreEmbeddedRegistry(t)
 	h := newSemanticTestHandler(t)
 
@@ -627,24 +625,40 @@ func TestOnSemanticCoreUpdate_SameHashNoOp(t *testing.T) {
 	require.NoError(t, err)
 	semantics.UpdateRegistry(liveReg)
 
-	// Push a payload with a DIFFERENT version but the SAME content_hash. The
-	// handler must NOT swap the registry — the sentinel concept must still be
-	// reachable after the push, even though the concepts in this payload
-	// differ (the hash is trusted, not recomputed).
+	// Push a payload with different mappings but the same declared content hash.
 	const sameHashDifferentVersion = `{"version":"sentinel-1.1","metadata":{"content_hash":"hash-sentinel"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`
 	statuses, cb := captureStatuses()
 	h.onSemanticCoreUpdate(map[string]state.RawConfig{
 		"datadog/2/APM_SEMANTIC_CORE_DD/cfg/config": {Config: []byte(sameHashDifferentVersion)},
 	}, cb)
 
-	// Sentinel concept survived: the swap was skipped.
-	assert.NotNil(t, semantics.DefaultRegistry().GetAttributePrecedence(semantics.ConceptPeerService))
-	assert.Nil(t, semantics.DefaultRegistry().GetAttributePrecedence(semantics.ConceptDBStatement),
-		"db.statement must not be present — the second push was supposed to be a no-op")
-	assert.Equal(t, "sentinel-1.0", semantics.DefaultRegistry().Version())
-	// Even though we skipped the swap, the cfgPath is still acknowledged: the
-	// payload was valid, we just decided we didn't need to apply it.
+	assert.Nil(t, semantics.DefaultRegistry().GetAttributePrecedence(semantics.ConceptPeerService))
+	assert.NotNil(t, semantics.DefaultRegistry().GetAttributePrecedence(semantics.ConceptDBStatement))
+	assert.Equal(t, "sentinel-1.1", semantics.DefaultRegistry().Version())
 	assert.Equal(t, state.ApplyStateAcknowledged, statuses["datadog/2/APM_SEMANTIC_CORE_DD/cfg/config"].State)
+}
+
+// TestOnSemanticCoreUpdate_DifferentMetadataSameMappingsNoOp verifies the
+// converse of TestOnSemanticCoreUpdate_SameHashChangedMappingsApplied: changed
+// producer metadata cannot force a swap when the parsed mappings are identical.
+func TestOnSemanticCoreUpdate_DifferentMetadataSameMappingsNoOp(t *testing.T) {
+	restoreEmbeddedRegistry(t)
+	h := newSemanticTestHandler(t)
+
+	const liveJSON = `{"version":"sentinel-1.0","metadata":{"content_hash":"hash-old"},"concepts":{"peer.service":{"canonical":"peer.service","fallbacks":[{"name":"x.sentinel","provider":"datadog","type":"string"}]}}}`
+	liveRegistry, err := semantics.NewRegistryFromJSON([]byte(liveJSON))
+	require.NoError(t, err)
+	semantics.UpdateRegistry(liveRegistry)
+
+	const differentMetadataSameMappings = `{"version":"sentinel-2.0","metadata":{"content_hash":"hash-new"},"concepts":{"peer.service":{"canonical":"peer.service","fallbacks":[{"name":"x.sentinel","provider":"datadog","type":"string"}]}}}`
+	statuses, cb := captureStatuses()
+	const cfgPath = "datadog/2/APM_SEMANTIC_CORE_DD/cfg/config"
+	h.onSemanticCoreUpdate(map[string]state.RawConfig{
+		cfgPath: {Config: []byte(differentMetadataSameMappings)},
+	}, cb)
+
+	assert.Same(t, liveRegistry, semantics.DefaultRegistry(), "identical parsed mappings must not replace the live registry")
+	assert.Equal(t, state.ApplyStateAcknowledged, statuses[cfgPath].State)
 }
 
 // TestOnSemanticCoreUpdate_EmptyUpdatesWhileEmbedded verifies that an empty
@@ -656,12 +670,14 @@ func TestOnSemanticCoreUpdate_EmptyUpdatesWhileEmbedded(t *testing.T) {
 	embedded, err := semantics.NewEmbeddedRegistry()
 	require.NoError(t, err)
 	semantics.UpdateRegistry(embedded)
+	before := semantics.DefaultRegistry()
 	beforeVersion := semantics.DefaultRegistry().Version()
 
 	called := 0
 	h.onSemanticCoreUpdate(map[string]state.RawConfig{}, func(string, state.ApplyStatus) { called++ })
 
 	assert.Equal(t, beforeVersion, semantics.DefaultRegistry().Version(), "registry must remain on the embedded version")
+	assert.Same(t, before, semantics.DefaultRegistry(), "equal embedded mappings must not replace the live registry")
 	assert.Equal(t, 0, called, "no applyStateCallback invocations on empty updates")
 }
 

--- a/pkg/trace/semantics/registry.go
+++ b/pkg/trace/semantics/registry.go
@@ -8,15 +8,10 @@ package semantics
 import (
 	"crypto/sha256"
 	_ "embed" //nolint:revive
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"hash"
-	"io"
-	"sort"
-	"strconv"
 	"sync/atomic"
 )
 
@@ -110,65 +105,13 @@ func (r *EmbeddedRegistry) loadFromJSON(data []byte) error {
 	r.hash = rd.Metadata.ContentHash
 	r.mappings = make(map[Concept][]TagInfo, len(rd.Concepts))
 	for conceptName, mapping := range rd.Concepts {
-		// Canonical is deliberately dropped and excluded from the fingerprint
-		// because it does not currently affect registry behaviour.
+		// Canonical is deliberately dropped because it does not currently affect
+		// registry lookups. It remains covered by the raw-payload fingerprint.
 		r.mappings[Concept(conceptName)] = mapping.Fallbacks
 	}
-	r.fingerprint = fingerprint(r.mappings)
+	sum := sha256.Sum256(data)
+	r.fingerprint = hex.EncodeToString(sum[:])
 	return nil
-}
-
-func writeField(h hash.Hash, s string) {
-	var n [8]byte
-	binary.LittleEndian.PutUint64(n[:], uint64(len(s)))
-	_, _ = h.Write(n[:])
-	_, _ = io.WriteString(h, s)
-}
-
-// fingerprint returns a content-derived identity for the parsed mappings.
-// It is compared only against other fingerprints computed by this binary, so
-// the encoding needs to be deterministic within a process and nothing more:
-// it is deliberately not a stable wire format and must never be published,
-// persisted, or compared against a producer-supplied hash. It covers only the
-// agent's current behavioural input and must be extended if a currently-dropped
-// field starts affecting behaviour.
-func fingerprint(m map[Concept][]TagInfo) string {
-	concepts := make([]string, 0, len(m))
-	for concept := range m {
-		concepts = append(concepts, string(concept))
-	}
-	sort.Strings(concepts)
-
-	h := sha256.New()
-	writeField(h, strconv.Itoa(len(concepts)))
-	for _, concept := range concepts {
-		writeField(h, concept)
-		tags := m[Concept(concept)]
-		writeField(h, strconv.Itoa(len(tags)))
-		for _, tag := range tags {
-			writeField(h, tag.Name)
-			writeField(h, string(tag.Provider))
-			writeField(h, tag.Version)
-			writeField(h, string(tag.Type))
-			writeField(h, strconv.Itoa(len(tag.When)))
-			for _, condition := range tag.When {
-				writeField(h, condition.Attribute)
-				if condition.Present == nil {
-					writeField(h, "nil")
-				} else {
-					writeField(h, "set")
-					writeField(h, strconv.FormatBool(*condition.Present))
-				}
-				if condition.Eq == nil {
-					writeField(h, "nil")
-				} else {
-					writeField(h, "set")
-					writeField(h, *condition.Eq)
-				}
-			}
-		}
-	}
-	return hex.EncodeToString(h.Sum(nil))
 }
 
 // GetAttributePrecedence returns the ordered attribute keys for a concept.
@@ -197,7 +140,11 @@ func (r *EmbeddedRegistry) ContentHash() string {
 	return r.hash
 }
 
-// Fingerprint returns the locally-computed identity of the parsed concept mappings.
+// Fingerprint returns the locally computed identity of the payload this registry
+// was built from. It is the correct key for deciding registry publication and
+// invalidating registry-derived state. It is never published, persisted, or
+// compared against a producer-supplied hash, and carries no cross-process or
+// cross-version meaning.
 func (r *EmbeddedRegistry) Fingerprint() string {
 	return r.fingerprint
 }
@@ -207,7 +154,11 @@ func (r *EmbeddedRegistry) Source() string {
 	return r.source
 }
 
-// RegistryEqual reports whether two registries have the same parsed concept mappings.
+// RegistryEqual reports whether two registries were built from identical
+// payload bytes. It is the key for both publishing a registry and invalidating
+// registry-derived state. It is presentation-sensitive, so cosmetically
+// reformatted payloads compare unequal; this is accepted because
+// over-invalidating is cheap while under-invalidating is the bug.
 func RegistryEqual(a, b Registry) bool {
 	if a == nil || b == nil {
 		return a == nil && b == nil

--- a/pkg/trace/semantics/registry.go
+++ b/pkg/trace/semantics/registry.go
@@ -6,10 +6,17 @@
 package semantics
 
 import (
+	"crypto/sha256"
 	_ "embed" //nolint:revive
+	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
+	"io"
+	"sort"
+	"strconv"
 	"sync/atomic"
 )
 
@@ -35,10 +42,11 @@ type registryData struct {
 
 // EmbeddedRegistry loads semantic mappings from embedded JSON.
 type EmbeddedRegistry struct {
-	version  string
-	hash     string
-	source   string
-	mappings map[Concept][]TagInfo
+	version     string
+	hash        string
+	fingerprint string
+	source      string
+	mappings    map[Concept][]TagInfo
 }
 
 var globalRegistry atomic.Pointer[Registry]
@@ -102,9 +110,65 @@ func (r *EmbeddedRegistry) loadFromJSON(data []byte) error {
 	r.hash = rd.Metadata.ContentHash
 	r.mappings = make(map[Concept][]TagInfo, len(rd.Concepts))
 	for conceptName, mapping := range rd.Concepts {
+		// Canonical is deliberately dropped and excluded from the fingerprint
+		// because it does not currently affect registry behaviour.
 		r.mappings[Concept(conceptName)] = mapping.Fallbacks
 	}
+	r.fingerprint = fingerprint(r.mappings)
 	return nil
+}
+
+func writeField(h hash.Hash, s string) {
+	var n [8]byte
+	binary.LittleEndian.PutUint64(n[:], uint64(len(s)))
+	_, _ = h.Write(n[:])
+	_, _ = io.WriteString(h, s)
+}
+
+// fingerprint returns a content-derived identity for the parsed mappings.
+// It is compared only against other fingerprints computed by this binary, so
+// the encoding needs to be deterministic within a process and nothing more:
+// it is deliberately not a stable wire format and must never be published,
+// persisted, or compared against a producer-supplied hash. It covers only the
+// agent's current behavioural input and must be extended if a currently-dropped
+// field starts affecting behaviour.
+func fingerprint(m map[Concept][]TagInfo) string {
+	concepts := make([]string, 0, len(m))
+	for concept := range m {
+		concepts = append(concepts, string(concept))
+	}
+	sort.Strings(concepts)
+
+	h := sha256.New()
+	writeField(h, strconv.Itoa(len(concepts)))
+	for _, concept := range concepts {
+		writeField(h, concept)
+		tags := m[Concept(concept)]
+		writeField(h, strconv.Itoa(len(tags)))
+		for _, tag := range tags {
+			writeField(h, tag.Name)
+			writeField(h, string(tag.Provider))
+			writeField(h, tag.Version)
+			writeField(h, string(tag.Type))
+			writeField(h, strconv.Itoa(len(tag.When)))
+			for _, condition := range tag.When {
+				writeField(h, condition.Attribute)
+				if condition.Present == nil {
+					writeField(h, "nil")
+				} else {
+					writeField(h, "set")
+					writeField(h, strconv.FormatBool(*condition.Present))
+				}
+				if condition.Eq == nil {
+					writeField(h, "nil")
+				} else {
+					writeField(h, "set")
+					writeField(h, *condition.Eq)
+				}
+			}
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // GetAttributePrecedence returns the ordered attribute keys for a concept.
@@ -127,9 +191,15 @@ func (r *EmbeddedRegistry) Version() string {
 	return r.version
 }
 
-// ContentHash returns the content-bound hash of the registry's concept mappings.
+// ContentHash returns the producer-declared registry version label verbatim.
+// It is not an integrity check or a key for invalidating derived state.
 func (r *EmbeddedRegistry) ContentHash() string {
 	return r.hash
+}
+
+// Fingerprint returns the locally-computed identity of the parsed concept mappings.
+func (r *EmbeddedRegistry) Fingerprint() string {
+	return r.fingerprint
 }
 
 // Source reports where the registry came from (SourceEmbedded or SourceRemoteConfig).
@@ -137,11 +207,10 @@ func (r *EmbeddedRegistry) Source() string {
 	return r.source
 }
 
-// RegistryEqual reports whether two registries carry the same concept
-// mappings, by comparing their content_hash.
+// RegistryEqual reports whether two registries have the same parsed concept mappings.
 func RegistryEqual(a, b Registry) bool {
 	if a == nil || b == nil {
 		return a == nil && b == nil
 	}
-	return a.ContentHash() == b.ContentHash()
+	return a.Fingerprint() == b.Fingerprint()
 }

--- a/pkg/trace/semantics/registry.go
+++ b/pkg/trace/semantics/registry.go
@@ -158,7 +158,7 @@ func (r *EmbeddedRegistry) Source() string {
 // payload bytes. It is the key for both publishing a registry and invalidating
 // registry-derived state. It is presentation-sensitive, so cosmetically
 // reformatted payloads compare unequal; this is accepted because
-// over-invalidating is cheap while under-invalidating is the bug.
+// over-invalidating is cheap while under-invalidating is a bug.
 func RegistryEqual(a, b Registry) bool {
 	if a == nil || b == nil {
 		return a == nil && b == nil

--- a/pkg/trace/semantics/registry_update_test.go
+++ b/pkg/trace/semantics/registry_update_test.go
@@ -6,6 +6,7 @@
 package semantics
 
 import (
+	"strings"
 	"sync"
 	"testing"
 
@@ -63,16 +64,8 @@ func registryFingerprint(t *testing.T, data string) string {
 func TestFingerprintChangesWithParsedMappings(t *testing.T) {
 	base := registryFingerprint(t, fingerprintBaseJSON)
 	tests := map[string]string{
-		"fallback name":   `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.changed","provider":"datadog","version":"1.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"client"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
-		"provider":        `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"otel","version":"1.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"client"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
-		"version":         `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"datadog","version":"2.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"client"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
-		"type":            `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"datadog","version":"1.0","type":"int64"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"client"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
-		"fallback order":  `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"client"}]},{"name":"alpha.one","provider":"datadog","version":"1.0","type":"string"}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
-		"when attribute":  `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"datadog","version":"1.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"operation","present":true,"eq":"client"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
-		"when present":    `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"datadog","version":"1.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":false,"eq":"client"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
-		"when equality":   `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"datadog","version":"1.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"server"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
-		"added concept":   `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"datadog","version":"1.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"client"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]},"gamma":{"fallbacks":[{"name":"gamma.one","provider":"otel","type":"string"}]}}}`,
-		"removed concept": `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"datadog","version":"1.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"client"}]}]}}}`,
+		"fallback name": strings.Replace(fingerprintBaseJSON, `"name":"alpha.one"`, `"name":"alpha.changed"`, 1),
+		"condition":     strings.Replace(fingerprintBaseJSON, `"eq":"client"`, `"eq":"server"`, 1),
 	}
 
 	for name, data := range tests {
@@ -82,38 +75,17 @@ func TestFingerprintChangesWithParsedMappings(t *testing.T) {
 	}
 }
 
-func TestFingerprintIgnoresJSONPresentationAndMetadata(t *testing.T) {
-	reformatted := `{"timestamp":"2030-12-31T23:59:59Z","concepts":{"beta":{"fallbacks":[{"type":"string","provider":"datadog","name":"beta.one"}],"canonical":"changed.but.ignored"},"alpha":{"fallbacks":[{"type":"string","version":"1.0","provider":"datadog","name":"alpha.one"},{"when":[{"eq":"client","present":true,"attribute":"span.kind"}],"type":"float64","name":"alpha.two","provider":"otel"}],"canonical":"also.changed"}},"metadata":{"content_hash":"same-declared-hash"},"git_commit":"commit-b","version":"9.9.9"}`
+func TestFingerprintChangesWithJSONPresentationAndMetadata(t *testing.T) {
+	base := registryFingerprint(t, fingerprintBaseJSON)
 
-	assert.Equal(t, registryFingerprint(t, fingerprintBaseJSON), registryFingerprint(t, reformatted))
-}
+	// Presentation-sensitive identity can over-invalidate on cosmetic changes.
+	// That is accepted because rebuilding derived state is cheap, while missing a
+	// payload change can leave that state stale.
+	reformatted := strings.ReplaceAll(fingerprintBaseJSON, "  ", "    ")
+	assert.NotEqual(t, base, registryFingerprint(t, reformatted))
 
-func TestFingerprintFieldBoundariesAreUnambiguous(t *testing.T) {
-	withinFallbacksA := map[Concept][]TagInfo{"concept": {{Name: "ab"}, {Name: ""}}}
-	withinFallbacksB := map[Concept][]TagInfo{"concept": {{Name: "a"}, {Name: "b"}}}
-	assert.NotEqual(t, fingerprint(withinFallbacksA), fingerprint(withinFallbacksB))
-
-	acrossConceptAndFieldA := map[Concept][]TagInfo{"ab": {{Name: "c"}}}
-	acrossConceptAndFieldB := map[Concept][]TagInfo{"a": {{Name: "bc"}}}
-	assert.NotEqual(t, fingerprint(acrossConceptAndFieldA), fingerprint(acrossConceptAndFieldB))
-}
-
-func TestFingerprintDistinguishesUnsetConditionFields(t *testing.T) {
-	t.Run("present absent versus false", func(t *testing.T) {
-		presentFalse := false
-		absent := map[Concept][]TagInfo{"concept": {{Name: "tag", When: []Condition{{Attribute: "attribute"}}}}}
-		set := map[Concept][]TagInfo{"concept": {{Name: "tag", When: []Condition{{Attribute: "attribute", Present: &presentFalse}}}}}
-
-		assert.NotEqual(t, fingerprint(absent), fingerprint(set))
-	})
-
-	t.Run("eq absent versus empty", func(t *testing.T) {
-		empty := ""
-		absent := map[Concept][]TagInfo{"concept": {{Name: "tag", When: []Condition{{Attribute: "attribute"}}}}}
-		set := map[Concept][]TagInfo{"concept": {{Name: "tag", When: []Condition{{Attribute: "attribute", Eq: &empty}}}}}
-
-		assert.NotEqual(t, fingerprint(absent), fingerprint(set))
-	})
+	metadataChanged := strings.Replace(fingerprintBaseJSON, `"git_commit":"commit-a"`, `"git_commit":"commit-b"`, 1)
+	assert.NotEqual(t, base, registryFingerprint(t, metadataChanged))
 }
 
 func TestFingerprintDeterministicAcrossLoads(t *testing.T) {
@@ -136,28 +108,37 @@ func TestUpdateRegistry_AtomicSwap(t *testing.T) {
 	assert.Equal(t, "test-version", DefaultRegistry().Version())
 }
 
-func TestRegistryEqual_SameMappingsDifferentVersion(t *testing.T) {
+func TestRegistryEqual_IdenticalPayloadBytesRegardlessOfSource(t *testing.T) {
+	remote, err := NewRegistryFromJSON(mappingsJSON)
+	require.NoError(t, err)
+	embedded, err := NewEmbeddedRegistry()
+	require.NoError(t, err)
+	require.NotEqual(t, remote.Source(), embedded.Source())
+	assert.True(t, RegistryEqual(remote, embedded), "registries built from identical payload bytes compare equal regardless of source")
+}
+
+func TestRegistryEqual_DifferentPayloadBytesWhenVersionChanges(t *testing.T) {
 	a, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"hash-a"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
 	require.NoError(t, err)
 	b, err := NewRegistryFromJSON([]byte(`{"version":"2.0.0","metadata":{"content_hash":"hash-a"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
 	require.NoError(t, err)
-	assert.True(t, RegistryEqual(a, b), "metadata changes do not change parsed concept mappings")
+	assert.False(t, RegistryEqual(a, b), "changing the version changes the payload bytes")
 }
 
-func TestRegistryEqual_SameHashDifferentMappings(t *testing.T) {
+func TestRegistryEqual_DifferentPayloadBytesWhenMappingsChange(t *testing.T) {
 	a, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"hash-a"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
 	require.NoError(t, err)
 	b, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"hash-a"},"concepts":{"http.method":{"canonical":"http.method","fallbacks":[{"name":"http.method","provider":"otel","type":"string"}]}}}`))
 	require.NoError(t, err)
-	assert.False(t, RegistryEqual(a, b), "the declared hash does not override changed parsed mappings")
+	assert.False(t, RegistryEqual(a, b), "changing the mappings changes the payload bytes even when the declared hash is unchanged")
 }
 
-func TestRegistryEqual_DifferentHashSameMappings(t *testing.T) {
+func TestRegistryEqual_DifferentPayloadBytesWhenDeclaredHashChanges(t *testing.T) {
 	a, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"hash-a"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
 	require.NoError(t, err)
-	b, err := NewRegistryFromJSON([]byte(`{"version":"2.0.0","metadata":{"content_hash":"hash-b"},"concepts":{"db.statement":{"canonical":"different.canonical","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
+	b, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"hash-b"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
 	require.NoError(t, err)
-	assert.True(t, RegistryEqual(a, b))
+	assert.False(t, RegistryEqual(a, b), "changing the producer-declared hash changes the payload bytes even when the mappings are unchanged")
 }
 
 func TestRegistryEqual_NilHandling(t *testing.T) {

--- a/pkg/trace/semantics/registry_update_test.go
+++ b/pkg/trace/semantics/registry_update_test.go
@@ -38,6 +38,91 @@ func TestNewRegistryFromJSON_MissingContentHash(t *testing.T) {
 	assert.Error(t, err)
 }
 
+const fingerprintBaseJSON = `{
+  "version":"1.0.0",
+  "git_commit":"commit-a",
+  "timestamp":"2026-01-01T00:00:00Z",
+  "metadata":{"content_hash":"same-declared-hash"},
+  "concepts":{
+    "alpha":{"canonical":"ignored.alpha","fallbacks":[
+      {"name":"alpha.one","provider":"datadog","version":"1.0","type":"string"},
+      {"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"client"}]}
+    ]},
+    "beta":{"canonical":"ignored.beta","fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}
+  }
+}`
+
+func registryFingerprint(t *testing.T, data string) string {
+	t.Helper()
+	r, err := NewRegistryFromJSON([]byte(data))
+	require.NoError(t, err)
+	require.Equal(t, "same-declared-hash", r.ContentHash())
+	return r.Fingerprint()
+}
+
+func TestFingerprintChangesWithParsedMappings(t *testing.T) {
+	base := registryFingerprint(t, fingerprintBaseJSON)
+	tests := map[string]string{
+		"fallback name":   `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.changed","provider":"datadog","version":"1.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"client"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
+		"provider":        `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"otel","version":"1.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"client"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
+		"version":         `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"datadog","version":"2.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"client"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
+		"type":            `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"datadog","version":"1.0","type":"int64"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"client"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
+		"fallback order":  `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"client"}]},{"name":"alpha.one","provider":"datadog","version":"1.0","type":"string"}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
+		"when attribute":  `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"datadog","version":"1.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"operation","present":true,"eq":"client"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
+		"when present":    `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"datadog","version":"1.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":false,"eq":"client"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
+		"when equality":   `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"datadog","version":"1.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"server"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]}}}`,
+		"added concept":   `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"datadog","version":"1.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"client"}]}]},"beta":{"fallbacks":[{"name":"beta.one","provider":"datadog","type":"string"}]},"gamma":{"fallbacks":[{"name":"gamma.one","provider":"otel","type":"string"}]}}}`,
+		"removed concept": `{"version":"1","metadata":{"content_hash":"same-declared-hash"},"concepts":{"alpha":{"fallbacks":[{"name":"alpha.one","provider":"datadog","version":"1.0","type":"string"},{"name":"alpha.two","provider":"otel","type":"float64","when":[{"attribute":"span.kind","present":true,"eq":"client"}]}]}}}`,
+	}
+
+	for name, data := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.NotEqual(t, base, registryFingerprint(t, data))
+		})
+	}
+}
+
+func TestFingerprintIgnoresJSONPresentationAndMetadata(t *testing.T) {
+	reformatted := `{"timestamp":"2030-12-31T23:59:59Z","concepts":{"beta":{"fallbacks":[{"type":"string","provider":"datadog","name":"beta.one"}],"canonical":"changed.but.ignored"},"alpha":{"fallbacks":[{"type":"string","version":"1.0","provider":"datadog","name":"alpha.one"},{"when":[{"eq":"client","present":true,"attribute":"span.kind"}],"type":"float64","name":"alpha.two","provider":"otel"}],"canonical":"also.changed"}},"metadata":{"content_hash":"same-declared-hash"},"git_commit":"commit-b","version":"9.9.9"}`
+
+	assert.Equal(t, registryFingerprint(t, fingerprintBaseJSON), registryFingerprint(t, reformatted))
+}
+
+func TestFingerprintFieldBoundariesAreUnambiguous(t *testing.T) {
+	withinFallbacksA := map[Concept][]TagInfo{"concept": {{Name: "ab"}, {Name: ""}}}
+	withinFallbacksB := map[Concept][]TagInfo{"concept": {{Name: "a"}, {Name: "b"}}}
+	assert.NotEqual(t, fingerprint(withinFallbacksA), fingerprint(withinFallbacksB))
+
+	acrossConceptAndFieldA := map[Concept][]TagInfo{"ab": {{Name: "c"}}}
+	acrossConceptAndFieldB := map[Concept][]TagInfo{"a": {{Name: "bc"}}}
+	assert.NotEqual(t, fingerprint(acrossConceptAndFieldA), fingerprint(acrossConceptAndFieldB))
+}
+
+func TestFingerprintDistinguishesUnsetConditionFields(t *testing.T) {
+	t.Run("present absent versus false", func(t *testing.T) {
+		presentFalse := false
+		absent := map[Concept][]TagInfo{"concept": {{Name: "tag", When: []Condition{{Attribute: "attribute"}}}}}
+		set := map[Concept][]TagInfo{"concept": {{Name: "tag", When: []Condition{{Attribute: "attribute", Present: &presentFalse}}}}}
+
+		assert.NotEqual(t, fingerprint(absent), fingerprint(set))
+	})
+
+	t.Run("eq absent versus empty", func(t *testing.T) {
+		empty := ""
+		absent := map[Concept][]TagInfo{"concept": {{Name: "tag", When: []Condition{{Attribute: "attribute"}}}}}
+		set := map[Concept][]TagInfo{"concept": {{Name: "tag", When: []Condition{{Attribute: "attribute", Eq: &empty}}}}}
+
+		assert.NotEqual(t, fingerprint(absent), fingerprint(set))
+	})
+}
+
+func TestFingerprintDeterministicAcrossLoads(t *testing.T) {
+	want := registryFingerprint(t, fingerprintBaseJSON)
+	for i := 0; i < 100; i++ {
+		assert.Equal(t, want, registryFingerprint(t, fingerprintBaseJSON))
+	}
+}
+
 func TestUpdateRegistry_AtomicSwap(t *testing.T) {
 	original, err := NewEmbeddedRegistry()
 	require.NoError(t, err)
@@ -51,28 +136,28 @@ func TestUpdateRegistry_AtomicSwap(t *testing.T) {
 	assert.Equal(t, "test-version", DefaultRegistry().Version())
 }
 
-func TestRegistryEqual_SameHashDifferentVersion(t *testing.T) {
+func TestRegistryEqual_SameMappingsDifferentVersion(t *testing.T) {
 	a, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"hash-a"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
 	require.NoError(t, err)
 	b, err := NewRegistryFromJSON([]byte(`{"version":"2.0.0","metadata":{"content_hash":"hash-a"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
 	require.NoError(t, err)
-	assert.True(t, RegistryEqual(a, b), "same content_hash means same concepts, regardless of the CI-bumped version string")
+	assert.True(t, RegistryEqual(a, b), "metadata changes do not change parsed concept mappings")
 }
 
-func TestRegistryEqual_DifferentHashSameVersion(t *testing.T) {
+func TestRegistryEqual_SameHashDifferentMappings(t *testing.T) {
 	a, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"hash-a"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
 	require.NoError(t, err)
-	b, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"hash-b"},"concepts":{"http.method":{"canonical":"http.method","fallbacks":[{"name":"http.method","provider":"otel","type":"string"}]}}}`))
+	b, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"hash-a"},"concepts":{"http.method":{"canonical":"http.method","fallbacks":[{"name":"http.method","provider":"otel","type":"string"}]}}}`))
 	require.NoError(t, err)
-	assert.False(t, RegistryEqual(a, b), "differing content_hash means the concepts changed, even if version happens to match")
+	assert.False(t, RegistryEqual(a, b), "the declared hash does not override changed parsed mappings")
 }
 
-func TestRegistryEqual_DifferentHash(t *testing.T) {
+func TestRegistryEqual_DifferentHashSameMappings(t *testing.T) {
 	a, err := NewRegistryFromJSON([]byte(`{"version":"1.0.0","metadata":{"content_hash":"hash-a"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
 	require.NoError(t, err)
-	b, err := NewRegistryFromJSON([]byte(`{"version":"2.0.0","metadata":{"content_hash":"hash-b"},"concepts":{"db.statement":{"canonical":"db.statement","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
+	b, err := NewRegistryFromJSON([]byte(`{"version":"2.0.0","metadata":{"content_hash":"hash-b"},"concepts":{"db.statement":{"canonical":"different.canonical","fallbacks":[{"name":"db.statement","provider":"datadog","type":"string"}]}}}`))
 	require.NoError(t, err)
-	assert.False(t, RegistryEqual(a, b))
+	assert.True(t, RegistryEqual(a, b))
 }
 
 func TestRegistryEqual_NilHandling(t *testing.T) {

--- a/pkg/trace/semantics/semantics.go
+++ b/pkg/trace/semantics/semantics.go
@@ -163,8 +163,14 @@ type Registry interface {
 	// Version returns the semantic registry version string.
 	Version() string
 
-	// ContentHash returns the content-bound hash of the registry's concept mappings.
+	// ContentHash returns the producer-declared registry version label verbatim.
+	// It is not an integrity check or a key for invalidating derived state.
 	ContentHash() string
+
+	// Fingerprint returns a locally-computed identity for the registry's parsed
+	// concept mappings. Unlike ContentHash, it carries no cross-version or
+	// cross-process meaning and is the correct key for invalidating derived state.
+	Fingerprint() string
 
 	// Source reports where the registry came from (SourceEmbedded or SourceRemoteConfig).
 	Source() string

--- a/pkg/trace/semantics/semantics.go
+++ b/pkg/trace/semantics/semantics.go
@@ -167,9 +167,11 @@ type Registry interface {
 	// It is not an integrity check or a key for invalidating derived state.
 	ContentHash() string
 
-	// Fingerprint returns a locally-computed identity for the registry's parsed
-	// concept mappings. Unlike ContentHash, it carries no cross-version or
-	// cross-process meaning and is the correct key for invalidating derived state.
+	// Fingerprint returns the locally computed identity of the payload this
+	// registry was built from. It is the correct key for deciding registry
+	// publication and invalidating registry-derived state. It is never published,
+	// persisted, or compared against a producer-supplied hash, and carries no
+	// cross-process or cross-version meaning.
 	Fingerprint() string
 
 	// Source reports where the registry came from (SourceEmbedded or SourceRemoteConfig).

--- a/pkg/trace/stats/concentrator.go
+++ b/pkg/trace/stats/concentrator.go
@@ -95,9 +95,11 @@ func NewConcentrator(conf *config.AgentConfig, writer Writer, now time.Time, sta
 
 // getPeerTagKeys returns the cached peer-tag key set, rebuilding it via
 // AgentConfig.PeerTagsCache when the live semantic registry has been replaced
-// (its Fingerprint() differs from the cached snapshot's Fingerprint). Two
-// concurrent callers that observe staleness may both rebuild and Store; the
-// result is identical so last-Store-wins is benign.
+// by one built from different payload bytes (its Fingerprint() differs from the
+// cached snapshot's Fingerprint). Concurrent callers that observe staleness may
+// rebuild from different live registries if a swap happens between their loads.
+// An older snapshot winning the last Store is benign: the next call detects the
+// fingerprint mismatch and repairs the cache, making it eventually consistent.
 func (c *Concentrator) getPeerTagKeys() []string {
 	snap := c.peerTagsCache.Load()
 	if snap == nil || snap.Fingerprint != semantics.DefaultRegistry().Fingerprint() {

--- a/pkg/trace/stats/concentrator.go
+++ b/pkg/trace/stats/concentrator.go
@@ -50,9 +50,9 @@ type Concentrator struct {
 	statsd        statsd.ClientInterface
 	conf          *config.AgentConfig
 	// peerTagsCache caches the peer-tag attribute key set keyed by the
-	// semantic registry version it was derived from. Readers call
+	// semantic registry fingerprint it was derived from. Readers call
 	// getPeerTagKeys, which rebuilds the cache (via conf.PeerTagsCache) when
-	// the live registry content_hash no longer matches — this is how the
+	// the live registry fingerprint no longer matches — this is how the
 	// Concentrator picks up semantic-core RC updates without explicit
 	// notification from the RC handler. The stored snapshot's Keys slice is
 	// never mutated in place; getPeerTagKeys always Stores a fresh snapshot.
@@ -95,12 +95,12 @@ func NewConcentrator(conf *config.AgentConfig, writer Writer, now time.Time, sta
 
 // getPeerTagKeys returns the cached peer-tag key set, rebuilding it via
 // AgentConfig.PeerTagsCache when the live semantic registry has been replaced
-// (its ContentHash() differs from the cached snapshot's ContentHash). Two
+// (its Fingerprint() differs from the cached snapshot's Fingerprint). Two
 // concurrent callers that observe staleness may both rebuild and Store; the
 // result is identical so last-Store-wins is benign.
 func (c *Concentrator) getPeerTagKeys() []string {
 	snap := c.peerTagsCache.Load()
-	if snap == nil || snap.ContentHash != semantics.DefaultRegistry().ContentHash() {
+	if snap == nil || snap.Fingerprint != semantics.DefaultRegistry().Fingerprint() {
 		snap = c.conf.PeerTagsCache()
 		c.peerTagsCache.Store(snap)
 	}

--- a/pkg/trace/stats/concentrator_test.go
+++ b/pkg/trace/stats/concentrator_test.go
@@ -136,6 +136,30 @@ func TestNewConcentratorPeerTags(t *testing.T) {
 	})
 }
 
+func TestConcentratorRefreshesPeerTagsForChangedMappingsWithSameContentHash(t *testing.T) {
+	original := semantics.DefaultRegistry()
+	t.Cleanup(func() { semantics.UpdateRegistry(original) })
+
+	const oldJSON = `{"version":"old","metadata":{"content_hash":"same-hash"},"concepts":{"peer.service":{"fallbacks":[{"name":"peer.old","provider":"datadog","type":"string"}]}}}`
+	oldRegistry, err := semantics.NewRegistryFromJSON([]byte(oldJSON))
+	require.NoError(t, err)
+	semantics.UpdateRegistry(oldRegistry)
+
+	cfg := config.AgentConfig{
+		BucketInterval:      time.Duration(testBucketInterval),
+		PeerTagsAggregation: true,
+	}
+	c := NewTestConcentratorWithCfg(time.Now(), &cfg)
+	require.Contains(t, c.getPeerTagKeys(), "peer.old")
+
+	const newJSON = `{"version":"new","metadata":{"content_hash":"same-hash"},"concepts":{"peer.service":{"fallbacks":[{"name":"peer.new","provider":"datadog","type":"string"}]}}}`
+	newRegistry, err := semantics.NewRegistryFromJSON([]byte(newJSON))
+	require.NoError(t, err)
+	semantics.UpdateRegistry(newRegistry)
+
+	assert.Equal(t, []string{"peer.new"}, c.getPeerTagKeys())
+}
+
 func TestNewConcentratorAdditionalMetricTagsValueLengthCapUsesAgentSentinel(t *testing.T) {
 	cfg := config.AgentConfig{
 		BucketInterval: time.Duration(testBucketInterval),
@@ -890,9 +914,9 @@ func TestPeerTags(t *testing.T) {
 		testTrace := toProcessedTrace(spans, "none", "", "", "", "", "")
 		c := NewTestConcentrator(now)
 		// Inject a peer-tag key set directly, keyed by the live registry's
-		// content hash so getPeerTagKeys returns it without rebuilding from conf.
+		// fingerprint so getPeerTagKeys returns it without rebuilding from conf.
 		c.peerTagsCache.Store(&config.PeerTagsCache{
-			ContentHash: semantics.DefaultRegistry().ContentHash(),
+			Fingerprint: semantics.DefaultRegistry().Fingerprint(),
 			Keys:        []string{"db.instance", "db.system", "peer.service"},
 		})
 		c.addNow(testTrace, infraTags{})

--- a/pkg/trace/stats/concentrator_test.go
+++ b/pkg/trace/stats/concentrator_test.go
@@ -160,6 +160,35 @@ func TestConcentratorRefreshesPeerTagsForChangedMappingsWithSameContentHash(t *t
 	assert.Equal(t, []string{"peer.new"}, c.getPeerTagKeys())
 }
 
+func TestConcentratorRebuildsPeerTagCacheForMetadataOnlyRegistrySwap(t *testing.T) {
+	original := semantics.DefaultRegistry()
+	t.Cleanup(func() { semantics.UpdateRegistry(original) })
+
+	const oldJSON = `{"version":"old","metadata":{"content_hash":"old-hash"},"concepts":{"peer.service":{"fallbacks":[{"name":"peer.same","provider":"datadog","type":"string"}]}}}`
+	oldRegistry, err := semantics.NewRegistryFromJSON([]byte(oldJSON))
+	require.NoError(t, err)
+	semantics.UpdateRegistry(oldRegistry)
+
+	cfg := config.AgentConfig{
+		BucketInterval:      time.Duration(testBucketInterval),
+		PeerTagsAggregation: true,
+	}
+	c := NewTestConcentratorWithCfg(time.Now(), &cfg)
+	cached := c.peerTagsCache.Load()
+	require.NotNil(t, cached)
+
+	const newJSON = `{"version":"new","metadata":{"content_hash":"new-hash"},"concepts":{"peer.service":{"fallbacks":[{"name":"peer.same","provider":"datadog","type":"string"}]}}}`
+	newRegistry, err := semantics.NewRegistryFromJSON([]byte(newJSON))
+	require.NoError(t, err)
+	require.NotEqual(t, oldRegistry.Fingerprint(), newRegistry.Fingerprint())
+	semantics.UpdateRegistry(newRegistry)
+
+	assert.Equal(t, []string{"peer.same"}, c.getPeerTagKeys())
+	// A metadata-only payload change deliberately rebuilds this cheap cache so
+	// every payload change is guaranteed to invalidate registry-derived state.
+	assert.NotSame(t, cached, c.peerTagsCache.Load())
+}
+
 func TestNewConcentratorAdditionalMetricTagsValueLengthCapUsesAgentSentinel(t *testing.T) {
 	cfg := config.AgentConfig{
 		BucketInterval: time.Duration(testBucketInterval),
@@ -212,7 +241,7 @@ func TestNewConcentratorAdditionalMetricTagsCardinalityLimitUsesAgentSentinel(t 
 // TestConcentrator_PeerTagKeysFollowRegistry verifies that getPeerTagKeys
 // rebuilds the cached peer-tag set when the live semantic registry has been
 // swapped (e.g. by an RC update) — driven entirely by the registry's
-// Version() string, with no explicit notification from the RC handler.
+// fingerprint, with no explicit notification from the RC handler.
 func TestConcentrator_PeerTagKeysFollowRegistry(t *testing.T) {
 	original, err := semantics.NewEmbeddedRegistry()
 	require.NoError(t, err)
@@ -237,7 +266,7 @@ func TestConcentrator_PeerTagKeysFollowRegistry(t *testing.T) {
 
 	refreshedKeys := c.getPeerTagKeys()
 	assert.Contains(t, refreshedKeys, "x.custom.peer", "getPeerTagKeys must pick up the new peer-tag mapping after the registry was swapped")
-	assert.NotContains(t, refreshedKeys, "peer.service", "the old peer.service mapping must be gone after the version-keyed cache invalidates")
+	assert.NotContains(t, refreshedKeys, "peer.service", "the old peer.service mapping must be gone after the fingerprint-keyed cache invalidates")
 }
 
 // TestTracerHostname tests if `Concentrator` uses the tracer hostname rather than agent hostname, if there is one.

--- a/releasenotes/notes/apm-semantic-registry-fingerprint-7f4c3b2a1d9e8f60.yaml
+++ b/releasenotes/notes/apm-semantic-registry-fingerprint-7f4c3b2a1d9e8f60.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    APM peer-tag aggregation now refreshes derived tag keys when Remote
+    Configuration changes semantic registry mappings without changing the
+    producer-declared content hash.


### PR DESCRIPTION
### What does this PR do?

Add a locally computed fingerprinting mechanism, instead of the producer-declared `content_hash`. This is used to determine whether local registry needs to be updated, or peer tags invalidated. `content_hash` keeps its role as the version label in logs and the status page.

### Motivation

`content_hash` is producer-supplied and never recomputed by the agent, so mappings that change under an unchanged hash were treated as a no-op: the RC update was skipped and the peer-tag cache went stale. The embedded `mappings.json` already declares a hash that does not match its content, so the drift is not hypothetical. Recomputing `content_hash` in Go would mean reimplementing the producer's JSON canonicalization exactly and keeping it in sync forever; the fingerprint avoids that because it is only ever compared against another fingerprint from the same binary.

### Describe how you validated your changes

Test coverage added for the new behaviour in `semantics`, `stats` and `remoteconfighandler`.

### Additional Notes