### PR TITLE
chore(telemetry): include client and client_transport tags in dogstatsd COAT telemetry

### DIFF
--- a/comp/aggregator/dogstatsdclienttelemetry/impl/BUILD.bazel
+++ b/comp/aggregator/dogstatsdclienttelemetry/impl/BUILD.bazel
@@ -24,6 +24,7 @@ dd_agent_go_test(
     deps = [
         "//comp/core/telemetry/mock",
         "//pkg/metrics",
+        "//pkg/tagset",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/comp/aggregator/dogstatsdclienttelemetry/impl/dogstatsdclienttelemetry.go
+++ b/comp/aggregator/dogstatsdclienttelemetry/impl/dogstatsdclienttelemetry.go
@@ -92,11 +92,29 @@ func clientTelemetryTags(serie *metrics.Serie) (string, string) {
 	transport := unknownTagValue
 	serie.Tags.Find(func(tag string) bool {
 		if strings.HasPrefix(tag, dogStatsDClientLibraryTagPrefix) {
-			client = strings.TrimPrefix(tag, dogStatsDClientLibraryTagPrefix)
+			client = normalizeClientLibrary(strings.TrimPrefix(tag, dogStatsDClientLibraryTagPrefix))
 		} else if strings.HasPrefix(tag, dogStatsDClientTransportTagPrefix) {
-			transport = strings.TrimPrefix(tag, dogStatsDClientTransportTagPrefix)
+			transport = normalizeClientTransport(strings.TrimPrefix(tag, dogStatsDClientTransportTagPrefix))
 		}
 		return client != unknownTagValue && transport != unknownTagValue
 	})
 	return client, transport
+}
+
+func normalizeClientLibrary(client string) string {
+	switch client {
+	case "go", "py", "java", "ruby", "csharp", "php", "rust":
+		return client
+	default:
+		return unknownTagValue
+	}
+}
+
+func normalizeClientTransport(transport string) string {
+	switch transport {
+	case "udp", "uds", "uds-stream", "uds-datagram", "namedpipe", "named_pipe", "custom", "http":
+		return transport
+	default:
+		return unknownTagValue
+	}
 }

--- a/comp/aggregator/dogstatsdclienttelemetry/impl/dogstatsdclienttelemetry.go
+++ b/comp/aggregator/dogstatsdclienttelemetry/impl/dogstatsdclienttelemetry.go
@@ -8,6 +8,7 @@ package dogstatsdclienttelemetryimpl
 
 import (
 	"math"
+	"strings"
 
 	dogstatsdclienttelemetry "github.com/DataDog/datadog-agent/comp/aggregator/dogstatsdclienttelemetry/def"
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
@@ -20,6 +21,9 @@ const (
 	dogStatsDClientBytesDroppedMetric       = "datadog.dogstatsd.client.bytes_dropped"
 	dogStatsDClientBytesDroppedQueueMetric  = "datadog.dogstatsd.client.bytes_dropped_queue"
 	dogStatsDClientBytesDroppedWriterMetric = "datadog.dogstatsd.client.bytes_dropped_writer"
+	dogStatsDClientLibraryTagPrefix         = "client:"
+	dogStatsDClientTransportTagPrefix       = "client_transport:"
+	unknownTagValue                         = "unknown"
 )
 
 // Requires defines the dependencies for the DogStatsD client telemetry component.
@@ -34,19 +38,20 @@ type Provides struct {
 }
 
 type component struct {
-	bytesSent          telemetry.SimpleCounter
-	bytesDropped       telemetry.SimpleCounter
-	bytesDroppedQueue  telemetry.SimpleCounter
-	bytesDroppedWriter telemetry.SimpleCounter
+	bytesSent          telemetry.Counter
+	bytesDropped       telemetry.Counter
+	bytesDroppedQueue  telemetry.Counter
+	bytesDroppedWriter telemetry.Counter
 }
 
 // NewComponent creates the DogStatsD client telemetry component.
 func NewComponent(req Requires) Provides {
+	tags := []string{"client", "client_transport"}
 	component := &component{
-		bytesSent:          req.Telemetry.NewSimpleCounter("dogstatsd_client", "bytes_sent", "Total bytes sent by DogStatsD clients"),
-		bytesDropped:       req.Telemetry.NewSimpleCounter("dogstatsd_client", "bytes_dropped", "Total bytes dropped by DogStatsD clients"),
-		bytesDroppedQueue:  req.Telemetry.NewSimpleCounter("dogstatsd_client", "bytes_dropped_queue", "Total bytes dropped because the DogStatsD client sender queue is full"),
-		bytesDroppedWriter: req.Telemetry.NewSimpleCounter("dogstatsd_client", "bytes_dropped_writer", "Total bytes dropped because the DogStatsD client writer cannot send"),
+		bytesSent:          req.Telemetry.NewCounter("dogstatsd_client", "bytes_sent", tags, "Total bytes sent by DogStatsD clients"),
+		bytesDropped:       req.Telemetry.NewCounter("dogstatsd_client", "bytes_dropped", tags, "Total bytes dropped by DogStatsD clients"),
+		bytesDroppedQueue:  req.Telemetry.NewCounter("dogstatsd_client", "bytes_dropped_queue", tags, "Total bytes dropped because the DogStatsD client sender queue is full"),
+		bytesDroppedWriter: req.Telemetry.NewCounter("dogstatsd_client", "bytes_dropped_writer", tags, "Total bytes dropped because the DogStatsD client writer cannot send"),
 	}
 	return Provides{Comp: component, Observer: component}
 }
@@ -58,7 +63,7 @@ func (c *component) ObserveFinalDogStatsDSerie(serie *metrics.Serie) {
 		return
 	}
 
-	var counter telemetry.SimpleCounter
+	var counter telemetry.Counter
 	switch serie.Name {
 	case dogStatsDClientBytesSentMetric:
 		counter = c.bytesSent
@@ -72,11 +77,26 @@ func (c *component) ObserveFinalDogStatsDSerie(serie *metrics.Serie) {
 		return
 	}
 
+	client, transport := clientTelemetryTags(serie)
 	for _, point := range serie.Points {
 		bytes := point.Value * float64(serie.Interval)
 		if !(bytes >= 0 && bytes < math.MaxUint64) {
 			continue
 		}
-		counter.Add(bytes)
+		counter.Add(bytes, client, transport)
 	}
+}
+
+func clientTelemetryTags(serie *metrics.Serie) (string, string) {
+	client := unknownTagValue
+	transport := unknownTagValue
+	serie.Tags.Find(func(tag string) bool {
+		if strings.HasPrefix(tag, dogStatsDClientLibraryTagPrefix) {
+			client = strings.TrimPrefix(tag, dogStatsDClientLibraryTagPrefix)
+		} else if strings.HasPrefix(tag, dogStatsDClientTransportTagPrefix) {
+			transport = strings.TrimPrefix(tag, dogStatsDClientTransportTagPrefix)
+		}
+		return client != unknownTagValue && transport != unknownTagValue
+	})
+	return client, transport
 }

--- a/comp/aggregator/dogstatsdclienttelemetry/impl/dogstatsdclienttelemetry.go
+++ b/comp/aggregator/dogstatsdclienttelemetry/impl/dogstatsdclienttelemetry.go
@@ -112,7 +112,7 @@ func normalizeClientLibrary(client string) string {
 
 func normalizeClientTransport(transport string) string {
 	switch transport {
-	case "udp", "uds", "uds-stream", "uds-datagram", "namedpipe", "named_pipe", "custom", "http":
+	case "udp", "uds", "uds-stream", "uds-datagram", "pipe", "namedpipe", "named_pipe", "custom", "http":
 		return transport
 	default:
 		return unknownTagValue

--- a/comp/aggregator/dogstatsdclienttelemetry/impl/dogstatsdclienttelemetry_bench_test.go
+++ b/comp/aggregator/dogstatsdclienttelemetry/impl/dogstatsdclienttelemetry_bench_test.go
@@ -59,6 +59,11 @@ func BenchmarkComponentFinalDogStatsDSerieObserver_1MFinalSeries(b *testing.B) {
 			b.StopTimer()
 
 			countMetrics, err := telemetry.GetCountMetric("dogstatsd_client", "bytes_sent")
+			if benchmark.expected == 0 {
+				require.Error(b, err)
+				b.ReportMetric(float64(finalDogStatsDClientTelemetrySeriesPerOperation), "final-series/op")
+				return
+			}
 			require.NoError(b, err)
 			require.Len(b, countMetrics, 1)
 			require.Equal(b, benchmark.expected*float64(b.N), countMetrics[0].Value())

--- a/comp/aggregator/dogstatsdclienttelemetry/impl/dogstatsdclienttelemetry_test.go
+++ b/comp/aggregator/dogstatsdclienttelemetry/impl/dogstatsdclienttelemetry_test.go
@@ -15,6 +15,7 @@ import (
 
 	telemetrymock "github.com/DataDog/datadog-agent/comp/core/telemetry/mock"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/tagset"
 )
 
 func TestComponentObservesClientByteRateSeries(t *testing.T) {
@@ -37,12 +38,13 @@ func TestComponentObservesClientByteRateSeries(t *testing.T) {
 				MType:    metrics.APIRateType,
 				Interval: 10,
 				Points:   []metrics.Point{{Value: test.value}},
+				Tags:     tagset.CompositeTagsFromSlice([]string{"client:go", "client_transport:uds"}),
 			})
 
 			metrics, err := telemetry.GetCountMetric("dogstatsd_client", test.name[len("datadog.dogstatsd.client."):])
 			require.NoError(t, err)
 			require.Len(t, metrics, 1)
-			require.Empty(t, metrics[0].Tags())
+			require.Equal(t, map[string]string{"client": "go", "client_transport": "uds"}, metrics[0].Tags())
 			require.Equal(t, test.expected, metrics[0].Value())
 		})
 	}

--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -2818,8 +2818,8 @@ func TestDefaultAndNoDefaultPromRegistries(t *testing.T) {
 func TestDefaultProfilesExportRARClientByteCounters(t *testing.T) {
 	config := getCommonYAMLConfig(true, "")
 	tel := makeTelMock(t)
-	counter := tel.NewCounter("dogstatsd_client", "bytes_sent", []string{"emitter"}, "")
-	counter.Add(100, "agent-data-plane")
+	counter := tel.NewCounter("dogstatsd_client", "bytes_sent", []string{"client", "client_transport", "emitter"}, "")
+	counter.Add(100, "go", "uds", "agent-data-plane")
 
 	sender := &senderMock{}
 	runner := newRunnerMock()
@@ -2834,7 +2834,7 @@ func TestDefaultProfilesExportRARClientByteCounters(t *testing.T) {
 	require.Len(t, sender.sentMetrics[0].metrics, 1)
 	metric := sender.sentMetrics[0].metrics[0]
 	assert.Equal(t, 100.0, metric.GetCounter().GetValue())
-	assert.Equal(t, map[string]string{"emitter": "agent-data-plane"}, metricLabels(metric))
+	assert.Equal(t, map[string]string{"client": "go", "client_transport": "uds", "emitter": "agent-data-plane"}, metricLabels(metric))
 }
 
 func TestDefaultProfilesExportRARTransactionSuccessCounters(t *testing.T) {
@@ -2913,10 +2913,10 @@ func TestDefaultProfilesDoNotListMandatoryEmitter(t *testing.T) {
 	}{
 		{name: "dogstatsd.udp_packets_bytes"},
 		{name: "dogstatsd.uds_packets_bytes"},
-		{name: "dogstatsd_client.bytes_sent"},
-		{name: "dogstatsd_client.bytes_dropped"},
-		{name: "dogstatsd_client.bytes_dropped_queue"},
-		{name: "dogstatsd_client.bytes_dropped_writer"},
+		{name: "dogstatsd_client.bytes_sent", preserveTags: []string{"client", "client_transport"}},
+		{name: "dogstatsd_client.bytes_dropped", preserveTags: []string{"client", "client_transport"}},
+		{name: "dogstatsd_client.bytes_dropped_queue", preserveTags: []string{"client", "client_transport"}},
+		{name: "dogstatsd_client.bytes_dropped_writer", preserveTags: []string{"client", "client_transport"}},
 		{name: "logs.bytes_sent", aggregateTotal: true},
 		{name: "logs.encoded_bytes_sent", preserveTags: []string{"compression_kind"}, aggregateTotal: true},
 		{name: "point.sent", preserveTags: []string{"domain"}},

--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -36,9 +36,21 @@ profiles:
       - name: dogstatsd.udp_packets_bytes
       - name: dogstatsd.uds_packets_bytes
       - name: dogstatsd_client.bytes_sent
+        preserve_tags:
+          - client
+          - client_transport
       - name: dogstatsd_client.bytes_dropped
+        preserve_tags:
+          - client
+          - client_transport
       - name: dogstatsd_client.bytes_dropped_queue
+        preserve_tags:
+          - client
+          - client_transport
       - name: dogstatsd_client.bytes_dropped_writer
+        preserve_tags:
+          - client
+          - client_transport
       - name: logs.bytes_missed
       - name: logs.bytes_sent
         aggregate_total: true


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Updates `preserve_tags` for existing dogstatsd client telemetry in COAT to  include the `client` and `client_transport` tags

### Motivation
So that we can analyze dropped bytes by `client` and `client_transport`

### Describe how you validated your changes

### Additional Notes
