### PR TITLE
Extend FQDN resolution to other trace-agent intake URLs built from site

### DIFF
--- a/comp/trace/config/impl/config_test.go
+++ b/comp/trace/config/impl/config_test.go
@@ -592,6 +592,170 @@ func TestProfilingURL(t *testing.T) {
 	}
 }
 
+func TestDebuggerURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "default site",
+			expected: "https://http-intake.logs.datadoghq.com./api/v2/logs",
+		},
+		{
+			name:     "configured Datadog site",
+			settings: map[string]interface{}{"site": "datadoghq.eu"},
+			expected: "https://http-intake.logs.datadoghq.eu./api/v2/logs",
+		},
+		{
+			name:     "custom site",
+			settings: map[string]interface{}{"site": "example.com"},
+			expected: "https://http-intake.logs.example.com/api/v2/logs",
+		},
+		{
+			name: "explicit debugger URL",
+			settings: map[string]interface{}{
+				"site":                       "datadoghq.eu",
+				"apm_config.debugger_dd_url": "https://debugger.example.com/custom/path",
+			},
+			expected: "https://debugger.example.com/custom/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := buildConfigComponentFromOverrides(t, true, tt.settings)
+			cfg := config.Object()
+
+			require.NotNil(t, cfg)
+			assert.Equal(t, tt.expected, cfg.DebuggerProxy.DDURL)
+		})
+	}
+}
+
+func TestDebuggerIntakeURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "default site",
+			expected: "https://debugger-intake.datadoghq.com./api/v2/debugger",
+		},
+		{
+			name:     "configured Datadog site",
+			settings: map[string]interface{}{"site": "datadoghq.eu"},
+			expected: "https://debugger-intake.datadoghq.eu./api/v2/debugger",
+		},
+		{
+			name:     "custom site",
+			settings: map[string]interface{}{"site": "example.com"},
+			expected: "https://debugger-intake.example.com/api/v2/debugger",
+		},
+		{
+			name: "explicit debugger diagnostics URL",
+			settings: map[string]interface{}{
+				"site":                                   "datadoghq.eu",
+				"apm_config.debugger_diagnostics_dd_url": "https://debugger-diag.example.com/custom/path",
+			},
+			expected: "https://debugger-diag.example.com/custom/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := buildConfigComponentFromOverrides(t, true, tt.settings)
+			cfg := config.Object()
+
+			require.NotNil(t, cfg)
+			assert.Equal(t, tt.expected, cfg.DebuggerIntakeProxy.DDURL)
+		})
+	}
+}
+
+func TestSymDBURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "default site",
+			expected: "https://debugger-intake.datadoghq.com./api/v2/debugger",
+		},
+		{
+			name:     "configured Datadog site",
+			settings: map[string]interface{}{"site": "datadoghq.eu"},
+			expected: "https://debugger-intake.datadoghq.eu./api/v2/debugger",
+		},
+		{
+			name:     "custom site",
+			settings: map[string]interface{}{"site": "example.com"},
+			expected: "https://debugger-intake.example.com/api/v2/debugger",
+		},
+		{
+			name: "explicit symdb URL",
+			settings: map[string]interface{}{
+				"site":                    "datadoghq.eu",
+				"apm_config.symdb_dd_url": "https://symdb.example.com/custom/path",
+			},
+			expected: "https://symdb.example.com/custom/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := buildConfigComponentFromOverrides(t, true, tt.settings)
+			cfg := config.Object()
+
+			require.NotNil(t, cfg)
+			assert.Equal(t, tt.expected, cfg.SymDBProxy.DDURL)
+		})
+	}
+}
+
+func TestOpenLineageURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "default site",
+			expected: "https://data-obs-intake.datadoghq.com./api/v1/lineage",
+		},
+		{
+			name:     "configured Datadog site",
+			settings: map[string]interface{}{"site": "datadoghq.eu"},
+			expected: "https://data-obs-intake.datadoghq.eu./api/v1/lineage",
+		},
+		{
+			name:     "custom site",
+			settings: map[string]interface{}{"site": "example.com"},
+			expected: "https://data-obs-intake.example.com/api/v1/lineage",
+		},
+		{
+			name: "explicit openlineage URL",
+			settings: map[string]interface{}{
+				"site":                   "datadoghq.eu",
+				"ol_proxy_config.dd_url": "https://ol.example.com/custom/path",
+			},
+			expected: "https://ol.example.com/custom/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := buildConfigComponentFromOverrides(t, true, tt.settings)
+			cfg := config.Object()
+
+			require.NotNil(t, cfg)
+			assert.Equal(t, tt.expected, cfg.OpenLineageProxy.DDURL)
+		})
+	}
+}
+
 func TestDefaultConfig(t *testing.T) {
 	config := buildConfigComponent(t, true)
 	cfg := config.Object()

--- a/comp/trace/config/impl/setup.go
+++ b/comp/trace/config/impl/setup.go
@@ -667,6 +667,10 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if k := "apm_config.debugger_dd_url"; core.IsConfigured(k) {
 		c.DebuggerProxy.DDURL = core.GetString(k)
 	}
+	if c.DebuggerProxy.DDURL == "" {
+		// Resolve the implicit URL here to keep config dependencies out of pkg/trace.
+		c.DebuggerProxy.DDURL = utils.BuildURLWithPrefix(config.DebuggerLogsEndpointPrefix, c.Site) + config.DebuggerLogsEndpointPath
+	}
 	if k := "apm_config.debugger_api_key"; core.IsConfigured(k) {
 		c.DebuggerProxy.APIKey = core.GetString(k)
 	}
@@ -676,6 +680,10 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if k := "apm_config.debugger_diagnostics_dd_url"; core.IsConfigured(k) {
 		c.DebuggerIntakeProxy.DDURL = core.GetString(k)
 	}
+	if c.DebuggerIntakeProxy.DDURL == "" {
+		// Resolve the implicit URL here to keep config dependencies out of pkg/trace.
+		c.DebuggerIntakeProxy.DDURL = utils.BuildURLWithPrefix(config.DebuggerIntakeEndpointPrefix, c.Site) + config.DebuggerIntakeEndpointPath
+	}
 	if k := "apm_config.debugger_diagnostics_api_key"; core.IsConfigured(k) {
 		c.DebuggerIntakeProxy.APIKey = core.GetString(k)
 	}
@@ -684,6 +692,10 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	}
 	if k := "apm_config.symdb_dd_url"; core.IsConfigured(k) {
 		c.SymDBProxy.DDURL = core.GetString(k)
+	}
+	if c.SymDBProxy.DDURL == "" {
+		// Resolve the implicit URL here to keep config dependencies out of pkg/trace.
+		c.SymDBProxy.DDURL = utils.BuildURLWithPrefix(config.DebuggerIntakeEndpointPrefix, c.Site) + config.DebuggerIntakeEndpointPath
 	}
 	if k := "apm_config.symdb_api_key"; core.IsConfigured(k) {
 		c.SymDBProxy.APIKey = core.GetString(k)
@@ -708,6 +720,10 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	c.OpenLineageProxy.Enabled = core.GetBool("ol_proxy_config.enabled")
 	if k := "ol_proxy_config.dd_url"; core.IsConfigured(k) {
 		c.OpenLineageProxy.DDURL = core.GetString(k)
+	}
+	if c.OpenLineageProxy.DDURL == "" {
+		// Resolve the implicit URL here to keep config dependencies out of pkg/trace.
+		c.OpenLineageProxy.DDURL = utils.BuildURLWithPrefix(config.OpenLineageEndpointPrefix, c.Site) + config.OpenLineageEndpointPath
 	}
 	if k := "ol_proxy_config.api_key"; core.IsConfigured(k) {
 		c.OpenLineageProxy.APIKey = core.GetString(k)

--- a/pkg/trace/api/debugger.go
+++ b/pkg/trace/api/debugger.go
@@ -23,10 +23,10 @@ import (
 
 const (
 	// logsIntakeURLTemplate is the template for building the logs intake URL for each site.
-	logsIntakeURLTemplate = "https://http-intake.logs.%s/api/v2/logs"
+	logsIntakeURLTemplate = config.DebuggerLogsEndpointPrefix + "%s" + config.DebuggerLogsEndpointPath
 
 	// debuggerIntakeURLTemplate specifies the template for obtaining the intake URL along with the site.
-	debuggerIntakeURLTemplate = "https://debugger-intake.%s/api/v2/debugger"
+	debuggerIntakeURLTemplate = config.DebuggerIntakeEndpointPrefix + "%s" + config.DebuggerIntakeEndpointPath
 
 	// ddTagsQueryStringMaxLen is the maximum number of characters we send as ddtags in the intake query string.
 	// This limit is not imposed by the event platform intake, it's a safeguard we've added to guarantee an upper

--- a/pkg/trace/api/openlineage.go
+++ b/pkg/trace/api/openlineage.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	openlineageURLTemplate = "https://data-obs-intake.%s/api/v1/lineage"
-	openlineageURLDefault  = "https://data-obs-intake.datadoghq.com/api/v1/lineage"
+	openlineageURLTemplate = config.OpenLineageEndpointPrefix + "%s" + config.OpenLineageEndpointPath
+	openlineageURLDefault  = config.OpenLineageEndpointPrefix + "datadoghq.com" + config.OpenLineageEndpointPath
 )
 
 // openLineageEndpoint returns the openlineage intake url and the corresponding API key.

--- a/pkg/trace/config/endpoints.go
+++ b/pkg/trace/config/endpoints.go
@@ -10,4 +10,19 @@ const (
 	ProfilingEndpointPrefix = "https://intake.profile."
 	// ProfilingEndpointPath is the API path for the profiling intake.
 	ProfilingEndpointPath = "/api/v2/profile"
+
+	// DebuggerLogsEndpointPrefix is the URL prefix for the debugger logs intake.
+	DebuggerLogsEndpointPrefix = "https://http-intake.logs."
+	// DebuggerLogsEndpointPath is the API path for the debugger logs intake.
+	DebuggerLogsEndpointPath = "/api/v2/logs"
+
+	// DebuggerIntakeEndpointPrefix is the URL prefix for the debugger diagnostics/symbol database intake.
+	DebuggerIntakeEndpointPrefix = "https://debugger-intake."
+	// DebuggerIntakeEndpointPath is the API path for the debugger diagnostics/symbol database intake.
+	DebuggerIntakeEndpointPath = "/api/v2/debugger"
+
+	// OpenLineageEndpointPrefix is the URL prefix for the openlineage intake.
+	OpenLineageEndpointPrefix = "https://data-obs-intake."
+	// OpenLineageEndpointPath is the API path for the openlineage intake.
+	OpenLineageEndpointPath = "/api/v1/lineage"
 )


### PR DESCRIPTION
### What does this PR do?

PR #55642 ([PROF-12409](https://datadoghq.atlassian.net/browse/PROF-12409)) made the profiling intake URL resolve through `utils.BuildURLWithPrefix`, which appends a trailing DNS dot for known Datadog sites when `convert_dd_site_fqdn.enabled` is set. This avoids unnecessary DNS lookups against `/etc/resolv.conf` search domains, notably in Kubernetes with `ndots:5`. That PR intentionally scoped the fix to profiling only.

This PR extends the same resolution to the other trace-agent intake URLs that were still built via plain `fmt.Sprintf(..., conf.Site)` (no FQDN dot):

* `DebuggerProxy.DDURL`
* `DebuggerIntakeProxy.DDURL`
* `SymDBProxy.DDURL`
* openlineage intake (`OpenLineageProxy.DDURL`)

Explicit `*_dd_url` config overrides and custom (non-Datadog) sites are unchanged. The resolution happens in `comp/trace/config/impl/setup.go`, which already depends on `pkg/config/utils`, mirroring the approach from #55642.

### Motivation

Fix [APMSP-3986](https://datadoghq.atlassian.net/browse/APMSP-3986).

### Describe how you validated your changes

- `dda inv test --targets=./comp/trace/config/impl,./pkg/trace/api,./pkg/trace/config` (all passed)
- `dda inv linter.go --targets=./comp/trace/config/impl,./pkg/trace/api,./pkg/trace/config` (0 issues)
- Added `TestDebuggerURL`, `TestDebuggerIntakeURL`, `TestSymDBURL`, `TestOpenLineageURL` in `comp/trace/config/impl/config_test.go`, mirroring the existing `TestProfilingURL`.

### Additional Notes

No release note: this is an internal DNS-resolution efficiency fix with no user-facing configuration or API change, consistent with #55642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PROF-12409]: https://datadoghq.atlassian.net/browse/PROF-12409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMSP-3986]: https://datadoghq.atlassian.net/browse/APMSP-3986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ