### PR TITLE
fix: remove stale sockets before binding IPC server

### DIFF
--- a/comp/api/api/apiimpl/listener/listener_nix.go
+++ b/comp/api/api/apiimpl/listener/listener_nix.go
@@ -19,6 +19,17 @@ import (
 
 // platformSpecificListener returns a unix net.Listener for linux platforms
 func platformSpecificListener(address string) (net.Listener, error) {
+	fi, err := os.Stat(address)
+	if err == nil {
+		// already exists
+		if fi.Mode()&os.ModeSocket == 0 {
+			return nil, fmt.Errorf("cannot reuse %q; not a unix socket", address)
+		}
+		if err := os.Remove(address); err != nil {
+			return nil, fmt.Errorf("unable to remove stale socket: %v", err)
+		}
+	}
+
 	ln, err := net.Listen("unix", address)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Remove stale socket file before binding IPC server socket.

### Motivation
When the agent crashes and a stale socket is left behind, the agent will fail to bind on restart unless the file is removed.
This has caused an issue during internal testing of the unix socket based IPC server.

### Describe how you validated your changes
CI
Also reproduced the issue locally and validated the fix.

### Additional Notes
This is done for every single unix socket used by the agent.
A follow-up PR will unify this cleanup logic which is currently duplicated everywhere in the codebase. 
