### PR TITLE
[CONTINT-5581] Docker check: try every PID when reading container routes

### DIFF
--- a/pkg/collector/corechecks/containers/docker/check_linux_test.go
+++ b/pkg/collector/corechecks/containers/docker/check_linux_test.go
@@ -343,8 +343,6 @@ func TestFindDockerNetworksPIDSelection(t *testing.T) {
 		},
 	}
 
-	// 0x000012AC / 0x0000FFFF is 172.18.0.0/16 in the little-endian representation used by
-	// /proc/<pid>/net/route, so it matches the 172.18.0.2 address of the `ubuntu_default` network.
 	liveRoutes := []system.NetworkRoute{
 		{
 			Interface: "eth1",
@@ -386,8 +384,6 @@ func TestFindDockerNetworksPIDSelection(t *testing.T) {
 			expectedTried:   nil,
 		},
 		{
-			// A failure that is not a vanished process would repeat identically for every PID,
-			// so it must abort the loop instead of walking the whole process list.
 			name:            "permanent failure stops at the first PID",
 			pids:            []int{deniedPID, livePID},
 			expectedMapping: nil,

--- a/pkg/collector/corechecks/containers/docker/check_linux_test.go
+++ b/pkg/collector/corechecks/containers/docker/check_linux_test.go
@@ -324,6 +324,8 @@ func TestFindDockerNetworksPIDSelection(t *testing.T) {
 	// handed out to the short-lived children it forks.
 	const livePID = 2280542
 	const deadPID, otherDeadPID = 1510160, 1511051
+	// PID whose routes cannot be read for a reason that is not tied to that PID, e.g. EACCES.
+	const deniedPID = 1600000
 
 	rawContainer := container.Summary{
 		ID:    "docker-app",
@@ -383,6 +385,14 @@ func TestFindDockerNetworksPIDSelection(t *testing.T) {
 			expectedMapping: nil,
 			expectedTried:   nil,
 		},
+		{
+			// A failure that is not a vanished process would repeat identically for every PID,
+			// so it must abort the loop instead of walking the whole process list.
+			name:            "permanent failure stops at the first PID",
+			pids:            []int{deniedPID, livePID},
+			expectedMapping: nil,
+			expectedTried:   []int{deniedPID},
+		},
 	}
 
 	for _, test := range tests {
@@ -390,10 +400,14 @@ func TestFindDockerNetworksPIDSelection(t *testing.T) {
 			var tried []int
 			getRoutesFunc = func(_ string, pid int) ([]system.NetworkRoute, error) {
 				tried = append(tried, pid)
-				if pid != livePID {
+				switch pid {
+				case livePID:
+					return liveRoutes, nil
+				case deniedPID:
+					return nil, fmt.Errorf("unable to read routes for pid %d: %w", pid, os.ErrPermission)
+				default:
 					return nil, fmt.Errorf("unable to read routes for pid %d: %w", pid, os.ErrNotExist)
 				}
-				return liveRoutes, nil
 			}
 			t.Cleanup(func() { getRoutesFunc = system.ParseProcessRoutes })
 

--- a/pkg/collector/corechecks/containers/docker/check_linux_test.go
+++ b/pkg/collector/corechecks/containers/docker/check_linux_test.go
@@ -8,8 +8,12 @@
 package docker
 
 import (
+	"fmt"
 	"net/netip"
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/moby/moby/api/types/container"
 	dockerNetworkTypes "github.com/moby/moby/api/types/network"
@@ -92,8 +96,13 @@ func TestDockerNetworkExtension(t *testing.T) {
 	}
 
 	getRoutesFunc = func(_ string, pid int) ([]system.NetworkRoute, error) {
-		return routeForPID[pid], nil
+		routes, found := routeForPID[pid]
+		if !found {
+			return nil, fmt.Errorf("unable to read routes for pid %d: %w", pid, os.ErrNotExist)
+		}
+		return routes, nil
 	}
+	t.Cleanup(func() { getRoutesFunc = system.ParseProcessRoutes })
 
 	mockSender := mocksender.NewMockSender(t, "docker-network-extension")
 	mockSender.SetupAcceptAll()
@@ -104,7 +113,7 @@ func TestDockerNetworkExtension(t *testing.T) {
 	// container1 is host network in Kubernetes - linked to PID 100
 	// container2 is normal container in Kubernetes (no network config) - linked to container3 and PID 101
 	// container3 is a pause container in Kubernetes (owns the network config) - linked to nothing
-	// container4 is a normal docker container connected to 2 networks 0 linked to PID 200
+	// container4 is a normal docker container connected to 2 networks - linked to PIDs 150 (dead) and 200
 	container1 := generic.CreateContainerMeta("docker", "kube-host-network")
 	mockCollector.SetContainerEntry(container1.ID, mock.ContainerEntry{
 		PIDs: []int{100},
@@ -200,7 +209,11 @@ func TestDockerNetworkExtension(t *testing.T) {
 
 	container4 := generic.CreateContainerMeta("docker", "docker-app")
 	mockCollector.SetContainerEntry(container4.ID, mock.ContainerEntry{
-		PIDs: []int{200},
+		// Once the kernel PID counter has wrapped around, the short-lived children of a
+		// container get PIDs below the one of its main process. Here 150 belongs to such a
+		// child, which already exited, and only the main process (200) can be used to read
+		// the container routing table.
+		PIDs: []int{150, 200},
 		NetworkStats: &metrics.ContainerNetworkStats{
 			Interfaces: map[string]metrics.InterfaceNetStats{
 				"eth0": {
@@ -299,4 +312,96 @@ func TestNetworkCustomOnFailure(t *testing.T) {
 		SizeRootFs: 200,
 	})
 	networkExt.postRun()
+}
+
+// TestFindDockerNetworksPIDSelection covers the PID selection when reading the container routing
+// table. Regression test for https://github.com/DataDog/datadog-agent/issues/55676: the first PID
+// of the list is not necessarily the container main process, and is often already gone once the
+// kernel PID counter has wrapped around.
+func TestFindDockerNetworksPIDSelection(t *testing.T) {
+	// PIDs shaped like the ones reported in the issue: the main process has been running
+	// since before the PID counter wrapped around, so it holds a PID above the ones now
+	// handed out to the short-lived children it forks.
+	const livePID = 2280542
+	const deadPID, otherDeadPID = 1510160, 1511051
+
+	rawContainer := container.Summary{
+		ID:    "docker-app",
+		State: container.ContainerState(workloadmeta.ContainerStatusRunning),
+		HostConfig: struct {
+			NetworkMode string            `json:",omitempty"`
+			Annotations map[string]string `json:",omitempty"`
+		}{NetworkMode: "ubuntu_default"},
+		NetworkSettings: &container.NetworkSettingsSummary{
+			Networks: map[string]*dockerNetworkTypes.EndpointSettings{
+				"ubuntu_default": {
+					IPAddress: netip.MustParseAddr("172.18.0.2"),
+				},
+			},
+		},
+	}
+
+	// 0x000012AC / 0x0000FFFF is 172.18.0.0/16 in the little-endian representation used by
+	// /proc/<pid>/net/route, so it matches the 172.18.0.2 address of the `ubuntu_default` network.
+	liveRoutes := []system.NetworkRoute{
+		{
+			Interface: "eth1",
+			Subnet:    0x000012AC,
+			Mask:      0x0000FFFF,
+			Gateway:   0x00000000,
+		},
+	}
+	expectedMapping := map[string]string{"eth1": "ubuntu_default"}
+
+	tests := []struct {
+		name            string
+		pids            []int
+		expectedMapping map[string]string
+		expectedTried   []int
+	}{
+		{
+			name:            "first PID is alive",
+			pids:            []int{livePID, deadPID},
+			expectedMapping: expectedMapping,
+			expectedTried:   []int{livePID},
+		},
+		{
+			name:            "first PIDs are gone, falls back to the live one",
+			pids:            []int{deadPID, otherDeadPID, livePID},
+			expectedMapping: expectedMapping,
+			expectedTried:   []int{deadPID, otherDeadPID, livePID},
+		},
+		{
+			name:            "all PIDs are gone",
+			pids:            []int{deadPID, otherDeadPID},
+			expectedMapping: nil,
+			expectedTried:   []int{deadPID, otherDeadPID},
+		},
+		{
+			name:            "no PID at all",
+			pids:            nil,
+			expectedMapping: nil,
+			expectedTried:   nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var tried []int
+			getRoutesFunc = func(_ string, pid int) ([]system.NetworkRoute, error) {
+				tried = append(tried, pid)
+				if pid != livePID {
+					return nil, fmt.Errorf("unable to read routes for pid %d: %w", pid, os.ErrNotExist)
+				}
+				return liveRoutes, nil
+			}
+			t.Cleanup(func() { getRoutesFunc = system.ParseProcessRoutes })
+
+			entry := &containerNetworkEntry{containerID: rawContainer.ID, pids: test.pids}
+			findDockerNetworks("/proc", entry, rawContainer)
+
+			assert.Equal(t, test.expectedMapping, entry.ifaceNetworkMapping)
+			assert.Equal(t, test.expectedTried, tried)
+		})
+	}
 }

--- a/pkg/collector/corechecks/containers/docker/check_network.go
+++ b/pkg/collector/corechecks/containers/docker/check_network.go
@@ -9,7 +9,10 @@ package docker
 
 import (
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"net"
+	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -197,16 +200,27 @@ var (
 // several seconds old, and its order is not guaranteed to put the container main process first.
 // In particular, once the kernel PID counter has wrapped around, the lowest PID of a container is
 // the youngest process, hence the most likely to be gone already.
-func routesForContainer(procPath string, entry *containerNetworkEntry) (routes []system.NetworkRoute, err error) {
+//
+// Mirrors the PID selection of `buildNetworkStats`: only a vanished process is worth retrying with
+// another PID.
+func routesForContainer(procPath string, entry *containerNetworkEntry) ([]system.NetworkRoute, error) {
 	for _, pid := range entry.pids {
-		if routes, err = getRoutesFunc(procPath, pid); err == nil {
+		routes, err := getRoutesFunc(procPath, pid)
+		if err == nil {
 			return routes, nil
+		}
+
+		// Any other failure (permission denied, malformed route file, Windows routing table API
+		// error, …) is not tied to that particular PID and would repeat identically for all of
+		// them, so report it right away instead of hammering the whole process list.
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
 		}
 
 		log.Tracef("Cannot list routes for container id %s through pid %d: %s, trying next pid", entry.containerID, pid, err)
 	}
 
-	return routes, err
+	return nil, fmt.Errorf("none of the %d known PIDs of the container are still running", len(entry.pids))
 }
 
 func findDockerNetworks(procPath string, entry *containerNetworkEntry, container container.Summary) {

--- a/pkg/collector/corechecks/containers/docker/check_network.go
+++ b/pkg/collector/corechecks/containers/docker/check_network.go
@@ -192,17 +192,6 @@ var (
 	getRoutesFunc = system.ParseProcessRoutes
 )
 
-// routesForContainer returns the routes of the container network namespace, trying each of its
-// PIDs until one is readable.
-//
-// All the processes of a container share the same network namespace, so they all (normally) yield
-// the same routes. Picking a single PID is not enough: `entry.pids` is a snapshot that may be
-// several seconds old, and its order is not guaranteed to put the container main process first.
-// In particular, once the kernel PID counter has wrapped around, the lowest PID of a container is
-// the youngest process, hence the most likely to be gone already.
-//
-// Mirrors the PID selection of `buildNetworkStats`: only a vanished process is worth retrying with
-// another PID.
 func routesForContainer(procPath string, entry *containerNetworkEntry) ([]system.NetworkRoute, error) {
 	for _, pid := range entry.pids {
 		routes, err := getRoutesFunc(procPath, pid)
@@ -210,9 +199,6 @@ func routesForContainer(procPath string, entry *containerNetworkEntry) ([]system
 			return routes, nil
 		}
 
-		// Any other failure (permission denied, malformed route file, Windows routing table API
-		// error, …) is not tied to that particular PID and would repeat identically for all of
-		// them, so report it right away instead of hammering the whole process list.
 		if !errors.Is(err, os.ErrNotExist) {
 			return nil, err
 		}

--- a/pkg/collector/corechecks/containers/docker/check_network.go
+++ b/pkg/collector/corechecks/containers/docker/check_network.go
@@ -189,6 +189,26 @@ var (
 	getRoutesFunc = system.ParseProcessRoutes
 )
 
+// routesForContainer returns the routes of the container network namespace, trying each of its
+// PIDs until one is readable.
+//
+// All the processes of a container share the same network namespace, so they all (normally) yield
+// the same routes. Picking a single PID is not enough: `entry.pids` is a snapshot that may be
+// several seconds old, and its order is not guaranteed to put the container main process first.
+// In particular, once the kernel PID counter has wrapped around, the lowest PID of a container is
+// the youngest process, hence the most likely to be gone already.
+func routesForContainer(procPath string, entry *containerNetworkEntry) (routes []system.NetworkRoute, err error) {
+	for _, pid := range entry.pids {
+		if routes, err = getRoutesFunc(procPath, pid); err == nil {
+			return routes, nil
+		}
+
+		log.Tracef("Cannot list routes for container id %s through pid %d: %s, trying next pid", entry.containerID, pid, err)
+	}
+
+	return routes, err
+}
+
 func findDockerNetworks(procPath string, entry *containerNetworkEntry, container container.Summary) {
 	netMode := container.HostConfig.NetworkMode
 	// Check the known network modes that require specific handling.
@@ -219,7 +239,6 @@ func findDockerNetworks(procPath string, entry *containerNetworkEntry, container
 		return
 	}
 
-	var err error
 	interfaces := make(map[string]uint64)
 	for netName, netConf := range netSettings.Networks {
 		if netName == "host" {
@@ -238,9 +257,9 @@ func findDockerNetworks(procPath string, entry *containerNetworkEntry, container
 		interfaces[netName] = uint64(binary.LittleEndian.Uint32(ip.To4()))
 	}
 
-	destinations, err := getRoutesFunc(procPath, entry.pids[0])
+	destinations, err := routesForContainer(procPath, entry)
 	if err != nil {
-		log.Warnf("Cannot list routes for container id %s: %s, skipping", entry.containerID, err)
+		log.Debugf("Cannot list routes for container id %s: %s, falling back to raw interface names for the docker_network tag", entry.containerID, err)
 		return
 	}
 

--- a/releasenotes/notes/docker-check-routes-pid-e5f404c90e3fea3b.yaml
+++ b/releasenotes/notes/docker-check-routes-pid-e5f404c90e3fea3b.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fix the Docker check logging a ``Cannot list routes for container id ...``
+    warning on every check run, and reporting ``docker.net.*`` metrics tagged
+    with the raw interface name (for example ``docker_network:eth0``) instead
+    of the Docker network name (``docker_network:bridge``). When reading the
+    routing table of a container, the check now tries all the processes of that
+    container instead of a single one, which could already have exited on hosts
+    where the kernel PID counter has wrapped around.


### PR DESCRIPTION
### What does this PR do?

Makes the Docker check try every PID of a container when reading its routing table, instead of only `entry.pids[0]`.

The final failure is also downgraded from `Warnf` to `Debugf`, for consistency with every other early return in `findDockerNetworks` and because the consequence is a degraded tag, not a lost metric.

### Motivation

Fixes #55676.

`findDockerNetworks` wrongly assumed `entry.pids[0]` was the container's long-lived main process. Nothing guarantees that.

### Describe how you validated your changes

- `TestFindDockerNetworksPIDSelection`

### Additional Notes