### PR TITLE
cmd/privateactionrunner: migrate to dd_agent_go_binary

### DIFF
--- a/cmd/privateactionrunner/BUILD.bazel
+++ b/cmd/privateactionrunner/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
 load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+load("//bazel/rules/go:go_binary.bzl", "dd_agent_go_binary")
+load("//tasks:build_tags.bzl", "PRIVATEACTIONRUNNER_TAGS")
 
 #gazelle:dd_agent_go_test on
 
@@ -114,9 +116,10 @@ go_library(
     }),
 )
 
-go_binary(
+dd_agent_go_binary(
     name = "privateactionrunner",
     embed = [":privateactionrunner_lib"],
+    gotags = PRIVATEACTIONRUNNER_TAGS,
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/privateactionrunner/BUILD.bazel
+++ b/cmd/privateactionrunner/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 load("//bazel/rules/go:go_binary.bzl", "dd_agent_go_binary")
 load("//tasks:build_tags.bzl", "PRIVATEACTIONRUNNER_TAGS")


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Use `dd_agent_go_binary` for the privateactionrunner binary

### Motivation

This includes the usual build flags & build tags stanza out of the box and is closer from the existing dda based build

### Describe how you validated your changes

Local build

### Additional Notes
