### PR TITLE
[AGNTLOG-705] Report log data lost after rotation as an Agent Health issue

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -558,6 +558,7 @@
 /comp/core/gui/impl/systray/                                          @DataDog/windows-products @DataDog/fleet-remediation
 /comp/healthplatform/issues/ad-misconfiguration                       @DataDog/container-platform @DataDog/fleet-remediation
 /comp/healthplatform/issues/gpuenvironment                            @DataDog/gpu-monitoring-agent @DataDog/ebpf-platform @DataDog/fleet-remediation
+/comp/healthplatform/issues/missedbytes                               @DataDog/agent-log-pipelines @DataDog/fleet-remediation
 /comp/healthplatform/issues/rofspermissions                           @DataDog/container-platform @DataDog/fleet-remediation
 /pkg/cloudfoundry                                                     @DataDog/agent-integrations
 /pkg/clusteragent/                                                    @DataDog/container-platform

--- a/comp/healthplatform/AGENTS.md
+++ b/comp/healthplatform/AGENTS.md
@@ -290,7 +290,9 @@ Required test cases:
 
 ### Integration tests with fakeintake — when the issue is self-contained
 
-Use a fakeintake-backed integration test when the issue can be triggered and verified entirely in-process — no provisioned VM or real agent binary needed. These live in **`comp/healthplatform/bundle_test.go`** alongside the existing bundle tests.
+Use a fakeintake-backed integration test when the issue can be triggered and verified entirely in-process — no provisioned VM or real agent binary needed. These live in package `healthplatform`, either in **`comp/healthplatform/bundle_test.go`** alongside the existing bundle tests or, for a module with more than one case to cover, in its own **`comp/healthplatform/<module>_integration_test.go`** (see `missedbytes_integration_test.go`).
+
+Assert only what the unit tests cannot: that the report became the right issue type and that whatever the bundle transforms on the way through (aggregation, `Extra` structuring, state transitions) survived. Re-asserting every proto field duplicates `issue_test.go` and makes every wording change a two-file edit.
 
 The pattern (see `TestIssueStateLifecycleForwarded`):
 1. Start an in-process fakeintake server: `fi := fakeintakeserver.NewServer(...); fi.Start()`

--- a/comp/healthplatform/AGENTS.md
+++ b/comp/healthplatform/AGENTS.md
@@ -290,9 +290,7 @@ Required test cases:
 
 ### Integration tests with fakeintake — when the issue is self-contained
 
-Use a fakeintake-backed integration test when the issue can be triggered and verified entirely in-process — no provisioned VM or real agent binary needed. These live in package `healthplatform`, either in **`comp/healthplatform/bundle_test.go`** alongside the existing bundle tests or, for a module with more than one case to cover, in its own **`comp/healthplatform/<module>_integration_test.go`** (see `missedbytes_integration_test.go`).
-
-Assert only what the unit tests cannot: that the report became the right issue type and that whatever the bundle transforms on the way through (aggregation, `Extra` structuring, state transitions) survived. Re-asserting every proto field duplicates `issue_test.go` and makes every wording change a two-file edit.
+Use a fakeintake-backed integration test when the issue can be triggered and verified entirely in-process — no provisioned VM or real agent binary needed. These live in **`comp/healthplatform/bundle_test.go`** alongside the existing bundle tests.
 
 The pattern (see `TestIssueStateLifecycleForwarded`):
 1. Start an in-process fakeintake server: `fi := fakeintakeserver.NewServer(...); fi.Start()`

--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//comp/healthplatform/issues/dockerpermissions",
         "//comp/healthplatform/issues/invalidconfig",
         "//comp/healthplatform/issues/invalidsysprobeconfig",
+        "//comp/healthplatform/issues/missedbytes",
         "//comp/healthplatform/issues/rofspermissions",
         "//comp/healthplatform/runner/def",
         "//comp/healthplatform/runner/fx",
@@ -42,6 +43,7 @@ dd_agent_go_test(
     srcs = [
         "bundle_test.go",
         "invalidconfig_integration_test.go",
+        "missedbytes_integration_test.go",
     ],
     embed = [":healthplatform"],
     deps = [
@@ -54,9 +56,11 @@ dd_agent_go_test(
         "//comp/core/workloadmeta/fx-mock",
         "//comp/healthplatform/issues",
         "//comp/healthplatform/issues/invalidconfig",
+        "//comp/healthplatform/issues/missedbytes",
         "//comp/healthplatform/runner/def",
         "//comp/healthplatform/scheduler/def",
         "//comp/healthplatform/store/def",
+        "//comp/logs-library/metrics",
         "//pkg/config/schema",
         "//pkg/util/fxutil",
         "//test/fakeintake/client",

--- a/comp/healthplatform/README.md
+++ b/comp/healthplatform/README.md
@@ -121,6 +121,7 @@ affected-count is a backend follow-up, not handled by the agent today. Document 
 | `rofspermissions` | `rofs-permissions` | `Read-Only Filesystem Error` | `read-only_filesystem_error` | `"Agent cannot write to: <directories>"` | per-host (host-local failure) |
 | `admissionprobe` | `admission-controller-connectivity-failure` | `Admission Controller Unreachable` | `admission_controller_unreachable` | `"Admission Controller Unreachable"` | singleton |
 | `dockerpermissions` | `docker-socket-permissions` | `Docker File Tailing Disabled` | `docker_file_tailing_disabled` | `"Docker log tailing disabled for '<dockerDir>'"` | per-host (host-local failure) |
+| `missedbytes` | `log-data-lost-after-rotation:<digest>` | `Log Data Lost After Rotation` | `log_data_lost_after_rotation` | `"Lost <bytes> of logs from <N> sources in the last 24 hours"`, or `"from source <name>"` when one source and service account for all of it | per-host (host-local failure) |
 
 ## Adding a new issue module
 

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -33,6 +33,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"     // registers templates via init()
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/invalidconfig"         // registers templates via init()
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/invalidsysprobeconfig" // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/missedbytes"           // registers templates via init()
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"       // registers templates via init()
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 	runnerfx "github.com/DataDog/datadog-agent/comp/healthplatform/runner/fx"

--- a/comp/healthplatform/issues/missedbytes/BUILD.bazel
+++ b/comp/healthplatform/issues/missedbytes/BUILD.bazel
@@ -1,0 +1,42 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+
+go_library(
+    name = "missedbytes",
+    srcs = [
+        "check.go",
+        "issue.go",
+        "module.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/missedbytes",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/core/hostname/hostnameinterface/def",
+        "//comp/healthplatform/issues",
+        "//comp/healthplatform/runner/def",
+        "//comp/logs-library/metrics",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@com_github_dustin_go_humanize//:go-humanize",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)
+
+dd_agent_go_test(
+    name = "missedbytes_test",
+    srcs = [
+        "check_test.go",
+        "issue_test.go",
+        "module_test.go",
+    ],
+    embed = [":missedbytes"],
+    deps = [
+        "//comp/core/config",
+        "//comp/core/hostname/hostnameinterface/mock",
+        "//comp/healthplatform/issues",
+        "//comp/logs-library/metrics",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/comp/healthplatform/issues/missedbytes/check.go
+++ b/comp/healthplatform/issues/missedbytes/check.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package missedbytes
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"sort"
+	"strconv"
+	"time"
+
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
+	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
+	logsmetrics "github.com/DataDog/datadog-agent/comp/logs-library/metrics"
+)
+
+var errLogsAgentNotRunning = errors.New("missedbytes: logs agent not running")
+
+// maxBreakdownSources caps the tuples listed individually; totals cover them all.
+const maxBreakdownSources = 10
+
+type checker struct {
+	hostname hostnameinterface.Component
+}
+
+func newChecker(hostname hostnameinterface.Component) *checker {
+	return &checker{hostname: hostname}
+}
+
+// Run summarises every tuple in the tracker's window into one issue: the backend
+// keeps a single row per {org, issue_type}. Always empty on Windows, where the
+// tailer holds no os.File to size a loss with.
+func (c *checker) Run() ([]runnerdef.IssueReport, error) {
+	// Error means "state unknown" and leaves the scheduler's active ids alone; nil
+	// would resolve the running agent's issue. See MarkLogsAgentRunning.
+	if !logsmetrics.LogsAgentRunning() {
+		return nil, errLogsAgentNotRunning
+	}
+
+	summaries := logsmetrics.MissedBytesSnapshot()
+	if len(summaries) == 0 {
+		return nil, nil
+	}
+
+	var totalBytes, totalRotations int64
+	var lastLossAt time.Time
+	// Counted here, not in BuildIssue, which only receives the capped breakdown.
+	distinctSources := make(map[string]struct{}, len(summaries))
+	for _, s := range summaries {
+		totalBytes += s.Bytes
+		totalRotations += s.Rotations
+		distinctSources[s.Source] = struct{}{}
+		if s.LastLossAt.After(lastLossAt) {
+			lastLossAt = s.LastLossAt
+		}
+	}
+
+	top, omitted := rankSources(summaries)
+	encoded, err := json.Marshal(top)
+	if err != nil {
+		return nil, fmt.Errorf("missedbytes: encode breakdown: %w", err)
+	}
+
+	hostname := c.hostname.GetSafe(context.Background())
+	return []runnerdef.IssueReport{{
+		IssueID:   hostIssueID(hostname),
+		IssueName: IssueName,
+		Source:    issueSource,
+		Context: map[string]string{
+			contextKeyBytes:        strconv.FormatInt(totalBytes, 10),
+			contextKeyRotations:    strconv.FormatInt(totalRotations, 10),
+			contextKeySourceCount:  strconv.Itoa(len(distinctSources)),
+			contextKeyPairsOmitted: strconv.Itoa(omitted),
+			contextKeyLastLossAt:   lastLossAt.UTC().Format(time.RFC3339),
+			contextKeySources:      string(encoded),
+		},
+	}}, nil
+}
+
+// rankSources keeps the maxBreakdownSources largest tuples and returns how many it
+// dropped. Ties break on source then service so ticks stay byte-identical.
+func rankSources(summaries []logsmetrics.MissedBytesSummary) ([]sourceLoss, int) {
+	ranked := make([]sourceLoss, 0, len(summaries))
+	for _, s := range summaries {
+		ranked = append(ranked, sourceLoss{
+			Source:    s.Source,
+			Service:   s.Service,
+			Bytes:     s.Bytes,
+			Rotations: s.Rotations,
+		})
+	}
+
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].Bytes != ranked[j].Bytes {
+			return ranked[i].Bytes > ranked[j].Bytes
+		}
+		if ranked[i].Source != ranked[j].Source {
+			return ranked[i].Source < ranked[j].Source
+		}
+		return ranked[i].Service < ranked[j].Service
+	})
+
+	if len(ranked) <= maxBreakdownSources {
+		return ranked, 0
+	}
+	return ranked[:maxBreakdownSources], len(ranked) - maxBreakdownSources
+}
+
+// hostIssueID scopes IssueID to this host. The backend dedups on id alone, so
+// without the digest one host going clean resolves the issue for every host.
+func hostIssueID(hostname string) string {
+	h := fnv.New64a()
+	h.Write([]byte(hostname)) // never returns an error for hash.Hash
+	return fmt.Sprintf("%s:%016x", IssueID, h.Sum64())
+}

--- a/comp/healthplatform/issues/missedbytes/check_test.go
+++ b/comp/healthplatform/issues/missedbytes/check_test.go
@@ -1,0 +1,169 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package missedbytes
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	hostnamemock "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/mock"
+	logsmetrics "github.com/DataDog/datadog-agent/comp/logs-library/metrics"
+)
+
+// The tracker is a singleton, so these tests must not run in parallel.
+func newTestChecker(t *testing.T, hostname string) *checker {
+	t.Helper()
+	logsmetrics.ResetMissedBytesForTest()
+	t.Cleanup(logsmetrics.ResetMissedBytesForTest)
+	hn, _ := hostnamemock.NewMock(hostnamemock.MockHostname(hostname))
+	return newChecker(hn)
+}
+
+func reportSources(t *testing.T, ctx map[string]string) []sourceLoss {
+	t.Helper()
+	var got []sourceLoss
+	require.NoError(t, json.Unmarshal([]byte(ctx[contextKeySources]), &got))
+	return got
+}
+
+// The tracker is empty for reasons unrelated to loss, and the scheduler reads zero
+// issues as "everything resolved".
+func TestCheck_LogsAgentNotRunningErrors(t *testing.T) {
+	c := newTestChecker(t, "host-a")
+	logsmetrics.RecordMissedBytes("nginx", "web", 1024)
+
+	reports, err := c.Run()
+	require.ErrorIs(t, err, errLogsAgentNotRunning)
+	assert.Empty(t, reports, "an unestablished state must not be reported as no-loss")
+}
+
+func TestCheck_NoLossReportsNothing(t *testing.T) {
+	c := newTestChecker(t, "host-a")
+	logsmetrics.MarkLogsAgentRunning()
+
+	reports, err := c.Run()
+	require.NoError(t, err)
+	assert.Empty(t, reports)
+}
+
+// The backend keeps one row per issue type, so per-tuple reports would fight for it.
+func TestCheck_LossProducesOneSummaryReport(t *testing.T) {
+	c := newTestChecker(t, "host-a")
+	logsmetrics.MarkLogsAgentRunning()
+	logsmetrics.RecordMissedBytes("nginx", "web", 4000000)
+	logsmetrics.RecordMissedBytes("nginx", "web", 200000)
+	logsmetrics.RecordMissedBytes("redis", "cache", 512)
+
+	reports, err := c.Run()
+	require.NoError(t, err)
+	require.Len(t, reports, 1, "every tuple on the host folds into one issue")
+
+	report := reports[0]
+	assert.Equal(t, IssueName, report.IssueName)
+	assert.Equal(t, issueSource, report.Source)
+	assert.Equal(t, hostIssueID("host-a"), report.IssueID)
+
+	assert.Equal(t, "4200512", report.Context[contextKeyBytes], "totals sum across every tuple")
+	assert.Equal(t, "3", report.Context[contextKeyRotations])
+	assert.Equal(t, "2", report.Context[contextKeySourceCount])
+	assert.Equal(t, "0", report.Context[contextKeyPairsOmitted])
+	assert.NotEmpty(t, report.Context[contextKeyLastLossAt])
+
+	assert.Equal(t, []sourceLoss{
+		{Source: "nginx", Service: "web", Bytes: 4200000, Rotations: 2},
+		{Source: "redis", Service: "cache", Bytes: 512, Rotations: 1},
+	}, reportSources(t, report.Context))
+}
+
+// One entry per service under a shared source is the norm for container file tailing.
+func TestCheck_SourceCountIgnoresServices(t *testing.T) {
+	c := newTestChecker(t, "host-a")
+	logsmetrics.MarkLogsAgentRunning()
+	logsmetrics.RecordMissedBytes("nginx", "web", 4000000)
+	logsmetrics.RecordMissedBytes("nginx", "api", 200000)
+
+	reports, err := c.Run()
+	require.NoError(t, err)
+	require.Len(t, reports, 1)
+	ctx := reports[0].Context
+
+	assert.Equal(t, "1", ctx[contextKeySourceCount], "two services of one source are one source")
+	assert.Len(t, reportSources(t, ctx), 2, "the breakdown still lists both tuples")
+
+	issue, err := MissedBytesIssue{}.BuildIssue(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "Lost 4.2 MB of logs from 1 source in the last 24 hours", issue.GetTitle())
+}
+
+// The breakdown is capped, so it must spend its slots on the worst offenders.
+// source-00 and source-01 are dropped yet still counted, so this also covers a
+// source living only in a tuple BuildIssue never sees.
+func TestCheck_BreakdownKeepsLargestSourcesAndCountsTheRest(t *testing.T) {
+	c := newTestChecker(t, "host-a")
+	logsmetrics.MarkLogsAgentRunning()
+
+	// Named so snapshot order is the reverse of byte order: source-00 loses least.
+	const total = maxBreakdownSources + 2
+	for i := 0; i < total; i++ {
+		logsmetrics.RecordMissedBytes(fmt.Sprintf("source-%02d", i), "svc", int64(i+1)*1000)
+	}
+
+	reports, err := c.Run()
+	require.NoError(t, err)
+	require.Len(t, reports, 1)
+	ctx := reports[0].Context
+
+	assert.Equal(t, strconv.Itoa(total), ctx[contextKeySourceCount], "the count covers every source, not just the listed ones")
+	assert.Equal(t, "2", ctx[contextKeyPairsOmitted])
+
+	got := reportSources(t, ctx)
+	require.Len(t, got, maxBreakdownSources)
+	assert.Equal(t, "source-11", got[0].Source, "largest loss first")
+	assert.Equal(t, int64(12000), got[0].Bytes)
+	assert.Equal(t, "source-02", got[len(got)-1].Source, "the two smallest losses are the ones dropped")
+
+	var want int64
+	for i := 0; i < total; i++ {
+		want += int64(i+1) * 1000
+	}
+	assert.Equal(t, strconv.FormatInt(want, 10), ctx[contextKeyBytes])
+}
+
+// The report is re-sent every egress interval, so ties must not churn the payload.
+func TestCheck_BreakdownOrderIsDeterministicOnTies(t *testing.T) {
+	c := newTestChecker(t, "host-a")
+	logsmetrics.MarkLogsAgentRunning()
+	logsmetrics.RecordMissedBytes("beta", "two", 1000)
+	logsmetrics.RecordMissedBytes("alpha", "two", 1000)
+	logsmetrics.RecordMissedBytes("alpha", "one", 1000)
+
+	reports, err := c.Run()
+	require.NoError(t, err)
+	require.Len(t, reports, 1)
+
+	got := reportSources(t, reports[0].Context)
+	require.Len(t, got, 3)
+	assert.Equal(t, []string{"alpha/one", "alpha/two", "beta/two"}, []string{
+		got[0].Source + "/" + got[0].Service,
+		got[1].Source + "/" + got[1].Service,
+		got[2].Source + "/" + got[2].Service,
+	}, "ties break on source then service")
+}
+
+// An unstable id would file a new issue each tick instead of refreshing one.
+func TestHostIssueID_StableAndHostScoped(t *testing.T) {
+	base := hostIssueID("host-a")
+
+	assert.Equal(t, base, hostIssueID("host-a"))
+	assert.True(t, strings.HasPrefix(base, IssueID+":"), "id %q must keep the kebab-case prefix", base)
+	assert.NotEqual(t, base, hostIssueID("host-b"), "hostname must scope the id")
+}

--- a/comp/healthplatform/issues/missedbytes/issue.go
+++ b/comp/healthplatform/issues/missedbytes/issue.go
@@ -123,12 +123,18 @@ func (MissedBytesIssue) BuildIssue(ctx map[string]string) (*healthplatform.Issue
 		Source:   issueSource,
 		Extra:    extra,
 		Tags:     []string{"logs", "file-tailing", "rotation", "data-loss"},
+		// Ordered cheapest to most invasive, per the component's remediation rules.
+		// Steps 3-5 branch on the saturated component step 1 identifies.
 		Remediation: &healthplatform.Remediation{
-			Summary: "Run `agent status` and review the Logs Agent Backpressure section",
+			Summary: "Raise `logs_config.close_timeout` to give the tailer more time, then relieve any logs pipeline saturation reported by `datadog-agent status`.",
 			Steps: []*healthplatform.RemediationStep{
-				{Order: 1, Text: "Run `agent status` and review the Logs Agent Backpressure section for a saturated pipeline"},
-				{Order: 2, Text: "Raise `logs_config.close_timeout` (DD_LOGS_CONFIG_CLOSE_TIMEOUT) to give the tailer longer to finish a rotated file"},
-				{Order: 3, Text: "If the file rotates faster than the Agent can read it, lower the log volume or rotate less often"},
+				{Order: 1, Text: "Run `sudo datadog-agent status` and note any saturated component in the Logs Agent Backpressure section."},
+				{Order: 2, Text: "Raise `logs_config.close_timeout` (DD_LOGS_CONFIG_CLOSE_TIMEOUT) above its 60 second default to give the tailer longer to finish a rotated file."},
+				{Order: 3, Text: "If a `destination_reliable_N` or `worker` row is saturated, check the Agent log for failed or retried submissions and resolve any proxy, DNS, authentication, or connectivity errors."},
+				{Order: 4, Text: "If the `strategy` row is saturated, set `logs_config.use_compression` to false or raise `logs_config.pipelines`."},
+				{Order: 5, Text: "If the `processor` row is saturated, scope global `logs_config.processing_rules` to the affected source, or set `logs_config.auto_multi_line_detection` to false."},
+				{Order: 6, Text: "If the Agent still cannot keep up, drop unneeded logs with an `exclude_at_match` processing rule, or reduce the volume written to the file between rotations."},
+				{Order: 7, Text: "Re-run `sudo datadog-agent status` under representative log volume and confirm no new rotation warnings appear in the Agent log."},
 			},
 		},
 	}, nil

--- a/comp/healthplatform/issues/missedbytes/issue.go
+++ b/comp/healthplatform/issues/missedbytes/issue.go
@@ -126,7 +126,8 @@ func (MissedBytesIssue) BuildIssue(ctx map[string]string) (*healthplatform.Issue
 		// Ordered cheapest to most invasive, per the component's remediation rules.
 		// Steps 3-5 branch on the saturated component step 1 identifies.
 		Remediation: &healthplatform.Remediation{
-			Summary: "Raise `logs_config.close_timeout` to give the tailer more time, then relieve any logs pipeline saturation reported by `datadog-agent status`.",
+			// Plain text: Summary is not rendered as markdown.
+			Summary: "Give the Agent more time to finish reading rotated files, and relieve any saturation in the logs pipeline.",
 			Steps: []*healthplatform.RemediationStep{
 				{Order: 1, Text: "Run `sudo datadog-agent status` and note any saturated component in the Logs Agent Backpressure section."},
 				{Order: 2, Text: "Raise `logs_config.close_timeout` (DD_LOGS_CONFIG_CLOSE_TIMEOUT) above its 60 second default to give the tailer longer to finish a rotated file."},

--- a/comp/healthplatform/issues/missedbytes/issue.go
+++ b/comp/healthplatform/issues/missedbytes/issue.go
@@ -1,0 +1,215 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package missedbytes
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"github.com/dustin/go-humanize"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	contextKeyBytes     = "bytes_missed_24h"
+	contextKeyRotations = "rotation_count_24h"
+
+	// Distinct source names, not tuples: this is the count that reaches the prose.
+	contextKeySourceCount = "source_count"
+
+	contextKeyPairsOmitted = "source_service_pairs_omitted"
+
+	contextKeyLastLossAt = "last_loss_at"
+
+	// Context is map[string]string, so the breakdown travels as encoded sourceLoss.
+	contextKeySources = "sources"
+
+	// The reporting component, not the scheduler's checkSource label.
+	issueSource = "logs"
+
+	// The failing subsystem, not where the fix lands.
+	issueCategory = "logs_pipeline"
+
+	// Bounds one free-form name, which ships in both Description and Extra.
+	maxNameLen = 64
+
+	// ASCII on purpose: `agent diagnose` prints Description on non-UTF-8 consoles.
+	nameEllipsis = "..."
+
+	unknownValue = "unknown"
+)
+
+// sourceLoss is one tuple's share of the host total. Its JSON tags are the wire
+// contract with the check.
+type sourceLoss struct {
+	Source    string `json:"source"`
+	Service   string `json:"service"`
+	Bytes     int64  `json:"bytes"`
+	Rotations int64  `json:"rotations"`
+}
+
+// MissedBytesIssue is the template for "log-data-lost-after-rotation" issues.
+type MissedBytesIssue struct{}
+
+// BuildIssue decodes the IssueReport.Context and builds the proto Issue.
+func (MissedBytesIssue) BuildIssue(ctx map[string]string) (*healthplatform.Issue, error) {
+	// Read, not summed: the breakdown holds only the largest maxBreakdownSources.
+	bytesLost, _ := strconv.ParseInt(ctx[contextKeyBytes], 10, 64)
+	rotations, _ := strconv.ParseInt(ctx[contextKeyRotations], 10, 64)
+	sourceCount, _ := strconv.ParseInt(ctx[contextKeySourceCount], 10, 64)
+	omitted, _ := strconv.ParseInt(ctx[contextKeyPairsOmitted], 10, 64)
+
+	lastLossAt := ctx[contextKeyLastLossAt]
+	if lastLossAt == "" {
+		lastLossAt = unknownValue
+	}
+
+	sources := decodeSources(ctx[contextKeySources])
+
+	// Nameable only when one source and one service are the entire loss.
+	named := sourceCount == 1 && len(sources) == 1 && omitted == 0
+
+	scope := fmt.Sprintf("%d %s", sourceCount, pluralize(sourceCount, "source"))
+	subject := "Logs from " + scope
+	file := "a file"
+	breakdown := describeSources(sources, omitted)
+	if named {
+		scope = "source " + sources[0].Source
+		subject = fmt.Sprintf("Logs from source %q (service %q)", sources[0].Source, sources[0].Service)
+		file = "the file"
+		breakdown = ""
+	}
+
+	sentences := []string{
+		fmt.Sprintf("%s never reached Datadog: %d log %s closed %s before the Agent finished reading it.",
+			subject, rotations, pluralize(rotations, "rotation"), file),
+	}
+	if breakdown != "" {
+		sentences = append(sentences, breakdown)
+	}
+
+	extra, err := structpb.NewStruct(map[string]any{
+		contextKeyBytes:        bytesLost,
+		contextKeyRotations:    rotations,
+		contextKeySourceCount:  sourceCount,
+		contextKeyPairsOmitted: omitted,
+		contextKeyLastLossAt:   lastLossAt,
+		contextKeySources:      sourcesAsExtra(sources),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("missedbytes: build issue extra: %w", err)
+	}
+
+	return &healthplatform.Issue{
+		IssueName: IssueName,
+		IssueType: IssueType,
+		Title: fmt.Sprintf("Lost %s of logs from %s in the last 24 hours",
+			humanizeBytes(bytesLost), scope),
+		// One block, no newlines or markdown: `agent diagnose` prints this verbatim
+		// behind a fixed prefix (comp/core/diagnose/format/format.go).
+		Description: strings.Join(sentences, " "),
+		Category:    issueCategory,
+		Location:    "logs-agent",
+		// HIGH lands in the Fleet UI's "Agent Health: Broken" bucket.
+		Severity: healthplatform.IssueSeverity_ISSUE_SEVERITY_HIGH,
+		Source:   issueSource,
+		Extra:    extra,
+		Tags:     []string{"logs", "file-tailing", "rotation", "data-loss"},
+		Remediation: &healthplatform.Remediation{
+			Summary: "Run `agent status` and review the Logs Agent Backpressure section",
+			Steps: []*healthplatform.RemediationStep{
+				{Order: 1, Text: "Run `agent status` and review the Logs Agent Backpressure section for a saturated pipeline"},
+				{Order: 2, Text: "Raise `logs_config.close_timeout` (DD_LOGS_CONFIG_CLOSE_TIMEOUT) to give the tailer longer to finish a rotated file"},
+				{Order: 3, Text: "If the file rotates faster than the Agent can read it, lower the log volume or rotate less often"},
+			},
+		},
+	}, nil
+}
+
+// decodeSources tolerates a malformed value: totals stay usable, so a failure only
+// degrades the wording. Every consumer reads names through here, so it sanitizes.
+func decodeSources(encoded string) []sourceLoss {
+	if encoded == "" {
+		return nil
+	}
+	var sources []sourceLoss
+	if err := json.Unmarshal([]byte(encoded), &sources); err != nil {
+		return nil
+	}
+	for i := range sources {
+		sources[i].Source = sanitizeName(sources[i].Source)
+		sources[i].Service = sanitizeName(sources[i].Service)
+	}
+	return sources
+}
+
+// sanitizeName bounds a name and drops control characters: names come from user
+// YAML and reach Title and Description unescaped. Cuts on a rune boundary.
+func sanitizeName(name string) string {
+	name = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, name)
+
+	switch {
+	case name == "":
+		return unknownValue
+	case utf8.RuneCountInString(name) <= maxNameLen:
+		return name
+	}
+	return string([]rune(name)[:maxNameLen-utf8.RuneCountInString(nameEllipsis)]) + nameEllipsis
+}
+
+// describeSources renders the breakdown ranked by bytes, plus a count of what the
+// cap left out. Rotation counts are left to Extra.
+func describeSources(sources []sourceLoss, omitted int64) string {
+	if len(sources) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(sources)+1)
+	for _, s := range sources {
+		parts = append(parts, fmt.Sprintf("%s/%s %s", s.Source, s.Service, humanizeBytes(s.Bytes)))
+	}
+	if omitted > 0 {
+		parts = append(parts, fmt.Sprintf("and %d other %s", omitted, pluralize(omitted, "source/service pair")))
+	}
+	return "Most affected: " + strings.Join(parts, ", ") + "."
+}
+
+// sourcesAsExtra reshapes the breakdown so the backend receives objects, not a string.
+func sourcesAsExtra(sources []sourceLoss) []any {
+	values := make([]any, 0, len(sources))
+	for _, s := range sources {
+		values = append(values, map[string]any{
+			"source":    s.Source,
+			"service":   s.Service,
+			"bytes":     s.Bytes,
+			"rotations": s.Rotations,
+		})
+	}
+	return values
+}
+
+func humanizeBytes(n int64) string {
+	if n < 0 {
+		n = 0
+	}
+	return humanize.Bytes(uint64(n))
+}
+
+func pluralize(n int64, word string) string {
+	if n == 1 {
+		return word
+	}
+	return word + "s"
+}

--- a/comp/healthplatform/issues/missedbytes/issue_test.go
+++ b/comp/healthplatform/issues/missedbytes/issue_test.go
@@ -194,7 +194,8 @@ func TestBuildIssue(t *testing.T) {
 			assert.Equal(t, []string{"logs", "file-tailing", "rotation", "data-loss"}, issue.GetTags())
 
 			require.NotNil(t, issue.GetRemediation())
-			assert.Contains(t, issue.GetRemediation().GetSummary(), "logs_config.close_timeout")
+			assert.NotEmpty(t, issue.GetRemediation().GetSummary())
+			assert.NotContains(t, issue.GetRemediation().GetSummary(), "`", "Summary is not rendered as markdown")
 			assert.Nil(t, issue.GetRemediation().GetScript())
 
 			steps := issue.GetRemediation().GetSteps()

--- a/comp/healthplatform/issues/missedbytes/issue_test.go
+++ b/comp/healthplatform/issues/missedbytes/issue_test.go
@@ -1,0 +1,258 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package missedbytes
+
+import (
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+)
+
+// last_loss_at reaches Extra but not the prose: the platform tracks last-seen.
+func recentTimestamp() string {
+	return time.Now().Add(-90 * time.Minute).UTC().Format(time.RFC3339)
+}
+
+func TestBuildIssue(t *testing.T) {
+	tests := []struct {
+		name           string
+		ctx            map[string]string
+		title          string
+		descSubstrs    []string
+		descNotSubstrs []string
+		extraBytes     float64
+		extraRotate    float64
+		extraCount     float64
+		extraSource    []sourceLoss
+	}{
+		{
+			name: "several sources are summarised and broken down",
+			ctx: map[string]string{
+				contextKeyBytes:        "4200512",
+				contextKeyRotations:    "4",
+				contextKeySourceCount:  "3",
+				contextKeyPairsOmitted: "0",
+				contextKeyLastLossAt:   recentTimestamp(),
+				contextKeySources:      `[{"source":"nginx","service":"web","bytes":4000000,"rotations":2},{"source":"redis","service":"cache","bytes":200000,"rotations":1},{"source":"kafka","service":"queue","bytes":512,"rotations":1}]`,
+			},
+			title: "Lost 4.2 MB of logs from 3 sources in the last 24 hours",
+			descSubstrs: []string{
+				"Logs from 3 sources never reached Datadog",
+				"4 log rotations closed a file",
+				"Most affected: nginx/web 4.0 MB, redis/cache 200 kB, kafka/queue 512 B.",
+			},
+			extraBytes:  4200512,
+			extraRotate: 4,
+			extraCount:  3,
+			extraSource: []sourceLoss{
+				{Source: "nginx", Service: "web", Bytes: 4000000, Rotations: 2},
+				{Source: "redis", Service: "cache", Bytes: 200000, Rotations: 1},
+				{Source: "kafka", Service: "queue", Bytes: 512, Rotations: 1},
+			},
+		},
+		{
+			name: "a lone source is named instead of counted",
+			ctx: map[string]string{
+				contextKeyBytes:        "512",
+				contextKeyRotations:    "1",
+				contextKeySourceCount:  "1",
+				contextKeyPairsOmitted: "0",
+				contextKeyLastLossAt:   recentTimestamp(),
+				contextKeySources:      `[{"source":"app","service":"billing","bytes":512,"rotations":1}]`,
+			},
+			title: "Lost 512 B of logs from source app in the last 24 hours",
+			descSubstrs: []string{
+				`Logs from source "app" (service "billing") never reached Datadog`,
+				"1 log rotation closed the file",
+			},
+			descNotSubstrs: []string{"Most affected"},
+			extraBytes:     512,
+			extraRotate:    1,
+			extraCount:     1,
+			extraSource:    []sourceLoss{{Source: "app", Service: "billing", Bytes: 512, Rotations: 1}},
+		},
+		{
+			name: "a source with two services stays counted, not named",
+			ctx: map[string]string{
+				contextKeyBytes:        "4200000",
+				contextKeyRotations:    "2",
+				contextKeySourceCount:  "1",
+				contextKeyPairsOmitted: "0",
+				contextKeyLastLossAt:   recentTimestamp(),
+				contextKeySources:      `[{"source":"nginx","service":"web","bytes":4000000,"rotations":1},{"source":"nginx","service":"api","bytes":200000,"rotations":1}]`,
+			},
+			title: "Lost 4.2 MB of logs from 1 source in the last 24 hours",
+			descSubstrs: []string{
+				"Logs from 1 source never reached Datadog",
+				"Most affected: nginx/web 4.0 MB, nginx/api 200 kB.",
+			},
+			descNotSubstrs: []string{"(service "},
+			extraBytes:     4200000,
+			extraRotate:    2,
+			extraCount:     1,
+			extraSource: []sourceLoss{
+				{Source: "nginx", Service: "web", Bytes: 4000000, Rotations: 1},
+				{Source: "nginx", Service: "api", Bytes: 200000, Rotations: 1},
+			},
+		},
+		{
+			// Hostile name here too: the breakdown interpolates with %s, unlike the
+			// named case's %q, and %q would escape a newline rather than strip it.
+			name: "omitted tuples are counted in the description",
+			ctx: map[string]string{
+				contextKeyBytes:        "1000",
+				contextKeyRotations:    "2",
+				contextKeySourceCount:  "192",
+				contextKeyPairsOmitted: "190",
+				contextKeyLastLossAt:   recentTimestamp(),
+				contextKeySources:      `[{"source":"nginx\nDiagnosis: fake","service":"web","bytes":600,"rotations":1},{"source":"redis","service":"cache","bytes":400,"rotations":1}]`,
+			},
+			title: "Lost 1.0 kB of logs from 192 sources in the last 24 hours",
+			descSubstrs: []string{
+				"Most affected: nginxDiagnosis: fake/web 600 B, redis/cache 400 B, and 190 other source/service pairs.",
+			},
+			extraBytes:  1000,
+			extraRotate: 2,
+			extraCount:  192,
+			extraSource: []sourceLoss{
+				{Source: "nginxDiagnosis: fake", Service: "web", Bytes: 600, Rotations: 1},
+				{Source: "redis", Service: "cache", Bytes: 400, Rotations: 1},
+			},
+		},
+		{
+			name:        "nil context falls back to defaults",
+			ctx:         nil,
+			title:       "Lost 0 B of logs from 0 sources in the last 24 hours",
+			descSubstrs: []string{"Logs from 0 sources never reached Datadog"},
+		},
+		{
+			// A source we cannot name must not claim to name one.
+			name: "a malformed breakdown degrades to the counted form",
+			ctx: map[string]string{
+				contextKeyBytes:       "512",
+				contextKeyRotations:   "1",
+				contextKeySourceCount: "1",
+				contextKeySources:     `{"not":"an array"`,
+			},
+			title:       "Lost 512 B of logs from 1 source in the last 24 hours",
+			descSubstrs: []string{"Logs from 1 source never reached Datadog"},
+			extraBytes:  512,
+			extraRotate: 1,
+			extraCount:  1,
+		},
+		{
+			// Names come from user YAML and reach the Title unescaped.
+			name: "control characters are stripped from a named source",
+			ctx: map[string]string{
+				contextKeyBytes:       "512",
+				contextKeyRotations:   "1",
+				contextKeySourceCount: "1",
+				contextKeySources:     `[{"source":"nginx\nDiagnosis: fake","service":"web","bytes":512,"rotations":1}]`,
+			},
+			title:       "Lost 512 B of logs from source nginxDiagnosis: fake in the last 24 hours",
+			descSubstrs: []string{`Logs from source "nginxDiagnosis: fake" (service "web")`},
+			extraBytes:  512,
+			extraRotate: 1,
+			extraCount:  1,
+			extraSource: []sourceLoss{{Source: "nginxDiagnosis: fake", Service: "web", Bytes: 512, Rotations: 1}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			issue, err := MissedBytesIssue{}.BuildIssue(tc.ctx)
+			require.NoError(t, err)
+			require.NotNil(t, issue)
+
+			assert.Empty(t, issue.GetId(), "Id is set by the runner from the report, not by the template")
+			assert.Empty(t, issue.GetDetectedAt(), "DetectedAt is stamped by the store on every report")
+			assert.Equal(t, IssueName, issue.GetIssueName())
+			assert.Equal(t, IssueType, issue.GetIssueType())
+			assert.Equal(t, tc.title, issue.GetTitle())
+			for _, substr := range tc.descSubstrs {
+				assert.Contains(t, issue.GetDescription(), substr)
+			}
+			for _, substr := range tc.descNotSubstrs {
+				assert.NotContains(t, issue.GetDescription(), substr)
+			}
+			// `agent diagnose` prints this verbatim behind a fixed prefix.
+			assert.NotContains(t, issue.GetDescription(), "\n", "Description must not contain line breaks")
+			assert.NotContains(t, issue.GetDescription(), "  ", "Description must not contain double spaces")
+			assert.Equal(t, "logs_pipeline", issue.GetCategory())
+			assert.Equal(t, "logs-agent", issue.GetLocation())
+			assert.Equal(t, healthplatform.IssueSeverity_ISSUE_SEVERITY_HIGH, issue.GetSeverity())
+			assert.Equal(t, issueSource, issue.GetSource())
+			assert.Equal(t, []string{"logs", "file-tailing", "rotation", "data-loss"}, issue.GetTags())
+
+			require.NotNil(t, issue.GetRemediation())
+			assert.Contains(t, issue.GetRemediation().GetSummary(), "Logs Agent Backpressure")
+			assert.Nil(t, issue.GetRemediation().GetScript())
+
+			steps := issue.GetRemediation().GetSteps()
+			require.NotEmpty(t, steps)
+			assert.Contains(t, steps[0].GetText(), "agent status", "step 1 is the fastest diagnostic command")
+			for i, step := range steps {
+				assert.Equal(t, int32(i+1), step.GetOrder(), "Order must be contiguous and 1-indexed")
+			}
+
+			require.NotNil(t, issue.GetExtra())
+			fields := issue.GetExtra().GetFields()
+			for _, key := range []string{
+				contextKeyBytes, contextKeyRotations, contextKeySourceCount,
+				contextKeyPairsOmitted, contextKeyLastLossAt, contextKeySources,
+			} {
+				assert.NotNil(t, fields[key], "Extra must carry %q", key)
+			}
+			assert.Equal(t, tc.extraBytes, fields[contextKeyBytes].GetNumberValue())
+			assert.Equal(t, tc.extraRotate, fields[contextKeyRotations].GetNumberValue())
+			assert.Equal(t, tc.extraCount, fields[contextKeySourceCount].GetNumberValue())
+
+			// The breakdown must reach Extra as structured values, not as the
+			// JSON string it travelled through the context as.
+			list := fields[contextKeySources].GetListValue().GetValues()
+			require.Len(t, list, len(tc.extraSource))
+			for i, want := range tc.extraSource {
+				entry := list[i].GetStructValue().GetFields()
+				assert.Equal(t, want.Source, entry["source"].GetStringValue())
+				assert.Equal(t, want.Service, entry["service"].GetStringValue())
+				assert.Equal(t, float64(want.Bytes), entry["bytes"].GetNumberValue())
+				assert.Equal(t, float64(want.Rotations), entry["rotations"].GetNumberValue())
+			}
+		})
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"short names pass through", "nginx", "nginx"},
+		{"long ASCII is truncated", strings.Repeat("a", 200),
+			strings.Repeat("a", maxNameLen-len(nameEllipsis)) + nameEllipsis},
+		{"multi-byte cuts on a rune boundary", strings.Repeat("é", 200),
+			strings.Repeat("é", maxNameLen-len(nameEllipsis)) + nameEllipsis},
+		{"control characters are dropped", "ng\ninx\tweb\r", "nginxweb"},
+		{"a name of only control characters degrades", "\n\t\r", unknownValue},
+		{"an empty name degrades", "", unknownValue},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeName(tc.in)
+			assert.Equal(t, tc.want, got)
+			assert.LessOrEqual(t, utf8.RuneCountInString(got), maxNameLen)
+			assert.True(t, utf8.ValidString(got), "a multi-byte name must not be split into invalid UTF-8")
+		})
+	}
+}

--- a/comp/healthplatform/issues/missedbytes/issue_test.go
+++ b/comp/healthplatform/issues/missedbytes/issue_test.go
@@ -194,7 +194,7 @@ func TestBuildIssue(t *testing.T) {
 			assert.Equal(t, []string{"logs", "file-tailing", "rotation", "data-loss"}, issue.GetTags())
 
 			require.NotNil(t, issue.GetRemediation())
-			assert.Contains(t, issue.GetRemediation().GetSummary(), "Logs Agent Backpressure")
+			assert.Contains(t, issue.GetRemediation().GetSummary(), "logs_config.close_timeout")
 			assert.Nil(t, issue.GetRemediation().GetScript())
 
 			steps := issue.GetRemediation().GetSteps()

--- a/comp/healthplatform/issues/missedbytes/module.go
+++ b/comp/healthplatform/issues/missedbytes/module.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package missedbytes reports log data the file tailer lost to rotation.
+package missedbytes
+
+import (
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
+)
+
+const (
+	// IssueName is the human-readable issue name for log data lost to rotation.
+	IssueName = "Log Data Lost After Rotation"
+	// IssueType is IssueName lowercased with spaces replaced by underscores.
+	IssueType = "log_data_lost_after_rotation"
+	// IssueID is the instance id prefix; the check appends a per-host digest.
+	IssueID = "log-data-lost-after-rotation"
+)
+
+// checkSource must be unique: bundle.go only warns when Schedule rejects a dupe.
+const checkSource = "logs-missed-bytes"
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+type missedBytesModule struct {
+	cfg     config.Component
+	checker *checker
+}
+
+// NewModule creates the missed-bytes issue module.
+func NewModule(deps issues.ModuleDeps) issues.Module {
+	return &missedBytesModule{cfg: deps.Config, checker: newChecker(deps.Hostname)}
+}
+
+func (m *missedBytesModule) IssueName() string {
+	return IssueName
+}
+
+func (m *missedBytesModule) IssueType() string {
+	return IssueType
+}
+
+func (m *missedBytesModule) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	return MissedBytesIssue{}.BuildIssue(context)
+}
+
+// BuiltInPeriodicHealthCheck omits Interval to take the scheduler's 15-minute
+// default; the tracker's window is 24 hours. The logs gate is inside Fn, not here,
+// so a logs-disabled agent still resolves an issue a prior run left.
+func (m *missedBytesModule) BuiltInPeriodicHealthCheck() *runnerdef.BuiltInPeriodicHealthCheck {
+	return &runnerdef.BuiltInPeriodicHealthCheck{
+		BuiltInHealthCheck: runnerdef.BuiltInHealthCheck{
+			Source: checkSource,
+			Fn: func() ([]runnerdef.IssueReport, error) {
+				if !logsEnabled(m.cfg) {
+					return nil, nil
+				}
+				return m.checker.Run()
+			},
+		},
+	}
+}
+
+// logsEnabled mirrors the logs agent's own gate, which still honours the
+// deprecated log_enabled (comp/logs/agent/impl/agent.go).
+func logsEnabled(cfg config.Component) bool {
+	return cfg.GetBool("logs_enabled") || cfg.GetBool("log_enabled")
+}
+
+// BuiltInStartupHealthCheck returns nil: loss accrues while the agent runs.
+func (m *missedBytesModule) BuiltInStartupHealthCheck() *runnerdef.BuiltInHealthCheck {
+	return nil
+}

--- a/comp/healthplatform/issues/missedbytes/module_test.go
+++ b/comp/healthplatform/issues/missedbytes/module_test.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package missedbytes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	hostnamemock "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/mock"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+	logsmetrics "github.com/DataDog/datadog-agent/comp/logs-library/metrics"
+)
+
+// runModule runs the check function the scheduler would call. The tracker is a
+// singleton, so these tests must not run in parallel.
+func runModule(t *testing.T, yaml string) (int, error) {
+	t.Helper()
+	t.Cleanup(logsmetrics.ResetMissedBytesForTest)
+
+	hn, _ := hostnamemock.NewMock(hostnamemock.MockHostname("host-a"))
+	m := NewModule(issues.ModuleDeps{
+		Config:   config.NewMockFromYAML(t, yaml),
+		Hostname: hn,
+	})
+
+	check := m.BuiltInPeriodicHealthCheck()
+	require.NotNil(t, check, "the periodic check must always be registered")
+
+	reports, err := check.Fn()
+	return len(reports), err
+}
+
+// health_platform defaults on while logs_enabled defaults off, and an error here is
+// warn-logged by both the runner and the scheduler on every tick.
+func TestModule_LogsDisabledIsQuietAndResolves(t *testing.T) {
+	logsmetrics.ResetMissedBytesForTest()
+
+	n, err := runModule(t, "logs_enabled: false")
+
+	assert.NoError(t, err, "logs being disabled is a known state, not a failure to determine one")
+	assert.Zero(t, n, "no reports, so a stale issue from a previous logs-enabled run resolves")
+}
+
+// The logs gate must not swallow a real report. Deprecated log_enabled still
+// starts the logs agent, so it must reach the check too.
+func TestModule_LogsEnabledWithLossReports(t *testing.T) {
+	for _, yaml := range []string{"logs_enabled: true", "log_enabled: true"} {
+		t.Run(yaml, func(t *testing.T) {
+			logsmetrics.ResetMissedBytesForTest()
+			logsmetrics.MarkLogsAgentRunning()
+			logsmetrics.RecordMissedBytes("nginx", "web", 4096)
+
+			n, err := runModule(t, yaml)
+
+			require.NoError(t, err)
+			assert.Equal(t, 1, n)
+		})
+	}
+}

--- a/comp/healthplatform/missedbytes_integration_test.go
+++ b/comp/healthplatform/missedbytes_integration_test.go
@@ -1,0 +1,115 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package healthplatform
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/mock"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	telemetrymock "github.com/DataDog/datadog-agent/comp/core/telemetry/mock"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues/missedbytes"
+	logsmetrics "github.com/DataDog/datadog-agent/comp/logs-library/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	fakeintakeclient "github.com/DataDog/datadog-agent/test/fakeintake/client"
+	fakeintakeserver "github.com/DataDog/datadog-agent/test/fakeintake/server"
+)
+
+// team: fleet-remediation
+
+// The map key is IssueID scoped with a hostname digest, so match by prefix.
+func findMissedBytesIssue(issues map[string]*healthplatformpayload.Issue) *healthplatformpayload.Issue {
+	for id, iss := range issues {
+		if strings.HasPrefix(id, missedbytes.IssueID+":") {
+			return iss
+		}
+	}
+	return nil
+}
+
+// Covers what the unit tests cannot: module registration, the scheduler, BuildIssue,
+// the store, the forwarder, and the payload as the intake receives it. The loss is
+// seeded before the bundle starts so the assertion lands on the first tick.
+func TestMissedBytesSurvivesFullPipeline(t *testing.T) {
+	logsmetrics.ResetMissedBytesForTest()
+	t.Cleanup(logsmetrics.ResetMissedBytesForTest)
+
+	// Stands in for a running logs agent and two lossy rotations.
+	logsmetrics.MarkLogsAgentRunning()
+	logsmetrics.RecordMissedBytes("nginx", "web", 4096)
+	logsmetrics.RecordMissedBytes("redis", "cache", 1024)
+
+	ready := make(chan bool, 1)
+	fi := fakeintakeserver.NewServer(
+		fakeintakeserver.WithAddress("127.0.0.1:0"),
+		fakeintakeserver.WithReadyChannel(ready),
+	)
+	fi.Start()
+	require.True(t, <-ready, "fakeintake server did not become ready")
+	t.Cleanup(func() { _ = fi.Stop() })
+
+	fiClient := fakeintakeclient.NewClient(fi.URL())
+
+	const tickInterval = 50 * time.Millisecond
+
+	fxutil.Test[fxutil.NoDependencies](t,
+		Bundle(),
+		fx.Provide(func(t testing.TB) log.Component { return logmock.New(t) }),
+		fx.Provide(func(t testing.TB) config.Component {
+			cfg := config.NewMock(t)
+			cfg.SetInTest("api_key", "test-api-key")
+			cfg.SetInTest("dd_url", fi.URL())
+			cfg.SetInTest("logs_enabled", true)
+			cfg.SetInTest("health_platform.enabled", true)
+			cfg.SetInTest("health_platform.persist_on_kubernetes", true)
+			cfg.SetInTest("health_platform.forwarder.interval", tickInterval)
+			cfg.SetInTest("run_path", t.TempDir())
+			return cfg
+		}),
+		telemetrymock.Module(),
+		hostnameinterface.MockModule(),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	)
+
+	var received *healthplatformpayload.Issue
+	require.Eventually(t, func() bool {
+		payloads, err := fiClient.GetAgentHealth()
+		if err != nil {
+			return false
+		}
+		for _, p := range payloads {
+			if iss := findMissedBytesIssue(p.Issues); iss != nil {
+				received = iss
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, tickInterval, "log-data-lost-after-rotation issue never reached fakeintake")
+
+	// Field-level content is issue_test.go's job. Assert only what the trip changes:
+	// both tuples folded into one issue, breakdown arriving as objects not a string.
+	assert.Equal(t, missedbytes.IssueType, received.GetIssueType())
+	assert.Contains(t, received.GetTitle(), "from 2 sources")
+
+	sources := received.GetExtra().GetFields()["sources"].GetListValue().GetValues()
+	require.Len(t, sources, 2)
+	largest := sources[0].GetStructValue().GetFields()
+	assert.Equal(t, "nginx", largest["source"].GetStringValue())
+	assert.Equal(t, float64(4096), largest["bytes"].GetNumberValue())
+}

--- a/comp/logs-library/metrics/BUILD.bazel
+++ b/comp/logs-library/metrics/BUILD.bazel
@@ -6,8 +6,10 @@ go_library(
     srcs = [
         "capacity_monitor.go",
         "metrics.go",
+        "missed_bytes.go",
         "pipeline_monitor.go",
         "rolling_history.go",
+        "test_utils.go",
         "utilization_monitor.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/comp/logs-library/metrics",
@@ -25,6 +27,7 @@ dd_agent_go_test(
     srcs = [
         "capacity_monitor_test.go",
         "metrics_test.go",
+        "missed_bytes_test.go",
         "pipeline_monitor_test.go",
         "rolling_history_test.go",
         "utilization_monitor_test.go",

--- a/comp/logs-library/metrics/missed_bytes.go
+++ b/comp/logs-library/metrics/missed_bytes.go
@@ -1,0 +1,213 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
+
+	"github.com/benbjohnson/clock"
+)
+
+const (
+	// How long a loss stays in MissedBytesSnapshot. Dropping out resolves the issue.
+	missedBytesWindow = 24 * time.Hour
+
+	missedBytesBucketSize = time.Hour
+
+	// +1: a bucket counts while any part of it still overlaps the window.
+	missedBytesMaxBuckets = int(missedBytesWindow/missedBytesBucketSize) + 1
+
+	// Caps tuples held between two reads; service is unbounded user text.
+	missedBytesMaxKeys = 200
+
+	// Source and service every tuple past missedBytesMaxKeys folds into.
+	missedBytesOverflowLabel = "other"
+
+	// Caps the length of a key. Names are raw config strings (YAML, pod
+	// annotations), so bounding the entry count alone does not bound memory.
+	// Two names sharing a prefix this long fold into one tuple.
+	missedBytesMaxNameLen = 64
+)
+
+// MissedBytesSummary is one (source, service) tuple's loss over the trailing window.
+type MissedBytesSummary struct {
+	Source     string
+	Service    string
+	Bytes      int64
+	Rotations  int64
+	LastLossAt time.Time
+}
+
+type missedBytesKey struct {
+	source  string
+	service string
+}
+
+type missedBytesBucket struct {
+	bytes     int64
+	rotations int64
+}
+
+type missedBytesEntry struct {
+	// Keyed by bucket start, as Unix nanoseconds.
+	buckets      map[int64]*missedBytesBucket
+	lastLossNano int64
+}
+
+// pruneAndSum totals the buckets still overlapping the window ending at cutoffNano.
+// The only place buckets are removed.
+func (e *missedBytesEntry) pruneAndSum(cutoffNano int64) (bytes, rotations int64) {
+	for start, bucket := range e.buckets {
+		if start+int64(missedBytesBucketSize) <= cutoffNano {
+			delete(e.buckets, start)
+			continue
+		}
+		bytes += bucket.bytes
+		rotations += bucket.rotations
+	}
+	return bytes, rotations
+}
+
+// missedBytesTracker holds the trailing window of loss per tuple. Bounded without a
+// reader: at most missedBytesMaxKeys+1 entries of missedBytesMaxBuckets buckets.
+type missedBytesTracker struct {
+	mu      sync.Mutex
+	clk     clock.Clock
+	entries map[missedBytesKey]*missedBytesEntry
+}
+
+func newMissedBytesTracker(clk clock.Clock) *missedBytesTracker {
+	return &missedBytesTracker{
+		clk:     clk,
+		entries: make(map[missedBytesKey]*missedBytesEntry),
+	}
+}
+
+func (t *missedBytesTracker) record(source, service string, bytes int64) {
+	if bytes <= 0 {
+		return
+	}
+
+	nowNano := t.clk.Now().UnixNano()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	key := missedBytesKey{source: boundName(source), service: boundName(service)}
+	entry, ok := t.entries[key]
+	if !ok {
+		if len(t.entries) >= missedBytesMaxKeys {
+			key = missedBytesKey{source: missedBytesOverflowLabel, service: missedBytesOverflowLabel}
+			entry, ok = t.entries[key]
+		}
+		if !ok {
+			entry = &missedBytesEntry{buckets: make(map[int64]*missedBytesBucket)}
+			t.entries[key] = entry
+		}
+	}
+
+	// Pruned here too: nothing reads the tracker when health_platform.enabled is false.
+	entry.pruneAndSum(nowNano - int64(missedBytesWindow))
+
+	start := alignMissedBytesBucket(nowNano)
+	bucket, ok := entry.buckets[start]
+	if !ok {
+		bucket = &missedBytesBucket{}
+		entry.buckets[start] = bucket
+	}
+	bucket.bytes += bytes
+	bucket.rotations++
+	entry.lastLossNano = nowNano
+}
+
+// collectAndPrune returns one sorted summary per tuple still inside the window and
+// drops those that aged out, so a quiet agent returns to an empty tracker.
+func (t *missedBytesTracker) collectAndPrune() []MissedBytesSummary {
+	cutoff := t.clk.Now().UnixNano() - int64(missedBytesWindow)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	summaries := make([]MissedBytesSummary, 0, len(t.entries))
+	for key, entry := range t.entries {
+		bytes, rotations := entry.pruneAndSum(cutoff)
+
+		if bytes <= 0 {
+			delete(t.entries, key)
+			continue
+		}
+
+		summaries = append(summaries, MissedBytesSummary{
+			Source:     key.source,
+			Service:    key.service,
+			Bytes:      bytes,
+			Rotations:  rotations,
+			LastLossAt: time.Unix(0, entry.lastLossNano),
+		})
+	}
+
+	sort.Slice(summaries, func(i, j int) bool {
+		if summaries[i].Source != summaries[j].Source {
+			return summaries[i].Source < summaries[j].Source
+		}
+		return summaries[i].Service < summaries[j].Service
+	})
+
+	return summaries
+}
+
+func (t *missedBytesTracker) reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.entries = make(map[missedBytesKey]*missedBytesEntry)
+}
+
+func alignMissedBytesBucket(tsNano int64) int64 {
+	return (tsNano / int64(missedBytesBucketSize)) * int64(missedBytesBucketSize)
+}
+
+// boundName caps a key's length, cutting on a rune boundary. Rendering the cut for
+// a reader is the issue template's job.
+func boundName(name string) string {
+	if utf8.RuneCountInString(name) <= missedBytesMaxNameLen {
+		return name
+	}
+	return string([]rune(name)[:missedBytesMaxNameLen])
+}
+
+// Process-wide because runner.HealthCheckFunc takes no arguments. Like BytesMissed.
+var missedBytes = newMissedBytesTracker(clock.New())
+
+// Distinguishes "no loss" from "no logs agent here". One-shot commands wire the
+// health platform and share the agent's issue store, so their empty tracker must
+// not read as a resolution.
+var logsAgentRunning atomic.Bool
+
+// RecordMissedBytes records bytes lost when a rotation closed a file early. Never
+// reached on Windows, where the tailer holds no os.File to size the loss with.
+func RecordMissedBytes(source, service string, bytes int64) {
+	missedBytes.record(source, service, bytes)
+}
+
+// MissedBytesSnapshot returns in-window losses, sorted by source then service.
+func MissedBytesSnapshot() []MissedBytesSummary {
+	return missedBytes.collectAndPrune()
+}
+
+// MarkLogsAgentRunning records that the logs agent started here. Call only from the
+// logs agent's start path: analyze-logs starts a file launcher without one.
+func MarkLogsAgentRunning() {
+	logsAgentRunning.Store(true)
+}
+
+// LogsAgentRunning reports whether the logs agent started in this process.
+func LogsAgentRunning() bool {
+	return logsAgentRunning.Load()
+}

--- a/comp/logs-library/metrics/missed_bytes_test.go
+++ b/comp/logs-library/metrics/missed_bytes_test.go
@@ -1,0 +1,231 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/benbjohnson/clock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A whole number of missedBytesBucketSize since the epoch, so records land on
+// predictable bucket boundaries.
+var missedBytesBase = time.Unix(1704067200, 0)
+
+func newTestMissedBytesTracker() (*missedBytesTracker, *clock.Mock) {
+	clk := clock.NewMock()
+	clk.Set(missedBytesBase)
+	return newMissedBytesTracker(clk), clk
+}
+
+func summarize(summaries []MissedBytesSummary) []string {
+	out := make([]string, 0, len(summaries))
+	for _, s := range summaries {
+		out = append(out, fmt.Sprintf("%s:%s %d/%d", s.Source, s.Service, s.Bytes, s.Rotations))
+	}
+	return out
+}
+
+func findMissedBytes(t *testing.T, summaries []MissedBytesSummary, source, service string) MissedBytesSummary {
+	t.Helper()
+	for _, s := range summaries {
+		if s.Source == source && s.Service == service {
+			return s
+		}
+	}
+	t.Fatalf("no summary for %s:%s", source, service)
+	return MissedBytesSummary{}
+}
+
+func TestMissedBytesRecord(t *testing.T) {
+	tests := []struct {
+		name   string
+		record func(tr *missedBytesTracker, clk *clock.Mock)
+		want   []string
+	}{
+		{
+			name:   "one loss carries its bytes and rotation count",
+			record: func(tr *missedBytesTracker, _ *clock.Mock) { tr.record("nginx", "web", 4096) },
+			want:   []string{"nginx:web 4096/1"},
+		},
+		{
+			name: "repeated losses for one tuple accumulate",
+			record: func(tr *missedBytesTracker, clk *clock.Mock) {
+				for _, n := range []int64{100, 250, 25} {
+					tr.record("nginx", "web", n)
+					clk.Add(time.Minute)
+				}
+			},
+			want: []string{"nginx:web 375/3"},
+		},
+		{
+			name: "distinct tuples stay separate, sorted by source then service",
+			record: func(tr *missedBytesTracker, _ *clock.Mock) {
+				tr.record("nginx", "web", 10)
+				tr.record("apache", "web", 20)
+				tr.record("nginx", "api", 30)
+				tr.record("apache", "api", 40)
+			},
+			want: []string{"apache:api 40/1", "apache:web 20/1", "nginx:api 30/1", "nginx:web 10/1"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr, clk := newTestMissedBytesTracker()
+			tc.record(tr, clk)
+			assert.Equal(t, tc.want, summarize(tr.collectAndPrune()))
+		})
+	}
+}
+
+func TestMissedBytesLastLossAt(t *testing.T) {
+	tr, clk := newTestMissedBytesTracker()
+
+	tr.record("nginx", "web", 100)
+	clk.Add(time.Minute)
+	tr.record("nginx", "web", 100)
+
+	summaries := tr.collectAndPrune()
+	require.Len(t, summaries, 1)
+	assert.Equal(t, clk.Now().UnixNano(), summaries[0].LastLossAt.UnixNano())
+}
+
+func TestMissedBytesWindowExpiry(t *testing.T) {
+	tr, clk := newTestMissedBytesTracker()
+
+	tr.record("nginx", "web", 512)
+
+	clk.Add(missedBytesWindow - missedBytesBucketSize)
+	require.Equal(t, []string{"nginx:web 512/1"}, summarize(tr.collectAndPrune()))
+
+	// Takes one further bucket beyond the window to disappear entirely.
+	clk.Add(2 * missedBytesBucketSize)
+	assert.Empty(t, tr.collectAndPrune())
+	assert.Empty(t, tr.entries, "an aged-out tuple must be dropped from the map, not retained")
+}
+
+// collectAndPrune only runs when the health check is scheduled, so record has to
+// hold the line alone when health_platform.enabled is false.
+func TestMissedBytesBoundedWithoutCollect(t *testing.T) {
+	tr, clk := newTestMissedBytesTracker()
+
+	bucketsPerWindow := int(missedBytesWindow / missedBytesBucketSize)
+	steady := missedBytesKey{source: "nginx", service: "web"}
+
+	// Ten windows of hourly rotations: one steady tuple plus a fresh one each hour to
+	// push against the key cap. collectAndPrune is never called in the loop.
+	for hour := 0; hour < 10*bucketsPerWindow; hour++ {
+		tr.record(steady.source, steady.service, 1)
+		tr.record(fmt.Sprintf("churn-%03d", hour), "svc", 1)
+		clk.Add(missedBytesBucketSize)
+
+		require.LessOrEqual(t, len(tr.entries), missedBytesMaxKeys+1,
+			"tracked tuples must stay capped at hour %d", hour)
+		for key, entry := range tr.entries {
+			require.LessOrEqual(t, len(entry.buckets), missedBytesMaxBuckets,
+				"%s:%s held more than one window of buckets at hour %d", key.source, key.service, hour)
+		}
+	}
+
+	assert.Len(t, tr.entries[steady].buckets, missedBytesMaxBuckets,
+		"a continuously losing tuple must settle at exactly one window of buckets")
+
+	// record's pruning drops only what aged out, so a reader still sees a full window
+	// summed across every bucket in it.
+	assert.Equal(t, int64(bucketsPerWindow), findMissedBytes(t, tr.collectAndPrune(),
+		steady.source, steady.service).Bytes)
+}
+
+func TestMissedBytesOverflowFoldsIntoSharedKey(t *testing.T) {
+	tr, _ := newTestMissedBytesTracker()
+
+	const overflow = 5
+	for i := 0; i < missedBytesMaxKeys+overflow; i++ {
+		tr.record(fmt.Sprintf("source-%03d", i), "svc", 10)
+	}
+
+	require.Len(t, tr.entries, missedBytesMaxKeys+1,
+		"the map must hold at most the cap plus the shared overflow key")
+
+	summaries := tr.collectAndPrune()
+	other := findMissedBytes(t, summaries, missedBytesOverflowLabel, missedBytesOverflowLabel)
+	assert.Equal(t, int64(overflow*10), other.Bytes, "every tuple past the cap must land in the overflow summary")
+	assert.Equal(t, int64(overflow), other.Rotations)
+}
+
+// Names are raw config strings, so the entry cap alone does not bound memory.
+func TestMissedBytesBoundsKeyLength(t *testing.T) {
+	tr, _ := newTestMissedBytesTracker()
+
+	long := strings.Repeat("a", 4096)
+	tr.record(long, strings.Repeat("é", 4096), 10)
+
+	require.Len(t, tr.entries, 1)
+	for key := range tr.entries {
+		assert.Equal(t, missedBytesMaxNameLen, utf8.RuneCountInString(key.source))
+		assert.Equal(t, missedBytesMaxNameLen, utf8.RuneCountInString(key.service))
+		assert.True(t, utf8.ValidString(key.service), "a multi-byte name must not be cut mid-rune")
+	}
+}
+
+func TestMissedBytesNonPositiveIgnored(t *testing.T) {
+	tr, _ := newTestMissedBytesTracker()
+
+	tr.record("nginx", "web", 0)
+	tr.record("nginx", "web", -100)
+
+	assert.Empty(t, tr.collectAndPrune())
+	assert.Empty(t, tr.entries, "a rotation that lost no bytes must not allocate an entry")
+
+	tr.record("nginx", "web", 200)
+	tr.record("nginx", "web", 0)
+
+	assert.Equal(t, []string{"nginx:web 200/1"}, summarize(tr.collectAndPrune()),
+		"a zero-byte rotation must not count as a rotation")
+}
+
+// Exists for -race: nothing else exercises collectAndPrune against a concurrent
+// record. Totals are left unasserted, being forced by the unconditional mutex.
+func TestMissedBytesConcurrentRecord(t *testing.T) {
+	tr, _ := newTestMissedBytesTracker()
+
+	stopReader, readerDone := make(chan struct{}), make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		for {
+			select {
+			case <-stopReader:
+				return
+			default:
+				tr.collectAndPrune()
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				tr.record(fmt.Sprintf("source-%d", (g+i)%4), "svc", 3)
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(stopReader)
+	<-readerDone
+
+	require.Len(t, tr.collectAndPrune(), 4)
+}

--- a/comp/logs-library/metrics/test_utils.go
+++ b/comp/logs-library/metrics/test_utils.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package metrics
+
+// ResetMissedBytesForTest clears process-wide state. It mutates the tracker rather
+// than replacing it, so it stays safe while tailer goroutines hold a reference.
+func ResetMissedBytesForTest() {
+	missedBytes.reset()
+	logsAgentRunning.Store(false)
+}

--- a/comp/logs/agent/impl/agent.go
+++ b/comp/logs/agent/impl/agent.go
@@ -296,6 +296,7 @@ func (a *logAgent) startSchedulers() {
 
 		a.log.Info("logs-agent started")
 		a.started.Store(status.StatusRunning)
+		metrics.MarkLogsAgentRunning()
 	})
 }
 

--- a/comp/logs/agent/impl/agent_test.go
+++ b/comp/logs/agent/impl/agent_test.go
@@ -306,6 +306,9 @@ func (suite *AgentTestSuite) TestAgentStopsWithWrongBackendTcp() {
 }
 
 func (suite *AgentTestSuite) TestGetPipelineProvider() {
+	metrics.ResetMissedBytesForTest()
+	defer metrics.ResetMissedBytesForTest()
+
 	l := mock.NewMockLogsIntake(suite.T())
 	defer l.Close()
 
@@ -313,10 +316,15 @@ func (suite *AgentTestSuite) TestGetPipelineProvider() {
 	endpoints := config.NewEndpoints(endpoint, nil, true, false)
 
 	agent, _, _ := createAgent(suite, endpoints)
+	assert.False(suite.T(), metrics.LogsAgentRunning())
+
 	agent.Start()
 	defer agent.Stop()
 
 	assert.NotNil(suite.T(), agent.GetPipelineProvider())
+	// Sole production call site of MarkLogsAgentRunning; if it goes, the check
+	// returns errLogsAgentNotRunning forever and the feature never fires.
+	assert.True(suite.T(), metrics.LogsAgentRunning())
 }
 
 func (suite *AgentTestSuite) TestAgentLiveness() {

--- a/pkg/logs/tailers/file/BUILD.bazel
+++ b/pkg/logs/tailers/file/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "file.go",
         "fingerprint.go",
         "fingerprint_mock.go",
+        "missed_bytes.go",
         "rotate.go",
         "rotate_nix.go",
         "rotate_windows.go",
@@ -19,6 +20,7 @@ go_library(
     deps = [
         "//comp/core/tagger/types",
         "//comp/logs-library/metrics",
+        "//comp/logs/agent/config",
         "//comp/logs/auditor/def",
         "//pkg/config/setup",
         "//pkg/logs/internal/decoder",
@@ -41,6 +43,7 @@ dd_agent_go_test(
     srcs = [
         "fingerprint_test.go",
         "tailer_integration_test.go",
+        "tailer_nix_test.go",
         "tailer_test.go",
         "tailer_windows_test.go",
     ],
@@ -57,6 +60,7 @@ dd_agent_go_test(
         "//pkg/logs/status/utils",
         "//pkg/logs/types",
         "//pkg/logs/util/opener",
+        "@com_github_stretchr_testify//require",
         "@com_github_stretchr_testify//suite",
         "@org_uber_go_goleak//:goleak",
     ] + select({

--- a/pkg/logs/tailers/file/missed_bytes.go
+++ b/pkg/logs/tailers/file/missed_bytes.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package file
+
+import (
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+)
+
+// missedBytesIdentity resolves the tuple to report a rotation loss under. The
+// IntegrationName fallback keeps integration-only configs off the bare tuple;
+// configs setting none of the three collapse onto ("unknown", "unknown").
+func missedBytesIdentity(cfg *config.LogsConfig) (source string, service string) {
+	const unknown = "unknown"
+	if cfg == nil {
+		return unknown, unknown
+	}
+
+	source = unknown
+	switch {
+	case cfg.Source != "":
+		source = cfg.Source
+	case cfg.IntegrationName != "":
+		source = cfg.IntegrationName
+	}
+
+	service = unknown
+	switch {
+	case cfg.Service != "":
+		service = cfg.Service
+	case cfg.Source != "":
+		service = cfg.Source
+	case cfg.IntegrationName != "":
+		service = cfg.IntegrationName
+	}
+
+	return source, service
+}

--- a/pkg/logs/tailers/file/tailer.go
+++ b/pkg/logs/tailers/file/tailer.go
@@ -308,6 +308,9 @@ func (t *Tailer) Stop() {
 func (t *Tailer) StopAfterFileRotation() {
 	t.didFileRotate.Store(true)
 	bytesReadAtRotationTime := t.bytesRead.Get()
+	// Resolved before the goroutine, which sleeps for closeTimeout first, to keep
+	// the source lock off that path.
+	missedSource, missedService := missedBytesIdentity(t.file.Source.Config())
 	go func() {
 		time.Sleep(t.closeTimeout)
 		if newBytesRead := t.bytesRead.Get() - bytesReadAtRotationTime; newBytesRead > 0 {
@@ -324,6 +327,7 @@ func (t *Tailer) StopAfterFileRotation() {
 					if remainingBytes > 0 {
 						metrics.BytesMissed.Add(remainingBytes)
 						metrics.TlmBytesMissed.Add(float64(remainingBytes))
+						metrics.RecordMissedBytes(missedSource, missedService, remainingBytes)
 						log.Warnf("After rotation close timeout (%s), there were %d bytes remaining unread for file %q. These unread logs are now lost. Consider increasing DD_LOGS_CONFIG_CLOSE_TIMEOUT", t.closeTimeout, remainingBytes, t.file.Path)
 					}
 				}

--- a/pkg/logs/tailers/file/tailer_nix_test.go
+++ b/pkg/logs/tailers/file/tailer_nix_test.go
@@ -1,0 +1,167 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test && !windows
+
+package file
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
+	"github.com/DataDog/datadog-agent/pkg/logs/util/opener"
+)
+
+// statCountingFile witnesses that the accounting ran: only a loss stats the file.
+type statCountingFile struct {
+	*opener.MockFile
+	stats atomic.Int64
+}
+
+func (f *statCountingFile) Stat() (os.FileInfo, error) {
+	f.stats.Add(1)
+	return f.MockFile.Stat()
+}
+
+// A tailer with no filesystem or pipeline behind it; callers drive
+// StopAfterFileRotation directly. fileSize backs the handle that path stats to
+// size the loss.
+func newMissedBytesTailer(t *testing.T, readOffset, fileSize int64) (*Tailer, *statCountingFile) {
+	t.Helper()
+
+	const path = "rotated.log"
+	source := sources.NewReplaceableSource(sources.NewLogSource("", &config.LogsConfig{
+		Type:    config.FileType,
+		Path:    path,
+		Source:  "missed-bytes-source",
+		Service: "missed-bytes-service",
+	}))
+	info := status.NewInfoRegistry()
+
+	tailer := NewTailer(&TailerOptions{
+		OutputChan:      make(chan *message.Message, 1),
+		File:            NewFile(path, source.UnderlyingSource(), false),
+		SleepDuration:   time.Millisecond,
+		Decoder:         decoder.NewDecoderFromSource(source, info),
+		Info:            info,
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
+		Registry:        auditor.NewMockRegistry(),
+		FileOpener:      opener.NewMockFileOpener(),
+	})
+	tailer.lastReadOffset.Store(readOffset)
+	// Post-rotation reads land after StopAfterFileRotation returns, inside this window.
+	tailer.closeTimeout = 500 * time.Millisecond
+	osFile := &statCountingFile{MockFile: opener.NewMockFile(path, [][]byte{make([]byte, fileSize)})}
+	tailer.osFile = osFile
+
+	return tailer, osFile
+}
+
+// The loss-is-recorded case lives in TestStopAfterFileRotationRealFileMissedBytes,
+// which covers it with a real file. These are the ways a rotation records nothing.
+func TestStopAfterFileRotationNoMissedBytes(t *testing.T) {
+	tests := []struct {
+		name       string
+		readOffset int64
+		fileSize   int64
+		// Read between the rotation and the close timeout. Non-zero is the
+		// pre-existing condition for a loss to be accounted at all.
+		readAfterRotation int64
+		// Keeps these cases from passing on an unrun path.
+		wantFileSized bool
+	}{
+		{"a fully read file lost nothing", 4096, 4096, 512, true},
+		{"a truncated file is unquantifiable, not lossless", 4096, 0, 512, true},
+		{"nothing read after the rotation leaves the loss unreported", 1024, 4096, 0, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			metrics.ResetMissedBytesForTest()
+			t.Cleanup(metrics.ResetMissedBytesForTest)
+
+			tailer, osFile := newMissedBytesTailer(t, tc.readOffset, tc.fileSize)
+			tailer.StopAfterFileRotation()
+			tailer.bytesRead.Add(tc.readAfterRotation)
+
+			// The goroutine signals stop after the accounting, so this synchronizes
+			// rather than polls.
+			select {
+			case <-tailer.stop:
+			case <-time.After(10 * time.Second):
+				t.Fatal("rotation close goroutine never finished")
+			}
+
+			if tc.wantFileSized {
+				require.NotZero(t, osFile.stats.Load(), "close path never sized the file, so the assertions below prove nothing")
+			} else {
+				require.Zero(t, osFile.stats.Load(), "close path sized the file even though nothing was read after the rotation")
+			}
+
+			require.Empty(t, metrics.MissedBytesSnapshot())
+		})
+	}
+}
+
+// The mock file cannot show a real rotation: the tailer stats an already-renamed
+// path through a handle opened before the rename.
+func TestStopAfterFileRotationRealFileMissedBytes(t *testing.T) {
+	metrics.ResetMissedBytesForTest()
+	t.Cleanup(metrics.ResetMissedBytesForTest)
+
+	const fileSize, readOffset = 4096, 1024
+	path := filepath.Join(t.TempDir(), "real-rotated.log")
+	require.NoError(t, os.WriteFile(path, make([]byte, fileSize), 0o600))
+
+	source := sources.NewReplaceableSource(sources.NewLogSource("", &config.LogsConfig{
+		Type:    config.FileType,
+		Path:    path,
+		Source:  "real-file-source",
+		Service: "real-file-service",
+	}))
+	info := status.NewInfoRegistry()
+	tailer := NewTailer(&TailerOptions{
+		OutputChan:      make(chan *message.Message, 1),
+		File:            NewFile(path, source.UnderlyingSource(), false),
+		SleepDuration:   time.Millisecond,
+		Decoder:         decoder.NewDecoderFromSource(source, info),
+		Info:            info,
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
+		Registry:        auditor.NewMockRegistry(),
+		FileOpener:      opener.NewFileOpener(),
+	})
+	require.NoError(t, tailer.setup(readOffset, io.SeekStart))
+	tailer.closeTimeout = 500 * time.Millisecond
+
+	require.NoError(t, os.Rename(path, path+".1"))
+	tailer.StopAfterFileRotation()
+	tailer.bytesRead.Add(512)
+
+	select {
+	case <-tailer.stop:
+	case <-time.After(10 * time.Second):
+		t.Fatal("rotation close goroutine never finished")
+	}
+
+	summaries := metrics.MissedBytesSnapshot()
+	require.Len(t, summaries, 1)
+	require.Equal(t, "real-file-source", summaries[0].Source)
+	require.Equal(t, "real-file-service", summaries[0].Service)
+	require.Equal(t, int64(fileSize-readOffset), summaries[0].Bytes)
+	require.Equal(t, int64(1), summaries[0].Rotations)
+}

--- a/pkg/logs/tailers/file/tailer_test.go
+++ b/pkg/logs/tailers/file/tailer_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
 
@@ -688,4 +689,28 @@ func TestNoGoLeakWithNonBlockingStop(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// The deferred goleak.VerifyNone() will detect if goroutine leaked
+}
+
+func TestMissedBytesIdentity(t *testing.T) {
+	tests := []struct {
+		name            string
+		cfg             *config.LogsConfig
+		source, service string
+	}{
+		{"nil config", nil, "unknown", "unknown"},
+		{"only the required fields are set", &config.LogsConfig{Type: config.FileType, Path: "/var/log/app.log"}, "unknown", "unknown"},
+		{"both set", &config.LogsConfig{Source: "nginx", Service: "web"}, "nginx", "web"},
+		{"service falls back to source", &config.LogsConfig{Source: "nginx"}, "nginx", "nginx"},
+		{"both fall back to the integration name", &config.LogsConfig{IntegrationName: "nginx-int"}, "nginx-int", "nginx-int"},
+		{"source falls back while service is set", &config.LogsConfig{IntegrationName: "nginx-int", Service: "web"}, "nginx-int", "web"},
+		{"source wins over the integration name", &config.LogsConfig{IntegrationName: "nginx-int", Source: "nginx"}, "nginx", "nginx"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			source, service := missedBytesIdentity(tc.cfg)
+			require.Equal(t, tc.source, source)
+			require.Equal(t, tc.service, service)
+		})
+	}
 }

--- a/releasenotes/notes/logs-missed-bytes-health-issue-b9bc8bcd1b563df1.yaml
+++ b/releasenotes/notes/logs-missed-bytes-health-issue-b9bc8bcd1b563df1.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    On Linux and macOS, the Agent now reports an Agent Health issue when the log
+    file tailer loses log data because a file was rotated before the tailer
+    finished reading it. The issue is reported once per host and covers every
+    affected log source, reporting the total bytes lost and rotations involved
+    over the last 24 hours together with a breakdown per source and service.
+    Loss recorded before an Agent restart is not carried across the restart.


### PR DESCRIPTION
### What does this PR do?

Reports log data lost during file rotation as an Agent Health issue: `log_data_lost_after_rotation`.

The file tailer already detects when `close_timeout` expires before a rotated file has been fully read. This PR records that loss by source and service, then reports a host-level issue containing:

- Total bytes and rotations over the last 24 hours
- The ten most affected source/service pairs
- The time of the most recent loss
- Remediation steps covering pipeline backpressure, `close_timeout`, and rotation frequency

The existing `BytesMissed` expvar and `logs.bytes_missed` metric remain unchanged. In particular, the metric does not gain source or service tags.

### Motivation

When the Agent cannot finish reading a rotated file before `logs_config.close_timeout`, the unread data is dropped. The Agent logs a warning and increments `logs.bytes_missed`, but neither identifies the affected source. The warning is also easy to miss after the rotation has occurred.

An Agent Health issue makes the loss visible after the fact and provides enough context to identify the affected log source and take corrective action.

[AGNTLOG-705](https://datadoghq.atlassian.net/browse/AGNTLOG-705)

### Implementation

The tailer records missed bytes in a process-wide tracker keyed by source and service. The tracker uses hourly buckets to maintain a rolling 24-hour window.

A health check runs on the default 15-minute schedule and combines the tracker contents into one issue per host. The issue ID includes a hash of the hostname because the backend deduplicates issues by ID; without a host-specific ID, resolving the issue on one host could resolve it for other hosts in the organization.

The tracker remains bounded even when Agent Health is disabled:

- At most 200 source/service pairs, with additional pairs grouped under `other`
- At most 25 hourly buckets per pair
- Source and service names limited to 64 runes

Source and service values are sanitized before being included in issue text. The check is also gated on the logs Agent actually running so one-shot commands do not incorrectly resolve an existing issue.

### Describe how you validated your changes

Ran the affected test suites with the race detector:

- `./comp/healthplatform/issues/missedbytes`
- `./comp/healthplatform`
- `./pkg/logs/tailers/file`
- `./comp/logs-library/metrics`

Also ran:

- `dda inv linter.go`
- `bazel build //comp/healthplatform/... //pkg/logs/tailers/file/...`

Coverage includes:

- End-to-end delivery through the real health-platform bundle to fakeintake
- Accounting through an actual file rename and forced tailer close
- Fully read, truncated, and unread rotated-file cases
- Tracker bounds when no health check collects from it
- Logs-enabled and logs-running gates
- Source/service sanitization and issue rendering

Finally, I ran a development Agent against a sandbox organization and confirmed that the issue renders correctly in Fleet.

### Additional Notes

- Missed-byte accounting is supported on Linux and macOS. It remains zero on Windows because the Windows tailer does not retain the file handle used to calculate unread bytes.
- The tracker is process-local, so recorded loss does not survive an Agent restart.


[AGNTLOG-705]: https://datadoghq.atlassian.net/browse/AGNTLOG-705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ