### PR TITLE
pkg/util/trivy: stop the cache telemetry goroutine on Close

### DIFF
--- a/pkg/util/trivy/BUILD.bazel
+++ b/pkg/util/trivy/BUILD.bazel
@@ -123,5 +123,6 @@ dd_agent_go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_fx//:fx",
+        "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/pkg/util/trivy/cache.go
+++ b/pkg/util/trivy/cache.go
@@ -189,6 +189,9 @@ type persistentCache struct {
 	currentCachedObjectTotalSize int
 	maximumCachedObjectSize      int
 	lastEvicted                  string
+	stop                         chan struct{}
+	stopped                      chan struct{}
+	closeOnce                    sync.Once
 }
 
 // newPersistentCache creates a new instance of persistentCache and returns a pointer to it.
@@ -201,6 +204,8 @@ func newPersistentCache(
 		db:                           localDB,
 		currentCachedObjectTotalSize: 0,
 		maximumCachedObjectSize:      maxCachedObjectSize,
+		stop:                         make(chan struct{}),
+		stopped:                      make(chan struct{}),
 	}
 
 	lruCache, err := simplelru.NewLRU(cacheSize, func(key string, _ struct{}) {
@@ -227,15 +232,7 @@ func newPersistentCache(
 		return nil, err
 	}
 
-	go func() {
-		ticker := time.NewTicker(telemetryTick)
-		for {
-			for range ticker.C {
-				persistentCache.collectTelemetry()
-			}
-			// TODO: add database compaction. BoltDB deletes the old pages but does not shrink the file.
-		}
-	}()
+	go persistentCache.collectTelemetryLoop()
 
 	return persistentCache, nil
 }
@@ -324,10 +321,14 @@ func (c *persistentCache) reduceSize(target int) error {
 	return nil
 }
 
-// Close closes the database.
+// Close stops the telemetry collection and closes the database.
 func (c *persistentCache) Close() error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
+	c.closeOnce.Do(func() {
+		close(c.stop)
+		<-c.stopped
+	})
 	return c.db.Close()
 }
 
@@ -453,6 +454,24 @@ func (c *persistentCache) collectTelemetry() {
 		log.Errorf("could not collect telemetry: %v", err)
 	}
 	telemetry.SBOMCacheDiskSize.Set(float64(diskSize))
+}
+
+// collectTelemetryLoop collects the database's size until the cache is closed.
+// TODO: add database compaction. BoltDB deletes the old pages but does not shrink the file.
+func (c *persistentCache) collectTelemetryLoop() {
+	defer close(c.stopped)
+
+	ticker := time.NewTicker(telemetryTick)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			c.collectTelemetry()
+		case <-c.stop:
+			return
+		}
+	}
 }
 
 func newMemoryCache() *memoryCache {

--- a/pkg/util/trivy/cache_test.go
+++ b/pkg/util/trivy/cache_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
+	"go.uber.org/goleak"
 )
 
 var (
@@ -376,6 +377,17 @@ func TestCustomBoltCache_GarbageCollector(t *testing.T) {
 
 	persistentCache := cache.(*ScannerCache).cache
 	require.Equal(t, 2*len(serializedBlobInfo)+len(serializedArtifactInfo), persistentCache.GetCurrentCachedObjectTotalSize())
+}
+
+func TestCustomBoltCache_CloseStopsTelemetry(t *testing.T) {
+	deps := createCacheDeps(t)
+	ignoreExisting := goleak.IgnoreCurrent()
+
+	cache, err := NewCustomBoltCache(deps.WMeta, t.TempDir(), defaultDiskSize)
+	require.NoError(t, err)
+	require.NoError(t, cache.Close())
+
+	goleak.VerifyNone(t, ignoreExisting)
 }
 
 func newTestArtifactInfo() types.ArtifactInfo {


### PR DESCRIPTION
newPersistentCache starts a goroutine that reports the BoltDB file size
once a minute. The inner loop over ticker.C never returns, so the
enclosing for loop is unreachable and the ticker outlives Close. Every
cache the process opens leaves a goroutine behind.

Close now closes a stop channel that the loop selects on and waits for
the goroutine to return before closing the database, so the ticker stops
and every tick runs against an open database. A test closes a fresh
cache and lets goleak confirm the goroutine exited.
