### PR TITLE
cmd/dogstatsd: add AAS inventory producer (SVLS-9604)

### DIFF
--- a/cmd/dogstatsd/aas/inventory/BUILD.bazel
+++ b/cmd/dogstatsd/aas/inventory/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+
+go_library(
+    name = "inventory",
+    srcs = ["inventory.go"],
+    importpath = "github.com/DataDog/datadog-agent/cmd/dogstatsd/aas/inventory",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/metadata/inventoryagent/def",
+        "//pkg/config/model",
+        "//pkg/trace/traceutil",
+        "@com_github_google_uuid//:uuid",
+    ],
+)
+
+dd_agent_go_test(
+    name = "inventory_test",
+    srcs = ["inventory_test.go"],
+    embed = [":inventory"],
+    deps = [
+        "//pkg/config/mock",
+        "//pkg/config/model",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/cmd/dogstatsd/aas/inventory/inventory.go
+++ b/cmd/dogstatsd/aas/inventory/inventory.go
@@ -1,0 +1,116 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package inventory wires the Azure App Service (.NET extension) dogstatsd.exe
+// process to the shared inventoryagent component so it can emit a serverless
+// inventory payload. All AAS-specific metadata derivation lives here; the
+// shared component stays generic.
+//
+// Temporary: the payload currently uses flavor "serverless-compat" so rows
+// land in the existing serverless_compat_agent REDAPL table for the sanity
+// test. Once serverless_extension_agent is created in dd-source and EPRW,
+// change aasInventoryFlavor to "serverless-extension".
+package inventory
+
+import (
+	"os"
+
+	"github.com/google/uuid"
+
+	inventoryagent "github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
+	configmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
+)
+
+// TODO(SVLS-9604): change to "serverless-extension" once serverless_extension_agent schema exists.
+const aasInventoryFlavor = "serverless-compat"
+
+const (
+	reportReasonStartup  = "startup"
+	reportReasonPeriodic = "periodic"
+
+	workloadTypeAzureAppService = "azure_app_service"
+	workloadTypeAzureFunction   = "azure_function"
+
+	// envInventoryEnabled gates AAS inventory reporting. Set to "1" in the
+	// Function App / Web App app settings to enable. Independent of the
+	// serverless-init gate so each producer rolls out separately.
+	envInventoryEnabled = "DD_SERVERLESS_AAS_EXTENSION_INVENTORY_ENABLED"
+)
+
+// IsEnabled reports whether AAS inventory reporting is active.
+func IsEnabled() bool {
+	return os.Getenv(envInventoryEnabled) == "1"
+}
+
+// NewCapabilities returns the inventoryagent Capabilities for dogstatsd running
+// inside the AAS extension: skip cross-process enrichment (no sibling agent
+// processes) and use a per-process UUID. Multiple workers sharing the same app
+// produce separate startup payloads but the REDAPL row deduplicates on
+// resource_id, so cardinality stays at one row per app.
+func NewCapabilities() *inventoryagent.Capabilities {
+	return inventoryagent.NewServerlessCapabilities(uuid.New().String())
+}
+
+// workloadType returns the downstream workload_type value for this AAS process.
+// Azure Function Apps set FUNCTIONS_WORKER_RUNTIME; plain Web Apps do not.
+func workloadType() string {
+	if _, ok := os.LookupEnv("FUNCTIONS_WORKER_RUNTIME"); ok {
+		return workloadTypeAzureFunction
+	}
+	return workloadTypeAzureAppService
+}
+
+// Inject sets the AAS-specific inventory fields on the shared inventoryagent
+// component. It is a no-op when IsEnabled() is false or when the Azure
+// resource ID cannot be derived (required REDAPL key; prevents a dangling row).
+//
+// Fields use unprefixed names (resource_id, workload_type, …) as required by
+// the EPRW decoder. agent_version_base and extension_version are omitted for
+// the temporary serverless-compat sanity test; add them when switching to
+// serverless-extension.
+func Inject(ia inventoryagent.Component, conf configmodel.Reader) {
+	if !IsEnabled() {
+		return
+	}
+
+	aasTags := traceutil.GetAppServicesTags()
+	resourceID := aasTags[traceutil.AASResourceID]
+	if resourceID == "" {
+		// Cannot form a valid REDAPL key; skip rather than emit a dangling row.
+		return
+	}
+
+	ia.Set("flavor", aasInventoryFlavor)
+	ia.Set("report_reason", reportReasonStartup)
+
+	ia.Set("resource_id", resourceID)
+	ia.Set("resource_name", os.Getenv("WEBSITE_SITE_NAME"))
+	ia.Set("workload_type", workloadType())
+
+	ia.Set("region", os.Getenv("REGION_NAME"))
+	ia.Set("azure_subscription_id", aasTags[traceutil.AASSubscriptionID])
+	ia.Set("azure_resource_group", aasTags[traceutil.AASResourceGroup])
+	ia.Set("runtime", aasTags[traceutil.AASRuntime])
+
+	ia.Set("dd_env", conf.GetString("env"))
+	ia.Set("dd_site", conf.GetString("site"))
+	ia.Set("dd_service", os.Getenv("DD_SERVICE"))
+	ia.Set("dd_version", os.Getenv("DD_VERSION"))
+}
+
+// Submit enqueues the inventory payload synchronously so it is delivered before
+// the metadata runner goroutine fires. After submission it switches
+// report_reason to "periodic" so subsequent runner cycles (~10 min) are tagged
+// correctly without another Inject call.
+//
+// It is a no-op when IsEnabled() is false.
+func Submit(ia inventoryagent.Component) {
+	if !IsEnabled() {
+		return
+	}
+	ia.Submit()
+	ia.Set("report_reason", reportReasonPeriodic)
+}

--- a/cmd/dogstatsd/aas/inventory/inventory_test.go
+++ b/cmd/dogstatsd/aas/inventory/inventory_test.go
@@ -1,0 +1,115 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package inventory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+// fakeComponent records Set calls and Submit invocations.
+type fakeComponent struct {
+	fields  map[string]interface{}
+	submits int
+}
+
+func newFake() *fakeComponent { return &fakeComponent{fields: map[string]interface{}{}} }
+
+func (f *fakeComponent) Set(name string, value interface{}) { f.fields[name] = value }
+func (f *fakeComponent) Get() map[string]interface{}        { return f.fields }
+func (f *fakeComponent) Submit()                            { f.submits++ }
+
+// aasEnv sets the minimum AAS environment variables needed to produce a valid
+// resource_id and cleans them up after the test.
+func aasEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("WEBSITE_SITE_NAME", "my-app")
+	t.Setenv("WEBSITE_OWNER_NAME", "sub-123+East US")
+	t.Setenv("WEBSITE_RESOURCE_GROUP", "my-rg")
+	t.Setenv("REGION_NAME", "East US")
+}
+
+func TestInjectGatedOff(t *testing.T) {
+	aasEnv(t)
+	conf := configmock.New(t)
+	ia := newFake()
+
+	Inject(ia, conf)
+
+	assert.Empty(t, ia.fields, "no fields must be set when gate is off")
+}
+
+func TestInjectSetsFieldsWebApp(t *testing.T) {
+	t.Setenv(envInventoryEnabled, "1")
+	aasEnv(t)
+	conf := configmock.New(t)
+	conf.Set("env", "staging", model.SourceAgentRuntime)
+	conf.Set("site", "datad0g.com", model.SourceAgentRuntime)
+	ia := newFake()
+
+	Inject(ia, conf)
+
+	assert.Equal(t, aasInventoryFlavor, ia.fields["flavor"])
+	assert.Equal(t, workloadTypeAzureAppService, ia.fields["workload_type"])
+	assert.Equal(t, reportReasonStartup, ia.fields["report_reason"])
+	assert.Equal(t, "staging", ia.fields["dd_env"])
+	assert.Equal(t, "datad0g.com", ia.fields["dd_site"])
+	assert.NotEmpty(t, ia.fields["resource_id"])
+	assert.Equal(t, "my-app", ia.fields["resource_name"])
+	assert.Zero(t, ia.submits, "Inject must not call Submit")
+}
+
+func TestInjectSetsFunctionAppWorkloadType(t *testing.T) {
+	t.Setenv(envInventoryEnabled, "1")
+	t.Setenv("FUNCTIONS_WORKER_RUNTIME", "dotnet")
+	aasEnv(t)
+	conf := configmock.New(t)
+	ia := newFake()
+
+	Inject(ia, conf)
+
+	assert.Equal(t, workloadTypeAzureFunction, ia.fields["workload_type"])
+}
+
+func TestInjectSkipsWhenResourceIDEmpty(t *testing.T) {
+	t.Setenv(envInventoryEnabled, "1")
+	// No WEBSITE_SITE_NAME / WEBSITE_OWNER_NAME / WEBSITE_RESOURCE_GROUP →
+	// traceutil.GetAppServicesTags() returns an empty resource_id.
+	conf := configmock.New(t)
+	ia := newFake()
+
+	Inject(ia, conf)
+
+	assert.Empty(t, ia.fields, "must not set any fields when resource_id cannot be derived")
+}
+
+func TestSubmitGatedOff(t *testing.T) {
+	ia := newFake()
+	Submit(ia)
+	assert.Zero(t, ia.submits)
+}
+
+func TestSubmitEnqueuesAndSwitchesToPeriodic(t *testing.T) {
+	t.Setenv(envInventoryEnabled, "1")
+	ia := newFake()
+
+	Submit(ia)
+
+	assert.Equal(t, 1, ia.submits)
+	assert.Equal(t, reportReasonPeriodic, ia.fields["report_reason"],
+		"report_reason must be switched to periodic after Submit so the runner uses it")
+}
+
+func TestWorkloadTypeDetection(t *testing.T) {
+	assert.Equal(t, workloadTypeAzureAppService, workloadType())
+
+	t.Setenv("FUNCTIONS_WORKER_RUNTIME", "node")
+	assert.Equal(t, workloadTypeAzureFunction, workloadType())
+}

--- a/cmd/dogstatsd/subcommands/start/BUILD.bazel
+++ b/cmd/dogstatsd/subcommands/start/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//comp/haagent/fx",
         "//comp/metadata/host/def",
         "//comp/metadata/host/fx",
+        "//cmd/dogstatsd/aas/inventory",
         "//comp/metadata/inventoryagent/def",
         "//comp/metadata/inventoryagent/fx",
         "//comp/metadata/inventoryhost/def",

--- a/cmd/dogstatsd/subcommands/start/command.go
+++ b/cmd/dogstatsd/subcommands/start/command.go
@@ -14,13 +14,14 @@ import (
 	"os/signal"
 	"syscall"
 
-	delegatedauthfx "github.com/DataDog/datadog-agent/comp/core/delegatedauth/fx"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
+	aasinventory "github.com/DataDog/datadog-agent/cmd/dogstatsd/aas/inventory"
 	demultiplexer "github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/def"
 	demultiplexerimpl "github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/impl"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	delegatedauthfx "github.com/DataDog/datadog-agent/comp/core/delegatedauth/fx"
 	healthprobe "github.com/DataDog/datadog-agent/comp/core/healthprobe/def"
 	healthprobefx "github.com/DataDog/datadog-agent/comp/core/healthprobe/fx"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
@@ -50,7 +51,7 @@ import (
 	haagentfx "github.com/DataDog/datadog-agent/comp/haagent/fx"
 	host "github.com/DataDog/datadog-agent/comp/metadata/host/def"
 	hostfx "github.com/DataDog/datadog-agent/comp/metadata/host/fx"
-	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
+	inventoryagent "github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
 	inventoryagentfx "github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/fx"
 	inventoryhost "github.com/DataDog/datadog-agent/comp/metadata/inventoryhost/def"
 	inventoryhostfx "github.com/DataDog/datadog-agent/comp/metadata/inventoryhost/fx"
@@ -166,6 +167,12 @@ func RunDogstatsdFct(cliParams *CLIParams, defaultConfPath string, defaultLogFil
 		resourcesfx.Module(),
 		hostfx.Module(),
 		inventoryagentfx.Module(),
+		fx.Provide(func() *inventoryagent.Capabilities {
+			if os.Getenv("DD_AZURE_APP_SERVICES") == "1" {
+				return aasinventory.NewCapabilities()
+			}
+			return &inventoryagent.Capabilities{}
+		}),
 		ipcfx.ModuleReadWrite(),
 		// sysprobeconfig is optionally required by inventoryagent
 		sysprobeconfig.NoneModule(),
@@ -194,7 +201,7 @@ func start(
 	_ runner.Component,
 	_ resources.Component,
 	_ host.Component,
-	_ inventoryagent.Component,
+	inventoryAgent inventoryagent.Component,
 	_ inventoryhost.Component,
 	_ healthprobe.Component,
 ) error {
@@ -213,6 +220,11 @@ func start(
 	err := RunDogstatsd(ctx, cliParams, config, log, params, components, demultiplexer)
 	if err != nil {
 		return err
+	}
+
+	if aasinventory.IsEnabled() {
+		aasinventory.Inject(inventoryAgent, config)
+		aasinventory.Submit(inventoryAgent)
 	}
 
 	// Block here until we receive a stop signal


### PR DESCRIPTION
## What

Wires `dogstatsd.exe` (bundled in the AAS .NET extension) to the shared `inventoryagent` component so Azure App Service processes emit a row in the `serverless_compat_agent` REDAPL table on startup.

Stacked on #55528.

## New package: `cmd/dogstatsd/aas/inventory`

| Symbol | Purpose |
|---|---|
| `IsEnabled()` | Gates on `DD_SERVERLESS_AAS_EXTENSION_INVENTORY_ENABLED=1` |
| `NewCapabilities()` | Per-process UUID via `NewServerlessCapabilities` |
| `workloadType()` | Detects `azure_function` vs `azure_app_service` via `FUNCTIONS_WORKER_RUNTIME` |
| `Inject(ia, conf)` | Sets inventory fields from `traceutil.GetAppServicesTags()`; skips if `resource_id` is empty |
| `Submit(ia)` | Calls `ia.Submit()` then switches `report_reason` to `periodic` |

## Changes to `cmd/dogstatsd/subcommands/start/command.go`

- Adds `*inventoryagent.Capabilities` provider: uses `NewCapabilities()` when `DD_AZURE_APP_SERVICES=1`, zero-value otherwise (preserves standard host-agent behavior)
- Names the `inventoryAgent` parameter; calls `Inject` + `Submit` after `RunDogstatsd` when enabled

## Temporary constraint

`flavor=serverless-compat` routes to the existing `serverless_compat_agent` table for the sanity test. Change `aasInventoryFlavor` to `serverless-extension` once that schema is created in dd-source/EPRW.

## Testing

- 7 unit tests in `cmd/dogstatsd/aas/inventory/inventory_test.go` covering gate, field population, workload type detection, `resource_id` guard, and submit lifecycle
- Manual sanity test: replace `dogstatsd.exe` via Kudu with binary from `windows_zip_agent_binaries_x64-a7` CI artifact; set `DD_SERVERLESS_AAS_EXTENSION_INVENTORY_ENABLED=1`; verify row in `serverless_compat_agent` with expected `workload_type`