### PR TITLE
leaderelection: inject telemetry component into the leader metric

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -710,7 +710,7 @@ func startAgent(
 
 	// Create the Leader election engine without initializing it
 	if cfg.GetBool("leader_election") {
-		leaderelection.CreateGlobalLeaderEngine(ctx)
+		leaderelection.CreateGlobalLeaderEngine(ctx, tlm)
 	}
 
 	// Setup stats telemetry handler

--- a/cmd/cluster-agent/subcommands/check/BUILD.bazel
+++ b/cmd/cluster-agent/subcommands/check/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     deps = select({
         "@rules_go//go/platform:aix": [
             "//cmd/cluster-agent/command",
-            "//comp/core/telemetry/impl/noops",
+            "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -20,7 +20,7 @@ go_library(
         ],
         "@rules_go//go/platform:android": [
             "//cmd/cluster-agent/command",
-            "//comp/core/telemetry/impl/noops",
+            "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -32,7 +32,7 @@ go_library(
         ],
         "@rules_go//go/platform:darwin": [
             "//cmd/cluster-agent/command",
-            "//comp/core/telemetry/impl/noops",
+            "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -44,7 +44,7 @@ go_library(
         ],
         "@rules_go//go/platform:dragonfly": [
             "//cmd/cluster-agent/command",
-            "//comp/core/telemetry/impl/noops",
+            "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -56,7 +56,7 @@ go_library(
         ],
         "@rules_go//go/platform:freebsd": [
             "//cmd/cluster-agent/command",
-            "//comp/core/telemetry/impl/noops",
+            "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -68,7 +68,7 @@ go_library(
         ],
         "@rules_go//go/platform:illumos": [
             "//cmd/cluster-agent/command",
-            "//comp/core/telemetry/impl/noops",
+            "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -80,7 +80,7 @@ go_library(
         ],
         "@rules_go//go/platform:ios": [
             "//cmd/cluster-agent/command",
-            "//comp/core/telemetry/impl/noops",
+            "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -92,7 +92,7 @@ go_library(
         ],
         "@rules_go//go/platform:js": [
             "//cmd/cluster-agent/command",
-            "//comp/core/telemetry/impl/noops",
+            "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -104,7 +104,7 @@ go_library(
         ],
         "@rules_go//go/platform:linux": [
             "//cmd/cluster-agent/command",
-            "//comp/core/telemetry/impl/noops",
+            "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -116,7 +116,7 @@ go_library(
         ],
         "@rules_go//go/platform:netbsd": [
             "//cmd/cluster-agent/command",
-            "//comp/core/telemetry/impl/noops",
+            "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -128,7 +128,7 @@ go_library(
         ],
         "@rules_go//go/platform:openbsd": [
             "//cmd/cluster-agent/command",
-            "//comp/core/telemetry/impl/noops",
+            "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -140,7 +140,7 @@ go_library(
         ],
         "@rules_go//go/platform:osx": [
             "//cmd/cluster-agent/command",
-            "//comp/core/telemetry/impl/noops",
+            "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -152,7 +152,7 @@ go_library(
         ],
         "@rules_go//go/platform:plan9": [
             "//cmd/cluster-agent/command",
-            "//comp/core/telemetry/impl/noops",
+            "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -164,7 +164,7 @@ go_library(
         ],
         "@rules_go//go/platform:qnx": [
             "//cmd/cluster-agent/command",
-            "//comp/core/telemetry/impl/noops",
+            "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -176,7 +176,7 @@ go_library(
         ],
         "@rules_go//go/platform:solaris": [
             "//cmd/cluster-agent/command",
-            "//comp/core/telemetry/impl/noops",
+            "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",

--- a/cmd/cluster-agent/subcommands/check/BUILD.bazel
+++ b/cmd/cluster-agent/subcommands/check/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = select({
         "@rules_go//go/platform:aix": [
             "//cmd/cluster-agent/command",
+            "//comp/core/telemetry/impl/noops",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -19,6 +20,7 @@ go_library(
         ],
         "@rules_go//go/platform:android": [
             "//cmd/cluster-agent/command",
+            "//comp/core/telemetry/impl/noops",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -30,6 +32,7 @@ go_library(
         ],
         "@rules_go//go/platform:darwin": [
             "//cmd/cluster-agent/command",
+            "//comp/core/telemetry/impl/noops",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -41,6 +44,7 @@ go_library(
         ],
         "@rules_go//go/platform:dragonfly": [
             "//cmd/cluster-agent/command",
+            "//comp/core/telemetry/impl/noops",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -52,6 +56,7 @@ go_library(
         ],
         "@rules_go//go/platform:freebsd": [
             "//cmd/cluster-agent/command",
+            "//comp/core/telemetry/impl/noops",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -63,6 +68,7 @@ go_library(
         ],
         "@rules_go//go/platform:illumos": [
             "//cmd/cluster-agent/command",
+            "//comp/core/telemetry/impl/noops",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -74,6 +80,7 @@ go_library(
         ],
         "@rules_go//go/platform:ios": [
             "//cmd/cluster-agent/command",
+            "//comp/core/telemetry/impl/noops",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -85,6 +92,7 @@ go_library(
         ],
         "@rules_go//go/platform:js": [
             "//cmd/cluster-agent/command",
+            "//comp/core/telemetry/impl/noops",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -96,6 +104,7 @@ go_library(
         ],
         "@rules_go//go/platform:linux": [
             "//cmd/cluster-agent/command",
+            "//comp/core/telemetry/impl/noops",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -107,6 +116,7 @@ go_library(
         ],
         "@rules_go//go/platform:netbsd": [
             "//cmd/cluster-agent/command",
+            "//comp/core/telemetry/impl/noops",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -118,6 +128,7 @@ go_library(
         ],
         "@rules_go//go/platform:openbsd": [
             "//cmd/cluster-agent/command",
+            "//comp/core/telemetry/impl/noops",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -129,6 +140,7 @@ go_library(
         ],
         "@rules_go//go/platform:osx": [
             "//cmd/cluster-agent/command",
+            "//comp/core/telemetry/impl/noops",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -140,6 +152,7 @@ go_library(
         ],
         "@rules_go//go/platform:plan9": [
             "//cmd/cluster-agent/command",
+            "//comp/core/telemetry/impl/noops",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -151,6 +164,7 @@ go_library(
         ],
         "@rules_go//go/platform:qnx": [
             "//cmd/cluster-agent/command",
+            "//comp/core/telemetry/impl/noops",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",
@@ -162,6 +176,7 @@ go_library(
         ],
         "@rules_go//go/platform:solaris": [
             "//cmd/cluster-agent/command",
+            "//comp/core/telemetry/impl/noops",
             "//comp/core/workloadmeta/collectors/catalog-clusteragent",
             "//pkg/cli/subcommands/check",
             "//pkg/clusteragent/autoscaling/autoscalinggate",

--- a/cmd/cluster-agent/subcommands/check/command.go
+++ b/cmd/cluster-agent/subcommands/check/command.go
@@ -10,7 +10,7 @@ package check
 
 import (
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/command"
-	noopsimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/check"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/autoscalinggate"
@@ -24,14 +24,6 @@ import (
 
 // Commands returns a slice of subcommands for the 'cluster-agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
-	ctx, _ := pkgcommon.GetMainCtxCancel()
-	// Create the Leader election engine without initializing it. This one-shot
-	// command never serves the telemetry endpoint, so the engine gets a no-op
-	// telemetry component.
-	if pkgconfigsetup.Datadog().GetBool("leader_election") {
-		leaderelection.CreateGlobalLeaderEngine(ctx, noopsimpl.NewComponent())
-	}
-
 	cmd := check.MakeCommand(func() check.GlobalParams {
 		return check.GlobalParams{
 			ConfFilePath: globalParams.ConfFilePath,
@@ -43,6 +35,14 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		// Required by the kubeapiserver collector, but never enabled in the
 		// "check" command because autoscaling doesn't run.
 		fx.Supply(autoscalinggate.New()),
+		// Create the Leader election engine without initializing it, using the
+		// telemetry component provided by fx.
+		fx.Invoke(func(tm telemetry.Component) {
+			if pkgconfigsetup.Datadog().GetBool("leader_election") {
+				ctx, _ := pkgcommon.GetMainCtxCancel()
+				leaderelection.CreateGlobalLeaderEngine(ctx, tm)
+			}
+		}),
 	))
 
 	return []*cobra.Command{cmd}

--- a/cmd/cluster-agent/subcommands/check/command.go
+++ b/cmd/cluster-agent/subcommands/check/command.go
@@ -35,8 +35,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		// Required by the kubeapiserver collector, but never enabled in the
 		// "check" command because autoscaling doesn't run.
 		fx.Supply(autoscalinggate.New()),
-		// Create the Leader election engine without initializing it, using the
-		// telemetry component provided by fx.
+		// Create the Leader election engine without initializing it
 		fx.Invoke(func(tm telemetry.Component) {
 			if pkgconfigsetup.Datadog().GetBool("leader_election") {
 				ctx, _ := pkgcommon.GetMainCtxCancel()

--- a/cmd/cluster-agent/subcommands/check/command.go
+++ b/cmd/cluster-agent/subcommands/check/command.go
@@ -10,6 +10,7 @@ package check
 
 import (
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/command"
+	noopsimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl/noops"
 	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/check"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/autoscalinggate"
@@ -24,9 +25,11 @@ import (
 // Commands returns a slice of subcommands for the 'cluster-agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	ctx, _ := pkgcommon.GetMainCtxCancel()
-	// Create the Leader election engine without initializing it
+	// Create the Leader election engine without initializing it. This one-shot
+	// command never serves the telemetry endpoint, so the engine gets a no-op
+	// telemetry component.
 	if pkgconfigsetup.Datadog().GetBool("leader_election") {
-		leaderelection.CreateGlobalLeaderEngine(ctx)
+		leaderelection.CreateGlobalLeaderEngine(ctx, noopsimpl.NewComponent())
 	}
 
 	cmd := check.MakeCommand(func() check.GlobalParams {

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -359,7 +359,7 @@ func start(log log.Component,
 	}()
 
 	// Create the Leader election engine and initialize it
-	leaderelection.CreateGlobalLeaderEngine(mainCtx)
+	leaderelection.CreateGlobalLeaderEngine(mainCtx, telemetry)
 	le, err := leaderelection.GetLeaderEngine()
 	if err != nil {
 		return err

--- a/pkg/util/kubernetes/apiserver/leaderelection/BUILD.bazel
+++ b/pkg/util/kubernetes/apiserver/leaderelection/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
     deps = [
         "//comp/core/status",
         "//comp/core/telemetry/def",
-        "//comp/core/telemetry/impl",
         "//internal/third_party/client-go/tools/leaderelection/resourcelock",
         "//pkg/config/setup",
         "//pkg/util/cache",

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -30,7 +30,6 @@ import (
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
-	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 	configmaplock "github.com/DataDog/datadog-agent/internal/third_party/client-go/tools/leaderelection/resourcelock"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -80,23 +79,16 @@ type LeaderEngine struct {
 	leaderMetric telemetry.Gauge
 }
 
-func newLeaderEngine(ctx context.Context) *LeaderEngine {
+func newLeaderEngine(ctx context.Context, tm telemetry.Component) *LeaderEngine {
 	return &LeaderEngine{
 		ctx:             ctx,
 		LeaseName:       pkgconfigsetup.Datadog().GetString("leader_lease_name"),
 		LeaderNamespace: namespace.GetResourcesNamespace(),
 		ServiceName:     pkgconfigsetup.Datadog().GetString("cluster_agent.kubernetes_service_name"),
-		leaderMetric:    metrics.NewLeaderMetric(),
+		leaderMetric:    metrics.NewLeaderMetric(tm),
 		subscribers:     []chan struct{}{},
 		LeaseDuration:   defaultLeaderLeaseDuration,
 	}
-}
-
-// ResetGlobalLeaderEngine is a helper to remove the current LeaderEngine global
-// It is ONLY to be used for tests
-func ResetGlobalLeaderEngine() {
-	globalLeaderEngine = nil
-	telemetryimpl.GetCompatComponent().Reset()
 }
 
 // Initialize initializes the leader engine
@@ -121,9 +113,9 @@ func GetLeaderEngine() (*LeaderEngine, error) {
 }
 
 // CreateGlobalLeaderEngine returns a non initialized leader engine client
-func CreateGlobalLeaderEngine(ctx context.Context) *LeaderEngine {
+func CreateGlobalLeaderEngine(ctx context.Context, tm telemetry.Component) *LeaderEngine {
 	if globalLeaderEngine == nil {
-		globalLeaderEngine = newLeaderEngine(ctx)
+		globalLeaderEngine = newLeaderEngine(ctx, tm)
 		globalLeaderEngine.initRetry.SetupRetrier(&retry.Config{ //nolint:errcheck
 			Name:              "leaderElection",
 			AttemptMethod:     globalLeaderEngine.init,

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_stub.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_stub.go
@@ -9,7 +9,11 @@
 // mechanism offered in Kubernetes.
 package leaderelection
 
-import "context"
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+)
 
 // CreateGlobalLeaderEngine does nothing
-func CreateGlobalLeaderEngine(_ context.Context) {}
+func CreateGlobalLeaderEngine(_ context.Context, _ telemetry.Component) {}

--- a/pkg/util/kubernetes/apiserver/leaderelection/metrics/BUILD.bazel
+++ b/pkg/util/kubernetes/apiserver/leaderelection/metrics/BUILD.bazel
@@ -7,6 +7,5 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/telemetry/def",
-        "//comp/core/telemetry/impl",
     ],
 )

--- a/pkg/util/kubernetes/apiserver/leaderelection/metrics/metrics.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/metrics/metrics.go
@@ -9,7 +9,6 @@ package metrics
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
-	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 )
 
 const (
@@ -22,8 +21,8 @@ const (
 )
 
 // NewLeaderMetric returns the leader_election_is_leader metric
-func NewLeaderMetric() telemetry.Gauge {
-	return telemetryimpl.GetCompatComponent().NewGaugeWithOpts(
+func NewLeaderMetric(tm telemetry.Component) telemetry.Gauge {
+	return tm.NewGaugeWithOpts(
 		"leader_election",
 		"is_leader",
 		[]string{JoinLeaderLabel, IsLeaderLabel}, // join_leader is for label joins, is_leader indicates if the pod is the current leader.


### PR DESCRIPTION
### What does this PR do?

Removes uses of `GetCompatComponent()` from `pkg/util/kubernetes/apiserver/leaderelection`.

### Motivation

We want to remove the global state in the telemetry component.

### Describe how you validated your changes

CI.