### PR TITLE
Fix codeowners for telemetry components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -484,8 +484,8 @@
 /comp/forwarder/eventplatform/impl/pipelines_softwareinventory.go @DataDog/windows-products
 
 # ebpf-platform also owns the stat wrappers in telemetry (previously pkg/telemetry/stat_*_wrapper.go)
-/comp/core/telemetry/def/stat_gauge_wrapper.go   @DataDog/agent-runtimes @DataDog/ebpf-platform
-/comp/core/telemetry/def/stat_counter_wrapper.go @DataDog/agent-runtimes @DataDog/ebpf-platform
+/comp/core/telemetry/def/stat_gauge_wrapper.go   @DataDog/fleet-remediation @DataDog/ebpf-platform
+/comp/core/telemetry/def/stat_counter_wrapper.go @DataDog/fleet-remediation @DataDog/ebpf-platform
 
 # trace-agent logging implementation should also notify agent-apm
 /comp/core/log/impl-trace @DataDog/agent-apm

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -398,6 +398,7 @@
 /comp/checks/agentcrashdetect @DataDog/windows-products
 /comp/checks/windowseventlog @DataDog/windows-products
 /comp/checks/winregistry @DataDog/windows-products
+/comp/core/agenttelemetry @DataDog/fleet-remediation
 /comp/core/autodiscovery @DataDog/container-platform
 /comp/core/config @DataDog/fleet-automation
 /comp/core/configfilesdiscovery @DataDog/agent-discovery
@@ -415,6 +416,7 @@
 /comp/core/status @DataDog/fleet-remediation
 /comp/core/sysprobeconfig @DataDog/ebpf-platform
 /comp/core/tagger @DataDog/container-platform
+/comp/core/telemetry @DataDog/fleet-remediation
 /comp/core/workloadfilter @DataDog/container-platform
 /comp/core/workloadmeta @DataDog/container-platform
 /comp/forwarder/connectionsforwarder @DataDog/container-experiences
@@ -480,8 +482,6 @@
 /comp/forwarder/eventplatform/impl/pipelines_dataobservability.go @DataDog/data-observability
 /comp/forwarder/eventplatform/impl/pipelines_datasecurity.go      @DataDog/sensitive-data-scanner
 /comp/forwarder/eventplatform/impl/pipelines_softwareinventory.go @DataDog/windows-products
-
-/comp/core/agenttelemetry @DataDog/fleet-remediation
 
 # ebpf-platform also owns the stat wrappers in telemetry (previously pkg/telemetry/stat_*_wrapper.go)
 /comp/core/telemetry/def/stat_gauge_wrapper.go   @DataDog/agent-runtimes @DataDog/ebpf-platform
@@ -612,6 +612,7 @@
 /pkg/collector/corechecks/system/winproc/                             @DataDog/windows-products
 /pkg/collector/corechecks/systemd/                                    @DataDog/agent-integrations
 /pkg/collector/corechecks/nvidia/                                     @DataDog/agent-runtimes
+/pkg/collector/corechecks/telemetry                                   @DataDog/fleet-remediation
 /pkg/config/                                                          @DataDog/fleet-automation
 /pkg/config/settings/runtime_setting_profiling_period*.go             @DataDog/agent-runtimes
 /pkg/config/example/application_monitoring.yaml.example               @DataDog/agent-apm

--- a/comp/README.md
+++ b/comp/README.md
@@ -105,6 +105,8 @@ agent flavors and binaries.
 
 ### [comp/core/agenttelemetry](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/core/agenttelemetry)
 
+*Datadog Team*: fleet-remediation
+
 Package agenttelemetry implements a component to generate Agent telemetry
 
 ### [comp/core/autodiscovery](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/core/autodiscovery)
@@ -257,6 +259,8 @@ component temporarily wraps pkg/config.
 Package tagger provides the tagger interface for the Datadog Agent
 
 ### [comp/core/telemetry](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/core/telemetry)
+
+*Datadog Team*: fleet-remediation
 
 Package telemetry defines the interfaces for the telemetry component.
 

--- a/comp/core/agenttelemetry/def/component.go
+++ b/comp/core/agenttelemetry/def/component.go
@@ -13,7 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log/errortracking"
 )
 
-// team: agent-runtimes
+// team: fleet-remediation
 
 // Component is the component type
 type Component interface {

--- a/comp/core/telemetry/def/component.go
+++ b/comp/core/telemetry/def/component.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 )
 
-// team: agent-runtimes
+// team: fleet-remediation
 
 // Component is the component type.
 type Component interface {


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Update codeowners for the agent's internal telemetry pieces to fleet-remediation.

### Motivation
Correct ownership.

### Describe how you validated your changes

### Additional Notes
