### PR TITLE
tools/bazel.bat: check symlink creation privilege before invoking Bazel

### DIFF
--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -77,17 +77,17 @@ for %%i in ("!more_than_8dot3_chars!") do if "%%~nxi"=="%%~snxi" (
 )
 
 :: Check symlink creation privilege (required by rules_python bootstrap on Windows)
-set "_sl_probe=%TEMP%\bazel_sl_probe"
-set "_sl_target=%TEMP%\bazel_sl_target"
+set "_sl_probe=%TEMP%\bazel_sl_probe_%RANDOM%_%RANDOM%"
+set "_sl_target=%TEMP%\bazel_sl_target_%RANDOM%_%RANDOM%"
 >"!_sl_target!" type nul
 2>nul mklink "!_sl_probe!" "!_sl_target!" >nul
-if !errorlevel! neq 0 (
-  2>nul del /f /q "!_sl_target!"
+set "_sl_rc=!errorlevel!"
+2>nul del /f /q "!_sl_probe!" "!_sl_target!"
+if !_sl_rc! neq 0 (
   >&2 echo 🔴 For `bazel` to work properly, please enable Windows Developer Mode, which grants symlink creation privilege:
   >&2 echo     Settings ^> System ^> Advanced ^> For developers ^> Developer Mode
   exit /b 2
 )
-2>nul del /f /q "!_sl_probe!" "!_sl_target!"
 
 set "args=%*"
 if defined args if defined extra_args call :insert_extra_args

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -76,6 +76,19 @@ for %%i in ("!more_than_8dot3_chars!") do if "%%~nxi"=="%%~snxi" (
   exit /b 2
 )
 
+:: Check symlink creation privilege (required by rules_python bootstrap on Windows)
+set "_sl_probe=%TEMP%\bazel_sl_probe"
+set "_sl_target=%TEMP%\bazel_sl_target"
+>"!_sl_target!" type nul
+2>nul mklink "!_sl_probe!" "!_sl_target!" >nul
+if !errorlevel! neq 0 (
+  2>nul del /f /q "!_sl_target!"
+  >&2 echo 🔴 For `bazel` to work properly, please enable Windows Developer Mode, which grants symlink creation privilege:
+  >&2 echo     Settings ^> System ^> Advanced ^> For developers ^> Developer Mode
+  exit /b 2
+)
+2>nul del /f /q "!_sl_probe!" "!_sl_target!"
+
 set "args=%*"
 if defined args if defined extra_args call :insert_extra_args
 "%BAZEL_REAL%" !startup_options! !args!


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Check for symlink support before attempting to build.

### Motivation

rules_python needs it to bootstrap, and the error it yields isn't obvious at all.
Better to check for support explicitly

### Describe how you validated your changes

Attempted to build on a fresh windows machine, the build failed with
```
ERROR: C:/users/hugo.beauzee/dd/datadog-agent/pkg/config/setup/constants/BUILD.bazel:9:11: RunBinary pkg/config/setup/constants/generated.go failed: (Exit 1): codegen_settings_main.exe failed: error executing RunBinary command (from _run_binary rule target //pkg/config/setup/constants:codegen_constants)
  cd /d C:/users/hugo.beauzee/_bazel_hugo.beauzee/xdbayvnp/execroot/_main
  SET PATH=C:\tools\msys64\usr\bin;C:\tools\msys64\bin;C:\Windows;C:\Windows\System32;C:\Windows\System32\WindowsPowerShell\v1.0
  bazel-out\x64_windows-opt-exec\bin\tasks\schema\codegen_settings_main.exe bazel-out/x64_windows-fastbuild/bin/pkg/config/setup/constants/ constants
# Configuration: dcefade0a93c2b7faa05f91c6cd58b5878c8e608638307729f08a0c06a14aaa3
# Execution platform: @@platforms//host:host
Traceback (most recent call last):
  File "C:\Users\hugo.beauzee\_bazel_hugo.beauzee\xdbayvnp\execroot\_main\bazel-out\x64_windows-opt-exec\bin\tasks\schema\codegen_settings_main", line 689, in <module>
    main()
  File "C:\Users\hugo.beauzee\_bazel_hugo.beauzee\xdbayvnp\execroot\_main\bazel-out\x64_windows-opt-exec\bin\tasks\schema\codegen_settings_main", line 643, in main
    python_program = _create_venv(runfiles_root, delete_dirs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\hugo.beauzee\_bazel_hugo.beauzee\xdbayvnp\execroot\_main\bazel-out\x64_windows-opt-exec\bin\tasks\schema\codegen_settings_main", line 406, in _create_venv
    _symlink_exist_ok(from_=venv_python_exe, to=python_exe_actual)
  File "C:\Users\hugo.beauzee\_bazel_hugo.beauzee\xdbayvnp\execroot\_main\bazel-out\x64_windows-opt-exec\bin\tasks\schema\codegen_settings_main", line 572, in _symlink_exist_ok
    os.symlink(to, from_, target_is_directory=os.path.isdir(to))
OSError: [WinError 1314] A required privilege is not held by the client: 'c:\\users\\hugo.beauzee\\_bazel_hugo.beauzee\\xdbayvnp\\execroot\\_main\\bazel-out\\x64_windows-opt-exec\\bin\\tasks\\schema\\codegen_settings_main.exe.runfiles\\rules_python++python+python_3_12_x86_64-pc-windows-msvc\\python.exe' -> 'C:\\Users\\HUGO~1.BEA\\AppData\\Local\\Temp\\bazel._codegen_settings_main.venv.a2x_kuyk\\Scripts\\python.exe'
```

with that change, it results in
```
PS C:\Users\hugo.beauzee\dd\datadog-agent\.claude\worktrees\agent-afefcb71a7ae24244> bazelisk build //cmd/systray
🔴 For `bazel` to work properly, please enable Windows Developer Mode, which grants symlink creation privilege:
    Settings > System > Advanced > For developers > Developer Mode
```

### Additional Notes

