### PR TITLE
Group `istio.io` Renovate updates to avoid conflicting PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -139,6 +139,11 @@
       },
       {
         "matchManagers": ["gomod"],
+        "matchDepNames": ["istio.io/**"],
+        "groupName": "istio"
+      },
+      {
+        "matchManagers": ["gomod"],
         "matchDepNames": ["k8s.io/**"],
         "matchUpdateTypes": ["patch"],
         "groupName": "k8s-io"


### PR DESCRIPTION
### What does this PR do?
Add a Renovate group rule for `istio.io/**` so `istio.io/api` and `istio.io/client-go` bump together in a single PR.

### Motivation
Renovate currently opens one PR per module.
Since `istio.io/api` and `istio.io/client-go` are pinned to the same version in `go.mod` and move in lockstep upstream, 2 separate PRs bumping them independently would conflict with each other.

### Describe how you validated your changes
`python3 -m json.tool renovate.json` and `npx -p renovate renovate-config-validator renovate.json` both pass.