### PR TITLE
pkg/network/tracer: use injected telemetry component for collector registration

### DIFF
--- a/pkg/network/tracer/BUILD.bazel
+++ b/pkg/network/tracer/BUILD.bazel
@@ -215,6 +215,7 @@ dd_agent_go_test(
         "@org_uber_go_mock//gomock",
     ] + select({
         "@rules_go//go/platform:android": [
+            "//comp/core/telemetry/impl",
             "//pkg/config/env",
             "//pkg/config/mock",
             "//pkg/ebpf",
@@ -291,6 +292,7 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:linux": [
+            "//comp/core/telemetry/impl",
             "//pkg/config/env",
             "//pkg/config/mock",
             "//pkg/ebpf",
@@ -343,6 +345,7 @@ dd_agent_go_test(
             "@org_golang_x_sys//unix",
         ],
         "@rules_go//go/platform:windows": [
+            "//comp/core/telemetry/impl",
             "//pkg/config/env",
             "//pkg/ebpf/ebpftest",
             "//pkg/network",

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -126,11 +126,6 @@ func NewTracer(config *config.Config, telemetryComponent telemetryComponent.Comp
 // newTracer is an internal function used by tests primarily
 // (and NewTracer above)
 func newTracer(cfg *config.Config, telemetryComponent telemetryComponent.Component, statsd statsd.ClientInterface) (_ *Tracer, reterr error) {
-	// tests pass a nil telemetry component, default to the global registry
-	if telemetryComponent == nil {
-		telemetryComponent = telemetryimpl.GetCompatComponent()
-	}
-
 	// check if current platform is using old kernel API because it affects what kprobe are we going to enable
 	currKernelVersion, err := kernel.HostVersion()
 	if err != nil {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -126,6 +126,11 @@ func NewTracer(config *config.Config, telemetryComponent telemetryComponent.Comp
 // newTracer is an internal function used by tests primarily
 // (and NewTracer above)
 func newTracer(cfg *config.Config, telemetryComponent telemetryComponent.Component, statsd statsd.ClientInterface) (_ *Tracer, reterr error) {
+	// tests pass a nil telemetry component, default to the global registry
+	if telemetryComponent == nil {
+		telemetryComponent = telemetryimpl.GetCompatComponent()
+	}
+
 	// check if current platform is using old kernel API because it affects what kprobe are we going to enable
 	currKernelVersion, err := kernel.HostVersion()
 	if err != nil {
@@ -170,13 +175,13 @@ func newTracer(cfg *config.Config, telemetryComponent telemetryComponent.Compone
 	if err != nil {
 		return nil, err
 	}
-	telemetryimpl.GetCompatComponent().RegisterCollector(tr.ebpfTracer)
+	telemetryComponent.RegisterCollector(tr.ebpfTracer)
 
 	tr.conntracker, err = newConntracker(cfg, telemetryComponent)
 	if err != nil {
 		return nil, err
 	}
-	telemetryimpl.GetCompatComponent().RegisterCollector(tr.conntracker)
+	telemetryComponent.RegisterCollector(tr.conntracker)
 
 	if cfg.EnableGatewayLookup {
 		tr.gwLookup = network.NewGatewayLookup(cfg.GetRootNetNs, cfg.MaxTrackedConnections, telemetryComponent)
@@ -208,7 +213,7 @@ func newTracer(cfg *config.Config, telemetryComponent telemetryComponent.Compone
 		if tr.processCache, err = newProcessCache(cfg.MaxProcessesTracked); err != nil {
 			return nil, fmt.Errorf("could not create process cache; %w", err)
 		}
-		telemetryimpl.GetCompatComponent().RegisterCollector(tr.processCache)
+		telemetryComponent.RegisterCollector(tr.processCache)
 
 		if tr.timeResolver, err = ktime.NewResolver(); err != nil {
 			return nil, fmt.Errorf("could not create time resolver: %w", err)
@@ -412,7 +417,7 @@ func (t *Tracer) Stop() {
 	}
 	if t.ebpfTracer != nil {
 		t.ebpfTracer.Stop()
-		telemetryimpl.GetCompatComponent().UnregisterCollector(t.ebpfTracer)
+		t.telemetryComp.UnregisterCollector(t.ebpfTracer)
 	}
 	if t.usmMonitor != nil {
 		t.usmMonitor.Stop()
@@ -422,12 +427,12 @@ func (t *Tracer) Stop() {
 	}
 	if t.conntracker != nil {
 		t.conntracker.Close()
-		telemetryimpl.GetCompatComponent().UnregisterCollector(t.conntracker)
+		t.telemetryComp.UnregisterCollector(t.conntracker)
 	}
 	if t.processCache != nil {
 		events.UnregisterHandler(t.processCache)
 		t.processCache.Stop()
-		telemetryimpl.GetCompatComponent().UnregisterCollector(t.processCache)
+		t.telemetryComp.UnregisterCollector(t.processCache)
 	}
 	if t.containerStore != nil {
 		events.UnregisterHandler(t.containerStore)

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -46,6 +46,7 @@ import (
 	"go4.org/intern"
 	"golang.org/x/sys/unix"
 
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -735,7 +736,7 @@ func (s *TracerSuite) TestGatewayLookupEnabled() {
 
 		cfg := testConfig()
 		cfg.EnableGatewayLookup = true
-		tr, err := newTracer(cfg, nil, nil)
+		tr, err := newTracer(cfg, telemetryimpl.NewMock(t), nil)
 		require.NoError(t, err)
 		require.NotNil(t, tr)
 		t.Cleanup(tr.Stop)
@@ -842,7 +843,7 @@ func (s *TracerSuite) TestGatewayLookupSubnetLookupError() {
 	cfg := testConfig()
 	cfg.EnableGatewayLookup = true
 	// create the tracer without starting it
-	tr, err := newTracer(cfg, nil, nil)
+	tr, err := newTracer(cfg, telemetryimpl.NewMock(t), nil)
 	require.NoError(t, err)
 	require.NotNil(t, tr)
 	t.Cleanup(tr.Stop)
@@ -912,7 +913,7 @@ func (s *TracerSuite) TestGatewayLookupCrossNamespace() {
 
 	cfg := testConfig()
 	cfg.EnableGatewayLookup = true
-	tr, err := newTracer(cfg, nil, nil)
+	tr, err := newTracer(cfg, telemetryimpl.NewMock(t), nil)
 	require.NoError(t, err)
 	require.NotNil(t, tr)
 	t.Cleanup(tr.Stop)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/sync/errgroup"
 
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/network"
@@ -73,7 +74,7 @@ func setupTracer(t testing.TB, cfg *config.Config) *Tracer {
 		cfg.ProtocolClassificationEnabled = false
 	}
 
-	tr, err := NewTracer(cfg, nil, nil)
+	tr, err := NewTracer(cfg, telemetryimpl.NewMock(t), nil)
 	require.NoError(t, err)
 	t.Cleanup(tr.Stop)
 

--- a/pkg/network/usm/tests/BUILD.bazel
+++ b/pkg/network/usm/tests/BUILD.bazel
@@ -44,6 +44,7 @@ dd_agent_go_test(
     deps = select({
         "@rules_go//go/platform:android": [
             "//comp/api/grpcserver/helpers",
+            "//comp/core/telemetry/impl",
             "//pkg/config/env",
             "//pkg/ebpf/ebpftest",
             "//pkg/network",
@@ -92,6 +93,7 @@ dd_agent_go_test(
         ],
         "@rules_go//go/platform:linux": [
             "//comp/api/grpcserver/helpers",
+            "//comp/core/telemetry/impl",
             "//pkg/config/env",
             "//pkg/ebpf/ebpftest",
             "//pkg/network",
@@ -139,6 +141,7 @@ dd_agent_go_test(
             "@org_mongodb_go_mongo_driver_v2//mongo",
         ],
         "@rules_go//go/platform:windows": [
+            "//comp/core/telemetry/impl",
             "//pkg/config/env",
             "//pkg/ebpf/ebpftest",
             "//pkg/network",

--- a/pkg/network/usm/tests/tracer_classification_test.go
+++ b/pkg/network/usm/tests/tracer_classification_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/network"
@@ -61,7 +62,7 @@ func setupTracer(t testing.TB, cfg *config.Config) *tracer.Tracer {
 		cfg.ProtocolClassificationEnabled = false
 	}
 
-	tr, err := tracer.NewTracer(cfg, nil, nil)
+	tr, err := tracer.NewTracer(cfg, telemetryimpl.NewMock(t), nil)
 	require.NoError(t, err)
 	t.Cleanup(tr.Stop)
 

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -40,6 +40,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	grpchelpers "github.com/DataDog/datadog-agent/comp/api/grpcserver/helpers"
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
@@ -188,7 +189,7 @@ func (s *USMSuite) TestProtocolClassification() {
 	cfg.EnablePostgresMonitoring = true
 	cfg.EnableGoTLSSupport = gotlstestutil.GoTLSSupported(t, cfg)
 	cfg.BypassEnabled = true
-	tr, err := tracer.NewTracer(cfg, nil, nil)
+	tr, err := tracer.NewTracer(cfg, telemetryimpl.NewMock(t), nil)
 	require.NoError(t, err)
 	t.Cleanup(tr.Stop)
 
@@ -706,7 +707,7 @@ func TestFullMonitorWithTracer(t *testing.T) {
 	cfg.EnableGoTLSSupport = true
 	cfg.EnableNodeJSMonitoring = true
 
-	tr, err := tracer.NewTracer(cfg, nil, nil)
+	tr, err := tracer.NewTracer(cfg, telemetryimpl.NewMock(t), nil)
 	require.NoError(t, err)
 	t.Cleanup(tr.Stop)
 
@@ -2655,7 +2656,7 @@ func (s *USMSuite) TestVerifySketches() {
 	cfg.EnableRedisMonitoring = kv >= redis.MinimumKernelVersion
 	cfg.RedisTrackResources = true
 
-	tr, err := tracer.NewTracer(cfg, nil, nil)
+	tr, err := tracer.NewTracer(cfg, telemetryimpl.NewMock(t), nil)
 	require.NoError(t, err)
 	t.Cleanup(tr.Stop)
 	require.NoError(t, tr.RegisterClient(clientID))


### PR DESCRIPTION
### What does this PR do?

Removes uses of `GetCompatComponent()` from `pkg/network/tracer`.

### Motivation

We want to remove the global state in the telemetry component.

### Describe how you validated your changes

CI.