### PR TITLE
cmd/sbomgen: switch to dd_agent_go_binary

### DIFF
--- a/cmd/sbomgen/BUILD.bazel
+++ b/cmd/sbomgen/BUILD.bazel
@@ -1,4 +1,6 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:go_binary.bzl", "dd_agent_go_binary")
+load("//tasks:build_tags.bzl", "SBOMGEN_TAGS")
 
 go_library(
     name = "sbomgen_lib",
@@ -33,15 +35,10 @@ go_library(
     }),
 )
 
-go_binary(
+dd_agent_go_binary(
     name = "sbomgen",
     embed = [":sbomgen_lib"],
-    gotags = [
-        "trivy",
-        "containerd",
-        "docker",
-        "crio",
-    ],  # keep
+    gotags = SBOMGEN_TAGS,
     linkmode = "pie",  # keep
     target_compatible_with = ["@platforms//os:linux"],  # keep
     visibility = ["//visibility:public"],


### PR DESCRIPTION


<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Migrate from `go_binary` to `dd_agent_go_binary` for `cmd/sbomgen`

### Motivation

This way the resulting binary will be built with the expected tags & ldflags, bringing us closer from being able to build that binary with bazel

### Describe how you validated your changes

Local build

### Additional Notes
