### PR TITLE
Move telemetry ownership to fleet-remediation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -482,10 +482,11 @@
 /comp/forwarder/eventplatform/impl/pipelines_softwareinventory.go @DataDog/windows-products
 
 /comp/core/agenttelemetry @DataDog/fleet-remediation
+/comp/core/telemetry @DataDog/fleet-remediation
 
 # ebpf-platform also owns the stat wrappers in telemetry (previously pkg/telemetry/stat_*_wrapper.go)
-/comp/core/telemetry/def/stat_gauge_wrapper.go   @DataDog/agent-runtimes @DataDog/ebpf-platform
-/comp/core/telemetry/def/stat_counter_wrapper.go @DataDog/agent-runtimes @DataDog/ebpf-platform
+/comp/core/telemetry/def/stat_gauge_wrapper.go   @DataDog/fleet-remediation @DataDog/ebpf-platform
+/comp/core/telemetry/def/stat_counter_wrapper.go @DataDog/fleet-remediation @DataDog/ebpf-platform
 
 # trace-agent logging implementation should also notify agent-apm
 /comp/core/log/impl-trace @DataDog/agent-apm
@@ -612,6 +613,7 @@
 /pkg/collector/corechecks/system/winproc/                             @DataDog/windows-products
 /pkg/collector/corechecks/systemd/                                    @DataDog/agent-integrations
 /pkg/collector/corechecks/nvidia/                                     @DataDog/agent-runtimes
+/pkg/collector/corechecks/telemetry                                   @DataDog/fleet-remediation
 /pkg/config/                                                          @DataDog/fleet-automation
 /pkg/config/settings/runtime_setting_profiling_period*.go             @DataDog/agent-runtimes
 /pkg/config/example/application_monitoring.yaml.example               @DataDog/agent-apm


### PR DESCRIPTION
## Summary
- Move CODEOWNERS entries for `comp/core/telemetry` and `pkg/collector/corechecks/telemetry` to `@DataDog/fleet-remediation`, aligning with the existing `comp/core/agenttelemetry` ownership.
- Update the `stat_gauge_wrapper.go` / `stat_counter_wrapper.go` overrides from `agent-runtimes` to `fleet-remediation`, keeping the `ebpf-platform` co-ownership.

## Test plan
- [x] `dda inv github.lint-codeowner` passes
- [x] Verified path resolution with `dda inv owners.find-codeowners` for affected files