### PR TITLE
Fix superfluous WriteHeader calls in telemetryWriterWrapper

### DIFF
--- a/pkg/clusteragent/api/handler_telemetry.go
+++ b/pkg/clusteragent/api/handler_telemetry.go
@@ -102,6 +102,17 @@ func SetSpanError(w http.ResponseWriter, err error) {
 	}
 }
 
+// Write implements http.ResponseWriter.Write. It routes through WriteHeader so that
+// the implicit http.StatusOK header write performed by the standard library (when a
+// handler calls Write before WriteHeader) is tracked by wroteHeader, preventing a
+// subsequent explicit WriteHeader call from writing the header twice.
+func (w *telemetryWriterWrapper) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(b)
+}
+
 func (w *telemetryWriterWrapper) WriteHeader(statusCode int) {
 	if w.wroteHeader {
 		return

--- a/pkg/clusteragent/api/handler_telemetry_test.go
+++ b/pkg/clusteragent/api/handler_telemetry_test.go
@@ -225,6 +225,65 @@ func TestWithTelemetryWrapper_NotForwarded(t *testing.T) {
 	assert.Nil(t, spans[0].Tag("forwarded"))
 }
 
+// countingResponseWriter mimics the real net/http server ResponseWriter: calling
+// Write before WriteHeader implicitly sends a 200 status. It counts how many times
+// WriteHeader is invoked so tests can detect a superfluous second header write.
+type countingResponseWriter struct {
+	header       http.Header
+	headerWrites int
+	firstStatus  int
+	headerSent   bool
+}
+
+func newCountingResponseWriter() *countingResponseWriter {
+	return &countingResponseWriter{header: make(http.Header)}
+}
+
+func (w *countingResponseWriter) Header() http.Header { return w.header }
+
+func (w *countingResponseWriter) WriteHeader(statusCode int) {
+	w.headerWrites++
+	if !w.headerSent {
+		w.headerSent = true
+		w.firstStatus = statusCode
+	}
+}
+
+func (w *countingResponseWriter) Write(b []byte) (int, error) {
+	if !w.headerSent {
+		w.WriteHeader(http.StatusOK)
+	}
+	return len(b), nil
+}
+
+// TestWithTelemetryWrapper_WriteThenWriteHeaderDoesNotDoubleWrite reproduces
+// https://github.com/DataDog/datadog-agent/issues/55745: a handler that calls Write
+// before WriteHeader (implicitly sending a 200) and then explicitly calls WriteHeader
+// (e.g. via http.Error) must not write the header twice on the delegate writer.
+func TestWithTelemetryWrapper_WriteThenWriteHeaderDoesNotDoubleWrite(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	rec := newCountingResponseWriter()
+	th := &TelemetryHandler{
+		handlerName: "writeThenErrorHandler",
+		handler: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("partial"))
+			w.WriteHeader(http.StatusInternalServerError)
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	th.handle(rec, req)
+
+	assert.Equal(t, 1, rec.headerWrites, "delegate WriteHeader must be invoked exactly once, not twice")
+	assert.Equal(t, http.StatusOK, rec.firstStatus)
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, float64(200), spans[0].Tag("http.status_code"))
+}
+
 func TestWithTelemetryWrapper_NoErrorWhenNilCapturedErr(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()

--- a/releasenotes-dca/notes/fix-superfluous-writeheader-2f6392ce17e473ff.yaml
+++ b/releasenotes-dca/notes/fix-superfluous-writeheader-2f6392ce17e473ff.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix a Cluster Agent API bug that could log spurious
+    ``superfluous response.WriteHeader call`` warnings. The internal telemetry
+    wrapper now correctly tracks the response status when a handler writes the
+    response body before explicitly setting the status code.


### PR DESCRIPTION
### What does this PR do?
Adds a `Write` override to `telemetryWriterWrapper` so it correctly tracks `wroteHeader` when a handler writes the response body before calling `WriteHeader`. Previously the delegate writer's implicit header write went untracked, so a later explicit `WriteHeader` call would write it a second time.

### Motivation
Fixes #55745. The cluster-agent was logging `superfluous response.WriteHeader call` warnings from `telemetryWriterWrapper`.

Significantly reduces the stable state amount of logs the cluster-agent produces:

<img width="1434" height="527" alt="image" src="https://github.com/user-attachments/assets/e69ebfb0-dfd2-4f02-8b59-a1d3dc123aa3" />


### Describe how you validated your changes
Added a regression test (`TestWithTelemetryWrapper_WriteThenWriteHeaderDoesNotDoubleWrite`) with a fake `ResponseWriter` mimicking `net/http`'s implicit-header behavior; it fails without the fix and passes with it.