### PR TITLE
ssi: skip UST env var injection when OTel-native equivalent is present

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/mutator_core.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/mutator_core.go
@@ -309,7 +309,7 @@ func (m *mutatorCore) ustEnvVarMutator(pod *corev1.Pod, config extractedPodLibIn
 		tags.Version: kubernetes.VersionTagEnvVar,
 		tags.Env:     kubernetes.EnvTagEnvVar,
 	} {
-		if mutator := ustEnvVarMutatorForPodMeta(pod, m.config.podMetaAsTags, tag, envVarName); mutator != nil {
+		if mutator := ustEnvVarMutatorForPodMeta(pod, m.config.podMetaAsTags, tag, envVarName, otelEquivalentOf(envVarName)); mutator != nil {
 			mutators = append(mutators, mutator)
 		}
 	}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/otel_env_vars.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/otel_env_vars.go
@@ -1,0 +1,120 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+)
+
+// OpenTelemetry SDK env vars carrying Unified Service Tagging equivalents.
+// https://opentelemetry.io/docs/languages/sdk-configuration/general
+// https://opentelemetry.io/docs/specs/semconv/resource/
+const (
+	envVarOtelServiceName        = "OTEL_SERVICE_NAME"
+	envVarOtelResourceAttributes = "OTEL_RESOURCE_ATTRIBUTES"
+)
+
+// otelResourceAttributeKeysByDDEnvVar maps a Datadog UST env var to the
+// OTEL_RESOURCE_ATTRIBUTES keys that carry an equivalent value.
+//
+// Keep in sync with the tagger's own OTel resource-attribute mapping, see
+// otelResourceAttributesMapping in
+// comp/core/tagger/collectors/workloadmeta_extract.go.
+var otelResourceAttributeKeysByDDEnvVar = map[string][]string{
+	kubernetes.VersionTagEnvVar: {"service.version"},
+	kubernetes.EnvTagEnvVar:     {"deployment.environment", "deployment.environment.name"},
+}
+
+// otelEquivalentCheck reports whether a container already carries an
+// OpenTelemetry-native equivalent of a Datadog env var that SSI would
+// otherwise inject. It's used to avoid clobbering or duplicating
+// configuration that's already owned by an OTel-native SDK (e.g. a DDOT
+// SDK), so that DD-native and OTel-native instrumentation can coexist
+// during a progressive rollout.
+type otelEquivalentCheck func(c *corev1.Container) bool
+
+// otelEquivalentOf returns a check for whether a container already defines
+// an OpenTelemetry equivalent of ddEnvVarName: OTEL_SERVICE_NAME for
+// DD_SERVICE, or the relevant OTEL_RESOURCE_ATTRIBUTES key for DD_ENV /
+// DD_VERSION. Returns nil if ddEnvVarName has no known OTel equivalent.
+func otelEquivalentOf(ddEnvVarName string) otelEquivalentCheck {
+	if ddEnvVarName == kubernetes.ServiceTagEnvVar {
+		return func(c *corev1.Container) bool {
+			return containerHasEnvVarName(c, envVarOtelServiceName)
+		}
+	}
+
+	keys, ok := otelResourceAttributeKeysByDDEnvVar[ddEnvVarName]
+	if !ok {
+		return nil
+	}
+
+	return func(c *corev1.Container) bool {
+		value, ok := containerStaticEnvVarValue(c, envVarOtelResourceAttributes)
+		if !ok {
+			return false
+		}
+
+		attrs := parseOtelResourceAttributes(value)
+		for _, key := range keys {
+			if _, present := attrs[key]; present {
+				return true
+			}
+		}
+
+		return false
+	}
+}
+
+func containerHasEnvVarName(c *corev1.Container, name string) bool {
+	for _, e := range c.Env {
+		if e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// containerStaticEnvVarValue returns the literal value of a container env
+// var. ok is false if the container doesn't declare the var, or declares it
+// via ValueFrom: such values can't be resolved statically at admission time.
+func containerStaticEnvVarValue(c *corev1.Container, name string) (string, bool) {
+	for _, e := range c.Env {
+		if e.Name != name {
+			continue
+		}
+		if e.ValueFrom != nil {
+			return "", false
+		}
+		return e.Value, true
+	}
+	return "", false
+}
+
+// parseOtelResourceAttributes parses an OTEL_RESOURCE_ATTRIBUTES value
+// ("key1=value1,key2=value2"), the same way the tagger does. See
+// addOpenTelemetryStandardTags in
+// comp/core/tagger/collectors/workloadmeta_extract.go.
+func parseOtelResourceAttributes(value string) map[string]string {
+	attrs := make(map[string]string)
+	for _, pair := range strings.Split(value, ",") {
+		fields := strings.SplitN(pair, "=", 2)
+		if len(fields) != 2 {
+			continue
+		}
+		key, val := strings.TrimSpace(fields[0]), strings.TrimSpace(fields[1])
+		if key != "" {
+			attrs[key] = val
+		}
+	}
+	return attrs
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/otel_env_vars_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/otel_env_vars_test.go
@@ -1,0 +1,208 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+)
+
+func TestOtelEquivalentOf(t *testing.T) {
+	envVar := func(k, v string) corev1.EnvVar {
+		return corev1.EnvVar{Name: k, Value: v}
+	}
+
+	envValueFrom := func(k, fieldPath string) corev1.EnvVar {
+		return corev1.EnvVar{
+			Name: k,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: fieldPath,
+				},
+			},
+		}
+	}
+
+	container := func(env ...corev1.EnvVar) *corev1.Container {
+		return &corev1.Container{Env: env}
+	}
+
+	testData := []struct {
+		name        string
+		ddEnvVar    string
+		container   *corev1.Container
+		expectCheck bool
+		expectMatch bool
+	}{
+		{
+			name:        "unknown DD env var has no OTel equivalent",
+			ddEnvVar:    "DD_SOMETHING_ELSE",
+			container:   container(),
+			expectCheck: false,
+		},
+		{
+			name:        "DD_SERVICE matches when OTEL_SERVICE_NAME present",
+			ddEnvVar:    kubernetes.ServiceTagEnvVar,
+			container:   container(envVar("OTEL_SERVICE_NAME", "my-service")),
+			expectCheck: true,
+			expectMatch: true,
+		},
+		{
+			name:        "DD_SERVICE matches even when OTEL_SERVICE_NAME is ValueFrom",
+			ddEnvVar:    kubernetes.ServiceTagEnvVar,
+			container:   container(envValueFrom("OTEL_SERVICE_NAME", "some-field")),
+			expectCheck: true,
+			expectMatch: true,
+		},
+		{
+			name:        "DD_SERVICE does not match when OTEL_SERVICE_NAME absent",
+			ddEnvVar:    kubernetes.ServiceTagEnvVar,
+			container:   container(envVar("OTHER", "value")),
+			expectCheck: true,
+			expectMatch: false,
+		},
+		{
+			name:        "DD_VERSION matches on service.version resource attribute",
+			ddEnvVar:    kubernetes.VersionTagEnvVar,
+			container:   container(envVar("OTEL_RESOURCE_ATTRIBUTES", "service.version=1.2.3")),
+			expectCheck: true,
+			expectMatch: true,
+		},
+		{
+			name:        "DD_VERSION does not match when key absent from resource attributes",
+			ddEnvVar:    kubernetes.VersionTagEnvVar,
+			container:   container(envVar("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=prod")),
+			expectCheck: true,
+			expectMatch: false,
+		},
+		{
+			name:        "DD_VERSION does not match when OTEL_RESOURCE_ATTRIBUTES is ValueFrom",
+			ddEnvVar:    kubernetes.VersionTagEnvVar,
+			container:   container(envValueFrom("OTEL_RESOURCE_ATTRIBUTES", "some-field")),
+			expectCheck: true,
+			expectMatch: false,
+		},
+		{
+			name:        "DD_ENV matches on deployment.environment resource attribute",
+			ddEnvVar:    kubernetes.EnvTagEnvVar,
+			container:   container(envVar("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=prod")),
+			expectCheck: true,
+			expectMatch: true,
+		},
+		{
+			name:        "DD_ENV matches on deployment.environment.name resource attribute",
+			ddEnvVar:    kubernetes.EnvTagEnvVar,
+			container:   container(envVar("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment.name=prod")),
+			expectCheck: true,
+			expectMatch: true,
+		},
+		{
+			name:        "DD_ENV does not match when OTEL_RESOURCE_ATTRIBUTES absent",
+			ddEnvVar:    kubernetes.EnvTagEnvVar,
+			container:   container(),
+			expectCheck: true,
+			expectMatch: false,
+		},
+	}
+
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			check := otelEquivalentOf(tt.ddEnvVar)
+			if !tt.expectCheck {
+				require.Nil(t, check)
+				return
+			}
+
+			require.NotNil(t, check)
+			require.Equal(t, tt.expectMatch, check(tt.container))
+		})
+	}
+}
+
+func TestContainerHasEnvVarName(t *testing.T) {
+	c := &corev1.Container{
+		Env: []corev1.EnvVar{
+			{Name: "OTEL_SERVICE_NAME", Value: "svc"},
+		},
+	}
+
+	require.True(t, containerHasEnvVarName(c, "OTEL_SERVICE_NAME"))
+	require.False(t, containerHasEnvVarName(c, "OTHER"))
+}
+
+func TestContainerStaticEnvVarValue(t *testing.T) {
+	c := &corev1.Container{
+		Env: []corev1.EnvVar{
+			{Name: "STATIC", Value: "banana"},
+			{
+				Name: "DYNAMIC",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "some-field"},
+				},
+			},
+		},
+	}
+
+	value, ok := containerStaticEnvVarValue(c, "STATIC")
+	require.True(t, ok)
+	require.Equal(t, "banana", value)
+
+	_, ok = containerStaticEnvVarValue(c, "DYNAMIC")
+	require.False(t, ok)
+
+	_, ok = containerStaticEnvVarValue(c, "MISSING")
+	require.False(t, ok)
+}
+
+func TestParseOtelResourceAttributes(t *testing.T) {
+	testData := []struct {
+		name     string
+		value    string
+		expected map[string]string
+	}{
+		{
+			name:     "empty value",
+			value:    "",
+			expected: map[string]string{},
+		},
+		{
+			name:  "single pair",
+			value: "service.version=1.2.3",
+			expected: map[string]string{
+				"service.version": "1.2.3",
+			},
+		},
+		{
+			name:  "multiple pairs with spaces",
+			value: "service.version=1.2.3, deployment.environment=prod",
+			expected: map[string]string{
+				"service.version":        "1.2.3",
+				"deployment.environment": "prod",
+			},
+		},
+		{
+			name:  "malformed pair without equals is skipped",
+			value: "service.version=1.2.3,malformed,deployment.environment=prod",
+			expected: map[string]string{
+				"service.version":        "1.2.3",
+				"deployment.environment": "prod",
+			},
+		},
+	}
+
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, parseOtelResourceAttributes(tt.value))
+		})
+	}
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/pod_meta_as_tags.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/pod_meta_as_tags.go
@@ -81,14 +81,14 @@ func envVarSourceFromFieldRef(kind podMetaKind, path string) *corev1.EnvVarSourc
 	}
 }
 
-func ustEnvVarMutatorForPodMeta(pod *corev1.Pod, mappingSource podMetaAsTags, tag, envVarName string) *ustEnvVarMutator {
+func ustEnvVarMutatorForPodMeta(pod *corev1.Pod, mappingSource podMetaAsTags, tag, envVarName string, skipIfOTELEquivalent otelEquivalentCheck) *ustEnvVarMutator {
 	env, found := envVarForPodMetaMapping(pod, podMetaKindLabels, mappingSource, tag, envVarName)
 	if found {
-		return &ustEnvVarMutator{EnvVar: env}
+		return &ustEnvVarMutator{EnvVar: env, skipIfOTELEquivalent: skipIfOTELEquivalent}
 	}
 
 	if env, found := envVarForPodMetaMapping(pod, podMetaKindAnnotations, mappingSource, tag, envVarName); found {
-		return &ustEnvVarMutator{EnvVar: env}
+		return &ustEnvVarMutator{EnvVar: env, skipIfOTELEquivalent: skipIfOTELEquivalent}
 	}
 
 	return nil
@@ -97,6 +97,10 @@ func ustEnvVarMutatorForPodMeta(pod *corev1.Pod, mappingSource podMetaAsTags, ta
 type ustEnvVarMutator struct {
 	EnvVar corev1.EnvVar
 	Source *corev1.EnvVar
+
+	// skipIfOTELEquivalent, if set, skips injecting EnvVar into a container
+	// that already carries an OpenTelemetry-native equivalent of it.
+	skipIfOTELEquivalent otelEquivalentCheck
 }
 
 func (m *ustEnvVarMutator) mutateContainer(c *corev1.Container) error {
@@ -113,6 +117,10 @@ func (m *ustEnvVarMutator) mutateContainer(c *corev1.Container) error {
 		if e.Name == m.EnvVar.Name {
 			return nil
 		}
+	}
+
+	if m.skipIfOTELEquivalent != nil && m.skipIfOTELEquivalent(c) {
+		return nil
 	}
 
 	var envs []corev1.EnvVar

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/service_name.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/service_name.go
@@ -57,8 +57,9 @@ func (s *serviceNameMutator) mutateContainer(c *corev1.Container) error {
 	}
 
 	mutator := &ustEnvVarMutator{
-		EnvVar: s.EnvVar,
-		Source: source,
+		EnvVar:               s.EnvVar,
+		Source:               source,
+		skipIfOTELEquivalent: otelEquivalentOf(kubernetes.ServiceTagEnvVar),
 	}
 
 	return mutator.mutateContainer(c)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/service_name_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/service_name_test.go
@@ -145,3 +145,37 @@ func TestFindServiceNameInPod(t *testing.T) {
 		})
 	}
 }
+
+func TestServiceNameMutatorSkipsInjectionWhenOtelServiceNamePresent(t *testing.T) {
+	mutator := &serviceNameMutator{
+		EnvVar: corev1.EnvVar{Name: "DD_SERVICE", Value: "banana"},
+		Source: serviceNameSourceOwnerName,
+	}
+
+	c := &corev1.Container{
+		Env: []corev1.EnvVar{
+			{Name: "OTEL_SERVICE_NAME", Value: "otel-service"},
+		},
+	}
+
+	err := mutator.mutateContainer(c)
+	require.NoError(t, err)
+	require.Equal(t, []corev1.EnvVar{
+		{Name: "OTEL_SERVICE_NAME", Value: "otel-service"},
+	}, c.Env)
+}
+
+func TestServiceNameMutatorInjectsWhenNoOtelServiceName(t *testing.T) {
+	mutator := &serviceNameMutator{
+		EnvVar: corev1.EnvVar{Name: "DD_SERVICE", Value: "banana"},
+		Source: serviceNameSourceOwnerName,
+	}
+
+	c := &corev1.Container{}
+
+	err := mutator.mutateContainer(c)
+	require.NoError(t, err)
+	require.Len(t, c.Env, 2)
+	require.Equal(t, "DD_SERVICE", c.Env[0].Name)
+	require.Equal(t, "banana", c.Env[0].Value)
+}


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Makes Single Step Instrumentation's admission-controller webhook skip injecting `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` into a container that already declares the OpenTelemetry-native equivalent (`OTEL_SERVICE_NAME`, or the relevant `OTEL_RESOURCE_ATTRIBUTES` key: `service.version`, `deployment.environment`/`deployment.environment.name`).

Adds a new `otelEquivalentCheck` mechanism (`otel_env_vars.go`) and wires it into the existing `ustEnvVarMutator` used by `service_name.go`, `pod_meta_as_tags.go`, and `mutator_core.go`.

### Motivation

SSI currently injects DD_* UST env vars unconditionally, which can clobber or duplicate configuration already owned by an OTel-native SDK (e.g. a DDOT SDK). This blocks progressive rollout of DDOT SDKs alongside DD-native APM SDKs. The Agent's tagger already handles the equivalent OTel-to-UST mapping for telemetry tagging (#26118); this PR mirrors that mapping for the SSI pod-mutation path, which was missing it.

### Describe how you validated your changes

Added unit tests in `otel_env_vars_test.go` covering `otelEquivalentOf` for `DD_SERVICE`/`DD_ENV`/`DD_VERSION`, including the case where `OTEL_RESOURCE_ATTRIBUTES` is set via `ValueFrom` (correctly not treated as a static equivalent). Added tests to `service_name_test.go` for the end-to-end skip/inject behavior. Full package test suite passes (509/509).

### Additional Notes

Scoped intentionally to "skip injection if OTel equivalent present" rather than bidirectional value translation, to avoid ordering/env-substitution complications in Kubernetes.
