### PR TITLE
Fix local dev VM system-probe test issues

### DIFF
--- a/pkg/ebpf/uprobes/testutil_attacher_runner.go
+++ b/pkg/ebpf/uprobes/testutil_attacher_runner.go
@@ -368,6 +368,8 @@ func (r *ContainerizedAttacherRunner) RunAttacher(t *testing.T, configName Attac
 		ebpfCfg.KernelHeadersDownloadDir: ebpfCfg.KernelHeadersDownloadDir,
 		ebpfCfg.RuntimeCompilerOutputDir: ebpfCfg.RuntimeCompilerOutputDir,
 		ebpfCfg.BTFOutputDir:             ebpfCfg.BTFOutputDir,
+		"/usr/src":                       "/usr/src",             // for system kernel headers
+		"/lib/modules":                   "/lib/modules",         // for system kernel headers
 		"/etc/os-release":                "/host/etc/os-release", // for correct BTF detection
 		"/sys":                           "/sys",
 		"/proc":                          "/host/proc",

--- a/pkg/gpu/testutil/builder.go
+++ b/pkg/gpu/testutil/builder.go
@@ -30,9 +30,11 @@ func buildCBinary(srcDir, outPath string) (string, error) {
 
 	// If there is a compiled binary already, skip the compilation.
 	// Meant for the CI.
-	if _, err := os.Stat(cachedServerBinaryPath); err == nil {
-		log.Debugf("Using cached test binary: %s", cachedServerBinaryPath)
-		return cachedServerBinaryPath, nil
+	if _, ok := os.LookupEnv("GITLAB_CI"); ok {
+		if _, err := os.Stat(cachedServerBinaryPath); err == nil {
+			log.Debugf("Using cached test binary: %s", cachedServerBinaryPath)
+			return cachedServerBinaryPath, nil
+		}
 	}
 
 	// Build statically to avoid issues with shared libraries (specially libc if we run in alpine)

--- a/pkg/network/dns/snooper_test.go
+++ b/pkg/network/dns/snooper_test.go
@@ -286,8 +286,7 @@ func TestDNSOverNonPort53(t *testing.T) {
 	domains := []string{
 		"nonexistent.net.com",
 	}
-	shutdown, port := newTestServer(t, localhost, "udp")
-	defer shutdown()
+	port := newTestServer(t, localhost, "udp")
 
 	queryIP, queryPort, reps, err := testdns.SendDNSQueriesOnPort(domains, net.ParseIP(localhost), strconv.Itoa(int(port)), "udp")
 	require.NoError(t, err)
@@ -303,25 +302,24 @@ func TestDNSOverNonPort53(t *testing.T) {
 }
 
 func TestDNSOverCustomPort(t *testing.T) {
+	port := newTestServer(t, localhost, "udp")
+
 	cfg := testConfig()
 	cfg.CollectDNSStats = true
 	cfg.CollectLocalDNS = true
 	cfg.DNSTimeout = 1 * time.Second
-	// Add custom port 5353
-	cfg.DNSMonitoringPortList = []int{53, 5353}
+	// Add custom port
+	cfg.DNSMonitoringPortList = []int{53, int(port)}
 
 	rdns, err := NewReverseDNS(cfg, nil)
 	require.NoError(t, err)
 	err = rdns.Start()
 	require.NoError(t, err)
 	reverseDNS := rdns.(*dnsMonitor)
-	defer reverseDNS.Close()
-
+	t.Cleanup(reverseDNS.Close)
 	statKeeper := reverseDNS.statKeeper
-	domains := []string{"golang.org"}
-	shutdown, port := newTestServerOnPort(t, localhost, "udp", 5353)
-	defer shutdown()
 
+	domains := []string{"golang.org"}
 	queryIP, queryPort, reps, err := testdns.SendDNSQueriesOnPort(domains, net.ParseIP(localhost), strconv.Itoa(int(port)), "udp")
 	require.NoError(t, err)
 	require.NotNil(t, reps[0])
@@ -349,8 +347,7 @@ func TestDNSExceedsMaxPortsTruncates(t *testing.T) {
 	// with host services and sort well-after the fixed ports below.
 	var ports [2]uint16
 	for i := range ports {
-		shutdown, port := newTestServer(t, localhost, "udp")
-		defer shutdown()
+		port := newTestServer(t, localhost, "udp")
 		require.Greater(t, port, uint16(1006), "assumption about OS-assigned ports does not hold: got %d", port)
 		ports[i] = port
 	}
@@ -398,13 +395,14 @@ func TestDNSExceedsMaxPortsTruncates(t *testing.T) {
 // TestDNSDeduplicatesPorts verifies that duplicate entries in
 // DNSMonitoringPortList do not consume LOAD_CONSTANT slots.
 func TestDNSDeduplicatesPorts(t *testing.T) {
-	// 33 raw entries, but only 2 distinct (53 ×32 + 5353 ×1). Must succeed
+	port := newTestServer(t, localhost, "udp")
+	// 33 raw entries, but only 2 distinct (53 ×32 + open port ×1). Must succeed
 	// because after deduplication only two slots are needed.
 	ports := make([]int, 0, 33)
 	for i := 0; i < 32; i++ {
 		ports = append(ports, 53)
 	}
-	ports = append(ports, 5353)
+	ports = append(ports, int(port))
 	mock.NewSystemProbe(t).SetInTest("network_config.dns_monitoring_ports", ports)
 	cfg := config.New()
 	cfg.CollectDNSStats = true
@@ -416,13 +414,11 @@ func TestDNSDeduplicatesPorts(t *testing.T) {
 	err = rdns.Start()
 	require.NoError(t, err)
 	reverseDNS := rdns.(*dnsMonitor)
-	defer reverseDNS.Close()
+	t.Cleanup(reverseDNS.Close)
 
 	// Send DNS to the duplicate-of-53 port and to the non-duplicate 5353
 	// to confirm both distinct ports actually made it into BPF slots.
 	statKeeper := reverseDNS.statKeeper
-	shutdown, port := newTestServerOnPort(t, localhost, "udp", 5353)
-	defer shutdown()
 	queryIP, queryPort, reps, err := testdns.SendDNSQueriesOnPort([]string{"golang.org"}, net.ParseIP(localhost), strconv.Itoa(int(port)), "udp")
 	require.NoError(t, err)
 	require.NotNil(t, reps[0])
@@ -453,8 +449,7 @@ func TestDNSOverLastSlot(t *testing.T) {
 	defer reverseDNS.Close()
 
 	statKeeper := reverseDNS.statKeeper
-	shutdown, port := newTestServerOnPort(t, localhost, "udp", 10053)
-	defer shutdown()
+	port := newTestServerOnPort(t, localhost, "udp", 10053)
 	queryIP, queryPort, reps, err := testdns.SendDNSQueriesOnPort([]string{"golang.org"}, net.ParseIP(localhost), strconv.Itoa(int(port)), "udp")
 	require.NoError(t, err)
 	require.NotNil(t, reps[0])
@@ -465,11 +460,11 @@ func TestDNSOverLastSlot(t *testing.T) {
 	}, 3*time.Second, 10*time.Millisecond, "missing DNS data for port 10053 (slot index 7) — likely a regression in the unrolled is_dns_port scan or ConstantEditor emission")
 }
 
-func newTestServer(t *testing.T, ip string, protocol string) (func(), uint16) {
+func newTestServer(t *testing.T, ip string, protocol string) uint16 {
 	return newTestServerOnPort(t, ip, protocol, 0)
 }
 
-func newTestServerOnPort(t *testing.T, ip string, protocol string, port int) (func(), uint16) {
+func newTestServerOnPort(t *testing.T, ip string, protocol string, port int) uint16 {
 	t.Helper()
 	addr := net.JoinHostPort(ip, strconv.Itoa(port))
 	srv := &mdns.Server{
@@ -494,12 +489,13 @@ func newTestServerOnPort(t *testing.T, ip string, protocol string, port int) (fu
 
 	if err := <-initChan; err != nil {
 		t.Errorf("could not initialize DNS server: %s", err)
-		return func() {}, uint16(0)
+		return uint16(0)
 	}
 
-	return func() {
+	t.Cleanup(func() {
 		_ = srv.Shutdown()
-	}, uint16(srv.PacketConn.LocalAddr().(*net.UDPAddr).Port)
+	})
+	return uint16(srv.PacketConn.LocalAddr().(*net.UDPAddr).Port)
 }
 
 func TestDNSOverUDPTimeoutCount(t *testing.T) {
@@ -644,10 +640,8 @@ func TestDNSPortReconfiguration(t *testing.T) {
 	domains := []string{"golang.org"}
 
 	// Start test servers on both ports
-	shutdown5300, port5300 := newTestServerOnPort(t, localhost, "udp", 5300)
-	defer shutdown5300()
-	shutdown5301, port5301 := newTestServerOnPort(t, localhost, "udp", 5301)
-	defer shutdown5301()
+	port5300 := newTestServerOnPort(t, localhost, "udp", 5300)
+	port5301 := newTestServerOnPort(t, localhost, "udp", 5301)
 
 	// Send queries to port 5300 (should be captured)
 	queryIP5300, queryPort5300, reps, err := testdns.SendDNSQueriesOnPort(domains, net.ParseIP(localhost), strconv.Itoa(int(port5300)), "udp")

--- a/pkg/network/protocols/http/testutil/pythonserver.go
+++ b/pkg/network/protocols/http/testutil/pythonserver.go
@@ -87,8 +87,7 @@ func HTTPPythonServer(t *testing.T, addr string, options Options) *exec.Cmd {
 	require.NoError(t, err)
 
 	cmd := exec.Command("python3", scriptFile.Name(), strconv.FormatBool(options.EnableTLS))
-
-	go require.NoError(t, cmd.Start())
+	require.NoError(t, cmd.Start())
 
 	// Waiting for the server to be ready
 	portCtx, cancelPortCtx := context.WithDeadline(context.Background(), time.Now().Add(time.Second*5))

--- a/pkg/network/usm/testutil/generic_testutil_builder.go
+++ b/pkg/network/usm/testutil/generic_testutil_builder.go
@@ -28,8 +28,10 @@ func buildGoBinary(srcDir, outPath, buildFlags string) (string, error) {
 
 	// If there is a compiled binary already, skip the compilation.
 	// Meant for the CI.
-	if _, err := os.Stat(cachedServerBinaryPath); err == nil {
-		return cachedServerBinaryPath, nil
+	if _, ok := os.LookupEnv("GITLAB_CI"); ok {
+		if _, err := os.Stat(cachedServerBinaryPath); err == nil {
+			return cachedServerBinaryPath, nil
+		}
 	}
 
 	c := exec.Command("go", "build", "-buildvcs=false", "-a", "-tags=test,netgo,bpf", buildFlags, "-o", cachedServerBinaryPath, serverSrcDir)

--- a/pkg/util/testutil/docker/config.go
+++ b/pkg/util/testutil/docker/config.go
@@ -119,7 +119,9 @@ func (r runConfig) commandArgs(t subCommandType) []string {
 
 		// Add mounts
 		for hostPath, containerPath := range r.Mounts {
-			args = append(args, "-v", fmt.Sprintf("%s:%s", hostPath, containerPath))
+			if hostPath != "" && containerPath != "" {
+				args = append(args, "-v", fmt.Sprintf("%s:%s", hostPath, containerPath))
+			}
 		}
 
 		// Pass environment variables to the container as docker args

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -368,7 +368,8 @@ def test(
         args["dir"] = pdir
         testto = timeout if timeout else get_test_timeout(pdir)
         args["timeout"] = f"-timeout {testto}" if testto else ""
-        cmd = '{sudo}{go} test -mod=readonly -v {failfast} {timeout} -tags "{build_tags}" {extra_arguments} {output_params} {dir} {run}'
+        # we must negate the -s flag, otherwise the test binary will not include required DWARF information
+        cmd = '{sudo}{go} test -ldflags="-s=0" -mod=readonly -v {failfast} {timeout} -tags "{build_tags}" {extra_arguments} {output_params} {dir} {run}'
         res = ctx.run(cmd.format(**args), env=env, warn=True)
         if res.exited is None or res.exited > 0:
             failed_pkgs.append(os.path.relpath(pdir, ctx.cwd))


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Fixes several bugs found while running system-probe tests in a local dev VM:
- Ensures the test binary includes DWARF information, even if run via `go test`
- Mount kernel header directories in docker containers that need it
- Use less hard-coded port numbers in DNS tests, avoids issues with common ports (`5353`)
- Fix calling `require.NoError` in a separate goroutine, this is not allowed.
- Do not add blank docker volume mounts
- Do not check for cached test binaries locally. They could easily get out of sync.

### Motivation

Better local dev VM experience

### Describe how you validated your changes

### Additional Notes
