### PR TITLE
fix(ci): refetch broken Bazel repositories on macOS runners

### DIFF
--- a/.gitlab/.pre/common/macos.yml
+++ b/.gitlab/.pre/common/macos.yml
@@ -91,7 +91,7 @@
     - !reference [.aws_retry_config]
     # Drop GOPROXY entries not usable from macOS runners, before any go command.
     - !reference [.sanitize_goproxy]
-    - !reference [.kill_bazel_server]
+    - !reference [.bazel:recover_from_canceled_job]
     # Selecting the current Go version
     - |
       eval $(gimme $(cat .go-version))

--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -45,10 +45,19 @@
   variables:
     XDG_CACHE_HOME: "$CI_PROJECT_DIR/.cache"
 
-# Temporarily kill any Bazel server running on that slot until https://github.com/bazelbuild/bazel/issues/30435 is fixed
-# in our Bazel version, i.e. through https://github.com/bazelbuild/bazel/commit/058adaacae08166ce6e6edb0e2fdb28a67524314
-.kill_bazel_server:
+# Temporarily recover a persistent runner's Bazel state from a possibly canceled previous job:
+# - kill any Bazel server still running on that slot, until https://github.com/bazelbuild/bazel/issues/30954 is fixed in
+#   our Bazel version, through e.g., https://github.com/bazelbuild/bazel/pull/30960,
+# - refetch any repository left with a missing package or target, to be reassessed once
+#   https://github.com/bazel-contrib/bazel-gazelle/issues/2206 gets addressed.
+.bazel:recover_from_canceled_job:
   - pkill -f "output_base=$XDG_CACHE_HOME" || [ "$?" -eq 1 ]  # No processes matched
+  - >
+    (bazel cquery --keep_going --noshow_progress 'deps(//...)' 2>&1 >/dev/null || true)
+    | grep -Fv WARNING:
+    | (grep -Eo "@@[^ './:]+" || true)
+    | sort -u
+    | xargs -I{} bazel fetch --force --repo={}
 
 .bazel:defs:cache:macos:
   extends: .bazel:defs
@@ -58,7 +67,7 @@
     # Drop GOPROXY entries not usable from macOS runners before bazel forwards
     # GOPROXY into its repository rules.
     - !reference [.sanitize_goproxy]
-    - !reference [.kill_bazel_server]
+    - !reference [.bazel:recover_from_canceled_job]
 
 .bazel:defs:cache:persistent:
   extends: .bazel:defs

--- a/.gitlab/build/package_build/dmg.yml
+++ b/.gitlab/build/package_build/dmg.yml
@@ -71,7 +71,7 @@
     - !reference [.macos_runner_maintenance]
     - !reference [.macos_setup_cache]
     - !reference [.sanitize_goproxy]
-    - !reference [.kill_bazel_server]
+    - !reference [.bazel:recover_from_canceled_job]
     # Populate AWS_SHARED_CREDENTIALS_FILE via CI Identities (no macOS IAM instance role needed);
     # must run before build_agent_dmg.sh since Omnibus reads it for S3 cache access during the build.
     - ci-identities-gitlab-job-client assume-role


### PR DESCRIPTION
### What does this PR do?
Extend the earlier `.kill_bazel_server` to a broader `.bazel:recover_from_canceled_job` with a `bazel fetch --force --repo=@@<canonical name>` step that refetches any external repository currently missing a package or target.

### Motivation
`bazel:coverage:macos-arm64` and `bazel:test:macos-*` jobs on some runner slots (esp. `t3_C7z16h` and `t3_kJ5gyy`) have been repeatedly failing with `BUILD file not found` and `no such target` errors for `go_deps` repos (`envoyproxy/go-control-plane`, `google-cloud-go/compute`, `hashicorp/vault`, `openshift/client-go`, etc.), including after `.kill_bazel_server` was introduced in #55663, e.g.:
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1991849162
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/2001321660
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/2002844429
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/2006105987

A canceled `bazel`-powered job, the scenario `.kill_bazel_server` works around, can also leave `gazelle`'s BUILD file generation for a `go_deps` repository incomplete, so killing the stale server alone won't repair the damage.

`bazel cquery --keep_going 'deps(//...)'` surfaces every currently broken repository in one pass, and `bazel fetch --force --repo=@@<canonical name>` refetches only those, avoiding an expensive `bazel fetch`'s implicit `--all` when given no repository argument.

### Describe how you validated your changes
Ran `dda inv linter.gitlab-ci` and `dda inv linter.gitlab-ci-shellcheck` against the changed files, both passing with no new findings, and `shellcheck` directly against the new script lines in isolation.

Works well in CI ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/2008049804/viewer#L26)):
```bash
$ (bazel cquery --keep_going --noshow_progress 'deps(//...)' 2>&1 >/dev/null || true) | grep -Fv WARNING: | (grep -Eo "@@[^ './:]+" || true) | sort -u | xargs -I{} bazel fetch --force --repo={}
INFO: Invocation ID: e6fc307d-e324-4c59-8794-9636fb3cfaf6
Computing main repo mapping: 
...
Computing main repo mapping: 
INFO: All requested repos fetched successfully.
INFO: Invocation ID: e485e910-d937-43ec-b285-7fbccde5588a
WARNING: Repository '@@gazelle++go_deps+bazel_gazelle_go_repository_config' will be fetched again since the file 'go_env.bzl' has been modified externally. External modifications can lead to incorrect builds.
WARNING: Repository '@@gazelle++go_deps+com_github_aliyun_alibaba_cloud_sdk_go' will be fetched again since the file '' has been modified externally. External modifications can lead to incorrect builds.
Computing main repo mapping: 
...
Computing main repo mapping: 
INFO: All requested repos fetched successfully.
```

### Additional Notes
bazel-contrib/bazel-gazelle#2206 documents a related, deterministic Gazelle bug for Go modules containing independently-versioned submodules.

This change addresses the corrupted-cache symptom observed on shared macOS runners, not that separate root cause.