### PR TITLE
pkg/util/containerd: release the view snapshot on a live context

### DIFF
--- a/pkg/util/containerd/BUILD.bazel
+++ b/pkg/util/containerd/BUILD.bazel
@@ -51,6 +51,7 @@ dd_agent_go_test(
         "@com_github_containerd_containerd_v2//client",
         "@com_github_containerd_containerd_v2//core/containers",
         "@com_github_containerd_containerd_v2//pkg/cio",
+        "@com_github_containerd_containerd_v2//pkg/namespaces",
         "@com_github_containerd_containerd_v2//pkg/oci",
         "@com_github_containerd_typeurl_v2//:typeurl",
         "@com_github_gogo_protobuf//types",

--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -397,6 +397,17 @@ func (c *ContainerdUtil) Mounts(ctx context.Context, expiration time.Duration, n
 	return mounts, cleanup, err
 }
 
+// cleanupTimeout bounds the calls that release a view snapshot and its lease.
+const cleanupTimeout = 30 * time.Second
+
+// cleanupContext keeps ctx's values, the containerd namespace among them, and
+// replaces ctx's cancellation with a deadline of its own. Releasing a view
+// snapshot takes two RPCs, and the caller is usually cancelling by then, which
+// would fail both and leave the snapshot holding what it materialised.
+func cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+}
+
 // MountsWithSnapshotter is like Mounts but also returns the snapshotter name
 // backing the mounts, so callers that need to talk to the same SnapshotService
 // (e.g. to verify the snapshot's parent chain) don't have to re-probe.
@@ -438,9 +449,11 @@ func (c *ContainerdUtil) MountsWithSnapshotter(ctx context.Context, expiration t
 	// Getting top layer image id
 	diffIDs, err := img.RootFS(ctx)
 	if err != nil {
-		if err := done(ctx); err != nil {
+		releaseCtx, cancel := cleanupContext(ctx)
+		if err := done(releaseCtx); err != nil {
 			log.Warnf("Unable to cancel containerd lease with id: %s, err: %v", imageID, err)
 		}
+		cancel()
 		return nil, "", nil, fmt.Errorf("unable to get layers digests for image: %s, err: %w", imageID, err)
 	}
 	chainID := identity.ChainID(diffIDs).String()
@@ -448,9 +461,11 @@ func (c *ContainerdUtil) MountsWithSnapshotter(ctx context.Context, expiration t
 	s := c.cl.SnapshotService(snapshotter)
 	mounts, err := s.View(ctx, imageID, chainID)
 	if err != nil && !errdefs.IsAlreadyExists(err) {
-		if err := done(ctx); err != nil {
+		releaseCtx, cancel := cleanupContext(ctx)
+		if err := done(releaseCtx); err != nil {
 			log.Warnf("Unable to cancel containerd lease with id: %s, err: %v", imageID, err)
 		}
+		cancel()
 		return nil, "", nil, fmt.Errorf("unable to build snapshot for image: %s, err: %w", imageID, err)
 	}
 	cleanSnapshot := func(ctx context.Context) error {
@@ -459,12 +474,14 @@ func (c *ContainerdUtil) MountsWithSnapshotter(ctx context.Context, expiration t
 
 	// Nothing returned
 	if len(mounts) == 0 {
-		if err := cleanSnapshot(ctx); err != nil {
+		releaseCtx, cancel := cleanupContext(ctx)
+		if err := cleanSnapshot(releaseCtx); err != nil {
 			log.Warnf("Unable to clean snapshot with id: %s, err: %v", imageID, err)
 		}
-		if err := done(ctx); err != nil {
+		if err := done(releaseCtx); err != nil {
 			log.Warnf("Unable to cancel containerd lease with id: %s, err: %v", imageID, err)
 		}
+		cancel()
 		return nil, "", nil, fmt.Errorf("No snapshots returned for image: %s", imageID)
 	}
 
@@ -497,7 +514,8 @@ func (c *ContainerdUtil) MountsWithSnapshotter(ctx context.Context, expiration t
 	}
 
 	return mounts, snapshotter, func(ctx context.Context) error {
-		ctx = namespaces.WithNamespace(ctx, namespace)
+		ctx, cancel := cleanupContext(namespaces.WithNamespace(ctx, namespace))
+		defer cancel()
 		if err := cleanSnapshot(ctx); err != nil {
 			log.Warnf("Unable to clean snapshot with id: %s, err: %v", imageID, err)
 		}

--- a/pkg/util/containerd/containerd_util_test.go
+++ b/pkg/util/containerd/containerd_util_test.go
@@ -12,12 +12,14 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	"github.com/containerd/containerd/api/types"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/typeurl/v2"
 	prototypes "github.com/gogo/protobuf/types"
@@ -341,4 +343,23 @@ func makeCtn(value v1.Metrics, typeURL string, taskMetricsError error) container
 		},
 	}
 	return ctn
+}
+
+// TestCleanupContextOutlivesCaller checks that the containerd namespace
+// survives and the caller's cancellation does not.
+func TestCleanupContextOutlivesCaller(t *testing.T) {
+	ctx, cancel := context.WithCancel(namespaces.WithNamespace(context.Background(), "k8s.io"))
+	cancel()
+
+	releaseCtx, releaseCancel := cleanupContext(ctx)
+	defer releaseCancel()
+
+	require.NoError(t, releaseCtx.Err())
+	ns, ok := namespaces.Namespace(releaseCtx)
+	require.True(t, ok)
+	require.Equal(t, "k8s.io", ns)
+
+	deadline, ok := releaseCtx.Deadline()
+	require.True(t, ok)
+	require.WithinDuration(t, time.Now().Add(cleanupTimeout), deadline, time.Minute)
 }

--- a/releasenotes/notes/sbom-release-view-snapshot-on-timeout-efdf683cf910a4f9.yaml
+++ b/releasenotes/notes/sbom-release-view-snapshot-on-timeout-efdf683cf910a4f9.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Release the containerd view snapshot and lease taken for a container image
+    SBOM scan even when the scan is cancelled or times out. The release ran on
+    the scan's own context, so a scan that hit its deadline left the snapshot
+    behind, and on a lazy snapshotter that snapshot holds the layer it
+    materialised.


### PR DESCRIPTION
To read an image, MountsWithSnapshotter takes a containerd lease and a
view snapshot of the image's top layer, and hands the caller a function
that removes both. Both halves of that function are RPCs, and it ran
them on the caller's context. An SBOM scan reaching its deadline cancels
that context and then asks for the release, so both RPCs fail on a dead
context and the view snapshot stays. Nothing else removes an active
snapshot, and on a lazy snapshotter it holds whatever the view
materialised, which is gigabytes for a large image. Nodes were carrying
19 GiB of them across 197 snapshots.

The release now runs on a context that keeps the caller's values, the
containerd namespace among them, with its own deadline in place of the
caller's cancellation. The rollback paths inside
MountsWithSnapshotter use it too.

Fixes #incident-60060.

