### PR TITLE
comp/anomalydetection/observer: inject telemetry component instead of GetCompatComponent

### DIFF
--- a/comp/anomalydetection/observer/impl/BUILD.bazel
+++ b/comp/anomalydetection/observer/impl/BUILD.bazel
@@ -54,7 +54,6 @@ go_library(
         "//comp/anomalydetection/severityevents/impl",
         "//comp/core/config",
         "//comp/core/telemetry/def",
-        "//comp/core/telemetry/impl/noops",
         "//comp/def",
         "//pkg/config/structure",
         "//pkg/util/log",

--- a/comp/anomalydetection/observer/impl/anomaly_scorer_test.go
+++ b/comp/anomalydetection/observer/impl/anomaly_scorer_test.go
@@ -950,7 +950,7 @@ func TestSubscribeSeverityEventsCreatesIndependentDispatchers(t *testing.T) {
 // newScorerWithTelemetry is a test helper that creates a scorer with no-op
 // telemetry gauges so that the internal watcher is active.
 func newScorerWithTelemetry(cfg AnomalyScorerConfig) *anomalyScorer {
-	tel := noopsimpl.GetCompatComponent()
+	tel := noopsimpl.NewComponent()
 	severityGauge := tel.NewGauge("test", "scorer_severity", nil, "")
 	ewmaGauge := tel.NewGauge("test", "scorer_ewma", nil, "")
 	return newAnomalyScorerWithTelemetry(cfg, severityGauge, ewmaGauge)
@@ -1186,9 +1186,7 @@ func TestMaxEpisodeAnomalies(t *testing.T) {
 // wires the internal watcher self-subscription, updates the current severity
 // gauge, and does not panic on transitions.
 func TestScorerWithTelemetry_GaugesAndLogs(t *testing.T) {
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 	tel := newObserverTelemetry(telComp)
 
 	cfg := episodeTestCfg()

--- a/comp/anomalydetection/observer/impl/bench_ingestion_test.go
+++ b/comp/anomalydetection/observer/impl/bench_ingestion_test.go
@@ -121,9 +121,7 @@ func BenchmarkMetricFilterV1Rules(b *testing.B) {
 }
 
 func BenchmarkHandleObserveMetricV1RulesParallelRejectedMetric(b *testing.B) {
-	telemetryComp := telemetryimpl.GetCompatComponent()
-	telemetryComp.Reset()
-	b.Cleanup(telemetryComp.Reset)
+	telemetryComp := telemetryimpl.NewMock(b)
 
 	h := &handle{
 		source:    "check",

--- a/comp/anomalydetection/observer/impl/component_test.go
+++ b/comp/anomalydetection/observer/impl/component_test.go
@@ -115,9 +115,7 @@ anomaly_detection:
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := configmock.NewFromYAML(t, tc.yaml)
 			lc := &testLifecycle{}
-			telComp := telemetryimpl.GetCompatComponent()
-			telComp.Reset()
-			t.Cleanup(telComp.Reset)
+			telComp := telemetryimpl.NewMock(t)
 
 			_, err := NewComponent(Requires{
 				Lifecycle: lc,
@@ -141,9 +139,7 @@ anomaly_detection:
         source: dogstatsd
 `)
 	lc := &testLifecycle{}
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 
 	provides, err := NewComponent(Requires{
 		Lifecycle: lc,
@@ -205,6 +201,7 @@ anomaly_detection:
 			provides, err := NewComponent(Requires{
 				Lifecycle: &testLifecycle{},
 				Config:    cfg,
+				Telemetry: telemetryimpl.NewMock(t),
 			})
 			require.NoError(t, err)
 			obs, ok := provides.Comp.(*observerImpl)

--- a/comp/anomalydetection/observer/impl/filter_rules_test.go
+++ b/comp/anomalydetection/observer/impl/filter_rules_test.go
@@ -526,9 +526,7 @@ func TestFilteredMetricTelemetryAsyncPath(t *testing.T) {
 	}})
 	require.NoError(t, err)
 
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 
 	obs := &observerImpl{
 		engine:               newEngine(engineConfig{storage: newTimeSeriesStorage()}),
@@ -570,9 +568,7 @@ func TestHandleFilteredMetricTelemetryCachePreservesNormalizedSourceLabels(t *te
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			telComp := telemetryimpl.GetCompatComponent()
-			telComp.Reset()
-			t.Cleanup(telComp.Reset)
+			telComp := telemetryimpl.NewMock(t)
 
 			h := &handle{
 				source:    "check",
@@ -597,9 +593,7 @@ func TestFilteredMetricTelemetrySyncPath(t *testing.T) {
 	}})
 	require.NoError(t, err)
 
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 
 	obs := &observerImpl{
 		engine:       newEngine(engineConfig{storage: newTimeSeriesStorage()}),
@@ -617,9 +611,7 @@ func TestFilteredMetricTelemetrySyncPath(t *testing.T) {
 }
 
 func TestDefaultFilterAsyncPathIngestsAgentMetricsAndFiltersObserverTelemetry(t *testing.T) {
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 
 	defaultFilter, err := newDefaultMetricsFilterRules()
 	require.NoError(t, err)
@@ -696,9 +688,7 @@ func TestTagBasedFilterCountsOnlyFullyMatchingSamples(t *testing.T) {
 	}})
 	require.NoError(t, err)
 
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 
 	storage := newTimeSeriesStorage()
 	obs := &observerImpl{
@@ -740,9 +730,7 @@ func TestNamePrefixFilterCountsFilteredMetrics(t *testing.T) {
 	}})
 	require.NoError(t, err)
 
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 
 	storage := newTimeSeriesStorage()
 	obs := &observerImpl{
@@ -785,9 +773,7 @@ func TestMixedAgentRulesAsyncPathKeepsIncludedMetricAndCountsDroppedMetric(t *te
 	}, implicitMetricsProcessingRules()...))
 	require.NoError(t, err)
 
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 
 	storage := newTimeSeriesStorage()
 	obs := &observerImpl{
@@ -843,9 +829,7 @@ func TestAsyncAndSyncFilteringForCheckSourceRemainConsistent(t *testing.T) {
 	}})
 	require.NoError(t, err)
 
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 
 	storage := newTimeSeriesStorage()
 	obs := &observerImpl{
@@ -952,9 +936,7 @@ func TestFilteredMetricsAndChannelDropsIncrementSeparateCounters(t *testing.T) {
 	}})
 	require.NoError(t, err)
 
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 
 	obs := &observerImpl{
 		engine:               newEngine(engineConfig{storage: newTimeSeriesStorage()}),

--- a/comp/anomalydetection/observer/impl/ingest_metrics_disabled_test.go
+++ b/comp/anomalydetection/observer/impl/ingest_metrics_disabled_test.go
@@ -21,9 +21,7 @@ import (
 // ObserveMetric calls while logs and log-derived virtual metrics still
 // reach the engine.
 func TestObserverDropsMetricsWhenIngestMetricsDisabled(t *testing.T) {
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 
 	defaultFilter, err := newDefaultMetricsFilterRules()
 	require.NoError(t, err)

--- a/comp/anomalydetection/observer/impl/log_pattern_extractor_test.go
+++ b/comp/anomalydetection/observer/impl/log_pattern_extractor_test.go
@@ -137,9 +137,7 @@ func TestLogPatternExtractor_ResetClearsClusterState(t *testing.T) {
 }
 
 func TestLogPatternExtractorTelemetryTracksActivePatterns(t *testing.T) {
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 
 	e := NewLogPatternExtractor(DefaultLogPatternExtractorConfig())
 	e.SetObserverTelemetry(newObserverTelemetry(telComp))
@@ -205,9 +203,7 @@ func TestLogPatternExtractor_ZeroConfigAppliesGCDefaults(t *testing.T) {
 }
 
 func TestLogPatternExtractor_GarbageCollectRemovesStaleClusterAndContext(t *testing.T) {
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 
 	e := NewLogPatternExtractor(DefaultLogPatternExtractorConfig())
 	e.SetObserverTelemetry(newObserverTelemetry(telComp))
@@ -353,9 +349,7 @@ func TestLogPatternExtractor_NoGCBeforeInterval(t *testing.T) {
 }
 
 func TestLogPatternExtractor_LRUCapEvictsAndDropsContext(t *testing.T) {
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 
 	// Configure tight cap with MinClusterSizeBeforeEmit=1 so each new shape
 	// emits a metric (and therefore a context entry) on its first appearance.

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -28,7 +28,6 @@ import (
 	severityeventsdef "github.com/DataDog/datadog-agent/comp/anomalydetection/severityevents/def"
 	config "github.com/DataDog/datadog-agent/comp/core/config"
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
-	noopsimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
 
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
@@ -262,11 +261,7 @@ func NewComponent(deps Requires) (Provides, error) {
 		return Provides{}, fmt.Errorf("%s: %w", metricProcessingRulesConfigKey, err)
 	}
 
-	telemetryComp := deps.Telemetry
-	if telemetryComp == nil {
-		telemetryComp = noopsimpl.GetCompatComponent()
-	}
-	obsTelemetry := newObserverTelemetry(telemetryComp)
+	obsTelemetry := newObserverTelemetry(deps.Telemetry)
 
 	// Upgrade the raw scorer (no telemetry) to one with gauges. The catalog
 	// returns a plain *anomalyScorer; here we reconstruct it with the watcher

--- a/comp/anomalydetection/observer/impl/observer_disabled_test.go
+++ b/comp/anomalydetection/observer/impl/observer_disabled_test.go
@@ -12,6 +12,7 @@ import (
 
 	recorderdef "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def"
 	severityeventsdef "github.com/DataDog/datadog-agent/comp/anomalydetection/severityevents/def"
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
@@ -24,8 +25,9 @@ func TestNewComponentReturnsDisabledStubWhenOff(t *testing.T) {
 	cfg := configmock.New(t)
 
 	provides, err := NewComponent(Requires{
-		Config:   cfg,
-		Recorder: option.None[recorderdef.Component](),
+		Config:    cfg,
+		Telemetry: telemetryimpl.NewMock(t),
+		Recorder:  option.None[recorderdef.Component](),
 	})
 	require.NoError(t, err)
 
@@ -45,6 +47,7 @@ logs_config:
 	provides, err := NewComponent(Requires{
 		Lifecycle: lc,
 		Config:    cfg,
+		Telemetry: telemetryimpl.NewMock(t),
 		Recorder:  option.None[recorderdef.Component](),
 	})
 	require.NoError(t, err)

--- a/comp/anomalydetection/observer/impl/observer_test.go
+++ b/comp/anomalydetection/observer/impl/observer_test.go
@@ -105,9 +105,7 @@ func TestSeriesDetectorAdapter_ResetClearsVisibleCountCache(t *testing.T) {
 }
 
 func TestObserverPublishesSeriesCountOnAdvanceAndReplayBoundaries(t *testing.T) {
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 
 	filter, err := newDefaultMetricsFilterRules()
 	require.NoError(t, err)

--- a/comp/anomalydetection/observer/impl/telemetry_test.go
+++ b/comp/anomalydetection/observer/impl/telemetry_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestObserverTelemetry_NoopsDoNotPanic(_ *testing.T) {
-	tel := newObserverTelemetry(noopsimpl.GetCompatComponent())
+	tel := newObserverTelemetry(noopsimpl.NewComponent())
 	tel.recordObservationAccepted("logs", "containers")
 	tel.recordObservationDropped("logs", "containers")
 	tel.recordRRCFScore("rrcf", 0.7)
@@ -41,9 +41,7 @@ func TestObserverTelemetry_NoopsDoNotPanic(_ *testing.T) {
 }
 
 func TestObserverTelemetry_EmitsNewMetrics(t *testing.T) {
-	telComp := telemetryimpl.GetCompatComponent()
-	telComp.Reset()
-	t.Cleanup(telComp.Reset)
+	telComp := telemetryimpl.NewMock(t)
 
 	tel := newObserverTelemetry(telComp)
 	tel.recordLogAccepted("kubelet", 128)


### PR DESCRIPTION
### What does this PR do?

Removes uses of `GetCompatComponent()` from `comp/anomalydetection/observer`.

### Motivation

We want to remove the global state in the telemetry component.

### Describe how you validated your changes

CI.