### PR TITLE
Fix superfluous WriteHeader in remote config handler

### DIFF
--- a/cmd/trace-agent/config/remote/config.go
+++ b/cmd/trace-agent/config/remote/config.go
@@ -57,8 +57,9 @@ func ConfigHandler(r *api.HTTPReceiver, cf rcclient.ConfigFetcher, cfg *config.A
 		defer putBuffer(buf)
 		_, err := io.Copy(buf, req.Body)
 		if err != nil {
+			statusCode = http.StatusBadRequest
 			http.Error(w, err.Error(), http.StatusBadRequest)
-
+			return
 		}
 		var configsRequest pbgo.ClientGetConfigsRequest
 		err = json.Unmarshal(buf.Bytes(), &configsRequest)

--- a/cmd/trace-agent/config/remote/config_test.go
+++ b/cmd/trace-agent/config/remote/config_test.go
@@ -225,6 +225,56 @@ func TestEmptyResponse(t *testing.T) {
 	r.Body.Close()
 }
 
+// errReader is an io.Reader that returns err on every Read call after
+// optionally yielding the given initial bytes.
+type errReader struct {
+	done bool
+	err  error
+}
+
+func (e *errReader) Read(p []byte) (int, error) {
+	if e.done {
+		return 0, e.err
+	}
+	e.done = true
+	return 0, e.err
+}
+
+// writeHeaderCountingRecorder wraps httptest.ResponseRecorder to count
+// WriteHeader calls, allowing tests to detect superfluous WriteHeader
+// invocations (the root cause of the bug being fixed).
+type writeHeaderCountingRecorder struct {
+	*httptest.ResponseRecorder
+	writeHeaderCount int
+}
+
+func (r *writeHeaderCountingRecorder) WriteHeader(code int) {
+	r.writeHeaderCount++
+	r.ResponseRecorder.WriteHeader(code)
+}
+
+func TestBodyReadError(t *testing.T) {
+	assert := assert.New(t)
+	grpc := agentGRPCConfigFetcher{}
+	rcv := api.NewHTTPReceiver(config.New(), sampler.NewDynamicConfig(), make(chan *api.Payload, 5000), nil, nil, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, &timing.NoopReporter{})
+
+	// ClientGetConfigs must never be called when the body read fails.
+	grpc.On("ClientGetConfigs", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil).Maybe()
+
+	handler := ConfigHandler(rcv, &grpc, &config.AgentConfig{}, &statsd.NoOpClient{}, &timing.NoopReporter{})
+
+	req, _ := http.NewRequest("POST", "/v0.7/config", &errReader{err: io.ErrUnexpectedEOF})
+	req.Header.Set("Content-Type", "application/msgpack")
+	rec := &writeHeaderCountingRecorder{ResponseRecorder: httptest.NewRecorder()}
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(http.StatusBadRequest, rec.Code)
+	assert.Contains(rec.Body.String(), io.ErrUnexpectedEOF.Error())
+	assert.Equal(1, rec.writeHeaderCount, "WriteHeader should be called exactly once, not multiple times")
+	grpc.AssertNotCalled(t, "ClientGetConfigs")
+}
+
 type agentGRPCConfigFetcher struct {
 	pbgo.AgentSecureClient
 	mock.Mock

--- a/cmd/trace-agent/config/remote/config_test.go
+++ b/cmd/trace-agent/config/remote/config_test.go
@@ -232,7 +232,7 @@ type errReader struct {
 	err  error
 }
 
-func (e *errReader) Read(p []byte) (int, error) {
+func (e *errReader) Read(_ []byte) (int, error) {
 	if e.done {
 		return 0, e.err
 	}


### PR DESCRIPTION
## What this fixes

The trace-agent remote config HTTP handler (`ConfigHandler` in `cmd/trace-agent/config/remote/config.go`) logged `superfluous response.WriteHeader` warnings whenever reading the request body failed.

### Root cause

The `io.Copy` error branch was missing a `return`:

```go
_, err := io.Copy(buf, req.Body)
if err != nil {
    http.Error(w, err.Error(), http.StatusBadRequest)
    // ← no return: execution falls through
}
```

When `io.Copy` failed, `http.Error` wrote a `400` response (calling `WriteHeader`), but execution continued to `json.Unmarshal` on the empty/partial buffer. Unmarshal also failed, and the second `http.Error` call invoked `WriteHeader` again, producing the `superfluous response.WriteHeader` log.

### Side effect

The `statusCode` variable stayed at `200` in this error path, so the deferred `statsd` counter (`datadog.trace_agent.receiver.config_request`) mis-reported these failed reads as successful requests.

### Fix

Add the missing `return` and set `statusCode = http.StatusBadRequest`, matching the pattern already used in the other error branches of the same handler.

## Testing

Verified the package compiles cleanly (`go vet ./cmd/trace-agent/config/remote/` — no errors from the edited package).