### PR TITLE
Deflake `TestStartPipeline`: OS-assigned ports and a realistic budget

### DIFF
--- a/comp/otelcol/otlp/collector_test.go
+++ b/comp/otelcol/otlp/collector_test.go
@@ -32,12 +32,13 @@ func TestGetComponents(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func AssertSucessfulRun(t *testing.T, pcfg PipelineConfig) {
+func AssertSuccessfulRun(t *testing.T, pcfg PipelineConfig) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 
 	p, err := NewPipeline(pcfg, serializermock.NewMetricSerializer(t), make(chan *message.Message), fakeTagger, hostnameimpl.NewHostnameService(), nil)
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	const pipelineTimeout = 10 * time.Second
+	ctx, cancel := context.WithTimeout(t.Context(), pipelineTimeout)
 	defer cancel()
 
 	colDone := make(chan struct{})
@@ -48,15 +49,13 @@ func AssertSucessfulRun(t *testing.T, pcfg PipelineConfig) {
 
 	assert.Eventually(t, func() bool {
 		return otelcol.StateRunning == p.col.GetState()
-	}, time.Second*2, time.Millisecond*200)
+	}, pipelineTimeout-time.Second, time.Millisecond*200)
 
 	p.Stop()
 	p.Stop()
 	<-colDone
 
-	assert.Eventually(t, func() bool {
-		return otelcol.StateClosed == p.col.GetState()
-	}, time.Second*2, time.Millisecond*200)
+	assert.Equal(t, otelcol.StateClosed, p.col.GetState())
 }
 
 func AssertFailedRun(t *testing.T, pcfg PipelineConfig, expected string) {
@@ -64,7 +63,7 @@ func AssertFailedRun(t *testing.T, pcfg PipelineConfig, expected string) {
 
 	p, err := NewPipeline(pcfg, serializermock.NewMetricSerializer(t), make(chan *message.Message), fakeTagger, hostnameimpl.NewHostnameService(), nil)
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 	pipelineError := p.Run(ctx)
 	assert.ErrorContains(t, pipelineError, expected)
@@ -75,7 +74,7 @@ func TestStartPipeline(t *testing.T) {
 	cfg.SetInTest("hostname", "otlp-testhostname")
 
 	pcfg := getTestPipelineConfig()
-	AssertSucessfulRun(t, pcfg)
+	AssertSuccessfulRun(t, pcfg)
 }
 
 func TestStartPipelineFromConfig(t *testing.T) {
@@ -105,7 +104,7 @@ func TestStartPipelineFromConfig(t *testing.T) {
 			pcfg, err := FromAgentConfig(cfg)
 			require.NoError(t, err)
 			if testInstance.err == "" {
-				AssertSucessfulRun(t, pcfg)
+				AssertSuccessfulRun(t, pcfg)
 			} else {
 				AssertFailedRun(t, pcfg, testInstance.err)
 			}

--- a/comp/otelcol/otlp/collector_test_config.go
+++ b/comp/otelcol/otlp/collector_test_config.go
@@ -13,7 +13,8 @@ import (
 
 func getTestPipelineConfig() PipelineConfig {
 	return PipelineConfig{
-		OTLPReceiverConfig: testutil.OTLPConfigFromPorts("localhost", 4317, 4318),
+		// :0 picks a free port, avoiding flaky binds on the production default ports.
+		OTLPReceiverConfig: testutil.OTLPConfigFromEndpoints("localhost:0", "localhost:0"),
 		TracePort:          5003,
 		MetricsEnabled:     true,
 		TracesEnabled:      true,

--- a/comp/otelcol/otlp/collector_test_config_serverless.go
+++ b/comp/otelcol/otlp/collector_test_config_serverless.go
@@ -11,7 +11,8 @@ import "github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil"
 
 func getTestPipelineConfig() PipelineConfig {
 	return PipelineConfig{
-		OTLPReceiverConfig: testutil.OTLPConfigFromPorts("localhost", 4317, 4318),
+		// :0 picks a free port, avoiding flaky binds on the production default ports.
+		OTLPReceiverConfig: testutil.OTLPConfigFromEndpoints("localhost:0", "localhost:0"),
 		TracePort:          5003,
 		MetricsEnabled:     true,
 		TracesEnabled:      true,

--- a/comp/otelcol/otlp/testutil/testutil.go
+++ b/comp/otelcol/otlp/testutil/testutil.go
@@ -36,18 +36,32 @@ import (
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 )
 
-// OTLPConfigFromPorts creates a test OTLP config map.
+// OTLPConfigFromPorts creates a test OTLP config map. A 0-port disables its protocol.
 func OTLPConfigFromPorts(bindHost string, gRPCPort uint, httpPort uint) map[string]interface{} {
-	otlpConfig := map[string]interface{}{"protocols": map[string]interface{}{}}
-
+	var gRPCEndpoint, httpEndpoint string
 	if gRPCPort > 0 {
-		otlpConfig["protocols"].(map[string]interface{})["grpc"] = map[string]interface{}{
-			"endpoint": fmt.Sprintf("%s:%d", bindHost, gRPCPort),
-		}
+		gRPCEndpoint = fmt.Sprintf("%s:%d", bindHost, gRPCPort)
 	}
 	if httpPort > 0 {
+		httpEndpoint = fmt.Sprintf("%s:%d", bindHost, httpPort)
+	}
+	return OTLPConfigFromEndpoints(gRPCEndpoint, httpEndpoint)
+}
+
+// OTLPConfigFromEndpoints is like OTLPConfigFromPorts but takes full "host:port" endpoints
+// directly, so callers can pass a ":0" port to avoid flaky binds on a fixed port. An empty
+// endpoint disables its protocol.
+func OTLPConfigFromEndpoints(gRPCEndpoint string, httpEndpoint string) map[string]interface{} {
+	otlpConfig := map[string]interface{}{"protocols": map[string]interface{}{}}
+
+	if gRPCEndpoint != "" {
+		otlpConfig["protocols"].(map[string]interface{})["grpc"] = map[string]interface{}{
+			"endpoint": gRPCEndpoint,
+		}
+	}
+	if httpEndpoint != "" {
 		otlpConfig["protocols"].(map[string]interface{})["http"] = map[string]interface{}{
-			"endpoint": fmt.Sprintf("%s:%d", bindHost, httpPort),
+			"endpoint": httpEndpoint,
 		}
 	}
 	return otlpConfig


### PR DESCRIPTION
### What does this PR do?
Bind the OTLP receiver in `TestStartPipeline` to OS-assigned ports instead of the fixed **production** defaults (`4317`/`4318`).

Widen the `StateRunning` poll budget in `AssertSuccessfulRun` to match the 10-second pipeline `ctx` timeout the same function already accepts, instead of an optimistic 2 seconds.

Replace the `StateClosed` poll with a direct assertion, since `<-colDone` already happens after `Run` sets that state synchronously.

Use `t.Context()` instead of `context.Background()` in `AssertSuccessfulRun` and `AssertFailedRun`.

### Motivation
PR #55733 was kicked out of the merge queue twice by `TestStartPipeline`, see [1st try](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/2007323578) and [2nd try](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/2007440709):
```
Error:      	Condition never satisfied
Test:       	TestStartPipeline
--- FAIL: TestStartPipeline (2.21s)
```
Both jobs show the GRPC and HTTP servers binding successfully, then taking longer than the 2-second `assert.Eventually` budget to reach `StateRunning`, well inside the 10-second `ctx` timeout the same test already tolerates for the whole pipeline lifecycle.

CI Visibility shows a second, far more common failure mode for the same test: `listen tcp 127.0.0.1:4317: bind: address already in use`, present in 20 of the last 20 recorded failures, across unrelated branches and all 3 platforms, since it was first flagged flaky on 2026-07-31, per [Flaky Test Management](https://app.datadoghq.com/ci/test/flaky?query=fingerprint_fqn%3A9dc0cad9fb333d8b).

Both failure modes trace back to the same test binding real, fixed OTLP default ports and racing a real wall clock, so this fixes both instead of trading one flake for the other.

### Describe how you validated your changes
Ran `dda inv test --targets=./comp/otelcol/otlp`: 96/96 passing.

Ran `bazel run //internal/tools:gotestsum -- ... -race -run 'TestStartPipeline$' -count=20`: 20/20 passing, no races.

### Additional Notes
Tried wrapping the goroutine/clock synchronization in `testing/synctest` first, following the pattern from #55488: it panics with `select on synctest channel from outside bubble`, because starting a real listener pulls in runtime signal-handling machinery outside the bubble.
`synctest` only virtualizes bubble-native primitives (timers, channels, mutexes), not real syscalls, so it would involve more time I could afford in this iteration.