### PR TITLE
privileged-logs: set O_CLOEXEC in OpenPathWithoutSymlinks

### DIFF
--- a/pkg/privileged-logs/common/BUILD.bazel
+++ b/pkg/privileged-logs/common/BUILD.bazel
@@ -28,10 +28,12 @@ dd_agent_go_test(
         "@rules_go//go/platform:android": [
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
+            "@org_golang_x_sys//unix",
         ],
         "@rules_go//go/platform:linux": [
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
+            "@org_golang_x_sys//unix",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/privileged-logs/common/open_linux.go
+++ b/pkg/privileged-logs/common/open_linux.go
@@ -43,10 +43,6 @@ func OpenPathWithoutSymlinks(path string) (*os.File, error) {
 	// (list) permission on every directory component, which would wrongly
 	// reject files under directories that are traversable but not listable
 	// (e.g. mode 0711).
-	//
-	// O_CLOEXEC is set on every open so that none of the (transient directory
-	// or final file) descriptors can be inherited by a concurrently-started
-	// subprocess, matching the close-on-exec behavior of os.Open.
 	dirFd, err := unix.Open("/", unix.O_PATH|unix.O_NOFOLLOW|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open root directory: %w", err)
@@ -77,7 +73,6 @@ func OpenPathWithoutSymlinks(path string) (*os.File, error) {
 	// Open the final file component with O_NOFOLLOW. dirFd was opened with
 	// O_PATH, but it can still be used as the directory fd for this openat,
 	// which enforces the normal read-permission check on the file itself.
-	// O_CLOEXEC prevents the returned descriptor from leaking into subprocesses.
 	fileName := parts[len(parts)-1]
 	fileFd, err := unix.Openat(dirFd, fileName, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 	if err != nil {

--- a/pkg/privileged-logs/common/open_linux.go
+++ b/pkg/privileged-logs/common/open_linux.go
@@ -43,7 +43,11 @@ func OpenPathWithoutSymlinks(path string) (*os.File, error) {
 	// (list) permission on every directory component, which would wrongly
 	// reject files under directories that are traversable but not listable
 	// (e.g. mode 0711).
-	dirFd, err := unix.Open("/", unix.O_PATH|unix.O_NOFOLLOW|unix.O_DIRECTORY, 0)
+	//
+	// O_CLOEXEC is set on every open so that none of the (transient directory
+	// or final file) descriptors can be inherited by a concurrently-started
+	// subprocess, matching the close-on-exec behavior of os.Open.
+	dirFd, err := unix.Open("/", unix.O_PATH|unix.O_NOFOLLOW|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open root directory: %w", err)
 	}
@@ -60,7 +64,7 @@ func OpenPathWithoutSymlinks(path string) (*os.File, error) {
 			continue
 		}
 
-		newFd, err := unix.Openat(dirFd, parts[i], unix.O_PATH|unix.O_NOFOLLOW|unix.O_DIRECTORY, 0)
+		newFd, err := unix.Openat(dirFd, parts[i], unix.O_PATH|unix.O_NOFOLLOW|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open directory component %s: %w", parts[i], err)
 		}
@@ -73,8 +77,9 @@ func OpenPathWithoutSymlinks(path string) (*os.File, error) {
 	// Open the final file component with O_NOFOLLOW. dirFd was opened with
 	// O_PATH, but it can still be used as the directory fd for this openat,
 	// which enforces the normal read-permission check on the file itself.
+	// O_CLOEXEC prevents the returned descriptor from leaking into subprocesses.
 	fileName := parts[len(parts)-1]
-	fileFd, err := unix.Openat(dirFd, fileName, unix.O_RDONLY|unix.O_NOFOLLOW, 0)
+	fileFd, err := unix.Openat(dirFd, fileName, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %s: %w", fileName, err)
 	}

--- a/pkg/privileged-logs/common/open_linux_test.go
+++ b/pkg/privileged-logs/common/open_linux_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func TestOpenPathWithoutSymlinksNoSymlink(t *testing.T) {
@@ -30,6 +31,20 @@ func TestOpenPathWithoutSymlinksNoSymlink(t *testing.T) {
 	n, err := f.Read(buf)
 	require.NoError(t, err)
 	assert.Equal(t, "hello", string(buf[:n]))
+}
+
+func TestOpenPathWithoutSymlinksCloseOnExec(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "test.log")
+	require.NoError(t, os.WriteFile(logFile, []byte("hello"), 0644))
+
+	f, err := OpenPathWithoutSymlinks(logFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	flags, err := unix.FcntlInt(f.Fd(), unix.F_GETFD, 0)
+	require.NoError(t, err)
+	assert.NotZero(t, flags&unix.FD_CLOEXEC)
 }
 
 func TestOpenPathWithoutSymlinksSymlinkInFile(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Adds `O_CLOEXEC` to every `unix.Openat` call in `common.OpenPathWithoutSymlinks`, covering both intermediate directory descriptors and the returned file descriptor.

This prevents descriptors from being inherited by concurrently started subprocesses and matches the behavior of `os.Open`.

Descriptors received through `SCM_RIGHTS` need no change: Go already passes `MSG_CMSG_CLOEXEC` from `ReadMsgUnix`.

### Motivation

Prevent file descriptors from potentially leaking to child processes.

This hardening was split from #54303 to keep that PR focused on the NoFollow transport capability.

### Describe how you validated your changes

Unit test added (for the retrurned fd).
