### PR TITLE
Add orchestrion-instrumented flaky test CI job

### DIFF
--- a/.gitlab/test/e2e/e2e_devx.yml
+++ b/.gitlab/test/e2e/e2e_devx.yml
@@ -27,6 +27,44 @@ go_e2e_test_binaries:
     - !reference [.except_mergequeue]
     - when: on_success
 
+# Runs a single, deliberately flaky test (fails ~50% of the time) with orchestrion,
+# to exercise orchestrion-instrumented `go test` runs (CI Visibility, flaky detection).
+# The test binary is not pre-built: the job runs `orchestrion go test` directly.
+new-e2e-orchestrion-flaky-test:
+  stage: source_test
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  tags: ["arch:amd64", "specific:true"]
+  needs:
+    - go_e2e_deps
+  rules:
+    - !reference [.except_disable_unit_tests]
+    - !reference [.except_mergequeue]
+    - when: on_success
+  # The test is expected to fail about half of the time: don't retry it (the
+  # default job retry would skew the failure rate) and never gate merges on it.
+  retry: 0
+  allow_failure: true
+  variables:
+    KUBERNETES_CPU_REQUEST: 2
+    KUBERNETES_MEMORY_REQUEST: 4Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+  before_script:
+    - !reference [.retrieve_linux_go_e2e_deps]
+  script:
+    - pushd test/new-e2e
+    - go install github.com/DataDog/orchestrion
+    # Make sure the go install directory is on the PATH for the orchestrion binary
+    - go_bin="$(go env GOBIN)"; [ -n "$go_bin" ] || go_bin="$(go env GOPATH)/bin"; export PATH="$PATH:$go_bin"
+    # Same orchestrion/CI Visibility configuration as the E2E tests (see .new_e2e_template)
+    - export DD_ENV=nativetest
+    - export DD_CIVISIBILITY_ENABLED=true
+    - export DD_CIVISIBILITY_AGENTLESS_ENABLED=true
+    - export DD_CIVISIBILITY_FLAKY_RETRY_ENABLED=false
+    - export DD_TAGS="gitlab.pipeline_source:${CI_PIPELINE_SOURCE}"
+    - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
+    - orchestrion go test -count=1 -run '^TestRandomFailure$' ./flakytest
+    - popd
+
 new-e2e-base-coverage:
   extends: .new_e2e_template
   needs:

--- a/test/new-e2e/flakytest/flaky_test.go
+++ b/test/new-e2e/flakytest/flaky_test.go
@@ -13,9 +13,20 @@ import (
 	"testing"
 )
 
-// TestRandomFailure fails approximately 50% of the time on purpose.
+// TestRandomFailure fails approximately 50% of the time on purpose. Each of
+// its subtests also fails approximately 50% of the time, independently.
 func TestRandomFailure(t *testing.T) {
+	// t.Error rather than t.Fatal so the subtests below still run when the
+	// parent test fails.
 	if rand.Intn(2) == 0 {
-		t.Fatal("unlucky coin flip: this test fails about half of the time on purpose")
+		t.Error("unlucky coin flip: this test fails about half of the time on purpose")
+	}
+
+	for _, name := range []string{"subtest_1", "subtest_2", "subtest_3"} {
+		t.Run(name, func(t *testing.T) {
+			if rand.Intn(2) == 0 {
+				t.Fatal("unlucky coin flip: this subtest fails about half of the time on purpose")
+			}
+		})
 	}
 }

--- a/test/new-e2e/flakytest/flaky_test.go
+++ b/test/new-e2e/flakytest/flaky_test.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package flakytest holds a single test that fails about half of the time it
+// runs. It is only used by the new-e2e-orchestrion-flaky-test CI job to exercise
+// orchestrion-instrumented `go test` runs (CI Visibility, flaky test detection).
+package flakytest
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// TestRandomFailure fails approximately 50% of the time on purpose.
+func TestRandomFailure(t *testing.T) {
+	if rand.Intn(2) == 0 {
+		t.Fatal("unlucky coin flip: this test fails about half of the time on purpose")
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds a new very simple CI job, `new-e2e-orchestrion-flaky-test`, that runs a single go test failing ~50% of the time on purpose, built and executed with orchestrion:

- **The test** lives in `test/new-e2e/flakytest/flaky_test.go`, inside the new-e2e module so it reuses the orchestrion setup of the E2E tests (`orchestrion.tool.go` and the `orchestrion` / `dd-trace-go` go.mod dependencies). `TestRandomFailure` flips a coin and fails half of the time; it also has three subtests (`subtest_1`, `subtest_2`, `subtest_3`) that each fail ~50% of the time independently, so subtest-level results are exercised too. The parent uses `t.Error` rather than `t.Fatal` so the subtests always run.
- **The job** installs orchestrion the same way `go_e2e_test_binaries` does, then executes the test directly with `orchestrion go test` (no pre-built binary, so it does not need `go_e2e_test_binaries`), passing the same CI Visibility configuration as the E2E tests (`.new_e2e_template`): `DD_CIVISIBILITY_ENABLED=true`, agentless mode, flaky retry disabled, `DD_ENV`, `DD_TAGS`, `DD_API_KEY`.
- The job runs with `retry: 0` and `allow_failure: true` so its random failures do not gate merges.

## Notes for reviewers

- Draft PR: this is an experiment to exercise orchestrion-instrumented test runs (flaky detection / quarantine). Feel free to flag if the job should not run by default (`allow_failure` can be flipped, or the job can be made manual).