### PR TITLE
host_profiler: use shared build flags helpers

### DIFF
--- a/tasks/host_profiler.py
+++ b/tasks/host_profiler.py
@@ -11,7 +11,7 @@ from tasks.build_tags import get_default_build_tags
 from tasks.libs.common.color import color_message
 from tasks.libs.common.constants import ALLOWED_REPO_NIGHTLY_BRANCHES
 from tasks.libs.common.go import go_build
-from tasks.libs.common.utils import REPO_PATH, bin_name, get_version_ldflags
+from tasks.libs.common.utils import REPO_PATH, bin_name, get_build_flags
 from tasks.libs.releasing.json import get_current_milestone
 from tasks.libs.releasing.version import query_version
 from tasks.schema.generate import schema_codegen
@@ -70,15 +70,10 @@ def build(ctx):
     if os.path.exists(BIN_PATH):
         os.remove(BIN_PATH)
 
-    env = {"GO111MODULE": "on"}
     build_tags = get_default_build_tags(build="host-profiler")
-    ldflags = get_version_ldflags(ctx)
+    ldflags, gcflags, env = get_build_flags(ctx)
     if profiler_version := _get_profiler_agent_version(ctx):
         ldflags += f" -X {REPO_PATH}/pkg/version.AgentVersion={profiler_version}"
-    if os.environ.get("DELVE"):
-        gcflags = "all=-N -l"
-    else:
-        gcflags = ""
 
     # generate windows resources
     if sys.platform == 'win32':


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Use common flags computation for host_profiler

### Motivation

Slightly reduce code duplication to simplify the understanding of the code as part of the bazel migration

### Describe how you validated your changes

Local build, the CI will do the rest

### Additional Notes
