### PR TITLE
Validate same-site links against current build

### DIFF
--- a/.dda/extend/commands/run/docs/build/__init__.py
+++ b/.dda/extend/commands/run/docs/build/__init__.py
@@ -4,12 +4,13 @@ from typing import TYPE_CHECKING
 
 import click
 from dda.cli.base import dynamic_command, pass_app
+from utils.docs.deps import COMMAND_DEPENDENCIES
 
 if TYPE_CHECKING:
     from dda.cli.application import Application
 
 
-@dynamic_command(short_help="Build documentation")
+@dynamic_command(short_help="Build documentation", dependencies=COMMAND_DEPENDENCIES)
 @click.option("--check", is_flag=True, help="Ensure links are valid")
 @pass_app
 def cmd(app: Application, *, check: bool) -> None:

--- a/.dda/extend/commands/run/docs/check_links/__init__.py
+++ b/.dda/extend/commands/run/docs/check_links/__init__.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from dda.cli.base import dynamic_command, pass_app
+from utils.docs.deps import COMMAND_DEPENDENCIES
 
 if TYPE_CHECKING:
     from dda.cli.application import Application
 
 
-@dynamic_command(short_help="Check documentation links")
+@dynamic_command(short_help="Check documentation links", dependencies=COMMAND_DEPENDENCIES)
 @pass_app
 def cmd(app: Application) -> None:
     """

--- a/.dda/extend/pythonpath/utils/docs/deps.py
+++ b/.dda/extend/pythonpath/utils/docs/deps.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+COMMAND_DEPENDENCIES = ["pyyaml==6.0.1"]
+
 DEPENDENCIES = (
     "zensical~=0.0.50",
     # Fetching data

--- a/.dda/extend/pythonpath/utils/docs/links.py
+++ b/.dda/extend/pythonpath/utils/docs/links.py
@@ -1,6 +1,40 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
+from urllib.parse import urlsplit
+
+
+def _published_site_url(config_path: Path) -> str:
+    import yaml
+
+    # BaseLoader leaves Zensical's custom Python tags inert while reading the scalar site URL.
+    config = yaml.load(config_path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    site_url = config.get("site_url") if isinstance(config, dict) else None
+    if not isinstance(site_url, str):
+        raise ValueError(f"`site_url` must be an absolute HTTP(S) base URL in `{config_path}`")
+
+    site_url = site_url.strip()
+    parsed_url = urlsplit(site_url)
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc or parsed_url.query or parsed_url.fragment:
+        raise ValueError(f"`site_url` must be an absolute HTTP(S) base URL in `{config_path}`")
+
+    return f"{site_url.rstrip('/')}/"
+
+
+def _lychee_command(site_dir: Path, config_path: Path = Path("mkdocs.yml")) -> list[str]:
+    # Validate published-site URLs against this build so newly added pages do not depend on an
+    # earlier deployment.
+    local_site_url = f"{site_dir.resolve().as_uri()}/"
+    published_site_pattern = f"^{re.escape(_published_site_url(config_path))}"
+    return [
+        "lychee",
+        "--config",
+        ".lychee.toml",
+        "--remap",
+        f"{published_site_pattern} {local_site_url}",
+        str(site_dir),
+    ]
 
 
 def check_links(app) -> None:
@@ -13,5 +47,4 @@ def check_links(app) -> None:
 
     # Isolated so that the checker never enters the environment the documentation is built with, and
     # never resolves to a `lychee` that happens to be installed elsewhere.
-    lychee_command = ["lychee", "--config", ".lychee.toml", str(site_dir)]
-    app.tools.uv.exit_with(["tool", "run", "--isolated", "--from", LINK_CHECKER, *lychee_command])
+    app.tools.uv.exit_with(["tool", "run", "--isolated", "--from", LINK_CHECKER, *_lychee_command(site_dir)])

--- a/tasks/unit_tests/docs_links_tests.py
+++ b/tasks/unit_tests/docs_links_tests.py
@@ -1,0 +1,62 @@
+import importlib.util
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_links():
+    """Load the documentation link utilities without depending on the DDA extension path."""
+    path = ROOT / ".dda" / "extend" / "pythonpath" / "utils" / "docs" / "links.py"
+    spec = importlib.util.spec_from_file_location("docs_links", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+links = load_links()
+
+
+class TestLycheeCommand(unittest.TestCase):
+    def test_published_site_urls_are_mapped_to_the_local_build(self):
+        with tempfile.TemporaryDirectory() as directory:
+            site_dir = Path(directory, "site with spaces")
+            config_path = Path(directory, "mkdocs.yml")
+            config_path.write_text(
+                """site_url: https://example.test/docs
+slugify: !!python/object/apply:module.function
+  kwds:
+    case: lower
+""",
+                encoding="utf-8",
+            )
+            command = links._lychee_command(site_dir, config_path)
+            remap = command[command.index("--remap") + 1]
+            pattern, replacement = remap.split(" ", 1)
+
+            published_page = "https://example.test/docs/how-to/test/e2e/running/"
+            expected_page = f"{site_dir.resolve().as_uri()}/how-to/test/e2e/running/"
+            self.assertEqual(re.sub(pattern, replacement, published_page), expected_page)
+            self.assertEqual(command[-1], str(site_dir))
+
+    def test_missing_site_url_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config_path = Path(directory, "mkdocs.yml")
+            config_path.write_text("site_name: Documentation\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "`site_url` must be an absolute HTTP\\(S\\) base URL"):
+                links._published_site_url(config_path)
+
+    def test_site_url_with_a_fragment_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config_path = Path(directory, "mkdocs.yml")
+            config_path.write_text("site_url: https://example.test/docs/#fragment\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "`site_url` must be an absolute HTTP\\(S\\) base URL"):
+                links._published_site_url(config_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What does this PR do?

The documentation link check now resolves URLs beneath the configured `site_url` against the documentation built in the current job, rather than against the deployed site.

### Motivation

PR #55446 added four documentation pages whose generated canonical and sitemap URLs did not exist on the deployed site yet. The link check therefore received 404 responses and blocked the publication step that would have made those URLs available.

### Describe how you validated your changes

<details>
<summary><code>dda run docs build</code></summary>

```text
Syncing dependencies
Build started
No issues found
Build finished in 3.81s
```

</details>

<details>
<summary><code>dda run docs check-links</code></summary>

```text
🔍 7422 Total (in 1s 12ms) 🔗 963 Unique ✅ 7158 OK 🚫 0 Errors 👻 179 Excluded ⛔ 85 Unsupported
```

</details>

<details>
<summary><code>dda inv invoke-unit-tests.run --tests="docs_links,docs_repo_links" --directory=tasks/unit_tests</code></summary>

```text
Synchronizing dependencies
...
----------------------------------------------------------------------
Ran 3 tests in 0.028s

OK
................................
----------------------------------------------------------------------
Ran 32 tests in 0.097s

OK
Running tests from module docs_links_tests
Running tests from module docs_repo_links_tests
```

</details>

<details>
<summary>Focused Ruff formatting and lint checks</summary>

```text
5 files already formatted
All checks passed!
```

</details>

<details>
<summary>Missing generated page probe</summary>

The generated `site/how-to/test/e2e/running/index.html` page was temporarily moved aside and restored after the check.

```text
Issues found in 69 inputs. Find details below.

[site\sitemap.xml]:
[ERROR] file:///.../site/how-to/test/e2e/running/ | Cannot find index file within directory: An index file (index.html) is required | Remaps: https://datadoghq.dev/datadog-agent/how-to/test/e2e/running/ --> file:///.../site/how-to/test/e2e/running/

🔍 7325 Total (in 1s 1ms) 🔗 958 Unique ✅ 6988 OK 🚫 75 Errors 👻 177 Excluded ⛔ 85 Unsupported
Checker exit code: 2
```

</details>

### Additional Notes

Same-site pages and anchor fragments continue to be validated by Lychee, while links to external sites continue to be checked over the network.
