### PR TITLE
fix(anomalydetection): enforce series cap at admission

### DIFF
--- a/comp/anomalydetection/observer/AGENTS.md
+++ b/comp/anomalydetection/observer/AGENTS.md
@@ -117,6 +117,13 @@ Storage keeps sum/count summary stats per 1-second bucket.
 Aggregation kind (avg, sum, count) is chosen when reading, not when
 writing. Detectors can pick any aggregation without re-ingesting data.
 
+### Bounded series admission
+
+Storage never admits a new non-telemetry series above `MaxSeries`. At capacity,
+the incoming identity wins admission: storage evicts the least-recently-active
+existing series to the configured floor before allocating it, then synchronously
+clears evicted detector and auxiliary state before the next detection pass.
+
 ### Non-blocking ingestion
 
 Handles do non-blocking sends to a buffered channel. If the channel is full,

--- a/comp/anomalydetection/observer/impl/component_test.go
+++ b/comp/anomalydetection/observer/impl/component_test.go
@@ -6,6 +6,7 @@
 package observerimpl
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -38,6 +39,38 @@ func TestStorageConfigFromAgentConfigDerivesRetentionFromDetectorWindows(t *test
 			storageCfg := storageConfigFromAgentConfig(cfg, detectors)
 			require.Equal(t, test.want, storageCfg.PointRetentionSecs)
 			require.Equal(t, 120, storageCfg.MaxPointsPerSeries)
+		})
+	}
+}
+
+func TestStorageConfigFromAgentConfigValidatesSeriesCapacity(t *testing.T) {
+	defaults := DefaultStorageConfig()
+	tests := []struct {
+		name      string
+		maxSeries int
+		ratio     float64
+		wantMax   int
+		wantRatio float64
+	}{
+		{name: "valid lower bounds", maxSeries: 1, ratio: 0, wantMax: 1, wantRatio: 0},
+		{name: "valid ratio below one", maxSeries: 123, ratio: 0.999, wantMax: 123, wantRatio: 0.999},
+		{name: "zero max and ratio one use defaults", maxSeries: 0, ratio: 1, wantMax: defaults.MaxSeries, wantRatio: defaults.EvictionFloorRatio},
+		{name: "negative values use defaults", maxSeries: -1, ratio: -0.1, wantMax: defaults.MaxSeries, wantRatio: defaults.EvictionFloorRatio},
+		{name: "ratio above one uses default", maxSeries: 123, ratio: 1.1, wantMax: 123, wantRatio: defaults.EvictionFloorRatio},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := configmock.NewFromYAML(t, fmt.Sprintf(`
+anomaly_detection:
+  storage:
+    max_series: %d
+    eviction_floor_ratio: %g
+`, tc.maxSeries, tc.ratio))
+
+			got := storageConfigFromAgentConfig(cfg, nil)
+			require.Equal(t, tc.wantMax, got.MaxSeries)
+			require.Equal(t, tc.wantRatio, got.EvictionFloorRatio)
 		})
 	}
 }

--- a/comp/anomalydetection/observer/impl/engine.go
+++ b/comp/anomalydetection/observer/impl/engine.go
@@ -423,7 +423,8 @@ func (e *engine) sourceTagForIngest(source string) string {
 // to determine whether detectors should advance. Returns advance requests
 // that the caller should execute via Advance.
 func (e *engine) IngestMetric(source string, m *metricObs) []advanceRequest {
-	e.storage.Add(source, m.name, m.value, m.timestamp, m.tags)
+	addResult := e.storage.Add(source, m.name, m.value, m.timestamp, m.tags)
+	e.handleCapacityEvictions(addResult.CapacityEvictedRefs)
 	// Track points that arrive after their timestamp was already analyzed.
 	// These points are in storage but were invisible to detectors at analysis time.
 	if m.timestamp <= e.lastAnalyzedDataTime {
@@ -477,6 +478,7 @@ func (e *engine) IngestLog(source string, l *logObs) []advanceRequest {
 				continue
 			}
 			res := e.storage.Add(extractor.Name(), m.Name, m.Value, timestamp, tags)
+			e.handleCapacityEvictions(res.CapacityEvictedRefs)
 			if m.Context != nil && res.Ref >= 0 {
 				e.storage.SetContext(res.Ref, m.Context)
 			}
@@ -516,6 +518,25 @@ func (e *engine) removeEvictedMetricSeries(namespace string, evictedNames []stri
 		e.onStorageSeriesEvicted("extractor", len(freedAll))
 	}
 	e.fanOutSeriesRemoval(freedAll)
+}
+
+// handleCapacityEvictions synchronizes every state holder after storage makes
+// room for a newly admitted series or the post-advance safety check finds an
+// over-capacity catalog.
+func (e *engine) handleCapacityEvictions(freed []observerdef.SeriesRef) {
+	if len(freed) == 0 {
+		return
+	}
+	if e.logCounts != nil {
+		e.logCounts.removeSeriesByRefs(freed)
+	}
+	if e.onStorageCapacityHit != nil {
+		e.onStorageCapacityHit()
+	}
+	if e.onStorageSeriesEvicted != nil {
+		e.onStorageSeriesEvicted("capacity", len(freed))
+	}
+	e.fanOutSeriesRemoval(freed)
 }
 
 // fanOutSeriesRemoval notifies every detector that implements the optional
@@ -642,7 +663,7 @@ func (e *engine) advanceWithReason(upToSec int64, reason advanceReason) advanceR
 		e.completeDueBaselines(upToSec)
 	}
 	if e.logCounts != nil {
-		e.logCounts.flush(e.storage, upToSec)
+		e.handleCapacityEvictions(e.logCounts.flush(e.storage, upToSec))
 	}
 	// Inactivity eviction happens after materialized log-count buckets have
 	// restored their real last-observation activity time, and before detectors
@@ -652,19 +673,9 @@ func (e *engine) advanceWithReason(upToSec int64, reason advanceReason) advanceR
 
 	result := e.runDetectorsAndCorrelatorsSnapshot(upToSec, detectors, correlators)
 
-	// Evict series beyond the storage cap and fan freed refs to detectors.
-	if freed := e.storage.EvictDefault(); len(freed) > 0 {
-		if e.logCounts != nil {
-			e.logCounts.removeSeriesByRefs(freed)
-		}
-		if e.onStorageCapacityHit != nil {
-			e.onStorageCapacityHit()
-		}
-		if e.onStorageSeriesEvicted != nil {
-			e.onStorageSeriesEvicted("capacity", len(freed))
-		}
-		e.fanOutSeriesRemoval(freed)
-	}
+	// Admission normally keeps storage within its cap. Retain this post-advance
+	// check as a safety net for direct storage writes and configuration changes.
+	e.handleCapacityEvictions(e.storage.EvictDefault())
 
 	e.emit(engineEvent{
 		kind:      eventAdvanceCompleted,

--- a/comp/anomalydetection/observer/impl/engine_stepadvance_test.go
+++ b/comp/anomalydetection/observer/impl/engine_stepadvance_test.go
@@ -10,6 +10,7 @@ import (
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // fixedDetector is a mock detector that returns a fixed set of anomalies once.
@@ -251,6 +252,45 @@ func TestEngine_EvictsInactiveSeriesBeforeDetectionAtConfiguredCadence(t *testin
 	assert.Nil(t, storage.GetSeriesMeta(pending))
 	assert.ElementsMatch(t, []observer.SeriesRef{old, active, pending}, detector.removed)
 	assert.Equal(t, []string{"inactive", "inactive"}, evictionReasons)
+}
+
+func TestEngine_EvictsAtAdmissionAndSynchronizesDependentState(t *testing.T) {
+	storage := newTimeSeriesStorageWith(StorageConfig{
+		MaxSeries:          2,
+		EvictionFloorRatio: 0.5,
+	})
+	detector := &inactiveEvictionDetector{}
+	e := newEngine(engineConfig{storage: storage, detectors: []observer.Detector{detector}})
+
+	var capacityHits int
+	var capacityEvicted int
+	e.onStorageCapacityHit = func() { capacityHits++ }
+	e.onStorageSeriesEvicted = func(reason string, count int) {
+		require.Equal(t, "capacity", reason)
+		capacityEvicted += count
+	}
+
+	e.IngestMetric("workload", &metricObs{name: "first", value: 1, timestamp: 1})
+	firstMetas := storage.ListSeries(observer.WorkloadSeriesFilter())
+	require.Len(t, firstMetas, 1)
+	first := firstMetas[0].Ref
+	e.IngestMetric("workload", &metricObs{name: "second", value: 1, timestamp: 2})
+	secondMetas := storage.ListSeries(observer.WorkloadSeriesFilter())
+	require.Len(t, secondMetas, 2)
+	var second observer.SeriesRef
+	for _, meta := range secondMetas {
+		if meta.Ref != first {
+			second = meta.Ref
+		}
+	}
+	require.NotEqual(t, first, second)
+
+	e.IngestMetric("workload", &metricObs{name: "third", value: 1, timestamp: 3})
+
+	assert.Equal(t, 1, storage.TotalSeriesCount())
+	assert.ElementsMatch(t, []observer.SeriesRef{first, second}, detector.removed)
+	assert.Equal(t, 1, capacityHits)
+	assert.Equal(t, 2, capacityEvicted)
 }
 
 func TestEngine_InactiveSeriesEvictionDisabled(t *testing.T) {

--- a/comp/anomalydetection/observer/impl/log_count_bucketizer.go
+++ b/comp/anomalydetection/observer/impl/log_count_bucketizer.go
@@ -143,11 +143,13 @@ func (b *materializedLogCountBucketizer) observe(
 	return true
 }
 
-// flush writes every completed bucket through upTo into shared storage.
-func (b *materializedLogCountBucketizer) flush(storage *timeSeriesStorage, upTo int64) {
+// flush writes every completed bucket through upTo into shared storage and
+// returns any series evicted while admitting newly materialized series.
+func (b *materializedLogCountBucketizer) flush(storage *timeSeriesStorage, upTo int64) []observerdef.SeriesRef {
 	if upTo <= b.flushedThrough {
-		return
+		return nil
 	}
+	var capacityEvictedRefs []observerdef.SeriesRef
 	for key, state := range b.series {
 		remaining := state.intervals[:0]
 		for _, interval := range state.intervals {
@@ -160,6 +162,7 @@ func (b *materializedLogCountBucketizer) flush(storage *timeSeriesStorage, upTo 
 					nextEnd,
 					state.tags,
 				)
+				capacityEvictedRefs = append(capacityEvictedRefs, result.CapacityEvictedRefs...)
 				if state.context != nil && result.Ref >= 0 {
 					storage.SetContext(result.Ref, state.context)
 				}
@@ -183,6 +186,7 @@ func (b *materializedLogCountBucketizer) flush(storage *timeSeriesStorage, upTo 
 		}
 	}
 	b.flushedThrough = upTo
+	return capacityEvictedRefs
 }
 
 func (b *materializedLogCountBucketizer) removeMetricName(namespace, name string) {

--- a/comp/anomalydetection/observer/impl/log_count_bucketizer_test.go
+++ b/comp/anomalydetection/observer/impl/log_count_bucketizer_test.go
@@ -184,9 +184,11 @@ func TestEngineCapacityEvictionDropsIdleBucketizerState(t *testing.T) {
 		"fixed_log_count", "log.fixed.count", logTags, observerdef.AggregateAverage,
 	))
 
-	// A real metric observed later is more active than the log series. The
-	// synthetic zero written at t=10 must not make the log series look newer.
-	storage.Add("native", "metric", 1, 7, nil)
+	// A real metric observed later reaches the hard admission limit and evicts
+	// the log series before it is stored. Engine cleanup must immediately remove
+	// the corresponding bucketizer state.
+	e.IngestMetric("native", &metricObs{name: "metric", value: 1, timestamp: 7})
+	require.Empty(t, e.logCounts.series)
 	e.Advance(10)
 	require.Nil(t, storage.GetSeries(
 		"fixed_log_count", "log.fixed.count", logTags, observerdef.AggregateAverage,

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -449,10 +450,20 @@ func storageConfigFromAgentConfig(cfg config.Component, detectors []observerdef.
 		return storageCfg
 	}
 	if cfg.IsConfigured("anomaly_detection.storage.max_series") {
-		storageCfg.MaxSeries = cfg.GetInt("anomaly_detection.storage.max_series")
+		configuredMaxSeries := cfg.GetInt("anomaly_detection.storage.max_series")
+		if configuredMaxSeries <= 0 {
+			pkglog.Warnf("anomaly_detection.storage.max_series must be > 0, got %d; using default %d", configuredMaxSeries, storageCfg.MaxSeries)
+		} else {
+			storageCfg.MaxSeries = configuredMaxSeries
+		}
 	}
 	if cfg.IsConfigured("anomaly_detection.storage.eviction_floor_ratio") {
-		storageCfg.EvictionFloorRatio = cfg.GetFloat64("anomaly_detection.storage.eviction_floor_ratio")
+		configuredRatio := cfg.GetFloat64("anomaly_detection.storage.eviction_floor_ratio")
+		if math.IsNaN(configuredRatio) || configuredRatio < 0 || configuredRatio >= 1 {
+			pkglog.Warnf("anomaly_detection.storage.eviction_floor_ratio must be >= 0 and < 1, got %g; using default %g", configuredRatio, storageCfg.EvictionFloorRatio)
+		} else {
+			storageCfg.EvictionFloorRatio = configuredRatio
+		}
 	}
 	if cfg.IsConfigured("anomaly_detection.storage.point_retention") {
 		configuredRetention := cfg.GetDuration("anomaly_detection.storage.point_retention")

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -20,8 +20,9 @@ import (
 
 // StorageConfig holds tunable parameters for timeSeriesStorage.
 type StorageConfig struct {
-	// MaxSeries caps live series; when exceeded on Advance, series are evicted
-	// until count drops to MaxSeries*(1-EvictionFloorRatio). 0 disables eviction.
+	// MaxSeries caps live non-telemetry series. Before a new series is admitted at
+	// capacity, the oldest existing series are evicted until the incoming series
+	// can be added at MaxSeries*(1-EvictionFloorRatio). 0 disables the cap for replay.
 	MaxSeries int
 
 	// EvictionFloorRatio controls how far below MaxSeries eviction drains.
@@ -327,6 +328,9 @@ type AddResult struct {
 	// Ref is the SeriesRef assigned to this point's series.
 	// -1 when the point is dropped (non-finite or sentinel values).
 	Ref observer.SeriesRef
+	// CapacityEvictedRefs contains series evicted before admitting this point.
+	// Callers must fan these refs out to detector and auxiliary state cleanup.
+	CapacityEvictedRefs []observer.SeriesRef
 }
 
 // Add inserts a (namespace, name, value, timestamp, tags) point into storage.
@@ -371,7 +375,11 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 			}
 		}
 	}
+	var capacityEvictedRefs []observer.SeriesRef
 	if !exists {
+		if namespace != observer.TelemetryNamespace {
+			capacityEvictedRefs = s.evictForAdmissionLocked()
+		}
 		// Only intern on new series creation so the ref count tracks exactly
 		// the number of live series holding the canonical slice.
 		canonical, th := s.internTags(tags)
@@ -395,7 +403,7 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		}
 		s.seriesGen++
 	}
-	res := AddResult{IsNew: !exists, Ref: stats.ref}
+	res := AddResult{IsNew: !exists, Ref: stats.ref, CapacityEvictedRefs: capacityEvictedRefs}
 	stats.writeGeneration++
 	if len(stats.buckets) == 0 || timestamp > stats.lastActivityTimestamp {
 		stats.lastActivityTimestamp = timestamp
@@ -1208,6 +1216,15 @@ func (s *timeSeriesStorage) EvictToCapacity(seriesLimit, target int) []observer.
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.evictToCapacityLocked(seriesLimit, target)
+}
+
+// evictToCapacityLocked is EvictToCapacity with the storage write lock already
+// held. Capacity admission uses it before allocating the incoming series.
+func (s *timeSeriesStorage) evictToCapacityLocked(seriesLimit, target int) []observer.SeriesRef {
+	if target < 0 {
+		target = 0
+	}
 
 	// Common case is under the limit, skip allocation entirely.
 	count := s.liveSeriesCount
@@ -1221,7 +1238,7 @@ func (s *timeSeriesStorage) EvictToCapacity(seriesLimit, target int) []observer.
 	}
 	candidates := make([]entry, 0, count)
 	for _, st := range s.seriesIDStats {
-		if st == nil {
+		if st == nil || st.Namespace == observer.TelemetryNamespace {
 			continue
 		}
 		candidates = append(candidates, entry{ref: st.ref, lastTs: st.lastActivityTimestamp})
@@ -1255,6 +1272,35 @@ func (s *timeSeriesStorage) EvictToCapacity(seriesLimit, target int) []observer.
 	return freed
 }
 
+// capacityEvictionTarget is the number of live series that should remain after
+// a capacity event. Production config validation guarantees a ratio in [0, 1),
+// while the clamps keep explicit replay/test configurations safe as well.
+func (s *timeSeriesStorage) capacityEvictionTarget() int {
+	if s.cfg.MaxSeries <= 0 {
+		return 0
+	}
+	if math.IsNaN(s.cfg.EvictionFloorRatio) || s.cfg.EvictionFloorRatio < 0 {
+		return s.cfg.MaxSeries
+	}
+	if s.cfg.EvictionFloorRatio >= 1 {
+		return 1
+	}
+	target := s.cfg.MaxSeries - int(float64(s.cfg.MaxSeries)*s.cfg.EvictionFloorRatio)
+	return max(1, min(s.cfg.MaxSeries, target))
+}
+
+// evictForAdmissionLocked makes room before a new non-telemetry series is
+// allocated. New identities win admission even when their first point is older
+// than existing activity. It leaves one slot below the configured post-eviction
+// target so admitting the incoming series lands exactly on that target.
+func (s *timeSeriesStorage) evictForAdmissionLocked() []observer.SeriesRef {
+	if s.cfg.MaxSeries <= 0 || s.liveSeriesCount < s.cfg.MaxSeries {
+		return nil
+	}
+	targetBeforeAdmission := s.capacityEvictionTarget() - 1
+	return s.evictToCapacityLocked(s.cfg.MaxSeries-1, targetBeforeAdmission)
+}
+
 // EvictInactiveBefore removes non-telemetry series whose last activity is at
 // or before cutoff. The caller supplies a data-time cutoff so eviction is
 // deterministic in both live operation and replay.
@@ -1283,8 +1329,7 @@ func (s *timeSeriesStorage) EvictDefault() []observer.SeriesRef {
 	if s.cfg.MaxSeries <= 0 {
 		return nil
 	}
-	target := s.cfg.MaxSeries - int(float64(s.cfg.MaxSeries)*s.cfg.EvictionFloorRatio)
-	return s.EvictToCapacity(s.cfg.MaxSeries, target)
+	return s.EvictToCapacity(s.cfg.MaxSeries, s.capacityEvictionTarget())
 }
 
 // CompactSeriesID translates a full series key to its compact numeric ID string.

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -726,6 +726,54 @@ func TestTimeSeriesStorage_TotalSeriesCountTracksCapacityEviction(t *testing.T) 
 	require.Equal(t, 1, s.TotalSeriesCount())
 }
 
+func TestTimeSeriesStorage_AddEvictsBeforeAdmissionAtCapacity(t *testing.T) {
+	s := newTimeSeriesStorageWith(StorageConfig{
+		MaxSeries:          4,
+		EvictionFloorRatio: 0.5,
+	})
+	first := s.Add("workload", "first", 1, 1, nil).Ref
+	second := s.Add("workload", "second", 1, 2, nil).Ref
+	third := s.Add("workload", "third", 1, 3, nil).Ref
+	fourth := s.Add("workload", "fourth", 1, 4, nil).Ref
+	require.Equal(t, 4, s.TotalSeriesCount())
+
+	admitted := s.Add("workload", "new", 1, 5, nil)
+
+	require.True(t, admitted.IsNew)
+	require.GreaterOrEqual(t, admitted.Ref, observer.SeriesRef(0))
+	require.Equal(t, []observer.SeriesRef{first, second, third}, admitted.CapacityEvictedRefs)
+	require.Equal(t, 2, s.TotalSeriesCount(), "admission must land on the configured eviction target")
+	assert.Nil(t, s.GetSeriesMeta(first))
+	assert.Nil(t, s.GetSeriesMeta(second))
+	assert.Nil(t, s.GetSeriesMeta(third))
+	assert.NotNil(t, s.GetSeriesMeta(fourth))
+	assert.NotNil(t, s.GetSeriesMeta(admitted.Ref))
+
+	updated := s.Add("workload", "new", 2, 6, nil)
+	assert.False(t, updated.IsNew)
+	assert.Empty(t, updated.CapacityEvictedRefs, "updating an admitted series must not trigger eviction")
+	assert.Equal(t, 2, s.TotalSeriesCount())
+}
+
+func TestTimeSeriesStorage_AdmissionCapacityExcludesTelemetrySeries(t *testing.T) {
+	s := newTimeSeriesStorageWith(StorageConfig{
+		MaxSeries:          1,
+		EvictionFloorRatio: 0.5,
+	})
+	workload := s.Add("workload", "first", 1, 1, nil).Ref
+	telemetry := s.Add(observer.TelemetryNamespace, "internal", 1, 2, nil)
+	require.Empty(t, telemetry.CapacityEvictedRefs)
+	require.Equal(t, 1, s.TotalSeriesCount())
+
+	admitted := s.Add("workload", "second", 1, 3, nil)
+
+	require.Equal(t, []observer.SeriesRef{workload}, admitted.CapacityEvictedRefs)
+	require.Equal(t, 1, s.TotalSeriesCount())
+	assert.Nil(t, s.GetSeriesMeta(workload))
+	assert.NotNil(t, s.GetSeriesMeta(telemetry.Ref), "capacity admission must not evict telemetry series")
+	assert.NotNil(t, s.GetSeriesMeta(admitted.Ref))
+}
+
 func TestTimeSeriesStorage_EvictInactiveBefore(t *testing.T) {
 	s := newTimeSeriesStorage()
 	old := s.Add("workload", "old", 1, 100, []string{"env:test"}).Ref


### PR DESCRIPTION
### What does this PR do?

Enforce Observer's series cap before admitting a new series and immediately clean up evicted detector and log-bucket state. Invalid capacity settings fall back to safe defaults.

### Motivation

Waiting for the next analysis advance allowed storage to exceed `max_series`.

### Describe how you validated your changes

Added admission, cleanup, and config tests. The Observer test suite and Go linter pass.
