### PR TITLE
Store GenAI spans as LLM type

### DIFF
--- a/pkg/trace/agent/normalizer.go
+++ b/pkg/trace/agent/normalizer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
@@ -25,6 +26,8 @@ import (
 const (
 	// MaxTypeLen the maximum length a span type can have
 	MaxTypeLen = 100
+	// genAIAttributePrefix is used to identify GenAI spans that should be stored as LLM spans.
+	genAIAttributePrefix = "gen_ai."
 	// tagOrigin specifies the origin of the trace.
 	// DEPRECATED: Origin is now specified as a TraceChunk field.
 	tagOrigin = "_dd.origin"
@@ -145,6 +148,24 @@ func (a *Agent) validateAndFixType(ts *info.TagStats, spanType string) string {
 	return spanType
 }
 
+func hasGenAIAttribute(meta map[string]string) bool {
+	for key := range meta {
+		if strings.HasPrefix(key, genAIAttributePrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasGenAIAttributeV1(s *idx.InternalSpan) bool {
+	for keyRef := range s.Attributes() {
+		if strings.HasPrefix(s.Strings.Get(keyRef), genAIAttributePrefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // validateAndFixHTTPStatusCode handles HTTP status code validation for both pb.Span and idx.InternalSpan
 func (a *Agent) validateAndFixHTTPStatusCode(ts *info.TagStats, sc string) (string, bool) {
 	if !isValidStatusCode(sc) {
@@ -261,6 +282,9 @@ func (a *Agent) normalize(ts *info.TagStats, s *pb.Span) error {
 	s.Start = a.validateAndFixStartTime(ts, s.Start, s.Duration)
 
 	s.Type = a.validateAndFixType(ts, s.Type)
+	if hasGenAIAttribute(s.Meta) {
+		s.Type = "llm"
+	}
 
 	if env := semantics.LookupString(reg, spanAccessor, semantics.ConceptDDEnv); env != "" {
 		s.Meta["env"] = normalizeutil.NormalizeTagValue(env)
@@ -328,6 +352,9 @@ func (a *Agent) normalizeV1(ts *info.TagStats, s *idx.InternalSpan) error {
 	s.SetStart(a.validateAndFixStartTimeV1(ts, s.Start(), s.Duration()))
 
 	s.SetType(a.validateAndFixType(ts, s.Type()))
+	if hasGenAIAttributeV1(s) {
+		s.SetType("llm")
+	}
 
 	if env := s.Env(); env != "" {
 		s.SetEnv(normalizeutil.NormalizeTagValue(env))

--- a/pkg/trace/agent/normalizer_test.go
+++ b/pkg/trace/agent/normalizer_test.go
@@ -496,6 +496,40 @@ func TestNormalizeTypePassThru(t *testing.T) {
 	assert.Equal(t, newTagStats(), ts)
 }
 
+func TestNormalizeTypeFromGenAI(t *testing.T) {
+	a := &Agent{conf: config.New()}
+
+	for _, tt := range []struct {
+		name     string
+		meta     map[string]string
+		expected string
+	}{
+		{
+			name:     "gen_ai attribute",
+			meta:     map[string]string{"gen_ai.system": "openai"},
+			expected: "llm",
+		},
+		{
+			name:     "no gen_ai attribute",
+			meta:     map[string]string{"ai.system": "openai"},
+			expected: "browser",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newTagStats()
+			s := newTestSpan()
+			s.Type = "browser"
+			for k, v := range tt.meta {
+				s.Meta[k] = v
+			}
+
+			assert.NoError(t, a.normalize(ts, s))
+			assert.Equal(t, tt.expected, s.Type)
+			assert.Equal(t, newTagStats(), ts)
+		})
+	}
+}
+
 func TestNormalizeTypeTooLong(t *testing.T) {
 	a := &Agent{conf: config.New()}
 	ts := newTagStats()
@@ -974,6 +1008,38 @@ func TestNormalizeTypePassThruV1(t *testing.T) {
 	assert.NoError(t, a.normalizeV1(ts, s))
 	assert.Equal(t, before, s.Type())
 	assert.Equal(t, newTagStats(), ts)
+}
+
+func TestNormalizeTypeFromGenAIV1(t *testing.T) {
+	a := &Agent{conf: config.New()}
+
+	for _, tt := range []struct {
+		name     string
+		attrKey  string
+		expected string
+	}{
+		{
+			name:     "gen_ai attribute",
+			attrKey:  "gen_ai.system",
+			expected: "llm",
+		},
+		{
+			name:     "no gen_ai attribute",
+			attrKey:  "ai.system",
+			expected: "browser",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newTagStats()
+			s := newTestSpanV1(idx.NewStringTable())
+			s.SetType("browser")
+			s.SetStringAttribute(tt.attrKey, "openai")
+
+			assert.NoError(t, a.normalizeV1(ts, s))
+			assert.Equal(t, tt.expected, s.Type())
+			assert.Equal(t, newTagStats(), ts)
+		})
+	}
 }
 
 func TestNormalizeTypeTooLongV1(t *testing.T) {

--- a/pkg/trace/transform/otelutil.go
+++ b/pkg/trace/transform/otelutil.go
@@ -31,6 +31,8 @@ var (
 // DefaultOTLPServiceName is the default service name for OTel spans when no service name is found in the resource attributes.
 const DefaultOTLPServiceName = "otlpresourcenoservicename"
 
+const genAIAttributePrefix = "gen_ai."
+
 // checkDBType checks if the dbType is a known db type and returns the corresponding span.Type
 func checkDBType(dbType string) string {
 	spanType, ok := attributes.DBTypes[dbType]
@@ -226,11 +228,26 @@ func SpanKind2Type(span ptrace.Span, res pcommon.Resource) string {
 	return typ
 }
 
+func hasGenAIAttribute(attrs pcommon.Map) bool {
+	found := false
+	attrs.Range(func(k string, _ pcommon.Value) bool {
+		if strings.HasPrefix(k, genAIAttributePrefix) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
 // GetOTelSpanTypeWithAccessor returns the DD span type based on OTel span kind and attributes,
 // using a pre-created accessor to avoid repeated allocation when multiple lookups share the
 // same span and resource attribute maps.
 func GetOTelSpanTypeWithAccessor[A semantics.Accessor](span ptrace.Span, accessor A) string {
 	typ := lookupString(accessor, semantics.ConceptSpanType, false)
+	if hasGenAIAttribute(span.Attributes()) {
+		return "llm"
+	}
 	if typ != "" {
 		return typ
 	}

--- a/pkg/trace/transform/transform_test.go
+++ b/pkg/trace/transform/transform_test.go
@@ -23,6 +23,48 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 )
 
+func TestGetOTelSpanTypeFromGenAI(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		attrs    map[string]string
+		expected string
+	}{
+		{
+			name: "gen_ai attribute overrides explicit span.type",
+			attrs: map[string]string{
+				"span.type":     "browser",
+				"gen_ai.system": "openai",
+			},
+			expected: "llm",
+		},
+		{
+			name: "no gen_ai attribute keeps explicit span.type",
+			attrs: map[string]string{
+				"span.type": "browser",
+				"ai.system": "openai",
+			},
+			expected: "browser",
+		},
+		{
+			name: "gen_ai attribute overrides span-kind fallback",
+			attrs: map[string]string{
+				"gen_ai.request.model": "gpt-4",
+			},
+			expected: "llm",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			span := ptrace.NewSpan()
+			span.SetKind(ptrace.SpanKindClient)
+			for k, v := range tt.attrs {
+				span.Attributes().PutStr(k, v)
+			}
+
+			assert.Equal(t, tt.expected, GetOTelSpanType(span, pcommon.NewResource()))
+		})
+	}
+}
+
 func TestGetOTelEnv(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ed5b2a88-6058-4f4f-ac33-a243366a9321","source":"chat","resourceId":"e4d3309e-2914-493b-99ee-faeece9e4e1b","workflowId":"232510c8-b03c-4b01-9cf7-3041b08b18c3","codeChangeId":"232510c8-b03c-4b01-9cf7-3041b08b18c3","sourceType":"assistant"} -->
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Adds GenAI span-type detection in trace-agent normalization so spans carrying `gen_ai.*` attributes are stored as `llm` spans.

- Overrides v0 span `Type` after existing type validation when span meta contains a `gen_ai.` key.
- Overrides v1 internal span type after validation by resolving attribute key refs through the string table.
- Applies the same GenAI precedence in OTLP span type conversion after looking up `span.type` and before the span-kind fallback.

### Motivation
LLM/GenAI instrumentation can send spans with SDK-provided types like `browser` while also carrying GenAI semantic attributes. These spans should be classified and stored as LLM spans downstream.

### Describe how you validated your changes
- Added unit coverage for v0, v1, and OTLP paths covering GenAI override and non-GenAI pass-through.
- Ran `git diff --check`.
- Attempted `dda inv test --targets=./pkg/trace/agent,./pkg/trace/transform --test-run-name='TestNormalizeTypeFromGenAI|TestNormalizeTypeFromGenAIV1|TestGetOTelSpanTypeFromGenAI'`; the sandbox could not execute it because the pinned Go `1.26.6` is not installed, `goenv install 1.26.6` has no available definition, and the fallback `GOENV_VERSION=1.26.3` run was blocked while Bazelisk downloaded Bazel 9.2.0 from `releases.bazel.build` with `Bad Gateway`.

### Additional Notes
None.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/e4d3309e-2914-493b-99ee-faeece9e4e1b)

Comment @datadog to request changes