### PR TITLE
[CWS] emit observed hardening posture in the workload profile header

### DIFF
--- a/pkg/config/schema/yaml/system-probe-cws.yaml
+++ b/pkg/config/schema/yaml/system-probe-cws.yaml
@@ -756,6 +756,14 @@ properties:
             node_type: setting
             type: string
             default: 30s
+          hardening_posture:
+            node_type: section
+            type: object
+            properties:
+              enabled:
+                node_type: setting
+                type: boolean
+                default: false
       watch_dir:
         node_type: setting
         type: boolean

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -333,6 +333,10 @@ type RuntimeSecurityConfig struct {
 	SecurityProfileV2ExcludedImages []string
 	// SecurityProfileV2MaxDumpSize returns the V2-only max profile size in bytes.
 	SecurityProfileV2MaxDumpSize func() int
+	// SecurityProfileV2HardeningPostureEnabled defines whether workload profiles carry a hardening
+	// posture summary in their JSON header. The summary is indexed backend-side on every profile
+	// from every container, so it stays opt-in until that cost is validated.
+	SecurityProfileV2HardeningPostureEnabled bool
 
 	// AnomalyDetectionEventTypes defines the list of events that should be allowed to generate anomaly detections
 	AnomalyDetectionEventTypes []model.EventType
@@ -679,6 +683,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 			mds := max(pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.security_profile.v2.max_dump_size"), ADMinMaxDumSize)
 			return mds * (1 << 10)
 		},
+		SecurityProfileV2HardeningPostureEnabled: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.security_profile.v2.hardening_posture.enabled"),
 
 		// anomaly detection
 		AnomalyDetectionEventTypes:                   parseEventTypeStringSlice(pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.security_profile.anomaly_detection.event_types")),

--- a/pkg/security/security_profile/BUILD.bazel
+++ b/pkg/security/security_profile/BUILD.bazel
@@ -107,6 +107,7 @@ dd_agent_go_test(
     deps = select({
         "@rules_go//go/platform:android": [
             "//pkg/security/config",
+            "//pkg/security/probe/config",
             "//pkg/security/resolvers",
             "//pkg/security/resolvers/cgroup",
             "//pkg/security/resolvers/cgroup/model",
@@ -126,6 +127,7 @@ dd_agent_go_test(
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/security/config",
+            "//pkg/security/probe/config",
             "//pkg/security/resolvers",
             "//pkg/security/resolvers/cgroup",
             "//pkg/security/resolvers/cgroup/model",

--- a/pkg/security/security_profile/activity_tree/BUILD.bazel
+++ b/pkg/security/security_profile/activity_tree/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "dns_node.go",
         "file_node.go",
         "flow_node.go",
+        "hardening_posture.go",
         "imds_node.go",
         "network_device_node.go",
         "paths_reducer.go",
@@ -77,6 +78,7 @@ dd_agent_go_test(
     name = "activity_tree_test",
     srcs = [
         "activity_tree_test.go",
+        "hardening_posture_test.go",
         "paths_reducer_test.go",
         "process_node_snapshot_test.go",
         "size_test.go",

--- a/pkg/security/security_profile/activity_tree/hardening_posture.go
+++ b/pkg/security/security_profile/activity_tree/hardening_posture.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package activitytree holds activitytree related files
+package activitytree
+
+import (
+	"slices"
+)
+
+// HardeningObservations is the whole-tree aggregate of the runtime behavior the workload
+// hardening controls reason about. It unions over every process node in the tree, which is
+// the scope the dump header describes; per-image-tag rollups are a separate concern handled
+// at profile encoding time.
+type HardeningObservations struct {
+	// UIDs is the sorted union of every real, effective and filesystem UID observed on a
+	// process node. The three are unioned rather than reported separately because the
+	// question every hardening control asks is whether root was involved at all: a process
+	// that execs a setuid-root binary reports uid 1000 with euid 0, so reading the real uid
+	// alone would classify it as never-root.
+	UIDs []uint32
+
+	// CapabilitiesMask has bit i set when CAP_i was checked and held by some process. A
+	// capability that was checked and denied is deliberately absent: the control reasons
+	// about what the workload needs, not what it asked for.
+	CapabilitiesMask uint64
+
+	// CapabilitiesGrantedMask is the union of Credentials.CapEffective across processes,
+	// i.e. what the runtime granted as opposed to what was used. No manifest field states
+	// this, which is what makes the delta against CapabilitiesMask worth shipping.
+	CapabilitiesGrantedMask uint64
+
+	// RuntimeProcessNodes counts the process nodes added at runtime. Nodes from the procfs
+	// snapshot only describe what happened to be running when the dump started, so a tree
+	// holding none of these supports no claim about what the workload actually does.
+	RuntimeProcessNodes int
+}
+
+// capabilityMaskBits bounds the shift used to build the capability masks. CAP_LAST_CAP is
+// well below this today, but the masks are uint64 on the wire and a wider kernel constant
+// must not silently wrap into an unrelated bit.
+const capabilityMaskBits = 64
+
+// HardeningObservations walks the tree once and aggregates the observations the hardening
+// posture summary in the dump header is built from.
+func (at *ActivityTree) HardeningObservations() HardeningObservations {
+	var observations HardeningObservations
+	uids := make(map[uint32]struct{})
+
+	at.visit(func(processNode *ProcessNode) {
+		if processNode.GenerationType == Runtime {
+			observations.RuntimeProcessNodes++
+		}
+
+		credentials := &processNode.Process.Credentials
+		uids[credentials.UID] = struct{}{}
+		uids[credentials.EUID] = struct{}{}
+		uids[credentials.FSUID] = struct{}{}
+		observations.CapabilitiesGrantedMask |= credentials.CapEffective
+
+		for _, capabilityNode := range processNode.Capabilities {
+			if capabilityNode.Capable && capabilityNode.Capability < capabilityMaskBits {
+				observations.CapabilitiesMask |= 1 << capabilityNode.Capability
+			}
+		}
+	})
+
+	if len(uids) > 0 {
+		observations.UIDs = make([]uint32, 0, len(uids))
+		for uid := range uids {
+			observations.UIDs = append(observations.UIDs, uid)
+		}
+		slices.Sort(observations.UIDs)
+	}
+
+	return observations
+}

--- a/pkg/security/security_profile/activity_tree/hardening_posture_test.go
+++ b/pkg/security/security_profile/activity_tree/hardening_posture_test.go
@@ -1,0 +1,114 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package activitytree holds activitytree related files
+package activitytree
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+// newPostureTestNode builds a process node carrying the given credentials, so the posture
+// tests can state exactly which identity a process ran under.
+func newPostureTestNode(path string, generationType NodeGenerationType, creds model.Credentials) *ProcessNode {
+	return &ProcessNode{
+		NodeBase:       NewNodeBase(),
+		GenerationType: generationType,
+		Process: ProcessInfo{
+			FileEvent:   model.FileEvent{PathnameStr: path},
+			Credentials: creds,
+		},
+	}
+}
+
+func TestHardeningObservations_UIDsUnionRealEffectiveAndFilesystem(t *testing.T) {
+	// A process that execs a setuid-root binary reports uid 1000 with euid 0. Both values
+	// have to land in the union, otherwise the backend reads the workload as never-root.
+	tree := &ActivityTree{Stats: NewActivityTreeNodeStats()}
+	tree.ProcessNodes = []*ProcessNode{
+		newPostureTestNode("/usr/bin/app", Runtime, model.Credentials{UID: 1000, EUID: 0, FSUID: 1000}),
+	}
+
+	observations := tree.HardeningObservations()
+
+	assert.Equal(t, []uint32{0, 1000}, observations.UIDs)
+}
+
+func TestHardeningObservations_UIDsAreDeduplicatedAndSorted(t *testing.T) {
+	tree := &ActivityTree{Stats: NewActivityTreeNodeStats()}
+	parent := newPostureTestNode("/usr/bin/entrypoint", Runtime, model.Credentials{UID: 0, EUID: 0, FSUID: 0})
+	child := newPostureTestNode("/usr/bin/app", Runtime, model.Credentials{UID: 1000, EUID: 1000, FSUID: 1000})
+	sibling := newPostureTestNode("/usr/bin/sidecar", Runtime, model.Credentials{UID: 65534, EUID: 1000, FSUID: 65534})
+	parent.Children = []*ProcessNode{child, sibling}
+	tree.ProcessNodes = []*ProcessNode{parent}
+
+	observations := tree.HardeningObservations()
+
+	assert.Equal(t, []uint32{0, 1000, 65534}, observations.UIDs)
+}
+
+func TestHardeningObservations_CapabilitiesMaskOnlyCoversHeldCapabilities(t *testing.T) {
+	// CapabilityNode records the check; Capable says whether the process actually held it.
+	// A capability that was checked and denied must not appear in the used mask.
+	now := time.Now()
+	tree := &ActivityTree{Stats: NewActivityTreeNodeStats()}
+	tagID := tree.GetOrInsertImageTag("v1")
+
+	node := newPostureTestNode("/usr/bin/app", Runtime, model.Credentials{})
+	node.Capabilities = []*CapabilityNode{
+		NewCapabilityNode(7, true, now, tagID, Runtime),   // CAP_SETUID, held
+		NewCapabilityNode(12, false, now, tagID, Runtime), // CAP_NET_ADMIN, denied
+	}
+	tree.ProcessNodes = []*ProcessNode{node}
+
+	observations := tree.HardeningObservations()
+
+	assert.Equal(t, uint64(1<<7), observations.CapabilitiesMask)
+}
+
+func TestHardeningObservations_GrantedMaskUnionsCapEffective(t *testing.T) {
+	tree := &ActivityTree{Stats: NewActivityTreeNodeStats()}
+	tree.ProcessNodes = []*ProcessNode{
+		newPostureTestNode("/usr/bin/a", Runtime, model.Credentials{CapEffective: 1 << 7}),
+		newPostureTestNode("/usr/bin/b", Runtime, model.Credentials{CapEffective: 1 << 12}),
+	}
+
+	observations := tree.HardeningObservations()
+
+	assert.Equal(t, uint64(1<<7|1<<12), observations.CapabilitiesGrantedMask)
+}
+
+func TestHardeningObservations_OnlyRuntimeNodesAreCounted(t *testing.T) {
+	// A dump made entirely of procfs snapshot nodes describes what was running when the
+	// dump started, not what the workload does. The count is what lets the caller drop it.
+	tree := &ActivityTree{Stats: NewActivityTreeNodeStats()}
+	tree.ProcessNodes = []*ProcessNode{
+		newPostureTestNode("/usr/bin/snapshotted", Snapshot, model.Credentials{}),
+		newPostureTestNode("/usr/bin/observed", Runtime, model.Credentials{}),
+		newPostureTestNode("/usr/bin/drifted", ProfileDrift, model.Credentials{}),
+	}
+
+	observations := tree.HardeningObservations()
+
+	assert.Equal(t, 1, observations.RuntimeProcessNodes)
+}
+
+func TestHardeningObservations_EmptyTree(t *testing.T) {
+	tree := &ActivityTree{Stats: NewActivityTreeNodeStats()}
+
+	observations := tree.HardeningObservations()
+
+	assert.Empty(t, observations.UIDs)
+	assert.Zero(t, observations.CapabilitiesMask)
+	assert.Zero(t, observations.CapabilitiesGrantedMask)
+	assert.Zero(t, observations.RuntimeProcessNodes)
+}

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -487,6 +487,8 @@ func (m *ManagerV2) persistAllProfiles() {
 func (m *ManagerV2) persistProfile(p *profile.Profile) {
 	enabled := p.IsEnabled()
 
+	m.attachHardeningPosture(p)
+
 	encoded := make(map[config.StorageFormat]*bytes.Buffer)
 	for format, requests := range m.configuredStorageRequests {
 		for _, request := range requests {
@@ -535,6 +537,16 @@ func (m *ManagerV2) persistProfileToStorage(p *profile.Profile, request config.S
 	}
 
 	m.sendPersistenceMetrics(request, data.Len())
+}
+
+// attachHardeningPosture refreshes the profile's hardening posture summary so the storage
+// backends marshal it with the rest of the JSON header. It runs on every persist rather than
+// once, because the summary describes the tree as it stands at that moment.
+func (m *ManagerV2) attachHardeningPosture(p *profile.Profile) {
+	if !m.config.RuntimeSecurity.SecurityProfileV2HardeningPostureEnabled {
+		return
+	}
+	p.Header.Hardening = p.ComputeHardeningPosture(m.config.Probe.CapabilitiesMonitoringEnabled)
 }
 
 // sendPersistenceMetrics accumulates persistence metrics after successful profile persistence.

--- a/pkg/security/security_profile/manager_v2_test.go
+++ b/pkg/security/security_profile/manager_v2_test.go
@@ -20,6 +20,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
+	pconfig "github.com/DataDog/datadog-agent/pkg/security/probe/config"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
@@ -32,7 +33,8 @@ import (
 
 // newTestManagerV2WithLocalStorage builds a minimal ManagerV2 wired to a real on-disk local
 // storage backend, configured to persist profiles in the security-profile format (the format the
-// reload path reads back). Only the fields used by persistProfile are populated.
+// reload path reads back). Only the fields used by persistProfile are populated, config included:
+// persistProfile reads it, so it has to be present even when every setting is left at its zero value.
 func newTestManagerV2WithLocalStorage(t *testing.T) (*ManagerV2, string) {
 	t.Helper()
 
@@ -46,6 +48,10 @@ func newTestManagerV2WithLocalStorage(t *testing.T) (*ManagerV2, string) {
 		configuredStorageRequests: perFormatStorageRequests([]config.StorageRequest{
 			config.NewStorageRequest(config.LocalStorage, config.Profile, false, dir),
 		}),
+		config: &config.Config{
+			RuntimeSecurity: &config.RuntimeSecurityConfig{},
+			Probe:           &pconfig.Config{},
+		},
 	}
 	return m, dir
 }
@@ -147,4 +153,68 @@ func TestManagerV2_evictUnusedNodes_skipsDisabledProfile(t *testing.T) {
 	m.evictUnusedNodes()
 
 	assert.False(t, p.IsEnabled(), "eviction must not re-enable a disabled profile")
+}
+
+// newHardeningPostureTestProfile builds a profile whose tree holds a single runtime process
+// node, which is the minimum a posture summary can be derived from.
+func newHardeningPostureTestProfile(uid uint32) *profile.Profile {
+	p := profile.New(profile.WithWorkloadSelector(cgroupModel.WorkloadSelector{Image: "img", Tag: "v1"}))
+	p.Metadata = mtdt.Metadata{Name: "posture", Arch: "x86_64"}
+	p.ActivityTree.ProcessNodes = []*activity_tree.ProcessNode{{
+		NodeBase:       activity_tree.NewNodeBase(),
+		GenerationType: activity_tree.Runtime,
+		Process: activity_tree.ProcessInfo{
+			FileEvent:   model.FileEvent{PathnameStr: "/usr/bin/proc", BasenameStr: "proc"},
+			Credentials: model.Credentials{UID: uid, EUID: uid, FSUID: uid},
+		},
+	}}
+	p.ActivityTree.ComputeActivityTreeStats()
+	return p
+}
+
+func newHardeningPostureTestManager(t *testing.T, postureEnabled, capabilitiesEnabled bool) *ManagerV2 {
+	t.Helper()
+
+	m, _ := newTestManagerV2WithLocalStorage(t)
+	m.config.RuntimeSecurity.SecurityProfileV2HardeningPostureEnabled = postureEnabled
+	m.config.Probe.CapabilitiesMonitoringEnabled = capabilitiesEnabled
+	return m
+}
+
+// TestManagerV2_persistProfile_attachesHardeningPosture verifies the posture summary reaches the
+// dump header on the way out, and only when the feature is turned on: the block is indexed on
+// every profile from every container, so it must not appear by default.
+func TestManagerV2_persistProfile_attachesHardeningPosture(t *testing.T) {
+	t.Run("attaches the posture when enabled", func(t *testing.T) {
+		m := newHardeningPostureTestManager(t, true, true)
+		p := newHardeningPostureTestProfile(1000)
+
+		m.persistProfile(p)
+
+		require.NotNil(t, p.Header.Hardening)
+		assert.Equal(t, []uint32{1000}, p.Header.Hardening.Observed.UIDs)
+		assert.True(t, p.Header.Hardening.Observed.CapabilitiesCollected)
+		assert.Equal(t, "x86_64", p.Header.Hardening.Observed.Arch)
+	})
+
+	t.Run("attaches nothing when disabled", func(t *testing.T) {
+		m := newHardeningPostureTestManager(t, false, true)
+		p := newHardeningPostureTestProfile(1000)
+
+		m.persistProfile(p)
+
+		assert.Nil(t, p.Header.Hardening)
+	})
+
+	// Capability collection is a separate switch, off by default. The posture still ships, but
+	// it has to say the mask means "not collected" rather than "nothing used".
+	t.Run("records that capabilities were not collected", func(t *testing.T) {
+		m := newHardeningPostureTestManager(t, true, false)
+		p := newHardeningPostureTestProfile(1000)
+
+		m.persistProfile(p)
+
+		require.NotNil(t, p.Header.Hardening)
+		assert.False(t, p.Header.Hardening.Observed.CapabilitiesCollected)
+	})
 }

--- a/pkg/security/security_profile/profile/BUILD.bazel
+++ b/pkg/security/security_profile/profile/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "dump_header.go",
         "graph.go",
         "grpc.go",
+        "hardening_posture.go",
         "json.go",
         "profile.go",
         "profile_unsupported.go",
@@ -116,7 +117,10 @@ go_library(
 
 dd_agent_go_test(
     name = "profile_test",
-    srcs = ["disable_test.go"],
+    srcs = [
+        "disable_test.go",
+        "hardening_posture_test.go",
+    ],
     embed = [":profile"],
     deps = select({
         "@rules_go//go/platform:android": [
@@ -124,6 +128,7 @@ dd_agent_go_test(
             "//pkg/security/resolvers/cgroup/model",
             "//pkg/security/secl/model",
             "//pkg/security/security_profile/activity_tree",
+            "//pkg/security/utils",
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
         ],
@@ -132,6 +137,7 @@ dd_agent_go_test(
             "//pkg/security/resolvers/cgroup/model",
             "//pkg/security/secl/model",
             "//pkg/security/security_profile/activity_tree",
+            "//pkg/security/utils",
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
         ],

--- a/pkg/security/security_profile/profile/dump_header.go
+++ b/pkg/security/security_profile/profile/dump_header.go
@@ -30,4 +30,10 @@ type ActivityDumpHeader struct {
 	// this is a hack used to provide this global list to the backend in the JSON header
 	// instead of in the protobuf payload.
 	DNSNames *utils.StringKeys `json:"dns_names"`
+
+	// Hardening holds a whole-profile posture summary, hoisted here for the same reason as
+	// DNSNames above: the header is the only part of a dump the backend indexes, so this is
+	// what lets hardening controls be evaluated without opening the protobuf attachment.
+	// Omitted when the profile cannot support one, or when the feature is disabled.
+	Hardening *HardeningPosture `json:"hardening,omitempty"`
 }

--- a/pkg/security/security_profile/profile/hardening_posture.go
+++ b/pkg/security/security_profile/profile/hardening_posture.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package profile holds profile related files
+package profile
+
+const (
+	// postureVersion versions the shape of the hardening posture block, independently of the
+	// Agent build (@agent_version already carries that). Bump it on breaking changes only: a
+	// field removed, renamed, or the same field coming to mean something different. Adding a
+	// field is not breaking.
+	postureVersion = 1
+
+	// maxPostureUIDs bounds the uid list. The dump header is indexed on every dump from every
+	// container, so its width is a per-dump cost rather than a per-finding one.
+	maxPostureUIDs = 32
+)
+
+// HardeningPosture is a bounded summary of a workload's observed behaviour, hoisted into the
+// JSON dump header so the backend can evaluate hardening controls without opening the protobuf
+// attachment. Same rationale as ActivityDumpHeader.DNSNames.
+//
+// Everything here has to survive a union across dumps, because one dump is one container over
+// one interval and no control can be judged on that alone. Sets and masks merge; counts and
+// cardinalities do not, so they are derived backend-side and deliberately absent.
+type HardeningPosture struct {
+	PostureVersion int              `json:"posture_version"`
+	Observed       ObservedBehavior `json:"observed"`
+}
+
+// ObservedBehavior is what the workload was seen doing, as opposed to what its manifest
+// declares. Fields the backend can derive from these are not repeated here: runs_as_root is
+// exactly 0 ∈ uids, and which capabilities count as privilege-bearing is a judgement that
+// belongs with the rule, not the Agent.
+type ObservedBehavior struct {
+	// UIDs is the union of the real, effective and filesystem UIDs observed across the
+	// profile, sorted ascending and truncated to maxPostureUIDs. Sorting before truncating
+	// is load-bearing: it keeps uid 0 in the list, and dropping it would turn a root
+	// workload into a never-root one.
+	UIDs       []uint32 `json:"uids"`
+	UIDsCapped bool     `json:"uids_capped"`
+
+	// CapabilitiesCollected reports whether capability observation was actually running.
+	// It is off by default and unsupported below kernel 5.13 (5.17 on arm64), and without
+	// this flag an empty CapabilitiesMask reads identically to a workload that used no
+	// capabilities — which is the permissive answer for every control that reads it.
+	CapabilitiesCollected bool `json:"capabilities_collected"`
+
+	// CapabilitiesMask is what a process was observed holding when checked; bit i is CAP_i.
+	CapabilitiesMask uint64 `json:"capabilities_mask"`
+	// CapabilitiesGrantedMask is what the runtime granted. No manifest field states this: a
+	// container with no securityContext still receives the runtime's default set.
+	CapabilitiesGrantedMask uint64 `json:"capabilities_granted_mask"`
+
+	// Arch is the profile's architecture. Capability numbering is stable across the
+	// architectures we support, but the summary is only interpretable against a known one.
+	Arch string `json:"arch"`
+}
+
+// ComputeHardeningPosture builds the posture block for this profile, or returns nil when the
+// profile cannot support one. capabilitiesCollected reports whether capability observation was
+// enabled for this Agent, which the caller reads from the probe configuration.
+func (p *Profile) ComputeHardeningPosture(capabilitiesCollected bool) *HardeningPosture {
+	observations := p.ActivityTree.HardeningObservations()
+
+	// A tree with no runtime nodes holds only the procfs snapshot taken when the dump
+	// started. It says what was running, never what the workload does, so it cannot back an
+	// absence claim and ships nothing rather than an empty-looking one.
+	if observations.RuntimeProcessNodes == 0 {
+		return nil
+	}
+
+	uids := observations.UIDs
+	capped := len(uids) > maxPostureUIDs
+	if capped {
+		uids = uids[:maxPostureUIDs]
+	}
+
+	return &HardeningPosture{
+		PostureVersion: postureVersion,
+		Observed: ObservedBehavior{
+			UIDs:                    uids,
+			UIDsCapped:              capped,
+			CapabilitiesCollected:   capabilitiesCollected,
+			CapabilitiesMask:        observations.CapabilitiesMask,
+			CapabilitiesGrantedMask: observations.CapabilitiesGrantedMask,
+			Arch:                    p.Metadata.Arch,
+		},
+	}
+}

--- a/pkg/security/security_profile/profile/hardening_posture_test.go
+++ b/pkg/security/security_profile/profile/hardening_posture_test.go
@@ -1,0 +1,149 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package profile holds profile related files
+package profile
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
+)
+
+func newPostureTestProfile(nodes ...*activity_tree.ProcessNode) *Profile {
+	p := New()
+	p.ActivityTree.ProcessNodes = nodes
+	return p
+}
+
+func newPostureTestNode(generationType activity_tree.NodeGenerationType, creds model.Credentials) *activity_tree.ProcessNode {
+	return &activity_tree.ProcessNode{
+		NodeBase:       activity_tree.NewNodeBase(),
+		GenerationType: generationType,
+		Process:        activity_tree.ProcessInfo{Credentials: creds},
+	}
+}
+
+func TestComputeHardeningPosture_NilWhenNoRuntimeNodes(t *testing.T) {
+	// A snapshot-only dump describes what was already running when the dump started. It
+	// cannot support an "this behavior was never observed" claim, so it ships no posture.
+	p := newPostureTestProfile(
+		newPostureTestNode(activity_tree.Snapshot, model.Credentials{UID: 1000}),
+	)
+
+	assert.Nil(t, p.ComputeHardeningPosture(true))
+}
+
+func TestComputeHardeningPosture_UIDsCappedRetainingRoot(t *testing.T) {
+	// The header is indexed, so the uid list is bounded. Sorting ascending before the
+	// truncation is what keeps uid 0 in: losing it would turn a root workload into a
+	// never-root one, which is the one mistake this list must not make.
+	var nodes []*activity_tree.ProcessNode
+	nodes = append(nodes, newPostureTestNode(activity_tree.Runtime, model.Credentials{UID: 0, EUID: 0, FSUID: 0}))
+	for uid := uint32(100); uid <= 140; uid++ {
+		nodes = append(nodes, newPostureTestNode(activity_tree.Runtime, model.Credentials{UID: uid, EUID: uid, FSUID: uid}))
+	}
+
+	posture := newPostureTestProfile(nodes...).ComputeHardeningPosture(true)
+
+	require.NotNil(t, posture)
+	assert.Len(t, posture.Observed.UIDs, maxPostureUIDs)
+	assert.Equal(t, uint32(0), posture.Observed.UIDs[0])
+	assert.True(t, posture.Observed.UIDsCapped)
+}
+
+func TestComputeHardeningPosture_UIDsNotCappedUnderTheLimit(t *testing.T) {
+	p := newPostureTestProfile(
+		newPostureTestNode(activity_tree.Runtime, model.Credentials{UID: 1000, EUID: 1000, FSUID: 1000}),
+	)
+
+	posture := p.ComputeHardeningPosture(true)
+
+	require.NotNil(t, posture)
+	assert.Equal(t, []uint32{1000}, posture.Observed.UIDs)
+	assert.False(t, posture.Observed.UIDsCapped)
+}
+
+func TestComputeHardeningPosture_CapabilitiesCollectedIsRecorded(t *testing.T) {
+	// Capability collection is off by default and unsupported on older kernels. Without
+	// this flag an empty capabilities_mask is indistinguishable from a workload that used
+	// no capabilities, and every hardening control reading the mask would fail open.
+	p := newPostureTestProfile(
+		newPostureTestNode(activity_tree.Runtime, model.Credentials{UID: 1000, EUID: 1000, FSUID: 1000}),
+	)
+
+	posture := p.ComputeHardeningPosture(false)
+
+	require.NotNil(t, posture)
+	assert.False(t, posture.Observed.CapabilitiesCollected)
+	assert.Zero(t, posture.Observed.CapabilitiesMask)
+}
+
+func TestComputeHardeningPosture_CarriesMasksAndArch(t *testing.T) {
+	p := newPostureTestProfile(
+		newPostureTestNode(activity_tree.Runtime, model.Credentials{UID: 1000, EUID: 1000, FSUID: 1000, CapEffective: 1 << 12}),
+	)
+	p.Metadata.Arch = "x86_64"
+
+	posture := p.ComputeHardeningPosture(true)
+
+	require.NotNil(t, posture)
+	assert.Equal(t, uint64(1<<12), posture.Observed.CapabilitiesGrantedMask)
+	assert.Equal(t, "x86_64", posture.Observed.Arch)
+	assert.Equal(t, postureVersion, posture.PostureVersion)
+}
+
+func TestActivityDumpHeader_OmitsHardeningPostureWhenAbsent(t *testing.T) {
+	// The block is absent on the majority of dumps — capability collection off, snapshot-only
+	// trees, the feature disabled. Absent has to mean absent on the wire, not an empty object,
+	// so the backend can tell "the Agent did not collect this" from "there was nothing to say".
+	header := ActivityDumpHeader{DNSNames: utils.NewStringKeys(nil)}
+
+	encoded, err := json.Marshal(header)
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"dns_names": []}`, string(encoded))
+}
+
+func TestActivityDumpHeader_MarshalsHardeningPosture(t *testing.T) {
+	header := ActivityDumpHeader{
+		DNSNames: utils.NewStringKeys(nil),
+		Hardening: &HardeningPosture{
+			PostureVersion: postureVersion,
+			Observed: ObservedBehavior{
+				UIDs:                  []uint32{0, 1000},
+				CapabilitiesCollected: true,
+				CapabilitiesMask:      1 << 7,
+				Arch:                  "x86_64",
+			},
+		},
+	}
+
+	encoded, err := json.Marshal(header)
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"dns_names": [],
+		"hardening": {
+			"posture_version": 1,
+			"observed": {
+				"uids": [0, 1000],
+				"uids_capped": false,
+				"capabilities_collected": true,
+				"capabilities_mask": 128,
+				"capabilities_granted_mask": 0,
+				"arch": "x86_64"
+			}
+		}
+	}`, string(encoded))
+}


### PR DESCRIPTION
### What does this PR do?

Adds a bounded summary of the identities and Linux capabilities a workload was observed
using to the workload profile's JSON header, behind
`runtime_security_config.security_profile.v2.hardening_posture.enabled` (off by default).

```
activity tree ──► HardeningObservations()      uid/euid/fsuid union, capability masks,
   (per profile)     activity_tree/               runtime node count
                     hardening_posture.go
                          │
                          ▼
                  ComputeHardeningPosture()    cap uids at 32, stamp version + arch,
                     profile/                    drop the block if no runtime nodes
                     hardening_posture.go
                          │
                          ▼
                  ActivityDumpHeader.Hardening ──► JSON header ──► indexed backend-side
                     (omitempty)
```

The summary carries only values that survive a union across profiles — the uid set and the
two capability masks. Anything the backend can derive is deliberately absent.

### Motivation

Workload hardening findings are *absence* claims: "no root-requiring activity observed in
30 days". Percolation is a per-event match, so it can express presence but never absence —
whoever aggregates has to turn the absence into a positive assertion first.

Today the backend cannot aggregate at all: the activity tree ships as a gzipped protobuf
attachment, so nothing about a profile's *contents* is queryable at percolation time. This
hoists the part that matters into the header, which is the only piece of a profile that
gets indexed. Precedent is the `DNSNames` field immediately above it, added for exactly
the same reason.

Part of the Workload Protection hardening squad's findings-generation work
([RFC-1120](https://docs.google.com/document/d/1dCVCU5Zguc0TotVvoQiGF1jfXf1TORdwVot2T-XAv5A/edit)).
This is the observed half only; the declared `securityContext` half is a separate PR
through `comp/core/workloadmeta`.

### Describe how you validated your changes

16 new tests, written test-first. Each was watched failing for the intended reason before
the implementation existed.

| Check | Result |
| --- | --- |
| `dda inv test --targets=./pkg/security/security_profile,./pkg/security/config` | 918 passed, 0 failed |
| `dda inv linter.go --targets=./pkg/security/security_profile,./pkg/security/config` | 0 issues |
| `dda inv system-probe.build` | binary produced |
| `dda inv schema.locate runtime_security_config.security_profile.v2.hardening_posture.enabled` | resolves, default `false` |

Coverage: uid union across real/effective/filesystem, dedup and ordering, used-vs-attempted
capability masks, granted-mask union, runtime-vs-snapshot node counting, the 32-uid cap
retaining uid 0, nil posture on a snapshot-only tree, the `omitempty` JSON contract in both
directions, and the manager gate in all three config combinations.

`newTestManagerV2WithLocalStorage` left `config` nil, which `persistProfile` now reads.
`NewManagerV2` always sets it, so I fixed the stale helper rather than adding a nil guard to
production code.

### Additional Notes

**Three deviations from the RFC, all deliberate — please push back if you disagree:**

1. **`uids` unions EUID and FSUID**, where the RFC specifies real UIDs only. A process that
   execs a setuid-root binary reports `uid=1000, euid=0`; reading the real uid alone
   classifies it as never-root, which is the one mistake this field must not make. The data
   is already on the node — the exec event is emitted from the `mprotect_fixup` hook, well
   after `commit_creds`, so exec-time credentials already reflect setuid-binary escalation.
2. **`capabilities_collected` is new**, not in the RFC. Capability collection is off by
   default and unsupported below kernel 5.13 (5.17 on arm64). Without this flag an empty
   `capabilities_mask` is indistinguishable from a workload that used no capabilities, and
   every control reading the mask fails *open*.
3. **`runs_as_root` and `has_privilege_caps` are not shipped.** The RFC's merge invariant
   excludes them: `runs_as_root` is exactly `0 ∈ uids`, and which capabilities count as
   privilege-bearing is a judgement that belongs with the rule. Both derive from what is
   shipped here.

**Coupling with #54996.** `capabilities_mask` stays empty until that PR lands — it is what
enables `capabilities_monitoring` and adds `capabilities` to the V2 default event types.
Deviation 2 is what makes this safe to merge first. The two PRs write to different
destinations (#54996 targets the per-image-tag `ProfileContext` in the protobuf; this
targets the JSON header) and should not conflict.

**Not wired for V1.** `ManagerV2` only. V1 is the legacy path and mutually exclusive with
V2 (`probe_ebpf.go:587`).

**No release note** — the setting is opt-in and the feature is inert until the backend side
exists.

Suggested labels: `team/agent-security`, `component/system-probe`, `changelog/no-changelog`
