### PR TITLE
[CONTP-2053] fix(autodiscovery): prioritize endpoint check annotations

### DIFF
--- a/comp/core/autodiscovery/impl/BUILD.bazel
+++ b/comp/core/autodiscovery/impl/BUILD.bazel
@@ -67,6 +67,7 @@ dd_agent_go_test(
         "autoconfig_test.go",
         "common_test.go",
         "configmgr_discovery_test.go",
+        "configmgr_kube_endpoints_test.go",
         "configmgr_test.go",
         "multimap_test.go",
         "secrets_test.go",

--- a/comp/core/autodiscovery/impl/configmgr_kube_endpoints_test.go
+++ b/comp/core/autodiscovery/impl/configmgr_kube_endpoints_test.go
@@ -1,0 +1,126 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build clusterchecks && kubeapiserver && test
+
+package autodiscoveryimpl
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/listeners"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+)
+
+func matchProvider(provider string) func(integration.Config) bool {
+	return func(config integration.Config) bool {
+		return config.Provider == provider
+	}
+}
+
+func newEndpointAnnotationPrecedenceTemplate(endpointID, provider, source, version string) integration.Config {
+	return integration.Config{
+		Name:          "redisdb",
+		Provider:      provider,
+		Source:        source,
+		ADIdentifiers: []string{endpointID},
+		Instances:     []integration.Data{integration.Data("version: " + version)},
+	}
+}
+
+func (suite *ReconcilingConfigManagerSuite) TestEndpointAnnotationPrecedenceTransitions() {
+	newService := func() *listeners.KubeEndpointService {
+		return listeners.CreateDummyKubeEndpoint("myservice", "default", nil)
+	}
+	endpointID := newService().GetServiceID()
+	newTemplate := func(provider, source, version string) integration.Config {
+		return newEndpointAnnotationPrecedenceTemplate(endpointID, provider, source, version)
+	}
+
+	annotationV1 := newTemplate(names.KubeEndpointSlices, "kube_endpoints:default/myservice", "annotation-v1")
+	crV1 := newTemplate(names.KubeEndpointSlicesCR, "datadoginstrumentation:default/cr1", "cr-v1")
+	require.NotEqual(suite.T(), annotationV1.Digest(), crV1.Digest())
+
+	for _, tc := range []struct {
+		name  string
+		first integration.Config
+		last  integration.Config
+	}{
+		{name: "CR arrives first", first: crV1, last: annotationV1},
+		{name: "annotation arrives first", first: annotationV1, last: crV1},
+	} {
+		suite.Run(tc.name, func() {
+			cm := suite.factory()
+			changes := cm.processNewService(newService())
+			require.True(suite.T(), changes.IsEmpty())
+
+			changes, _ = cm.processNewConfig(tc.first)
+			assert.Len(suite.T(), changes.Schedule, 1)
+			assert.Empty(suite.T(), changes.Unschedule)
+
+			changes, _ = cm.processNewConfig(tc.last)
+			if tc.last.Provider == names.KubeEndpointSlices {
+				assertConfigsMatch(suite.T(), changes.Schedule, matchProvider(names.KubeEndpointSlices))
+				assertConfigsMatch(suite.T(), changes.Unschedule, matchProvider(names.KubeEndpointSlicesCR))
+			} else {
+				require.True(suite.T(), changes.IsEmpty())
+			}
+			assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlices))
+
+			// Removing the overridden CR must leave the annotation running.
+			changes = cm.processDelConfigs([]integration.Config{crV1})
+			require.True(suite.T(), changes.IsEmpty())
+			assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlices))
+
+			// Restoring the CR while the annotation exists has no scheduling effect;
+			// removing the annotation then hands scheduling back to the CR.
+			changes, _ = cm.processNewConfig(crV1)
+			require.True(suite.T(), changes.IsEmpty())
+			changes = cm.processDelConfigs([]integration.Config{annotationV1})
+			assertConfigsMatch(suite.T(), changes.Schedule, matchProvider(names.KubeEndpointSlicesCR))
+			assertConfigsMatch(suite.T(), changes.Unschedule, matchProvider(names.KubeEndpointSlices))
+			assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlicesCR))
+		})
+	}
+}
+
+func (suite *ReconcilingConfigManagerSuite) TestEndpointAnnotationPrecedenceUpdates() {
+	service := listeners.CreateDummyKubeEndpoint("myservice", "default", nil)
+	newTemplate := func(provider, source, version string) integration.Config {
+		return newEndpointAnnotationPrecedenceTemplate(service.GetServiceID(), provider, source, version)
+	}
+	annotationV1 := newTemplate(names.KubeEndpointSlices, "kube_endpoints:default/myservice", "annotation-v1")
+	crV1 := newTemplate(names.KubeEndpointSlicesCR, "datadoginstrumentation:default/cr1", "cr-v1")
+
+	cm := suite.factory()
+	changes := cm.processNewService(service)
+	require.True(suite.T(), changes.IsEmpty())
+	_, _ = cm.processNewConfig(crV1)
+	_, _ = cm.processNewConfig(annotationV1)
+
+	crV2 := newTemplate(names.KubeEndpointSlicesCR, "datadoginstrumentation:default/cr1", "cr-v2")
+	changes = cm.processDelConfigs([]integration.Config{crV1})
+	require.True(suite.T(), changes.IsEmpty())
+	changes, _ = cm.processNewConfig(crV2)
+	require.True(suite.T(), changes.IsEmpty())
+	assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlices))
+
+	annotationV2 := newTemplate(names.KubeEndpointSlices, "kube_endpoints:default/myservice", "annotation-v2")
+	changes = cm.processDelConfigs([]integration.Config{annotationV1})
+	assertConfigsMatch(suite.T(), changes.Schedule, matchProvider(names.KubeEndpointSlicesCR))
+	assertConfigsMatch(suite.T(), changes.Unschedule, matchProvider(names.KubeEndpointSlices))
+	require.Contains(suite.T(), string(changes.Schedule[0].Instances[0]), "version: cr-v2")
+	changes, _ = cm.processNewConfig(annotationV2)
+	assertConfigsMatch(suite.T(), changes.Schedule, matchProvider(names.KubeEndpointSlices))
+	assertConfigsMatch(suite.T(), changes.Unschedule, matchProvider(names.KubeEndpointSlicesCR))
+	require.Contains(suite.T(), string(changes.Schedule[0].Instances[0]), "version: annotation-v2")
+	assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlices))
+
+	changes = cm.processDelConfigs([]integration.Config{crV2})
+	require.True(suite.T(), changes.IsEmpty())
+	assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlices))
+}

--- a/comp/core/autodiscovery/impl/configmgr_test.go
+++ b/comp/core/autodiscovery/impl/configmgr_test.go
@@ -89,6 +89,12 @@ func matchDigest(digest string) func(integration.Config) bool {
 	}
 }
 
+func matchProvider(provider string) func(integration.Config) bool {
+	return func(config integration.Config) bool {
+		return config.Provider == provider
+	}
+}
+
 // matchLogsConfig matches config.LogsConfig (for verifying templates are applied)
 func matchLogsConfig(logsConfig string) func(integration.Config) bool {
 	return func(config integration.Config) bool {
@@ -539,6 +545,111 @@ func (suite *ReconcilingConfigManagerSuite) TestServiceTemplateFiltering() {
 		matchAll(matchName("cfg1"), matchSvc("my-service")),
 		matchAll(matchName("cfg2-keep"), matchSvc("my-service")),
 	)
+}
+
+func newEndpointAnnotationPrecedenceService() *listeners.KubeEndpointService {
+	return listeners.CreateDummyKubeEndpoint("myservice", "default", nil)
+}
+
+func newEndpointAnnotationPrecedenceTemplate(endpointID, provider, source, version string) integration.Config {
+	return integration.Config{
+		Name:          "redisdb",
+		Provider:      provider,
+		Source:        source,
+		ADIdentifiers: []string{endpointID},
+		Instances:     []integration.Data{integration.Data("version: " + version)},
+	}
+}
+
+func (suite *ReconcilingConfigManagerSuite) TestEndpointAnnotationPrecedenceTransitions() {
+	newService := newEndpointAnnotationPrecedenceService
+	endpointID := newService().GetServiceID()
+	newTemplate := func(provider, source, version string) integration.Config {
+		return newEndpointAnnotationPrecedenceTemplate(endpointID, provider, source, version)
+	}
+
+	annotationV1 := newTemplate(names.KubeEndpointSlices, "kube_endpoints:default/myservice", "annotation-v1")
+	crV1 := newTemplate(names.KubeEndpointSlicesCR, "datadoginstrumentation:default/cr1", "cr-v1")
+	require.NotEqual(suite.T(), annotationV1.Digest(), crV1.Digest())
+
+	for _, tc := range []struct {
+		name  string
+		first integration.Config
+		last  integration.Config
+	}{
+		{name: "CR arrives first", first: crV1, last: annotationV1},
+		{name: "annotation arrives first", first: annotationV1, last: crV1},
+	} {
+		suite.Run(tc.name, func() {
+			cm := suite.factory()
+			changes := cm.processNewService(newService())
+			require.True(suite.T(), changes.IsEmpty())
+
+			changes, _ = cm.processNewConfig(tc.first)
+			assert.Len(suite.T(), changes.Schedule, 1)
+			assert.Empty(suite.T(), changes.Unschedule)
+
+			changes, _ = cm.processNewConfig(tc.last)
+			if tc.last.Provider == names.KubeEndpointSlices {
+				assertConfigsMatch(suite.T(), changes.Schedule, matchProvider(names.KubeEndpointSlices))
+				assertConfigsMatch(suite.T(), changes.Unschedule, matchProvider(names.KubeEndpointSlicesCR))
+			} else {
+				require.True(suite.T(), changes.IsEmpty())
+			}
+			assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlices))
+
+			// Removing the overridden CR must leave the annotation running.
+			changes = cm.processDelConfigs([]integration.Config{crV1})
+			require.True(suite.T(), changes.IsEmpty())
+			assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlices))
+
+			// Restoring the CR while the annotation exists has no scheduling effect;
+			// removing the annotation then hands scheduling back to the CR.
+			changes, _ = cm.processNewConfig(crV1)
+			require.True(suite.T(), changes.IsEmpty())
+			changes = cm.processDelConfigs([]integration.Config{annotationV1})
+			assertConfigsMatch(suite.T(), changes.Schedule, matchProvider(names.KubeEndpointSlicesCR))
+			assertConfigsMatch(suite.T(), changes.Unschedule, matchProvider(names.KubeEndpointSlices))
+			assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlicesCR))
+		})
+	}
+}
+
+func (suite *ReconcilingConfigManagerSuite) TestEndpointAnnotationPrecedenceUpdates() {
+	service := newEndpointAnnotationPrecedenceService()
+	newTemplate := func(provider, source, version string) integration.Config {
+		return newEndpointAnnotationPrecedenceTemplate(service.GetServiceID(), provider, source, version)
+	}
+	annotationV1 := newTemplate(names.KubeEndpointSlices, "kube_endpoints:default/myservice", "annotation-v1")
+	crV1 := newTemplate(names.KubeEndpointSlicesCR, "datadoginstrumentation:default/cr1", "cr-v1")
+
+	cm := suite.factory()
+	changes := cm.processNewService(service)
+	require.True(suite.T(), changes.IsEmpty())
+	_, _ = cm.processNewConfig(crV1)
+	_, _ = cm.processNewConfig(annotationV1)
+
+	crV2 := newTemplate(names.KubeEndpointSlicesCR, "datadoginstrumentation:default/cr1", "cr-v2")
+	changes = cm.processDelConfigs([]integration.Config{crV1})
+	require.True(suite.T(), changes.IsEmpty())
+	changes, _ = cm.processNewConfig(crV2)
+	require.True(suite.T(), changes.IsEmpty())
+	assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlices))
+
+	annotationV2 := newTemplate(names.KubeEndpointSlices, "kube_endpoints:default/myservice", "annotation-v2")
+	changes = cm.processDelConfigs([]integration.Config{annotationV1})
+	assertConfigsMatch(suite.T(), changes.Schedule, matchProvider(names.KubeEndpointSlicesCR))
+	assertConfigsMatch(suite.T(), changes.Unschedule, matchProvider(names.KubeEndpointSlices))
+	require.Contains(suite.T(), string(changes.Schedule[0].Instances[0]), "version: cr-v2")
+	changes, _ = cm.processNewConfig(annotationV2)
+	assertConfigsMatch(suite.T(), changes.Schedule, matchProvider(names.KubeEndpointSlices))
+	assertConfigsMatch(suite.T(), changes.Unschedule, matchProvider(names.KubeEndpointSlicesCR))
+	require.Contains(suite.T(), string(changes.Schedule[0].Instances[0]), "version: annotation-v2")
+	assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlices))
+
+	changes = cm.processDelConfigs([]integration.Config{crV2})
+	require.True(suite.T(), changes.IsEmpty())
+	assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlices))
 }
 
 func TestReconcilingConfigManagement(t *testing.T) {

--- a/comp/core/autodiscovery/impl/configmgr_test.go
+++ b/comp/core/autodiscovery/impl/configmgr_test.go
@@ -89,12 +89,6 @@ func matchDigest(digest string) func(integration.Config) bool {
 	}
 }
 
-func matchProvider(provider string) func(integration.Config) bool {
-	return func(config integration.Config) bool {
-		return config.Provider == provider
-	}
-}
-
 // matchLogsConfig matches config.LogsConfig (for verifying templates are applied)
 func matchLogsConfig(logsConfig string) func(integration.Config) bool {
 	return func(config integration.Config) bool {
@@ -545,109 +539,6 @@ func (suite *ReconcilingConfigManagerSuite) TestServiceTemplateFiltering() {
 		matchAll(matchName("cfg1"), matchSvc("my-service")),
 		matchAll(matchName("cfg2-keep"), matchSvc("my-service")),
 	)
-}
-
-func newEndpointAnnotationPrecedenceTemplate(endpointID, provider, source, version string) integration.Config {
-	return integration.Config{
-		Name:          "redisdb",
-		Provider:      provider,
-		Source:        source,
-		ADIdentifiers: []string{endpointID},
-		Instances:     []integration.Data{integration.Data("version: " + version)},
-	}
-}
-
-func (suite *ReconcilingConfigManagerSuite) TestEndpointAnnotationPrecedenceTransitions() {
-	newService := func() *listeners.KubeEndpointService {
-		return listeners.CreateDummyKubeEndpoint("myservice", "default", nil)
-	}
-	endpointID := newService().GetServiceID()
-	newTemplate := func(provider, source, version string) integration.Config {
-		return newEndpointAnnotationPrecedenceTemplate(endpointID, provider, source, version)
-	}
-
-	annotationV1 := newTemplate(names.KubeEndpointSlices, "kube_endpoints:default/myservice", "annotation-v1")
-	crV1 := newTemplate(names.KubeEndpointSlicesCR, "datadoginstrumentation:default/cr1", "cr-v1")
-	require.NotEqual(suite.T(), annotationV1.Digest(), crV1.Digest())
-
-	for _, tc := range []struct {
-		name  string
-		first integration.Config
-		last  integration.Config
-	}{
-		{name: "CR arrives first", first: crV1, last: annotationV1},
-		{name: "annotation arrives first", first: annotationV1, last: crV1},
-	} {
-		suite.Run(tc.name, func() {
-			cm := suite.factory()
-			changes := cm.processNewService(newService())
-			require.True(suite.T(), changes.IsEmpty())
-
-			changes, _ = cm.processNewConfig(tc.first)
-			assert.Len(suite.T(), changes.Schedule, 1)
-			assert.Empty(suite.T(), changes.Unschedule)
-
-			changes, _ = cm.processNewConfig(tc.last)
-			if tc.last.Provider == names.KubeEndpointSlices {
-				assertConfigsMatch(suite.T(), changes.Schedule, matchProvider(names.KubeEndpointSlices))
-				assertConfigsMatch(suite.T(), changes.Unschedule, matchProvider(names.KubeEndpointSlicesCR))
-			} else {
-				require.True(suite.T(), changes.IsEmpty())
-			}
-			assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlices))
-
-			// Removing the overridden CR must leave the annotation running.
-			changes = cm.processDelConfigs([]integration.Config{crV1})
-			require.True(suite.T(), changes.IsEmpty())
-			assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlices))
-
-			// Restoring the CR while the annotation exists has no scheduling effect;
-			// removing the annotation then hands scheduling back to the CR.
-			changes, _ = cm.processNewConfig(crV1)
-			require.True(suite.T(), changes.IsEmpty())
-			changes = cm.processDelConfigs([]integration.Config{annotationV1})
-			assertConfigsMatch(suite.T(), changes.Schedule, matchProvider(names.KubeEndpointSlicesCR))
-			assertConfigsMatch(suite.T(), changes.Unschedule, matchProvider(names.KubeEndpointSlices))
-			assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlicesCR))
-		})
-	}
-}
-
-func (suite *ReconcilingConfigManagerSuite) TestEndpointAnnotationPrecedenceUpdates() {
-	service := listeners.CreateDummyKubeEndpoint("myservice", "default", nil)
-	newTemplate := func(provider, source, version string) integration.Config {
-		return newEndpointAnnotationPrecedenceTemplate(service.GetServiceID(), provider, source, version)
-	}
-	annotationV1 := newTemplate(names.KubeEndpointSlices, "kube_endpoints:default/myservice", "annotation-v1")
-	crV1 := newTemplate(names.KubeEndpointSlicesCR, "datadoginstrumentation:default/cr1", "cr-v1")
-
-	cm := suite.factory()
-	changes := cm.processNewService(service)
-	require.True(suite.T(), changes.IsEmpty())
-	_, _ = cm.processNewConfig(crV1)
-	_, _ = cm.processNewConfig(annotationV1)
-
-	crV2 := newTemplate(names.KubeEndpointSlicesCR, "datadoginstrumentation:default/cr1", "cr-v2")
-	changes = cm.processDelConfigs([]integration.Config{crV1})
-	require.True(suite.T(), changes.IsEmpty())
-	changes, _ = cm.processNewConfig(crV2)
-	require.True(suite.T(), changes.IsEmpty())
-	assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlices))
-
-	annotationV2 := newTemplate(names.KubeEndpointSlices, "kube_endpoints:default/myservice", "annotation-v2")
-	changes = cm.processDelConfigs([]integration.Config{annotationV1})
-	assertConfigsMatch(suite.T(), changes.Schedule, matchProvider(names.KubeEndpointSlicesCR))
-	assertConfigsMatch(suite.T(), changes.Unschedule, matchProvider(names.KubeEndpointSlices))
-	require.Contains(suite.T(), string(changes.Schedule[0].Instances[0]), "version: cr-v2")
-	changes, _ = cm.processNewConfig(annotationV2)
-	assertConfigsMatch(suite.T(), changes.Schedule, matchProvider(names.KubeEndpointSlices))
-	assertConfigsMatch(suite.T(), changes.Unschedule, matchProvider(names.KubeEndpointSlicesCR))
-	require.Contains(suite.T(), string(changes.Schedule[0].Instances[0]), "version: annotation-v2")
-	assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlices))
-
-	changes = cm.processDelConfigs([]integration.Config{crV2})
-	require.True(suite.T(), changes.IsEmpty())
-	assertLoadedConfigsMatch(suite.T(), cm, matchProvider(names.KubeEndpointSlices))
 }
 
 func TestReconcilingConfigManagement(t *testing.T) {

--- a/comp/core/autodiscovery/impl/configmgr_test.go
+++ b/comp/core/autodiscovery/impl/configmgr_test.go
@@ -547,10 +547,6 @@ func (suite *ReconcilingConfigManagerSuite) TestServiceTemplateFiltering() {
 	)
 }
 
-func newEndpointAnnotationPrecedenceService() *listeners.KubeEndpointService {
-	return listeners.CreateDummyKubeEndpoint("myservice", "default", nil)
-}
-
 func newEndpointAnnotationPrecedenceTemplate(endpointID, provider, source, version string) integration.Config {
 	return integration.Config{
 		Name:          "redisdb",
@@ -562,7 +558,9 @@ func newEndpointAnnotationPrecedenceTemplate(endpointID, provider, source, versi
 }
 
 func (suite *ReconcilingConfigManagerSuite) TestEndpointAnnotationPrecedenceTransitions() {
-	newService := newEndpointAnnotationPrecedenceService
+	newService := func() *listeners.KubeEndpointService {
+		return listeners.CreateDummyKubeEndpoint("myservice", "default", nil)
+	}
 	endpointID := newService().GetServiceID()
 	newTemplate := func(provider, source, version string) integration.Config {
 		return newEndpointAnnotationPrecedenceTemplate(endpointID, provider, source, version)
@@ -616,7 +614,7 @@ func (suite *ReconcilingConfigManagerSuite) TestEndpointAnnotationPrecedenceTran
 }
 
 func (suite *ReconcilingConfigManagerSuite) TestEndpointAnnotationPrecedenceUpdates() {
-	service := newEndpointAnnotationPrecedenceService()
+	service := listeners.CreateDummyKubeEndpoint("myservice", "default", nil)
 	newTemplate := func(provider, source, version string) integration.Config {
 		return newEndpointAnnotationPrecedenceTemplate(service.GetServiceID(), provider, source, version)
 	}

--- a/comp/core/autodiscovery/listeners/kube_endpoints.go
+++ b/comp/core/autodiscovery/listeners/kube_endpoints.go
@@ -513,9 +513,33 @@ func (s *KubeEndpointService) GetExtraConfig(key string) (string, error) {
 	return "", ErrNotSupported
 }
 
-// FilterTemplates filters the given configs based on the service's CEL selector.
+// FilterTemplates filters the given configs based on the service's CEL selector
+// and endpoint annotation precedence.
 func (s *KubeEndpointService) FilterTemplates(configs map[string]integration.Config) {
 	filterTemplatesMatched(s, configs)
+	s.filterTemplatesOverriddenChecks(configs)
+}
+
+// filterTemplatesOverriddenChecks drops DatadogInstrumentation endpoint
+// templates when an endpoint annotation configures the same integration.
+func (s *KubeEndpointService) filterTemplatesOverriddenChecks(configs map[string]integration.Config) {
+	annotationCheckNames := make(map[string]struct{})
+	for _, config := range configs {
+		if config.Provider == names.KubeEndpoints || config.Provider == names.KubeEndpointSlices {
+			annotationCheckNames[config.Name] = struct{}{}
+		}
+	}
+
+	for digest, config := range configs {
+		if config.Provider != names.KubeEndpointSlicesCR {
+			continue
+		}
+		if _, found := annotationCheckNames[config.Name]; found {
+			log.Debugf("Ignoring config from %s: endpoint annotation overrides check %s for service %s",
+				config.Source, config.Name, s.GetServiceID())
+			delete(configs, digest)
+		}
+	}
 }
 
 // GetFilterableEntity returns the filterable entity of the service

--- a/comp/core/autodiscovery/listeners/kube_endpoints_test.go
+++ b/comp/core/autodiscovery/listeners/kube_endpoints_test.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,6 +27,73 @@ import (
 	workloadfilterfxmock "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx-mock"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 )
+
+func TestKubeEndpointServiceFilterTemplatesOverriddenChecks(t *testing.T) {
+	endpointID := "kube_endpoint_uid://default/myservice/10.0.0.1"
+	annotationRedis := integration.Config{
+		Name:          "redisdb",
+		Provider:      names.KubeEndpointSlices,
+		Source:        "kube_endpoints:kube_endpoint_uid://default/myservice/",
+		ADIdentifiers: []string{endpointID},
+		Instances:     []integration.Data{integration.Data(`{"host":"%%host%%"}`)},
+	}
+	legacyAnnotationRedis := annotationRedis
+	legacyAnnotationRedis.Provider = names.KubeEndpoints
+	crRedis := annotationRedis
+	crRedis.Provider = names.KubeEndpointSlicesCR
+	crRedis.Source = "datadoginstrumentation:default/redis"
+	crRedis.Instances = []integration.Data{integration.Data(`{"host":"%%host%%","source":"cr"}`)}
+	crHTTP := crRedis
+	crHTTP.Name = "http_check"
+
+	tests := []struct {
+		name    string
+		configs []integration.Config
+		want    []string
+	}{
+		{
+			name:    "CR check without annotation is preserved",
+			configs: []integration.Config{crRedis},
+			want:    []string{names.KubeEndpointSlicesCR + "/redisdb"},
+		},
+		{
+			name:    "EndpointSlice annotation overrides same CR integration",
+			configs: []integration.Config{crRedis, annotationRedis},
+			want:    []string{names.KubeEndpointSlices + "/redisdb"},
+		},
+		{
+			name:    "legacy Endpoints annotation overrides same CR integration",
+			configs: []integration.Config{crRedis, legacyAnnotationRedis},
+			want:    []string{names.KubeEndpoints + "/redisdb"},
+		},
+		{
+			name:    "different integrations coexist",
+			configs: []integration.Config{crHTTP, annotationRedis},
+			want: []string{
+				names.KubeEndpointSlicesCR + "/http_check",
+				names.KubeEndpointSlices + "/redisdb",
+			},
+		},
+	}
+
+	service := &KubeEndpointService{entity: endpointID}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configs := make(map[string]integration.Config, len(tc.configs))
+			for _, config := range tc.configs {
+				configs[config.Digest()] = config
+			}
+
+			service.FilterTemplates(configs)
+
+			got := make([]string, 0, len(configs))
+			for _, config := range configs {
+				got = append(got, config.Provider+"/"+config.Name)
+			}
+			assert.ElementsMatch(t, tc.want, got)
+		})
+	}
+}
 
 func TestProcessEndpoints(t *testing.T) {
 	kep := &v1.Endpoints{

--- a/releasenotes-dca/notes/endpoint-check-annotation-precedence-b4387340022bd883.yaml
+++ b/releasenotes-dca/notes/endpoint-check-annotation-precedence-b4387340022bd883.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Ensure Kubernetes endpoint check annotations take precedence over
+    ``DatadogInstrumentation`` configurations that target the same Service and
+    integration. This prevents duplicate endpoint checks and restores the
+    CR-backed check when the overriding annotation is removed.


### PR DESCRIPTION
### What does this PR do?

Gives endpoint annotation checks precedence over Service-targeted DatadogInstrumentation checks for the same integration. CR checks for other integrations remain scheduled.

### Motivation

Configuring the same endpoint integration through both sources could schedule duplicate checks and leave stale configurations during updates.

### Describe how you validated your changes

Added unit tests for endpoint check annotation priority over CR backed endpoint checks. Including tests for transitions from CR to annotations.