### PR TITLE
[aad-45]: Make event reporting nonblocking

### DIFF
--- a/comp/anomalydetection/reporter/impl/BUILD.bazel
+++ b/comp/anomalydetection/reporter/impl/BUILD.bazel
@@ -28,10 +28,13 @@ dd_agent_go_test(
     srcs = [
         "notify_test.go",
         "payload_test.go",
+        "reporter_event_test.go",
     ],
     embed = [":impl"],
     deps = [
         "//comp/anomalydetection/observer/def",
+        "//comp/anomalydetection/reporter/def",
+        "//pkg/logs/message",
         "@com_github_stretchr_testify//assert",
     ],
 )

--- a/comp/anomalydetection/reporter/impl/notify.go
+++ b/comp/anomalydetection/reporter/impl/notify.go
@@ -278,7 +278,7 @@ func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
 	}
 
 	epMsg := message.NewMessage(body, nil, "", time.Now().UnixNano())
-	return s.forwarder.SendEventPlatformEventBlocking(epMsg, eventplatform.EventTypeEventManagement)
+	return s.forwarder.SendEventPlatformEvent(epMsg, eventplatform.EventTypeEventManagement)
 }
 
 // sendEpisodeEvent sends a v2 change event for a scorer EpisodeStarted or EpisodeEnded
@@ -359,7 +359,7 @@ func (s *eventSender) sendEpisodeEvent(evt observerdef.CorrelatorEvent) error {
 	}
 
 	epMsg := message.NewMessage(body, nil, "", time.Now().UnixNano())
-	return s.forwarder.SendEventPlatformEventBlocking(epMsg, eventplatform.EventTypeEventManagement)
+	return s.forwarder.SendEventPlatformEvent(epMsg, eventplatform.EventTypeEventManagement)
 }
 
 func formatScorerEpisodeMessage(evt observerdef.CorrelatorEvent, storage observerdef.StorageReader, direction string) string {

--- a/comp/anomalydetection/reporter/impl/reporter_event.go
+++ b/comp/anomalydetection/reporter/impl/reporter_event.go
@@ -26,12 +26,12 @@ type retryEntry struct {
 // correlationEmitter helper. The reporter forwards each CorrelatorEvent to the
 // appropriate sender method.
 //
-// CorrelationDetected sends that fail transiently are buffered in retryPending
-// and retried at the start of the next Report call. This preserves the
-// pre-refactor behaviour where seenCorrelations was only marked after a
-// successful send, so transient forwarder/intake failures were automatically
-// retried on the next advance cycle. An entry is evicted after maxRetries
-// consecutive failures; a warning is logged at eviction time.
+// CorrelationDetected sends whose synchronous forwarder enqueue fails are
+// buffered in retryPending and retried at the start of the next Report call.
+// This preserves the pre-refactor behaviour where seenCorrelations was only
+// marked after a successful enqueue. An entry is evicted after maxRetries
+// consecutive failures; a warning is logged at eviction time. Asynchronous
+// intake failures are not surfaced to the reporter.
 //
 // Episode events (EpisodeStarted/EpisodeEnded) remain at-most-once; each
 // transition fires exactly once so there is nothing to retry.
@@ -42,7 +42,7 @@ type EventReporter struct {
 	sender     *eventSender
 	maxRetries int
 	// retryPending holds CorrelationDetected entries whose last send attempt
-	// failed transiently. Retried at the start of each Report call; evicted
+	// failed synchronously. Retried at the start of each Report call; evicted
 	// after maxRetries consecutive failures.
 	retryPending []retryEntry
 }
@@ -68,9 +68,10 @@ func (r *EventReporter) SetStorage(storage observerdef.StorageReader) {
 //   - EpisodeStarted / EpisodeEnded  → sendEpisodeEvent (scorer severity transitions, at-most-once)
 //   - CorrelationDetected            → send (cluster/pattern first-seen, emitter-deduplicated)
 //
-// CorrelationDetected sends that fail are queued in retryPending and retried
-// at the start of the next call. Each entry is evicted after r.maxRetries
-// consecutive failures. Episode events are at-most-once (no retry).
+// CorrelationDetected sends whose synchronous enqueue fails are queued in
+// retryPending and retried at the start of the next call. Each entry is evicted
+// after r.maxRetries consecutive failures. Episode events are at-most-once (no
+// retry). Asynchronous intake failures are not surfaced here.
 func (r *EventReporter) Report(output reporterdef.ReportOutput) bool {
 	emitted := false
 

--- a/comp/anomalydetection/reporter/impl/reporter_event_test.go
+++ b/comp/anomalydetection/reporter/impl/reporter_event_test.go
@@ -1,0 +1,120 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package reporterimpl
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+	reporterdef "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/def"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+var errForwarderFull = errors.New("event platform forwarder pipeline channel is full")
+
+type fakeEventPlatformForwarder struct {
+	errors        []error
+	calls         int
+	blockingCalls int
+}
+
+func (f *fakeEventPlatformForwarder) SendEventPlatformEvent(_ *message.Message, _ string) error {
+	call := f.calls
+	f.calls++
+	if call < len(f.errors) {
+		return f.errors[call]
+	}
+	return nil
+}
+
+func (f *fakeEventPlatformForwarder) SendEventPlatformEventBlocking(_ *message.Message, _ string) error {
+	f.blockingCalls++
+	return errors.New("blocking send must not be called")
+}
+
+func (f *fakeEventPlatformForwarder) Purge() map[string][]*message.Message { return nil }
+
+func TestEventSenderUsesNonBlockingForwarder(t *testing.T) {
+	tests := []struct {
+		name string
+		send func(*eventSender) error
+	}{
+		{
+			name: "correlation",
+			send: func(sender *eventSender) error {
+				return sender.send(observerdef.ActiveCorrelation{Pattern: "pattern", FirstSeen: 1})
+			},
+		},
+		{
+			name: "episode",
+			send: func(sender *eventSender) error {
+				return sender.sendEpisodeEvent(observerdef.CorrelatorEvent{
+					Kind:           observerdef.CorrelatorEventEpisodeStarted,
+					CorrelatorName: "anomaly_scorer",
+					Correlation:    observerdef.ActiveCorrelation{Pattern: "episode", FirstSeen: 1},
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			forwarder := &fakeEventPlatformForwarder{errors: []error{errForwarderFull}}
+			sender := &eventSender{forwarder: forwarder}
+
+			err := tt.send(sender)
+
+			assert.ErrorIs(t, err, errForwarderFull)
+			assert.Equal(t, 1, forwarder.calls)
+			assert.Zero(t, forwarder.blockingCalls)
+		})
+	}
+}
+
+func TestEventReporterRetriesCorrelationAfterNonBlockingSendFailure(t *testing.T) {
+	forwarder := &fakeEventPlatformForwarder{errors: []error{errForwarderFull, nil}}
+	reporter := &EventReporter{
+		sender:     &eventSender{forwarder: forwarder},
+		maxRetries: defaultMaxRetryAttempts,
+	}
+	output := reporterdef.ReportOutput{CorrelatorEvents: []observerdef.CorrelatorEvent{{
+		Kind:        observerdef.CorrelatorEventCorrelationDetected,
+		Correlation: observerdef.ActiveCorrelation{Pattern: "pattern", FirstSeen: 1},
+	}}}
+
+	assert.False(t, reporter.Report(output))
+	assert.Len(t, reporter.retryPending, 1)
+	assert.Equal(t, 1, forwarder.calls)
+
+	assert.True(t, reporter.Report(reporterdef.ReportOutput{}))
+	assert.Empty(t, reporter.retryPending)
+	assert.Equal(t, 2, forwarder.calls)
+	assert.Zero(t, forwarder.blockingCalls)
+}
+
+func TestEventReporterDoesNotRetryEpisodeAfterNonBlockingSendFailure(t *testing.T) {
+	forwarder := &fakeEventPlatformForwarder{errors: []error{errForwarderFull}}
+	reporter := &EventReporter{
+		sender:     &eventSender{forwarder: forwarder},
+		maxRetries: defaultMaxRetryAttempts,
+	}
+	output := reporterdef.ReportOutput{CorrelatorEvents: []observerdef.CorrelatorEvent{{
+		Kind:           observerdef.CorrelatorEventEpisodeStarted,
+		CorrelatorName: "anomaly_scorer",
+		Correlation:    observerdef.ActiveCorrelation{Pattern: "episode", FirstSeen: 1},
+	}}}
+
+	assert.False(t, reporter.Report(output))
+	assert.Empty(t, reporter.retryPending)
+	assert.Equal(t, 1, forwarder.calls)
+
+	assert.False(t, reporter.Report(reporterdef.ReportOutput{}))
+	assert.Equal(t, 1, forwarder.calls)
+	assert.Zero(t, forwarder.blockingCalls)
+}

--- a/comp/anomalydetection/reporter/reporter.allium
+++ b/comp/anomalydetection/reporter/reporter.allium
@@ -642,9 +642,9 @@ deferred ForwarderTransport -- see: comp/forwarder/eventplatform
     -- Event-platform forwarder delivery semantics (HTTP intake selection,
     -- retry policy, backpressure, payload draining at shutdown) are owned
     -- by comp/forwarder/eventplatform and not specified here. The reporter
-    -- requires only that SendEventPlatformEventBlocking returns an error
-    -- when delivery fails synchronously; asynchronous failures are not
-    -- surfaced.
+    -- uses SendEventPlatformEvent so a full forwarder queue returns an error
+    -- instead of blocking the observer's advance loop; asynchronous failures
+    -- are not surfaced.
 
 deferred AnomalyProduction -- see: comp/anomalydetection/observer
     -- How Anomaly and Correlation values are produced (extractors,

--- a/comp/anomalydetection/reporter/reporter.allium
+++ b/comp/anomalydetection/reporter/reporter.allium
@@ -259,12 +259,12 @@ entity Reporter {
 variant StdoutReporter : Reporter {
 }
 
--- Publishes change events to the Event Management intake. Fully stateless:
--- deduplication and recurrence detection are entirely owned by the
--- correlators that produce CorrelatorEvents. The reporter forwards each
--- CorrelationDetected event as a ChangeEvent and each episode event as a
--- scorer-episode ChangeEvent. All events are at-most-once; a transient
--- forwarder failure logs an error and discards the event.
+-- Publishes change events to the Event Management intake. Deduplication and
+-- recurrence detection are entirely owned by the correlators that produce
+-- CorrelatorEvents. The reporter forwards each CorrelationDetected event as a
+-- ChangeEvent and each episode event as a scorer-episode ChangeEvent. It keeps
+-- bounded delivery state only for CorrelationDetected events whose synchronous
+-- forwarder enqueue fails; episode events remain at-most-once.
 variant EventReporter : Reporter {
 }
 
@@ -587,8 +587,9 @@ invariant GracefulDegradationWithoutForwarder {
 -- it fires CorrelationDetected at most once per episode per pattern. A
 -- new episode begins after the pattern leaves the active set and the
 -- correlator resets its emitter state. The reporter inherits the guarantee
--- without maintaining its own seen-pattern set. A forwarder failure on the
--- single emission discards the event (at-most-once, not exactly-once).
+-- without maintaining its own seen-pattern set. If the synchronous forwarder
+-- enqueue fails, the reporter may retry that same CorrelationDetected event;
+-- at most one enqueue succeeds. Episode events are not retried.
 
 ------------------------------------------------------------
 -- Surfaces
@@ -618,13 +619,15 @@ surface ObserverReportBoundary {
         -- advance cycle. Reporters use it to display or log ongoing patterns
         -- and to distinguish newly-detected patterns from ongoing ones.
         -- correlator_events carries only the events produced during this
-        -- cycle; events from prior cycles are not re-delivered.
+        -- cycle; the observer does not re-deliver events from prior cycles.
+        -- The EventReporter may retain a failed CorrelationDetected event
+        -- solely for its bounded delivery retry policy.
 
     @guarantee CorrelationsAreOpaque
         -- The reporter treats Correlation, Anomaly, and CorrelatorEvent as
-        -- read-only data carriers. It never mutates them, never persists
-        -- them beyond the current Report call, and never queries observer
-        -- internals.
+        -- read-only data carriers. It never mutates them and never queries
+        -- observer internals. The EventReporter may retain an immutable
+        -- Correlation snapshot solely for bounded delivery retries.
 
     @guidance
         -- An optional companion handshake exists for reporters that want
@@ -639,12 +642,14 @@ surface ObserverReportBoundary {
 ------------------------------------------------------------
 
 deferred ForwarderTransport -- see: comp/forwarder/eventplatform
-    -- Event-platform forwarder delivery semantics (HTTP intake selection,
-    -- retry policy, backpressure, payload draining at shutdown) are owned
-    -- by comp/forwarder/eventplatform and not specified here. The reporter
-    -- uses SendEventPlatformEvent so a full forwarder queue returns an error
-    -- instead of blocking the observer's advance loop; asynchronous failures
-    -- are not surfaced.
+    -- Event-platform transport semantics (HTTP intake selection, asynchronous
+    -- retry policy, backpressure, payload draining at shutdown) are owned by
+    -- comp/forwarder/eventplatform and not specified here. The reporter uses
+    -- SendEventPlatformEvent so a full forwarder queue returns an error instead
+    -- of blocking the observer's advance loop. Its response to that synchronous
+    -- enqueue error is specified here: retry CorrelationDetected events within
+    -- a bounded budget and discard episode events. Asynchronous delivery
+    -- failures are not surfaced to the reporter.
 
 deferred AnomalyProduction -- see: comp/anomalydetection/observer
     -- How Anomaly and Correlation values are produced (extractors,


### PR DESCRIPTION
### What does this PR do?

Use the nonblocking event-platform forwarder for correlation and scorer episode events. A full forwarder queue now returns an error instead of stalling the Observer advance loop.

Correlation events retain their existing retry behavior; episode events remain at-most-once.

### Motivation

Observer reporters run synchronously during each advance, so a blocking event-platform send could stop Observer ingestion when the forwarder backed up.

Addresses [AAD-45](https://datadoghq.atlassian.net/browse/AAD-45).

### Describe how you validated your changes

- `dda inv test --targets=./comp/anomalydetection/reporter/impl/`
- `bazel test //comp/anomalydetection/reporter/impl:impl_test`

[AAD-45]: https://datadoghq.atlassian.net/browse/AAD-45
