### PR TITLE
pkg/dyninst: release the binary when symbol extraction fails

### DIFF
--- a/pkg/dyninst/module/symdb.go
+++ b/pkg/dyninst/module/symdb.go
@@ -615,14 +615,10 @@ func (m *symdbManager) performUpload(
 	if dc, ok := m.objectLoader.(*object.DiskCache); ok {
 		extractOpts.DiskCache = dc
 	}
-	it, err := symdb.PackagesIterator(
+	it := symdb.PackagesIterator(
 		executablePath,
 		m.objectLoader,
 		extractOpts)
-	if err != nil {
-		return fmt.Errorf("failed to read symbols for process %s (service: %s, version: %s, runtime ID: %s, executable: %s): %w",
-			procID.pid, procID.service, procID.version, runtimeID, executablePath, err)
-	}
 
 	var diskCache *object.DiskCache
 	if dc, ok := m.objectLoader.(*object.DiskCache); ok {

--- a/pkg/dyninst/object/elf_file_with_dwarf.go
+++ b/pkg/dyninst/object/elf_file_with_dwarf.go
@@ -64,6 +64,8 @@ func OpenElfFileWithDwarf(path string) (*ElfFileWithDwarf, error) {
 	return newElfFileWithDwarf(mmf, anonymousMmapCompressedSectionLoader{})
 }
 
+// newElfFileWithDwarf takes ownership of mmf and releases it, along with any
+// sections already loaded, when the DWARF data will not load.
 func newElfFileWithDwarf(
 	mmf MMappingElfFile,
 	loader compressedSectionLoader,
@@ -75,6 +77,7 @@ func newElfFileWithDwarf(
 		},
 	}
 	if err := ret.dwarfData.init(&ret.decompressingMMappingElfFile); err != nil {
+		_ = ret.Close()
 		return nil, fmt.Errorf("failed to load dwarf data: %w", err)
 	}
 	return ret, nil

--- a/pkg/dyninst/symdb/cli/main.go
+++ b/pkg/dyninst/symdb/cli/main.go
@@ -375,10 +375,7 @@ func run() (retErr error) {
 
 	start := time.Now()
 
-	it, err := symdb.PackagesIterator(localBinPath, objectLoader, extractOpts)
-	if err != nil {
-		return err
-	}
+	it := symdb.PackagesIterator(localBinPath, objectLoader, extractOpts)
 
 	// Build the per-yield encoder. Three modes:
 	//  - -upload: real BatchEncoder shipping to a SymDB intake.

--- a/pkg/dyninst/symdb/cli/main_test.go
+++ b/pkg/dyninst/symdb/cli/main_test.go
@@ -81,10 +81,7 @@ func BenchmarkExtractAndUpload(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for range b.N {
-		it, err := symdb.PackagesIterator(binaryPath, diskCache, extractOpts)
-		if err != nil {
-			b.Fatalf("PackagesIterator: %v", err)
-		}
+		it := symdb.PackagesIterator(binaryPath, diskCache, extractOpts)
 		enc, err := uploader.NewBatchEncoder(
 			srv.URL,
 			"bench-service", "bench-version", "bench-runtime-id",

--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -37,19 +37,23 @@ var loclistErrorLogLimiter = rate.NewLimiter(rate.Every(1*time.Minute), 1)
 
 // PackagesIterator returns an iterator over the packages in the binary.
 //
+// The binary is opened when the iteration starts and released when it ends.
+// An error opening it is yielded by the iterator.
+//
 // The last package yielded by the iterator has its Final field set to true. No
 // more packages will be yielded after that, but an error may still be yielded.
 //
 // PackagesIterator can only be used if the packagesIterator was configured with
 // ExtractOptions.AccumulateInlineInfoAcrossCompileUnits=false.
-func PackagesIterator(binaryPath string, loader object.Loader, opt ExtractOptions) (iter.Seq2[PackageWithFinal, error], error) {
-	bin, err := openBinary(binaryPath, loader, opt)
-	if err != nil {
-		return nil, err
+func PackagesIterator(binaryPath string, loader object.Loader, opt ExtractOptions) iter.Seq2[PackageWithFinal, error] {
+	return func(yield func(PackageWithFinal, error) bool) {
+		bin, err := openBinary(binaryPath, loader, opt)
+		if err != nil {
+			yield(PackageWithFinal{}, err)
+			return
+		}
+		newPackagesIterator(bin, opt).iterator()(yield)
 	}
-
-	b := newPackagesIterator(bin, opt)
-	return b.iterator(), nil
 }
 
 // ExtractSymbols walks the DWARF data and accumulates the symbols to send to
@@ -643,6 +647,11 @@ func openBinary(binaryPath string, loader object.Loader, opt ExtractOptions) (bi
 	if err != nil {
 		return binaryInfo{}, fmt.Errorf("failed to open file: %w", err)
 	}
+	defer func() {
+		if obj != nil {
+			_ = obj.Close()
+		}
+	}()
 	// Parse the binary's build info to figure out the URL of the main module.
 	// Note that we'll get an empty URL for binaries built with Bazel.
 	binfo, err := buildinfo.ReadFile(binaryPath)
@@ -678,17 +687,19 @@ func openBinary(binaryPath string, loader object.Loader, opt ExtractOptions) (bi
 	} else if opt.Scope == ExtractScopeMainModuleOnly || opt.Scope == ExtractScopeModulesFromSameOrg {
 		filesFilter = []string{"external/", "GOROOT/"}
 	}
-	return binaryInfo{
+	bin := binaryInfo{
 		obj:                 obj,
 		mainModule:          mainModule,
 		goDebugSections:     &symTable.GoDebugSections,
 		symTable:            &symTable.GoSymbolTable,
 		firstPartyPkgPrefix: firstPartyPkgPrefix,
 		filesFilter:         filesFilter,
-	}, nil
+	}
+	obj = nil // ownership passes to bin
+	return bin, nil
 }
 
-// close frees resources associated with the iterator.
+// close frees resources associated with the iterator, the binary among them.
 func (b *packagesIterator) close() {
 	for _, f := range b.cleanupFuncs {
 		f()

--- a/pkg/dyninst/symdb/symdb_test.go
+++ b/pkg/dyninst/symdb/symdb_test.go
@@ -100,13 +100,12 @@ func TestSymDBSnapshot(t *testing.T) {
 					defer sem.Acquire()()
 					binaryPath := testprogs.MustGetBinary(t, prog, cfg)
 					t.Logf("exploring binary: %s", binaryPath)
-					it, err := symdb.PackagesIterator(
+					it := symdb.PackagesIterator(
 						binaryPath,
 						object.NewInMemoryLoader(),
 						symdb.ExtractOptions{
 							Scope: symdb.ExtractScopeMainModuleOnly,
 						})
-					require.NoError(t, err, "failed to open iterator on %s", binaryPath)
 
 					cs := newCapturingServer(t)
 					defer cs.close()

--- a/releasenotes/notes/dyninst-release-binary-on-extraction-error-889310ac77235271.yaml
+++ b/releasenotes/notes/dyninst-release-binary-on-extraction-error-889310ac77235271.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Release the executable that Dynamic Instrumentation opens to extract its
+    symbols as soon as the extraction fails, rather than when the garbage
+    collector reclaims it. An open descriptor keeps the file's blocks
+    allocated, so a container image deleted in the meantime held disk space
+    in system-probe.


### PR DESCRIPTION
Two paths dropped an opened executable without closing it, so its
descriptor and its decompressed DWARF sections were reclaimed whenever
the garbage collector got to them rather than when the code was done
with the file. A descriptor keeps the file's blocks allocated, so a
container image deleted in the meantime holds disk until then.

newElfFileWithDwarf takes ownership of the mapping it is given and now
releases it when the DWARF data will not load, the common case for a
stripped binary. PackagesIterator opens the binary when the iteration
starts, so ownership is scoped to the iteration, and openBinary releases
the object until ownership passes to the returned binaryInfo.

