### PR TITLE
pkg/ebpf: replace noops GetCompatComponent with NewComponent

### DIFF
--- a/pkg/ebpf/btf_test.go
+++ b/pkg/ebpf/btf_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
+	noopsimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
 )
 
 func TestEmbeddedBTFMatch(t *testing.T) {
@@ -32,7 +32,7 @@ func TestEmbeddedBTFMatch(t *testing.T) {
 
 	for subset, ext := range subsets {
 		t.Run(subset, func(t *testing.T) {
-			loader, err := initBTFLoader(&Config{}, nil, telemetryimpl.GetCompatComponent())
+			loader, err := initBTFLoader(&Config{}, nil, noopsimpl.NewComponent())
 			require.NoError(t, err)
 			loader.embeddedDir = filepath.Join(cd, "testdata", subset)
 
@@ -71,7 +71,7 @@ func TestEmbeddedBTFMatch(t *testing.T) {
 }
 
 func TestBTFTelemetry(t *testing.T) {
-	loader, err := initBTFLoader(NewConfig(), nil, telemetryimpl.GetCompatComponent())
+	loader, err := initBTFLoader(NewConfig(), nil, noopsimpl.NewComponent())
 	require.NoError(t, err)
 	ret, result, err := loader.Get()
 	assert.NoError(t, err)

--- a/pkg/ebpf/co_re_load_testutil.go
+++ b/pkg/ebpf/co_re_load_testutil.go
@@ -12,7 +12,7 @@ import (
 
 	manager "github.com/DataDog/ebpf-manager"
 
-	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
+	noopsimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 )
 
@@ -21,7 +21,7 @@ import (
 // be correctly recorded.
 // This test version will not use remote config and has a no-op telemetry component.
 func LoadCOREAsset(filename string, startFn func(bytecode.AssetReader, manager.Options) error) error {
-	loader, err := coreLoader(NewConfig(), nil, telemetryimpl.GetCompatComponent())
+	loader, err := coreLoader(NewConfig(), nil, noopsimpl.NewComponent())
 	if err != nil {
 		return err
 	}
@@ -30,7 +30,7 @@ func LoadCOREAsset(filename string, startFn func(bytecode.AssetReader, manager.O
 
 // GetBTFLoaderInfo Returns where the ebpf BTF files were sourced from
 func GetBTFLoaderInfo() (string, error) {
-	loader, err := coreLoader(NewConfig(), nil, telemetryimpl.GetCompatComponent())
+	loader, err := coreLoader(NewConfig(), nil, noopsimpl.NewComponent())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ebpf/rc_btf_test.go
+++ b/pkg/ebpf/rc_btf_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
+	noopsimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
@@ -58,7 +58,7 @@ func TestRemoteConfigBTFTimeout(t *testing.T) {
 	mockRC := &mockRCClient{t: t, sub: func(product data.Product, _ func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus))) {
 		require.Equal(t, string(product), state.ProductBTFDD)
 	}}
-	loader, err := initBTFLoader(cfg, mockRC, telemetryimpl.GetCompatComponent())
+	loader, err := initBTFLoader(cfg, mockRC, noopsimpl.NewComponent())
 	require.NoError(t, err)
 
 	_, err = loader.loadRemoteConfig(t.Context())
@@ -184,7 +184,7 @@ func TestRemoteConfigBTFFoundEntry(t *testing.T) {
 			}()
 		},
 	}
-	loader, err := initBTFLoader(cfg, mockRC, telemetryimpl.GetCompatComponent())
+	loader, err := initBTFLoader(cfg, mockRC, noopsimpl.NewComponent())
 	require.NoError(t, err)
 	ret, err := loader.loadRemoteConfig(t.Context())
 	require.NoError(t, err)
@@ -214,7 +214,7 @@ func TestRemoteConfigBTFHashMismatch(t *testing.T) {
 			}()
 		},
 	}
-	loader, err := initBTFLoader(cfg, mockRC, telemetryimpl.GetCompatComponent())
+	loader, err := initBTFLoader(cfg, mockRC, noopsimpl.NewComponent())
 	require.NoError(t, err)
 	ret, err := loader.loadRemoteConfig(t.Context())
 	require.Error(t, err)
@@ -244,7 +244,7 @@ func TestRemoteConfigBTFMissingEntry(t *testing.T) {
 			}()
 		},
 	}
-	loader, err := initBTFLoader(cfg, mockRC, telemetryimpl.GetCompatComponent())
+	loader, err := initBTFLoader(cfg, mockRC, noopsimpl.NewComponent())
 	require.NoError(t, err)
 	ret, err := loader.loadRemoteConfig(t.Context())
 	require.Error(t, err)

--- a/pkg/ebpf/uprobes/telemetry.go
+++ b/pkg/ebpf/uprobes/telemetry.go
@@ -123,7 +123,7 @@ func newUprobeAttacherTelemetry(tm telemetryComponent.Component, attacherName st
 		definitions = &telemetryDefinitions{
 			once: sync.Once{},
 		}
-		definitions.init(telemetryNoop.GetCompatComponent())
+		definitions.init(telemetryNoop.NewComponent())
 	} else {
 		definitions = &telemetryDefs
 		definitions.init(tm)

--- a/pkg/ebpf/verifier/stats.go
+++ b/pkg/ebpf/verifier/stats.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
+	noopsimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/names"
@@ -55,7 +55,7 @@ func BuildVerifierStats(opts *StatsOptions) (*StatsResult, map[string]struct{}, 
 	if kversion < kernel.VersionCode(4, 15, 0) {
 		return nil, nil, fmt.Errorf("Kernel %s does not expose verifier statistics", kversion)
 	}
-	err = ddebpf.Setup(ddebpf.NewConfig(), nil, telemetryimpl.GetCompatComponent())
+	err = ddebpf.Setup(ddebpf.NewConfig(), nil, noopsimpl.NewComponent())
 	if err != nil {
 		return nil, nil, fmt.Errorf("ebpf setup: %s", err)
 	}


### PR DESCRIPTION
### What does this PR do?

Removes uses of `GetCompatComponent()` from `pkg/ebpf`.

### Motivation

We want to remove the global state in the telemetry component.

### Describe how you validated your changes

CI.