### PR TITLE
Remove no bazel arg to fix AIX build

### DIFF
--- a/packaging/aix/stages/04-agent.sh
+++ b/packaging/aix/stages/04-agent.sh
@@ -112,7 +112,6 @@ rm -f "$STAGING/opt/datadog-agent/bin/agent/agent-bin"
 # needed globally (env.sh) for tools like ar that don't respect AIX_OBJECT_MODE.
 unset OBJECT_MODE
 python3.12 -m invoke agent.build \
-    --no-enable-bazel \
     --exclude-rtloader \
     --rtloader-root="$AGENT_SRC/rtloader" \
     --embedded-path="$EMBEDDED_DESTDIR" \


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Remove `--no-enable-bazel` from the agent.build invoke task call.

### Motivation
This flag doesn't exist anymore since https://github.com/DataDog/datadog-agent/pull/55378 so the command fails.

### Describe how you validated your changes
Checked on AIX.

### Additional Notes
