### PR TITLE
Add --enable-bazel flag to host-profiler.build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,6 +34,7 @@ common --remote_timeout=60
 common --rewind_lost_inputs # https://github.com/bazelbuild/bazel/pull/25477
 common --repo_env=DEPLOY_AGENT # Keep in sync with env_vars in MODULE.bazel
 common --repo_env=FORCED_PACKAGE_COMPRESSION_LEVEL # Keep in sync with env_vars in MODULE.bazel
+common --repo_env=FORCE_AGENT_VERSION # Keep in sync with env_vars in MODULE.bazel
 common --repo_env=GOCACHE # https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching
 common --repo_env=GOMODCACHE # https://wiki.archlinux.org/title/XDG_Base_Directory#Partial
 common --repo_env=GOTOOLCHAIN=local # Extend https://github.com/bazel-contrib/rules_go/pull/3660 to Go SDK patching rules

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,6 +19,10 @@ env_vars(
         # For some tests we want to run with higher compression, but
         # not break caching and rebuild the binaries.
         "FORCED_PACKAGE_COMPRESSION_LEVEL",
+        # Lets a caller force pkg/version.AgentVersion to an explicit value,
+        # overriding the PACKAGE_VERSION/release.json-derived default.
+        # Used by host-profiler's nightly/dev-branch version override.
+        "FORCE_AGENT_VERSION",
         # This is the build pipeline id, which is used in some symlink paths.
         "PACKAGE_VERSION",
         # macOS code signing: control whether to enable code signing

--- a/bazel/repo/env_vars.bzl
+++ b/bazel/repo/env_vars.bzl
@@ -36,6 +36,7 @@ exports_files(
     # We may expand this in the future, but let's limit inventiveness for now.
     visibility = [
         "@agent//bazel/rules:__subpackages__",
+        "@agent//cmd:__subpackages__",
         "@agent//packages:__subpackages__",
     ],
 )

--- a/bazel/rules/go/go_binary.bzl
+++ b/bazel/rules/go/go_binary.bzl
@@ -64,6 +64,23 @@ def _url_safe_to_standard(url_safe):
         return url_safe
     return url_safe[:idx] + "+git." + url_safe[idx + 5:]
 
+def _standard_to_url_safe(standard):
+    """Convert a standard SemVer agent version string to the URL-safe form.
+
+    Mirrors _url_safe_to_standard(): only the SemVer '+' build-metadata
+    separator is replaced with '.', matching the convention used by
+    `dda inv agent.version --url-safe`. No other character is touched.
+
+    Examples:
+      "7.81.0-devel+git.635.e3326d4.pipeline.1" -> "7.81.0-devel.git.635.e3326d4.pipeline.1"
+      "7.81.0-rc.1+git.635.e3326d4"             -> "7.81.0-rc.1.git.635.e3326d4"
+      "7.81.0"                                   -> "7.81.0"  (clean release, no change)
+    """
+    idx = standard.find("+git.")
+    if idx < 0:
+        return standard
+    return standard[:idx] + ".git." + standard[idx + 5:]
+
 def _make_agent_version_url_safe():
     """Return the URL-safe agent version string.
 

--- a/bazel/rules/go/go_binary.bzl
+++ b/bazel/rules/go/go_binary.bzl
@@ -11,6 +11,9 @@ Version string strategy (mirrors package_naming.bzl):
   AgentVersionURLSafe uses this directly; AgentVersion converts it back to standard
   SemVer form with '+' via _url_safe_to_standard().
 - Locally: fall back to release_json current_milestone + "-localbuild" for both.
+- The agent_version parameter, when passed, overrides both AgentVersion and AgentVersionURLSafe
+  so the two stay in sync. Used by callers that compute their own version outside of
+  PACKAGE_VERSION, e.g. host-profiler's nightly/dev-branch build.
 
 Run-path strategy, selected via //:linux_and_release and @platforms//os:linux:
 - Linux + release (//:linux_and_release): /opt/datadog-packages/run
@@ -92,7 +95,7 @@ def _make_agent_version_url_safe():
         return env_vars.PACKAGE_VERSION
     return release_json.get("current_milestone") + "-localbuild"
 
-def dd_agent_go_binary(name, gc_linkopts = None, gotags = None, exact_gotags = None, **kwargs):
+def dd_agent_go_binary(name, gc_linkopts = None, gotags = None, exact_gotags = None, agent_version = None, **kwargs):
     """Wrapper around go_binary that injects Datadog Agent version x_defs.
 
     Accepts all go_binary attributes.  x_defs and gc_linkopts are merged with
@@ -111,6 +114,8 @@ def dd_agent_go_binary(name, gc_linkopts = None, gotags = None, exact_gotags = N
       gotags: Base set of gotags for this binary. COMMON tags are added, and
               per-platform adjustments are made.
       exact_gotags: Like gotags, but if this is specified, no other tag sets are added.
+      agent_version: overrides pkg/version.AgentVersion and AgentVersionURLSafe (URL-safe
+                     encoded) instead of deriving them from PACKAGE_VERSION/release.json.
       **kwargs: arguments to be forwarded to go_binary
     """
     # TODO: When --stamp support is in place, also inject:
@@ -121,16 +126,20 @@ def dd_agent_go_binary(name, gc_linkopts = None, gotags = None, exact_gotags = N
     # Build two complete x_defs dicts — one per //:is_release branch.
     # string_dict attributes do not support per-value select(); the select()
     # must wrap the whole dict.
-    agent_version_url_safe = _make_agent_version_url_safe()
+    if agent_version:
+        agent_version_url_safe = _standard_to_url_safe(agent_version)
+    else:
+        agent_version_url_safe = _make_agent_version_url_safe()
+        agent_version = _url_safe_to_standard(agent_version_url_safe)
     release_x_defs = {
         _VERSION_PKG + ".AgentPayloadVersion": AGENT_PAYLOAD_VERSION,
-        _VERSION_PKG + ".AgentVersion": _url_safe_to_standard(agent_version_url_safe),
+        _VERSION_PKG + ".AgentVersion": agent_version,
         _VERSION_PKG + ".AgentVersionURLSafe": agent_version_url_safe,
         _SETUP_PKG + ".defaultRunPath": _RUN_PATH_RELEASE,
     }
     dev_x_defs = {
         _VERSION_PKG + ".AgentPayloadVersion": AGENT_PAYLOAD_VERSION,
-        _VERSION_PKG + ".AgentVersion": _url_safe_to_standard(agent_version_url_safe),
+        _VERSION_PKG + ".AgentVersion": agent_version,
         _VERSION_PKG + ".AgentVersionURLSafe": agent_version_url_safe,
         _SETUP_PKG + ".defaultRunPath": _RUN_PATH_DEV,
     }

--- a/cmd/host-profiler/BUILD.bazel
+++ b/cmd/host-profiler/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@agent_volatile//:env_vars.bzl", "env_vars")
 load("@rules_go//go:def.bzl", "go_library")
 load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 load("//bazel/rules/go:go_binary.bzl", "dd_agent_go_binary")
@@ -32,6 +33,7 @@ go_library(
 
 dd_agent_go_binary(
     name = "host-profiler",
+    agent_version = env_vars.FORCE_AGENT_VERSION or None,
     embed = [":host-profiler_lib"],
     gotags = HOST_PROFILER_TAGS,
     target_compatible_with = ["@platforms//os:linux"],

--- a/tasks/host_profiler.py
+++ b/tasks/host_profiler.py
@@ -8,6 +8,7 @@ from invoke.context import Context
 from invoke.exceptions import Exit
 
 from tasks.build_tags import get_default_build_tags
+from tasks.libs.build.bazel import build_binary_with_bazel
 from tasks.libs.common.color import color_message
 from tasks.libs.common.constants import ALLOWED_REPO_NIGHTLY_BRANCHES
 from tasks.libs.common.go import go_build
@@ -62,7 +63,7 @@ def _get_profiler_agent_version(ctx):
 
 
 @task
-def build(ctx):
+def build(ctx, enable_bazel=False):
     """
     Build the host profiler
     """
@@ -70,25 +71,30 @@ def build(ctx):
     if os.path.exists(BIN_PATH):
         os.remove(BIN_PATH)
 
-    build_tags = get_default_build_tags(build="host-profiler")
-    ldflags, gcflags, env = get_build_flags(ctx)
-    if profiler_version := _get_profiler_agent_version(ctx):
-        ldflags += f" -X {REPO_PATH}/pkg/version.AgentVersion={profiler_version}"
-
     # generate windows resources
     if sys.platform == 'win32':
         raise Exit("Windows is not supported for host-profiler")
 
-    go_build(
-        ctx,
-        f"{REPO_PATH}/cmd/host-profiler",
-        mod="readonly",
-        build_tags=build_tags,
-        ldflags=ldflags,
-        gcflags=gcflags,
-        bin_path=BIN_PATH,
-        env=env,
-    )
+    if enable_bazel:
+        if _get_profiler_agent_version(ctx):
+            raise NotImplementedError("--enable-bazel does not support the nightly/dev-branch AgentVersion override.")
+        build_binary_with_bazel("//cmd/host-profiler:host-profiler", bin_path=BIN_PATH)
+    else:
+        build_tags = get_default_build_tags(build="host-profiler")
+        ldflags, gcflags, env = get_build_flags(ctx)
+        if profiler_version := _get_profiler_agent_version(ctx):
+            ldflags += f" -X {REPO_PATH}/pkg/version.AgentVersion={profiler_version}"
+
+        go_build(
+            ctx,
+            f"{REPO_PATH}/cmd/host-profiler",
+            mod="readonly",
+            build_tags=build_tags,
+            ldflags=ldflags,
+            gcflags=gcflags,
+            bin_path=BIN_PATH,
+            env=env,
+        )
 
     dist_folder = os.path.join(BIN_DIR, "dist")
     if os.path.exists(dist_folder):

--- a/tasks/host_profiler.py
+++ b/tasks/host_profiler.py
@@ -76,9 +76,10 @@ def build(ctx, enable_bazel=False):
         raise Exit("Windows is not supported for host-profiler")
 
     if enable_bazel:
-        if _get_profiler_agent_version(ctx):
-            raise NotImplementedError("--enable-bazel does not support the nightly/dev-branch AgentVersion override.")
-        build_binary_with_bazel("//cmd/host-profiler:host-profiler", bin_path=BIN_PATH)
+        args = []
+        if profiler_version := _get_profiler_agent_version(ctx):
+            args.append(f"--repo_env=FORCE_AGENT_VERSION={profiler_version}")
+        build_binary_with_bazel("//cmd/host-profiler:host-profiler", args=args, bin_path=BIN_PATH)
     else:
         build_tags = get_default_build_tags(build="host-profiler")
         ldflags, gcflags, env = get_build_flags(ctx)


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Add an `--enable-bazel` flag to allow building host-profiler with bazel through dda

### Motivation

Allowing developers to try out the bazel migration

### Describe how you validated your changes

### Additional Notes
