### PR TITLE
[procmgr] Config gates for processes.d auto-start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,7 @@ dependencies = [
  "libc",
  "log",
  "nix",
+ "saphyr-parser",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -24,6 +24,7 @@ _LIB_DEPS = [
     "@crates//:serde",
     "@crates//:serde_json",
     "@crates//:serde_yaml",
+    "@crates//:saphyr-parser",
     "@crates//:tokio",
     "@crates//:tokio-stream",
     "@crates//:tonic",

--- a/pkg/procmgr/rust/Cargo.toml
+++ b/pkg/procmgr/rust/Cargo.toml
@@ -28,6 +28,7 @@ log.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml.workspace = true
+saphyr-parser.workspace = true
 dd-agent-log.workspace = true
 dd-procmgr-client.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "process", "fs", "time", "sync"] }

--- a/pkg/procmgr/rust/src/config.rs
+++ b/pkg/procmgr/rust/src/config.rs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+use crate::config_gate::ConditionConfigFile;
 use crate::platform;
 use anyhow::{Context, Result};
 use log::{debug, info, warn};
@@ -193,6 +194,8 @@ pub struct ProcessConfig {
     #[serde(default = "default_true")]
     pub auto_start: bool,
     pub condition_path_exists: Option<String>,
+    #[serde(default)]
+    pub condition_config_any: Vec<ConditionConfigFile>,
     pub stop_timeout: Option<u64>,
     #[serde(default = "default_restart")]
     pub restart: RestartPolicy,
@@ -228,6 +231,7 @@ impl Default for ProcessConfig {
             stderr: "inherit".to_string(),
             auto_start: true,
             condition_path_exists: None,
+            condition_config_any: Vec::new(),
             stop_timeout: None,
             restart: RestartPolicy::Never,
             restart_sec: None,
@@ -482,6 +486,34 @@ condition_path_exists: /usr/bin/sleep
         let result = load_configs(dir.path());
         fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_process_agent_config_gate_parsing() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = r#"
+command: /bin/process-agent
+auto_start: true
+condition_config_any:
+  - path: /etc/datadog-agent/datadog.yaml
+    keys:
+      - process_config.enabled
+      - process_config.process_collection.enabled
+  - path: /etc/datadog-agent/system-probe.yaml
+    keys:
+      - network_config.enabled
+"#;
+        fs::write(dir.path().join("proc.yaml"), yaml).unwrap();
+        let configs = load_configs(dir.path()).unwrap();
+        assert_eq!(configs.len(), 1);
+        assert_eq!(configs[0].config.condition_config_any.len(), 2);
+        assert_eq!(
+            configs[0].config.condition_config_any[0].keys,
+            vec![
+                "process_config.enabled".to_string(),
+                "process_config.process_collection.enabled".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/pkg/procmgr/rust/src/config_gate.rs
+++ b/pkg/procmgr/rust/src/config_gate.rs
@@ -1,0 +1,2917 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//! Optional `condition_config_any` gates for processes.d definitions.
+//!
+//! Mirrors the Windows legacy SCM startup checks in
+//! `cmd/agent/subcommands/run/dependent_services_windows.go`: start only when any
+//! configured key evaluates to true. Resolution order matches agent config
+//! (`pkg/config/model/types.go`): agent-runtime transforms, then fleet policy,
+//! environment variables, explicit base YAML, infra-mode, then agent default.
+//!
+//! When deprecated `process_config.enabled` is set in file or env, collection keys
+//! follow `loadProcessTransforms` in `pkg/config/setup/process.go`: the deprecated
+//! key fills only replacement settings that were not already set (file/env), then
+//! normalizes `process_config.enabled` to the resulting process-collection value.
+//! The transform runs in `LoadDatadog` before `MergeFleetPolicy`, so fleet-only
+//! `process_config.enabled` does not rewrite collection keys, and a transform
+//! write (`SourceAgentRuntime`) outranks a later fleet policy.
+//!
+//! `infrastructure_mode: end_user_device` enables process collection at
+//! `SourceInfraMode` (`applyInfrastructureModeOverrides`). That applies only when
+//! the key was not set via fleet, env, or file, and was not filled by the legacy
+//! transform.
+//!
+//! Derived `system_probe_config.enabled` (module knobs) is implemented in
+//! [`system_probe`] and must stay in sync with `pkg/system-probe/config/config.go`.
+//! Env bindings are centralized in [`env_bindings`].
+
+mod env_bindings;
+mod system_probe;
+mod yaml_load;
+
+use env_bindings::{env_bool_for_config_key, env_configured_for_key, env_string_for_config_key};
+
+use crate::env::expand_env_vars;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::path::Path;
+
+/// A YAML file and dotted config keys; any key set to true satisfies the gate.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ConditionConfigFile {
+    pub path: String,
+    #[serde(default)]
+    pub keys: Vec<String>,
+}
+
+struct GatedKeySpec {
+    key: &'static str,
+    default: bool,
+    /// Basename under `fleet_policies_dir` when fleet policy overrides apply.
+    fleet_policy_file: Option<&'static str>,
+}
+
+/// Single source of truth for gated keys (mirrors `pkg/config/setup/process_settings.go`
+/// and `pkg/config/setup/system_probe.go`).
+const GATED_KEY_SPECS: &[GatedKeySpec] = &[
+    GatedKeySpec {
+        key: "process_config.enabled",
+        default: false,
+        fleet_policy_file: Some("datadog.yaml"),
+    },
+    GatedKeySpec {
+        key: "process_config.process_collection.enabled",
+        default: false,
+        fleet_policy_file: Some("datadog.yaml"),
+    },
+    GatedKeySpec {
+        key: "process_config.container_collection.enabled",
+        default: true,
+        fleet_policy_file: Some("datadog.yaml"),
+    },
+    GatedKeySpec {
+        key: "process_config.process_discovery.enabled",
+        default: true,
+        fleet_policy_file: Some("datadog.yaml"),
+    },
+    GatedKeySpec {
+        key: "network_config.enabled",
+        default: false,
+        fleet_policy_file: Some("system-probe.yaml"),
+    },
+    GatedKeySpec {
+        key: "system_probe_config.enabled",
+        default: false,
+        fleet_policy_file: Some("system-probe.yaml"),
+    },
+];
+
+/// Legacy `process_config.enabled` values after `loadProcessTransforms`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProcessEnabledMode {
+    Disabled,
+    ProcessesOnly,
+    ContainersOnly,
+}
+
+impl ProcessEnabledMode {
+    fn process_collection(self) -> bool {
+        matches!(self, Self::ProcessesOnly)
+    }
+
+    fn container_collection(self) -> bool {
+        matches!(self, Self::ContainersOnly)
+    }
+}
+
+const LEGACY_PROCESS_ENABLED_KEY: &str = "process_config.enabled";
+
+impl GatedKeySpec {
+    /// Resolution order (most keys): legacy `process_config.enabled` transform
+    /// (collection keys not already set in file/env; AgentRuntime, so it outranks
+    /// fleet) → fleet policy → env → base YAML → infra-mode (`end_user_device`
+    /// enables process collection from pre-fleet env/base only) → agent default.
+    ///
+    /// `system_probe_config.enabled` is special: returns [`system_probe::derived_enabled`] only,
+    /// mirroring post-`load()`/`Adjust` `GetBool` (module-derived runtime value).
+    ///
+    /// When the transform runs, `process_config.enabled` is rewritten to the
+    /// resulting process-collection value. Fleet-only `process_config.enabled`
+    /// does not run the transform. Fleet policy outranks env vars
+    /// (`SourceFleetPolicies` > `SourceEnvVar`) for keys the transform did not write.
+    fn enabled(&self, base_path: &str, yaml: &mut YamlCache) -> anyhow::Result<bool> {
+        if let Some(enabled) = self.legacy_collection_override(base_path, yaml)? {
+            return Ok(enabled);
+        }
+        if let Some(enabled) = self.legacy_enabled_normalized(base_path, yaml)? {
+            return Ok(enabled);
+        }
+        if self.key == "system_probe_config.enabled" {
+            // Mirrors sysprobeConf.GetBool("system_probe_config.enabled") after load()+Adjust:
+            // runtime enabled is module-derived, not the literal YAML/env knob alone.
+            return system_probe::derived_enabled(base_path, yaml);
+        }
+        if let Some(enabled) = self.fleet_policy_value(base_path, yaml)? {
+            return Ok(enabled);
+        }
+        if let Some(enabled) = self.env_override() {
+            return Ok(enabled);
+        }
+        if let Some(enabled) = yaml.bool_key_if_exists(base_path, self.key)? {
+            return Ok(enabled);
+        }
+        if self.infra_mode_process_collection_override(base_path, yaml)? {
+            Ok(true)
+        } else {
+            Ok(self.default)
+        }
+    }
+
+    fn uses_legacy_process_enabled(&self) -> bool {
+        matches!(
+            self.key,
+            "process_config.process_collection.enabled"
+                | "process_config.container_collection.enabled"
+        )
+    }
+
+    fn legacy_collection_override(
+        &self,
+        base_path: &str,
+        yaml: &mut YamlCache,
+    ) -> anyhow::Result<Option<bool>> {
+        if !self.uses_legacy_process_enabled() {
+            return Ok(None);
+        }
+        let Some(mode) = resolve_legacy_process_enabled_mode(base_path, yaml)? else {
+            return Ok(None);
+        };
+        // User file/env wins; do not count fleet (transform runs before MergeFleetPolicy).
+        if transform_time_user_configured(yaml, base_path, self.key)? {
+            return Ok(None);
+        }
+        let enabled = match self.key {
+            "process_config.process_collection.enabled" => mode.process_collection(),
+            "process_config.container_collection.enabled" => mode.container_collection(),
+            _ => unreachable!(),
+        };
+        Ok(Some(enabled))
+    }
+
+    /// After `loadProcessTransforms`, `process_config.enabled` matches process collection.
+    ///
+    /// Uses the pre-fleet process-collection value (file/env or the transform fill).
+    fn legacy_enabled_normalized(
+        &self,
+        base_path: &str,
+        yaml: &mut YamlCache,
+    ) -> anyhow::Result<Option<bool>> {
+        if self.key != LEGACY_PROCESS_ENABLED_KEY {
+            return Ok(None);
+        }
+        let Some(mode) = resolve_legacy_process_enabled_mode(base_path, yaml)? else {
+            return Ok(None);
+        };
+        let process_collection =
+            transform_time_bool(yaml, base_path, "process_config.process_collection.enabled")?
+                .unwrap_or(mode.process_collection());
+        Ok(Some(process_collection))
+    }
+
+    /// `applyInfrastructureModeOverrides`: `end_user_device` enables process collection
+    /// at `SourceInfraMode` (above default, below file/env).
+    ///
+    /// Runs in `LoadDatadog` before `MergeFleetPolicy` and is not re-run after fleet
+    /// merge (unlike ADP overrides), so `infrastructure_mode` is read from env/base
+    /// YAML only.
+    fn infra_mode_process_collection_override(
+        &self,
+        base_path: &str,
+        yaml: &mut YamlCache,
+    ) -> anyhow::Result<bool> {
+        if self.key != "process_config.process_collection.enabled" {
+            return Ok(false);
+        }
+        Ok(yaml
+            .resolve_string_pre_fleet(base_path, "infrastructure_mode")?
+            .is_some_and(|mode| mode == "end_user_device"))
+    }
+
+    fn fleet_policy_value(
+        &self,
+        base_path: &str,
+        yaml: &mut YamlCache,
+    ) -> anyhow::Result<Option<bool>> {
+        let Some(filename) = self.fleet_policy_file else {
+            return Ok(None);
+        };
+        let Some(path) = yaml.fleet_policy_path(filename, base_path)? else {
+            return Ok(None);
+        };
+        yaml.bool_key_if_exists(&path, self.key)
+    }
+
+    fn env_override(&self) -> Option<bool> {
+        env_bool_for_config_key(self.key)
+    }
+}
+
+pub(super) struct YamlCache(HashMap<String, serde_yaml::Value>);
+
+impl YamlCache {
+    /// Mirrors system-probe/agent fleet policy loading: env → gated config file → registry/default.
+    ///
+    /// System-probe gates do not inherit `fleet_policies_dir` from sibling `datadog.yaml`
+    /// (matches `applyFleetPolicy` on the system-probe config object).
+    fn fleet_policies_dir(&mut self, config_path: &str) -> anyhow::Result<Option<String>> {
+        if let Some(dir) = env_bindings::env_var_value_for_name("DD_FLEET_POLICIES_DIR") {
+            return Ok(Some(dir));
+        }
+        if let Some(dir) = self.fleet_policies_dir_in_yaml(config_path)? {
+            return Ok(Some(dir));
+        }
+        #[cfg(windows)]
+        {
+            Ok(crate::platform::fleet_policies_dir_fallback()
+                .map(|path| path.to_string_lossy().into_owned()))
+        }
+        #[cfg(not(windows))]
+        {
+            Ok(None)
+        }
+    }
+
+    fn fleet_policies_dir_in_yaml(&mut self, config_path: &str) -> anyhow::Result<Option<String>> {
+        let Some(value) = self.dotted_key_if_exists(config_path, "fleet_policies_dir")? else {
+            return Ok(None);
+        };
+        Self::string_value(value)
+    }
+
+    fn fleet_policy_path(
+        &mut self,
+        filename: &str,
+        config_path: &str,
+    ) -> anyhow::Result<Option<String>> {
+        Ok(self.fleet_policies_dir(config_path)?.map(|dir| {
+            Path::new(&dir)
+                .join(filename)
+                .to_string_lossy()
+                .into_owned()
+        }))
+    }
+
+    /// Go `GetBool` parity for module derivation (malformed values → false).
+    pub(super) fn resolve_get_bool_with_default(
+        &mut self,
+        base_path: &str,
+        key: &str,
+        fleet_policy_file: Option<&str>,
+        default: bool,
+    ) -> anyhow::Result<bool> {
+        if let Some(filename) = fleet_policy_file
+            && let Some(path) = self.fleet_policy_path(filename, base_path)?
+            && self.dotted_key_if_exists(&path, key)?.is_some()
+        {
+            return self.get_bool_at(&path, key);
+        }
+        if env_configured_for_key(key) {
+            return Ok(env_bool_for_config_key(key).unwrap_or(false));
+        }
+        if self.dotted_key_if_exists(base_path, key)?.is_some() {
+            return self.get_bool_at(base_path, key);
+        }
+        Ok(default)
+    }
+
+    pub(super) fn resolve_get_bool(
+        &mut self,
+        base_path: &str,
+        key: &str,
+        fleet_policy_file: Option<&str>,
+    ) -> anyhow::Result<bool> {
+        self.resolve_get_bool_with_default(base_path, key, fleet_policy_file, false)
+    }
+
+    fn get_bool_at(&mut self, path: &str, key: &str) -> anyhow::Result<bool> {
+        Ok(match self.dotted_key_if_exists(path, key)? {
+            Some(value) => value_as_bool(value).unwrap_or(false),
+            None => false,
+        })
+    }
+
+    /// Env → base YAML (no fleet). Used where Go override funcs run before MergeFleetPolicy.
+    pub(super) fn resolve_string_pre_fleet(
+        &mut self,
+        base_path: &str,
+        key: &str,
+    ) -> anyhow::Result<Option<String>> {
+        if let Some(text) = env_string_for_config_key(key) {
+            return Ok(Some(text));
+        }
+        match self.dotted_key_if_exists(base_path, key)? {
+            Some(value) => Self::string_value(value),
+            None => Ok(None),
+        }
+    }
+
+    pub(super) fn resolve_string(
+        &mut self,
+        base_path: &str,
+        key: &str,
+        fleet_policy_file: Option<&str>,
+    ) -> anyhow::Result<Option<String>> {
+        if let Some(filename) = fleet_policy_file
+            && let Some(path) = self.fleet_policy_path(filename, base_path)?
+            && let Some(value) = self.dotted_key_if_exists(&path, key)?
+        {
+            return Self::string_value(value);
+        }
+        if let Some(text) = env_string_for_config_key(key) {
+            return Ok(Some(text));
+        }
+        match self.dotted_key_if_exists(base_path, key)? {
+            Some(value) => Self::string_value(value),
+            None => Ok(None),
+        }
+    }
+
+    /// Whether `key` is present in the base YAML file only (not fleet policy or env).
+    pub(super) fn key_in_yaml(&mut self, path: &str, key: &str) -> anyhow::Result<bool> {
+        Ok(self.dotted_key_if_exists(path, key)?.is_some())
+    }
+
+    /// Whether `key` is explicitly set via fleet policy, env, or base YAML.
+    ///
+    /// Mirrors Go `IsConfigured` for NPM back-compat (`adjust.go`).
+    pub(super) fn is_configured(
+        &mut self,
+        base_path: &str,
+        key: &str,
+        fleet_policy_file: Option<&str>,
+    ) -> anyhow::Result<bool> {
+        if env_configured_for_key(key) {
+            return Ok(true);
+        }
+        if let Some(filename) = fleet_policy_file
+            && let Some(path) = self.fleet_policy_path(filename, base_path)?
+            && self.dotted_key_if_exists(&path, key)?.is_some()
+        {
+            return Ok(true);
+        }
+        self.key_in_yaml(base_path, key)
+    }
+
+    fn string_value(value: &serde_yaml::Value) -> anyhow::Result<Option<String>> {
+        match value {
+            serde_yaml::Value::String(text) => Ok(Some(text.clone())),
+            serde_yaml::Value::Bool(_) | serde_yaml::Value::Number(_) => Ok(None),
+            _ => Ok(None),
+        }
+    }
+
+    fn load(&mut self, path: &str) -> anyhow::Result<&serde_yaml::Value> {
+        match self.0.entry(path.to_owned()) {
+            Entry::Occupied(entry) => Ok(entry.into_mut()),
+            Entry::Vacant(entry) => {
+                // Unreadable or invalid YAML: Agent `ReadInConfig` still initializes
+                // (`ErrConfigFileNotFound` wrap in `pkg/config/nodetreemodel/read_config_file.go`),
+                // then env and schema defaults apply. Cache an empty mapping so later keys
+                // on the same path do not retry or fail the gate.
+                let root = match std::fs::read_to_string(path) {
+                    Ok(contents) => match yaml_load::load_yaml(&contents) {
+                        Ok(root) => root,
+                        Err(err) => {
+                            log::warn!(
+                                "condition_config_any: parse {path}: {err:#}; using env and defaults"
+                            );
+                            serde_yaml::Value::Mapping(serde_yaml::Mapping::new())
+                        }
+                    },
+                    Err(err) => {
+                        log::warn!(
+                            "condition_config_any: read {path}: {err:#}; using env and defaults"
+                        );
+                        serde_yaml::Value::Mapping(serde_yaml::Mapping::new())
+                    }
+                };
+                Ok(entry.insert(root))
+            }
+        }
+    }
+
+    fn bool_key(&mut self, path: &str, key: &str) -> anyhow::Result<Option<bool>> {
+        let Some(value) = self.dotted_key(path, key)? else {
+            return Ok(None);
+        };
+        value_as_bool(value)
+            .ok_or_else(|| anyhow::anyhow!("key {key} is not a bool"))
+            .map(Some)
+    }
+
+    fn bool_key_if_exists(&mut self, path: &str, key: &str) -> anyhow::Result<Option<bool>> {
+        if !Path::new(path).is_file() {
+            return Ok(None);
+        }
+        self.bool_key(path, key)
+    }
+
+    fn dotted_key<'a>(
+        &'a mut self,
+        path: &str,
+        key: &str,
+    ) -> anyhow::Result<Option<&'a serde_yaml::Value>> {
+        Ok(lookup_dotted_key(self.load(path)?, key))
+    }
+
+    pub(super) fn dotted_key_if_exists<'a>(
+        &'a mut self,
+        path: &str,
+        key: &str,
+    ) -> anyhow::Result<Option<&'a serde_yaml::Value>> {
+        if !Path::new(path).is_file() {
+            return Ok(None);
+        }
+        self.dotted_key(path, key)
+    }
+
+    #[cfg(test)]
+    fn loaded_file_count(&self) -> usize {
+        self.0.len()
+    }
+}
+
+/// Returns true when `conditions` is empty or any `(path, key)` pair is enabled.
+pub fn condition_config_any_met(conditions: &[ConditionConfigFile]) -> bool {
+    if conditions.is_empty() {
+        return true;
+    }
+
+    let mut yaml = YamlCache(HashMap::new());
+    conditions.iter().any(|file| {
+        let path = expand_env_vars(&file.path);
+        file.keys.iter().any(|key| {
+            config_key_enabled(&path, key, &mut yaml).unwrap_or_else(|err| {
+                log::debug!("condition_config_any: {path} key {key}: {err:#}");
+                false
+            })
+        })
+    })
+}
+
+fn resolve_legacy_process_enabled_mode(
+    base_path: &str,
+    yaml: &mut YamlCache,
+) -> anyhow::Result<Option<ProcessEnabledMode>> {
+    // loadProcessTransforms runs in LoadDatadog before MergeFleetPolicy, so only
+    // env and the base YAML file participate.
+    if let Some(mode) = legacy_enabled_env_mode() {
+        return Ok(Some(mode));
+    }
+    legacy_enabled_mode_from_file(yaml, base_path)
+}
+
+/// File or env presence at transform time (`GetSource` > `SourceInfraMode`, before fleet).
+fn transform_time_user_configured(
+    yaml: &mut YamlCache,
+    base_path: &str,
+    key: &str,
+) -> anyhow::Result<bool> {
+    Ok(env_configured_for_key(key) || yaml.key_in_yaml(base_path, key)?)
+}
+
+fn transform_time_bool(
+    yaml: &mut YamlCache,
+    base_path: &str,
+    key: &str,
+) -> anyhow::Result<Option<bool>> {
+    if env_configured_for_key(key) {
+        Ok(env_bool_for_config_key(key))
+    } else if yaml.key_in_yaml(base_path, key)? {
+        yaml.bool_key_if_exists(base_path, key)
+    } else {
+        Ok(None)
+    }
+}
+
+fn legacy_enabled_mode_from_file(
+    yaml: &mut YamlCache,
+    path: &str,
+) -> anyhow::Result<Option<ProcessEnabledMode>> {
+    let Some(value) = yaml.dotted_key_if_exists(path, LEGACY_PROCESS_ENABLED_KEY)? else {
+        return Ok(None);
+    };
+    Ok(legacy_enabled_mode(value))
+}
+
+fn legacy_enabled_env_mode() -> Option<ProcessEnabledMode> {
+    env_string_for_config_key(LEGACY_PROCESS_ENABLED_KEY)
+        .map(|value| legacy_enabled_mode_from_string(&value))
+}
+
+fn legacy_enabled_mode(value: &serde_yaml::Value) -> Option<ProcessEnabledMode> {
+    legacy_enabled_scalar_as_string(value).map(|text| legacy_enabled_mode_from_string(&text))
+}
+
+/// Mirrors Go `GetString` for legacy `process_config.enabled` scalars (string, bool, number).
+fn legacy_enabled_scalar_as_string(value: &serde_yaml::Value) -> Option<String> {
+    match value {
+        serde_yaml::Value::String(text) => Some(text.clone()),
+        serde_yaml::Value::Bool(enabled) => Some(enabled.to_string()),
+        serde_yaml::Value::Number(number) => {
+            if let Some(value) = number.as_i64() {
+                return Some(value.to_string());
+            }
+            if let Some(value) = number.as_u64() {
+                return Some(value.to_string());
+            }
+            number.as_f64().map(|value| {
+                if value.fract() == 0.0 && value.is_finite() {
+                    format!("{}", value as i64)
+                } else {
+                    value.to_string()
+                }
+            })
+        }
+        _ => None,
+    }
+}
+
+fn legacy_enabled_mode_from_string(text: &str) -> ProcessEnabledMode {
+    // Mirror loadProcessTransforms: ToLower without trim; exact "disabled" match;
+    // ParseBool for the true branch; everything else is containers-only.
+    let lower = text.to_ascii_lowercase();
+    if lower == "disabled" {
+        ProcessEnabledMode::Disabled
+    } else if parse_agent_bool_string(&lower).unwrap_or(false) {
+        ProcessEnabledMode::ProcessesOnly
+    } else {
+        ProcessEnabledMode::ContainersOnly
+    }
+}
+
+fn config_key_enabled(path: &str, key: &str, yaml: &mut YamlCache) -> anyhow::Result<bool> {
+    GATED_KEY_SPECS
+        .iter()
+        .find(|spec| spec.key == key)
+        .ok_or_else(|| anyhow::anyhow!("unknown config key {key}"))?
+        .enabled(path, yaml)
+}
+
+fn lookup_mapping_case_insensitive<'a>(
+    mapping: &'a serde_yaml::Mapping,
+    key: &str,
+) -> Option<&'a serde_yaml::Value> {
+    if let Some(value) = mapping.get(key) {
+        return Some(value);
+    }
+    mapping.iter().find_map(|(k, v)| {
+        k.as_str()
+            .filter(|segment| segment.eq_ignore_ascii_case(key))
+            .map(|_| v)
+    })
+}
+
+fn lookup_dotted_key<'a>(root: &'a serde_yaml::Value, key: &str) -> Option<&'a serde_yaml::Value> {
+    lookup_dotted_key_in_mapping(root, key)
+}
+
+/// Whether a YAML node counts as an explicit config value for presence/`IsConfigured`.
+///
+/// Mirrors Agent `read_config_file.go`: known nil leaves (`setting_name:` with no value)
+/// are ignored and do not mark the key configured.
+fn yaml_value_is_set(value: &serde_yaml::Value) -> bool {
+    !matches!(value, serde_yaml::Value::Null)
+}
+
+/// Resolves a dotted config key in raw YAML, mirroring Agent flattened keys.
+///
+/// The Agent expands keys containing `.` into nested maps in
+/// `read_config_file.go`; serde_yaml preserves literal dotted keys. At each
+/// mapping, try the full remaining key before descending segment-by-segment.
+fn lookup_dotted_key_in_mapping<'a>(
+    current: &'a serde_yaml::Value,
+    key: &str,
+) -> Option<&'a serde_yaml::Value> {
+    let mapping = current.as_mapping()?;
+
+    if let Some(value) = lookup_mapping_case_insensitive(mapping, key) {
+        return yaml_value_is_set(value).then_some(value);
+    }
+
+    let (first, rest) = key.split_once('.')?;
+    let next = lookup_mapping_case_insensitive(mapping, first)?;
+    if !yaml_value_is_set(next) {
+        return None;
+    }
+    lookup_dotted_key_in_mapping(next, rest)
+}
+
+fn value_as_bool(value: &serde_yaml::Value) -> Option<bool> {
+    match value {
+        // Plain YAML 1.1 bools (`yes`/`on`/…) are coerced to bool at load time in [`yaml_load`].
+        serde_yaml::Value::Bool(enabled) => Some(*enabled),
+        // `cast.ToBoolE`: any non-zero number is true, including yaml.v2 floats such as `1.0`.
+        serde_yaml::Value::Number(number) => Some(number_as_bool(number)),
+        // Quoted scalars and env vars: `strconv.ParseBool` only.
+        serde_yaml::Value::String(text) => Some(parse_agent_bool_string(text).unwrap_or(false)),
+        _ => None,
+    }
+}
+
+fn number_as_bool(number: &serde_yaml::Number) -> bool {
+    if let Some(n) = number.as_i64() {
+        n != 0
+    } else if let Some(n) = number.as_u64() {
+        n != 0
+    } else if let Some(n) = number.as_f64() {
+        n != 0.0
+    } else {
+        false
+    }
+}
+
+/// Mirrors Go `strconv.ParseBool` for env var bindings.
+pub(super) fn parse_agent_bool_string(text: &str) -> Option<bool> {
+    match text {
+        "1" | "t" | "T" => Some(true),
+        "0" | "f" | "F" => Some(false),
+        _ if text.eq_ignore_ascii_case("true") => Some(true),
+        _ if text.eq_ignore_ascii_case("false") => Some(false),
+        _ => None,
+    }
+}
+
+/// Human-readable path for logs when a config gate blocks startup.
+pub fn condition_config_summary(conditions: &[ConditionConfigFile]) -> String {
+    conditions
+        .iter()
+        .flat_map(|file| {
+            let path = expand_env_vars(&file.path);
+            file.keys.iter().map(move |key| format!("{path}:{key}"))
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn write_config(dir: &Path, name: &str, body: &str) -> String {
+        let path = dir.join(name);
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(body.as_bytes()).unwrap();
+        path.to_string_lossy().into_owned()
+    }
+
+    /// Agent YAML with every process-agent gate key off (including `container_collection` default).
+    const ALL_PROCESS_GATES_OFF: &str = "\
+process_config:
+  process_collection:
+    enabled: false
+  container_collection:
+    enabled: false
+  process_discovery:
+    enabled: false
+";
+
+    fn process_agent_conditions(agent_path: String) -> Vec<ConditionConfigFile> {
+        vec![ConditionConfigFile {
+            path: agent_path,
+            keys: vec![
+                "process_config.enabled".into(),
+                "process_config.process_collection.enabled".into(),
+                "process_config.container_collection.enabled".into(),
+                "process_config.process_discovery.enabled".into(),
+            ],
+        }]
+    }
+
+    fn assert_gate_key(agent_path: &str, key: &str, expected: bool) {
+        let conditions = vec![ConditionConfigFile {
+            path: agent_path.to_string(),
+            keys: vec![key.into()],
+        }];
+        assert_eq!(
+            condition_config_any_met(&conditions),
+            expected,
+            "{key} expected {expected}"
+        );
+    }
+
+    fn process_agent_windows_conditions(
+        agent_path: String,
+        sysprobe_path: String,
+    ) -> Vec<ConditionConfigFile> {
+        vec![
+            ConditionConfigFile {
+                path: agent_path,
+                keys: vec![
+                    "process_config.enabled".into(),
+                    "process_config.process_collection.enabled".into(),
+                    "process_config.container_collection.enabled".into(),
+                    "process_config.process_discovery.enabled".into(),
+                ],
+            },
+            ConditionConfigFile {
+                path: sysprobe_path,
+                keys: vec![
+                    "network_config.enabled".into(),
+                    "system_probe_config.enabled".into(),
+                ],
+            },
+        ]
+    }
+
+    fn with_env_lock<F: FnOnce()>(test: F) {
+        let _lock = ENV_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+        test();
+    }
+
+    fn clear_gated_env_vars() {
+        // SAFETY: callers must hold ENV_TEST_LOCK.
+        unsafe { std::env::remove_var("DD_FLEET_POLICIES_DIR") };
+        for env_name in super::env_bindings::all_bound_env_var_names() {
+            // SAFETY: callers must hold ENV_TEST_LOCK.
+            unsafe { std::env::remove_var(env_name) };
+        }
+    }
+
+    struct EnvGuard {
+        name: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(name: &'static str, value: &str) -> Self {
+            let previous = std::env::var(name).ok();
+            // SAFETY: callers must hold ENV_TEST_LOCK.
+            unsafe { std::env::set_var(name, value) };
+            Self { name, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => unsafe { std::env::set_var(self.name, value) },
+                None => unsafe { std::env::remove_var(self.name) },
+            }
+        }
+    }
+
+    #[test]
+    fn empty_conditions_are_met() {
+        assert!(condition_config_any_met(&[]));
+    }
+
+    #[test]
+    fn any_matching_key_enables_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  process_discovery:\n    enabled: true\n",
+            );
+            let conditions = vec![ConditionConfigFile {
+                path: agent,
+                keys: vec![
+                    "process_config.process_collection.enabled".into(),
+                    "process_config.process_discovery.enabled".into(),
+                ],
+            }];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn lookup_dotted_key_is_case_insensitive() {
+        let yaml: serde_yaml::Value =
+            serde_yaml::from_str("process_config:\n  Process_Collection:\n    enabled: true\n")
+                .unwrap();
+        assert_eq!(
+            lookup_dotted_key(&yaml, "process_config.process_collection.enabled"),
+            Some(&serde_yaml::Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn lookup_dotted_key_supports_flattened_top_level_yaml() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str(
+            "process_config.process_collection.enabled: true\nprocess_config.container_collection.enabled: false\nprocess_config.process_discovery.enabled: false\n",
+        )
+        .unwrap();
+        assert_eq!(
+            lookup_dotted_key(&yaml, "process_config.process_collection.enabled"),
+            Some(&serde_yaml::Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn lookup_dotted_key_treats_null_leaf_as_absent() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str(
+            "network_config:\n  enabled:\nsystem_probe_config:\n  enabled: true\n",
+        )
+        .unwrap();
+        assert_eq!(lookup_dotted_key(&yaml, "network_config.enabled"), None);
+        assert_eq!(
+            lookup_dotted_key(&yaml, "system_probe_config.enabled"),
+            Some(&serde_yaml::Value::Bool(true))
+        );
+
+        let flat: serde_yaml::Value =
+            serde_yaml::from_str("network_config.enabled:\nsystem_probe_config.enabled: true\n")
+                .unwrap();
+        assert_eq!(lookup_dotted_key(&flat, "network_config.enabled"), None);
+    }
+
+    #[test]
+    fn lookup_dotted_key_supports_partially_flattened_yaml() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str(
+            "process_config:\n  process_collection.enabled: true\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+        )
+        .unwrap();
+        assert_eq!(
+            lookup_dotted_key(&yaml, "process_config.process_collection.enabled"),
+            Some(&serde_yaml::Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn flattened_yaml_key_enables_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config.process_collection.enabled: true\nprocess_config.container_collection.enabled: false\nprocess_config.process_discovery.enabled: false\n",
+            );
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn duplicate_yaml_key_last_value_wins_for_config_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  enabled: false\n  process_collection:\n    enabled: false\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\nprocess_config:\n  process_collection:\n    enabled: true\n",
+            );
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn mixed_case_yaml_key_enables_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  Process_Collection:\n    enabled: true\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn stock_config_uses_agent_defaults() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", "# api_key: placeholder\n");
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn all_false_keys_block_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  enabled: disabled\n  process_discovery:\n    enabled: false\n",
+            );
+            assert!(!condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn legacy_enabled_false_enables_container_collection() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn legacy_enabled_true_enables_process_collection() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  enabled: true\n  process_discovery:\n    enabled: false\n",
+            );
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn legacy_enabled_numeric_one_does_not_override_explicit_collection() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  enabled: 1\n  process_collection:\n    enabled: false\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            assert!(
+                !condition_config_any_met(&process_agent_conditions(agent)),
+                "explicit collection/discovery false must win over process_config.enabled"
+            );
+        });
+    }
+
+    #[test]
+    fn legacy_enabled_numeric_zero_enables_container_collection() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  enabled: 0\n  process_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn legacy_enabled_negative_prefixed_hex_enables_container_collection() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  enabled: -0x1\n  process_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            assert!(
+                condition_config_any_met(&process_agent_conditions(agent)),
+                "process_config.enabled: -0x1 must normalize to containers-only like Go GetString(\"-1\")"
+            );
+        });
+    }
+
+    #[test]
+    fn multi_document_yaml_uses_first_document_for_gates() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: true\n  process_discovery:\n    enabled: false\n---\nprocess_config:\n  process_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            assert_gate_key(&agent, "process_config.process_collection.enabled", true);
+        });
+    }
+
+    /// Mirrors `TestProcConfigEnabledTransformPrecedence` in pkg/config/setup/process_test.go.
+    #[test]
+    fn explicit_container_collection_wins_over_legacy_enabled() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _legacy = EnvGuard::set("DD_PROCESS_CONFIG_ENABLED", "false");
+            let _container =
+                EnvGuard::set("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", "false");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", "# api_key: placeholder\n");
+            assert_gate_key(&agent, "process_config.container_collection.enabled", false);
+            assert_gate_key(&agent, "process_config.process_collection.enabled", false);
+            assert_gate_key(&agent, "process_config.enabled", false);
+        });
+    }
+
+    #[test]
+    fn explicit_process_collection_wins_over_legacy_enabled() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _legacy = EnvGuard::set("DD_PROCESS_CONFIG_ENABLED", "true");
+            let _process = EnvGuard::set("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", "false");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", "# api_key: placeholder\n");
+            assert_gate_key(&agent, "process_config.process_collection.enabled", false);
+            assert_gate_key(&agent, "process_config.container_collection.enabled", false);
+            assert_gate_key(&agent, "process_config.enabled", false);
+        });
+    }
+
+    #[test]
+    fn explicit_collection_settings_win_over_legacy_disabled() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _legacy = EnvGuard::set("DD_PROCESS_CONFIG_ENABLED", "disabled");
+            let _container =
+                EnvGuard::set("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", "true");
+            let _process = EnvGuard::set("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", "true");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", "# api_key: placeholder\n");
+            assert_gate_key(&agent, "process_config.container_collection.enabled", true);
+            assert_gate_key(&agent, "process_config.process_collection.enabled", true);
+            assert_gate_key(&agent, "process_config.enabled", true);
+        });
+    }
+
+    #[test]
+    fn legacy_enabled_still_fills_unset_collection_key() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _legacy = EnvGuard::set("DD_PROCESS_CONFIG_ENABLED", "false");
+            let _process = EnvGuard::set("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", "true");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", "# api_key: placeholder\n");
+            assert_gate_key(&agent, "process_config.process_collection.enabled", true);
+            assert_gate_key(&agent, "process_config.container_collection.enabled", true);
+            assert_gate_key(&agent, "process_config.enabled", true);
+        });
+    }
+
+    #[test]
+    fn fleet_cannot_restore_normalized_legacy_enabled() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "datadog.yaml",
+                "process_config:\n  enabled: true\n",
+            );
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  enabled: true\n  process_collection:\n    enabled: false\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let _fleet = EnvGuard::set(
+                "DD_FLEET_POLICIES_DIR",
+                fleet_dir.to_string_lossy().as_ref(),
+            );
+            assert_gate_key(&agent, "process_config.enabled", false);
+            assert_gate_key(&agent, "process_config.process_collection.enabled", false);
+            assert!(!condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn end_user_device_enables_process_collection_when_unset() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "infrastructure_mode: end_user_device\nprocess_config:\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            assert_gate_key(&agent, "process_config.process_collection.enabled", true);
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn explicit_process_collection_wins_over_end_user_device() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "infrastructure_mode: end_user_device\nprocess_config:\n  process_collection:\n    enabled: false\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            assert_gate_key(&agent, "process_config.process_collection.enabled", false);
+            assert!(!condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn fleet_end_user_device_does_not_enable_process_collection() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "datadog.yaml",
+                "infrastructure_mode: end_user_device\nprocess_config:\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let _fleet = EnvGuard::set(
+                "DD_FLEET_POLICIES_DIR",
+                fleet_dir.to_string_lossy().as_ref(),
+            );
+            assert_gate_key(&agent, "process_config.process_collection.enabled", false);
+            assert!(!condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn end_user_device_env_enables_process_collection_when_unset() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _mode = EnvGuard::set("DD_INFRASTRUCTURE_MODE", "end_user_device");
+            let _container =
+                EnvGuard::set("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", "false");
+            let _discovery = EnvGuard::set("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", "false");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", "# api_key: placeholder\n");
+            assert_gate_key(&agent, "process_config.process_collection.enabled", true);
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn legacy_transform_overrides_end_user_device_process_collection() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "infrastructure_mode: end_user_device\nprocess_config:\n  enabled: disabled\n  process_discovery:\n    enabled: false\n",
+            );
+            assert_gate_key(&agent, "process_config.process_collection.enabled", false);
+            assert!(!condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn env_override_can_disable_default_enabled_keys() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _collection =
+                EnvGuard::set("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", "false");
+            let _discovery = EnvGuard::set("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", "false");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", "# api_key: placeholder\n");
+            assert!(!condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn env_override_can_enable_when_yaml_keys_missing() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _collection =
+                EnvGuard::set("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", "false");
+            let _discovery = EnvGuard::set("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", "true");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", "# api_key: placeholder\n");
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn env_bool_and_configured_ignore_empty_values() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _empty = EnvGuard::set("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", "");
+
+            assert_eq!(
+                env_bool_for_config_key("process_config.process_discovery.enabled"),
+                None
+            );
+            assert!(!env_configured_for_key(
+                "process_config.process_discovery.enabled"
+            ));
+        });
+    }
+
+    #[test]
+    fn env_bool_falls_through_empty_to_next_bound_var() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _empty = EnvGuard::set("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", "");
+            let _legacy = EnvGuard::set("DD_PROCESS_CONFIG_DISCOVERY_ENABLED", "true");
+
+            assert_eq!(
+                env_bool_for_config_key("process_config.process_discovery.enabled"),
+                Some(true)
+            );
+            assert!(env_configured_for_key(
+                "process_config.process_discovery.enabled"
+            ));
+        });
+    }
+
+    #[cfg(windows)]
+    struct CoreAgentScmEnvGuard;
+
+    #[cfg(windows)]
+    impl Drop for CoreAgentScmEnvGuard {
+        fn drop(&mut self) {
+            crate::platform::set_test_core_agent_scm_env(None);
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn env_bool_reads_core_agent_scm_when_process_env_unset() {
+        use std::collections::HashMap;
+
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            crate::platform::set_test_core_agent_scm_env(Some(HashMap::from([
+                (
+                    "DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED".to_string(),
+                    "false".to_string(),
+                ),
+                (
+                    "DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED".to_string(),
+                    "false".to_string(),
+                ),
+            ])));
+            let _scm = CoreAgentScmEnvGuard;
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", "# api_key: placeholder\n");
+            assert!(!condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn env_bool_prefers_core_agent_scm_over_process_env() {
+        use std::collections::HashMap;
+
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            crate::platform::set_test_core_agent_scm_env(Some(HashMap::from([(
+                "DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED".to_string(),
+                "false".to_string(),
+            )])));
+            let _scm = CoreAgentScmEnvGuard;
+            let _process = EnvGuard::set("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", "true");
+
+            assert_eq!(
+                env_bool_for_config_key("process_config.container_collection.enabled"),
+                Some(false)
+            );
+        });
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn legacy_enabled_env_reads_core_agent_scm_when_process_env_unset() {
+        use std::collections::HashMap;
+
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            crate::platform::set_test_core_agent_scm_env(Some(HashMap::from([
+                (
+                    "DD_PROCESS_CONFIG_ENABLED".to_string(),
+                    "disabled".to_string(),
+                ),
+                (
+                    "DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED".to_string(),
+                    "false".to_string(),
+                ),
+                (
+                    "DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED".to_string(),
+                    "false".to_string(),
+                ),
+            ])));
+            let _scm = CoreAgentScmEnvGuard;
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", "# api_key: placeholder\n");
+            assert!(!condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn legacy_enabled_env_ignores_empty_values() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _empty = EnvGuard::set("DD_PROCESS_CONFIG_ENABLED", "");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  enabled: disabled\n  process_discovery:\n    enabled: false\n",
+            );
+            assert!(!condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn legacy_enabled_env_falls_through_empty_to_next_bound_var() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _empty = EnvGuard::set("DD_PROCESS_CONFIG_ENABLED", "");
+            let _agent = EnvGuard::set("DD_PROCESS_AGENT_ENABLED", "disabled");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            assert!(!condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn fleet_policies_dir_reads_core_agent_scm_env() {
+        use std::collections::HashMap;
+
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: true\n",
+            );
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  enabled: false\n  process_collection:\n    enabled: false\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            crate::platform::set_test_core_agent_scm_env(Some(HashMap::from([(
+                "DD_FLEET_POLICIES_DIR".to_string(),
+                fleet_dir.to_string_lossy().into_owned(),
+            )])));
+            let _scm = CoreAgentScmEnvGuard;
+
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn fleet_policy_disables_default_enabled_keys() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "datadog.yaml",
+                "process_config:\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let agent = write_config(dir.path(), "datadog.yaml", "# api_key: placeholder\n");
+            let _fleet = EnvGuard::set(
+                "DD_FLEET_POLICIES_DIR",
+                fleet_dir.to_string_lossy().as_ref(),
+            );
+            assert!(!condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn fleet_policy_enables_when_base_config_is_all_false() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: true\n",
+            );
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  enabled: false\n  process_collection:\n    enabled: false\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let _fleet = EnvGuard::set(
+                "DD_FLEET_POLICIES_DIR",
+                fleet_dir.to_string_lossy().as_ref(),
+            );
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn fleet_policies_dir_from_agent_yaml_enables_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: true\n",
+            );
+            let fleet_dir_str = fleet_dir.to_string_lossy();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                &format!(
+                    "fleet_policies_dir: {fleet_dir_str}\nprocess_config:\n  enabled: false\n  process_collection:\n    enabled: false\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n"
+                ),
+            );
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn fleet_policies_dir_from_system_probe_yaml_enables_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "system-probe.yaml",
+                "network_config:\n  enabled: true\n",
+            );
+            let fleet_dir_str = fleet_dir.to_string_lossy();
+            write_config(dir.path(), "datadog.yaml", "# empty\n");
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                &format!(
+                    "fleet_policies_dir: {fleet_dir_str}\nnetwork_config:\n  enabled: false\n"
+                ),
+            );
+            let conditions = vec![ConditionConfigFile {
+                path: sysprobe,
+                keys: vec!["network_config.enabled".into()],
+            }];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn fleet_policies_dir_in_datadog_yaml_ignored_for_system_probe_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            let other_fleet_dir = dir.path().join("other-fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            std::fs::create_dir(&other_fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "system-probe.yaml",
+                "network_config:\n  enabled: true\n",
+            );
+            write_config(
+                &other_fleet_dir,
+                "system-probe.yaml",
+                "network_config:\n  enabled: false\n",
+            );
+            let fleet_dir_str = fleet_dir.to_string_lossy();
+            let other_fleet_dir_str = other_fleet_dir.to_string_lossy();
+            write_config(
+                dir.path(),
+                "datadog.yaml",
+                &format!("fleet_policies_dir: {other_fleet_dir_str}\n"),
+            );
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                &format!(
+                    "fleet_policies_dir: {fleet_dir_str}\nnetwork_config:\n  enabled: false\n"
+                ),
+            );
+            let conditions = vec![ConditionConfigFile {
+                path: sysprobe,
+                keys: vec!["network_config.enabled".into()],
+            }];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    /// Linux/non-Windows: no registry fallback, so datadog-only fleet dir must not apply.
+    #[cfg(not(windows))]
+    #[test]
+    fn fleet_policies_dir_only_in_datadog_yaml_ignored_for_system_probe_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "system-probe.yaml",
+                "network_config:\n  enabled: true\n",
+            );
+            let fleet_dir_str = fleet_dir.to_string_lossy();
+            write_config(
+                dir.path(),
+                "datadog.yaml",
+                &format!("fleet_policies_dir: {fleet_dir_str}\n"),
+            );
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "network_config:\n  enabled: false\n",
+            );
+            let conditions = vec![ConditionConfigFile {
+                path: sysprobe,
+                keys: vec!["network_config.enabled".into()],
+            }];
+            assert!(!condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn fleet_system_probe_policy_enables_when_local_file_missing() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "system-probe.yaml",
+                "network_config:\n  enabled: true\n",
+            );
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let sysprobe = dir.path().join("system-probe.yaml");
+            let _fleet = EnvGuard::set(
+                "DD_FLEET_POLICIES_DIR",
+                fleet_dir.to_string_lossy().as_ref(),
+            );
+            let conditions = vec![
+                ConditionConfigFile {
+                    path: agent,
+                    keys: vec![
+                        "process_config.process_collection.enabled".into(),
+                        "process_config.process_discovery.enabled".into(),
+                    ],
+                },
+                ConditionConfigFile {
+                    path: sysprobe.to_string_lossy().into_owned(),
+                    keys: vec!["network_config.enabled".into()],
+                },
+            ];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn fleet_system_probe_config_policy_enables_when_local_file_missing() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "system-probe.yaml",
+                "system_probe_config:\n  enabled: true\n",
+            );
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let sysprobe = dir.path().join("system-probe.yaml");
+            let _fleet = EnvGuard::set(
+                "DD_FLEET_POLICIES_DIR",
+                fleet_dir.to_string_lossy().as_ref(),
+            );
+            let conditions = vec![
+                ConditionConfigFile {
+                    path: agent,
+                    keys: vec![
+                        "process_config.process_collection.enabled".into(),
+                        "process_config.process_discovery.enabled".into(),
+                    ],
+                },
+                ConditionConfigFile {
+                    path: sysprobe.to_string_lossy().into_owned(),
+                    keys: vec!["system_probe_config.enabled".into()],
+                },
+            ];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn fleet_legacy_enabled_does_not_transform_collection_keys() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "datadog.yaml",
+                "process_config:\n  enabled: true\n",
+            );
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let _fleet = EnvGuard::set(
+                "DD_FLEET_POLICIES_DIR",
+                fleet_dir.to_string_lossy().as_ref(),
+            );
+            let collection_only = vec![ConditionConfigFile {
+                path: agent.clone(),
+                keys: vec![
+                    "process_config.process_collection.enabled".into(),
+                    "process_config.container_collection.enabled".into(),
+                    "process_config.process_discovery.enabled".into(),
+                ],
+            }];
+            assert!(
+                !condition_config_any_met(&collection_only),
+                "fleet-only process_config.enabled must not rewrite collection keys"
+            );
+            assert!(
+                condition_config_any_met(&process_agent_conditions(agent)),
+                "the deprecated key itself still honors fleet policy"
+            );
+        });
+    }
+
+    #[test]
+    fn fleet_policy_beats_local_system_probe_config() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "system-probe.yaml",
+                "network_config:\n  enabled: true\n",
+            );
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "network_config:\n  enabled: false\n",
+            );
+            let _fleet = EnvGuard::set(
+                "DD_FLEET_POLICIES_DIR",
+                fleet_dir.to_string_lossy().as_ref(),
+            );
+            let conditions = vec![
+                ConditionConfigFile {
+                    path: agent,
+                    keys: vec![
+                        "process_config.process_collection.enabled".into(),
+                        "process_config.process_discovery.enabled".into(),
+                    ],
+                },
+                ConditionConfigFile {
+                    path: sysprobe,
+                    keys: vec!["network_config.enabled".into()],
+                },
+            ];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn legacy_env_false_enables_container_collection() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _legacy = EnvGuard::set("DD_PROCESS_CONFIG_ENABLED", "false");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_discovery:\n    enabled: false\n",
+            );
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn legacy_env_whitespace_padded_disabled_enables_container_collection() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _legacy = EnvGuard::set("DD_PROCESS_CONFIG_ENABLED", " disabled ");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_discovery:\n    enabled: false\n",
+            );
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn legacy_yaml_whitespace_padded_disabled_enables_container_collection() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  enabled: \" disabled \"\n  process_discovery:\n    enabled: false\n",
+            );
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn missing_system_probe_without_fleet_blocks_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            // Linux schema default would otherwise enable discovery with no YAML file.
+            let _discovery = EnvGuard::set("DD_DISCOVERY_ENABLED", "false");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let sysprobe = dir.path().join("system-probe.yaml");
+            let conditions = vec![
+                ConditionConfigFile {
+                    path: agent,
+                    keys: vec![
+                        "process_config.process_collection.enabled".into(),
+                        "process_config.process_discovery.enabled".into(),
+                    ],
+                },
+                ConditionConfigFile {
+                    path: sysprobe.to_string_lossy().into_owned(),
+                    keys: vec![
+                        "network_config.enabled".into(),
+                        "system_probe_config.enabled".into(),
+                    ],
+                },
+            ];
+            assert!(!condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn local_system_probe_config_enables_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "network_config:\n  enabled: true\n",
+            );
+            let conditions = vec![
+                ConditionConfigFile {
+                    path: agent,
+                    keys: vec![
+                        "process_config.process_collection.enabled".into(),
+                        "process_config.process_discovery.enabled".into(),
+                    ],
+                },
+                ConditionConfigFile {
+                    path: sysprobe,
+                    keys: vec!["network_config.enabled".into()],
+                },
+            ];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn env_override_enables_system_probe_network() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _network = EnvGuard::set("DD_SYSTEM_PROBE_NETWORK_ENABLED", "true");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let sysprobe = dir.path().join("system-probe.yaml");
+            let conditions = vec![
+                ConditionConfigFile {
+                    path: agent,
+                    keys: vec![
+                        "process_config.process_collection.enabled".into(),
+                        "process_config.process_discovery.enabled".into(),
+                    ],
+                },
+                ConditionConfigFile {
+                    path: sysprobe.to_string_lossy().into_owned(),
+                    keys: vec!["network_config.enabled".into()],
+                },
+            ];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn fleet_policy_beats_env_override() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "datadog.yaml",
+                "process_config:\n  process_discovery:\n    enabled: true\n",
+            );
+            let agent = write_config(dir.path(), "datadog.yaml", "# api_key: placeholder\n");
+            let _fleet = EnvGuard::set(
+                "DD_FLEET_POLICIES_DIR",
+                fleet_dir.to_string_lossy().as_ref(),
+            );
+            let _discovery = EnvGuard::set("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", "false");
+            let _collection =
+                EnvGuard::set("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", "false");
+            assert!(condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    /// Env still drives `loadProcessTransforms`; fleet-only `process_config.enabled`
+    /// does not rewrite collection keys (`false` means containers-only).
+    #[test]
+    fn env_legacy_transform_not_overridden_by_fleet_enabled() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "datadog.yaml",
+                "process_config:\n  enabled: true\n",
+            );
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_discovery:\n    enabled: false\n",
+            );
+            let _fleet = EnvGuard::set(
+                "DD_FLEET_POLICIES_DIR",
+                fleet_dir.to_string_lossy().as_ref(),
+            );
+            let _legacy = EnvGuard::set("DD_PROCESS_CONFIG_ENABLED", "false");
+            let conditions = vec![ConditionConfigFile {
+                path: agent,
+                keys: vec!["process_config.process_collection.enabled".into()],
+            }];
+            assert!(!condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn yaml_cache_reads_each_path_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(
+            dir.path(),
+            "datadog.yaml",
+            "process_config:\n  container_collection:\n    enabled: true\n  process_discovery:\n    enabled: false\n",
+        );
+
+        let mut cache = YamlCache(HashMap::new());
+        for key in [
+            "process_config.container_collection.enabled",
+            "process_config.process_discovery.enabled",
+        ] {
+            cache.bool_key(&path, key).unwrap();
+        }
+        assert_eq!(cache.loaded_file_count(), 1);
+    }
+
+    #[test]
+    fn missing_file_blocks_gate() {
+        let conditions = vec![ConditionConfigFile {
+            path: "/nonexistent/datadog.yaml".into(),
+            keys: vec!["process_config.enabled".into()],
+        }];
+        assert!(!condition_config_any_met(&conditions));
+    }
+
+    #[test]
+    fn invalid_base_yaml_uses_default_enabled_keys() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", "{\n");
+            assert!(
+                condition_config_any_met(&process_agent_conditions(agent)),
+                "container_collection/process_discovery defaults should keep the gate open"
+            );
+        });
+    }
+
+    #[test]
+    fn invalid_base_yaml_keeps_default_disabled_keys_off() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", "{\n");
+            let conditions = vec![ConditionConfigFile {
+                path: agent,
+                keys: vec!["process_config.process_collection.enabled".into()],
+            }];
+            assert!(!condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn env_override_applies_when_base_yaml_is_invalid() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _collection = EnvGuard::set("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", "true");
+            let _container =
+                EnvGuard::set("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", "false");
+            let _discovery = EnvGuard::set("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", "false");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", "{\n");
+            let conditions = vec![ConditionConfigFile {
+                path: agent,
+                keys: vec!["process_config.process_collection.enabled".into()],
+            }];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn parse_agent_bool_string_matches_strconv_parse_bool() {
+        for (input, expected) in [
+            ("1", Some(true)),
+            ("t", Some(true)),
+            ("T", Some(true)),
+            ("true", Some(true)),
+            ("TRUE", Some(true)),
+            ("True", Some(true)),
+            ("0", Some(false)),
+            ("f", Some(false)),
+            ("F", Some(false)),
+            ("false", Some(false)),
+            ("FALSE", Some(false)),
+            ("False", Some(false)),
+            ("yes", None),
+            ("on", None),
+            ("disabled", None),
+            (" true ", None),
+            (" false ", None),
+            (" 1 ", None),
+        ] {
+            assert_eq!(parse_agent_bool_string(input), expected, "input={input:?}");
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn env_bool_scm_whitespace_padded_does_not_enable_process_gates() {
+        use std::collections::HashMap;
+
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            crate::platform::set_test_core_agent_scm_env(Some(HashMap::from([(
+                "DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED".to_string(),
+                " true ".to_string(),
+            )])));
+            let _scm = CoreAgentScmEnvGuard;
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", ALL_PROCESS_GATES_OFF);
+            assert!(!condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn env_whitespace_padded_bool_does_not_enable_process_gates() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _discovery = EnvGuard::set("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", " true ");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", ALL_PROCESS_GATES_OFF);
+            assert!(!condition_config_any_met(&process_agent_conditions(agent)));
+        });
+    }
+
+    #[test]
+    fn value_as_bool_handles_strings() {
+        assert_eq!(
+            value_as_bool(&serde_yaml::Value::String("disabled".into())),
+            Some(false)
+        );
+        assert_eq!(
+            value_as_bool(&serde_yaml::Value::String("true".into())),
+            Some(true)
+        );
+        assert_eq!(
+            value_as_bool(&serde_yaml::Value::String("1".into())),
+            Some(true)
+        );
+        assert_eq!(
+            value_as_bool(&serde_yaml::Value::String("yes".into())),
+            Some(false)
+        );
+        assert_eq!(value_as_bool(&serde_yaml::Value::Bool(true)), Some(true));
+        assert_eq!(
+            value_as_bool(&serde_yaml::Value::Number(1.into())),
+            Some(true)
+        );
+        assert_eq!(
+            value_as_bool(&serde_yaml::Value::Number(0.into())),
+            Some(false)
+        );
+        assert_eq!(
+            value_as_bool(&serde_yaml::Value::Number(1.0.into())),
+            Some(true)
+        );
+        assert_eq!(
+            value_as_bool(&serde_yaml::Value::Number(0.0.into())),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn condition_config_any_accepts_yaml_11_bool_spellings() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_discovery:\n    enabled: yes\n",
+            );
+            let conditions = vec![ConditionConfigFile {
+                path: agent,
+                keys: vec!["process_config.process_discovery.enabled".into()],
+            }];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn tagged_str_yaml_yes_does_not_enable_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_discovery:\n    enabled: !!str yes\n",
+            );
+            let conditions = vec![ConditionConfigFile {
+                path: agent,
+                keys: vec!["process_config.process_discovery.enabled".into()],
+            }];
+            assert!(!condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn quoted_yaml_yes_does_not_enable_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_discovery:\n    enabled: \"yes\"\n",
+            );
+            let conditions = vec![ConditionConfigFile {
+                path: agent,
+                keys: vec!["process_config.process_discovery.enabled".into()],
+            }];
+            assert!(!condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn plain_yaml_float_one_enables_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_discovery:\n    enabled: 1.0\n",
+            );
+            let conditions = vec![ConditionConfigFile {
+                path: agent,
+                keys: vec!["process_config.process_discovery.enabled".into()],
+            }];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn plain_yaml_dot_inf_enables_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_discovery:\n    enabled: .inf\n",
+            );
+            let conditions = vec![ConditionConfigFile {
+                path: agent,
+                keys: vec!["process_config.process_discovery.enabled".into()],
+            }];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn plain_yaml_u64_max_enables_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_discovery:\n    enabled: 18446744073709551615\n",
+            );
+            let conditions = vec![ConditionConfigFile {
+                path: agent,
+                keys: vec!["process_config.process_discovery.enabled".into()],
+            }];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn quoted_yaml_float_does_not_enable_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_discovery:\n    enabled: \"1.0\"\n",
+            );
+            let conditions = vec![ConditionConfigFile {
+                path: agent,
+                keys: vec!["process_config.process_discovery.enabled".into()],
+            }];
+            assert!(!condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn plain_yaml_hex_one_enables_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_discovery:\n    enabled: 0x1\n",
+            );
+            let conditions = vec![ConditionConfigFile {
+                path: agent,
+                keys: vec!["process_config.process_discovery.enabled".into()],
+            }];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn quoted_yaml_hex_does_not_enable_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_discovery:\n    enabled: \"0x1\"\n",
+            );
+            let conditions = vec![ConditionConfigFile {
+                path: agent,
+                keys: vec!["process_config.process_discovery.enabled".into()],
+            }];
+            assert!(!condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn env_yes_does_not_enable_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _discovery = EnvGuard::set("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", "yes");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", ALL_PROCESS_GATES_OFF);
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "discovery:\n  enabled: false\n",
+            );
+            assert!(!condition_config_any_met(
+                &process_agent_windows_conditions(agent, sysprobe)
+            ));
+        });
+    }
+
+    #[test]
+    fn invalid_bool_value_blocks_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: not-a-bool\n",
+            );
+            let conditions = vec![ConditionConfigFile {
+                path: agent,
+                keys: vec!["process_config.process_collection.enabled".into()],
+            }];
+            assert!(!condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn malformed_system_probe_bool_does_not_abort_module_derivation() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "network_config:\n  enabled: []\nservice_monitoring_config:\n  enabled: true\n",
+            );
+            let conditions = vec![ConditionConfigFile {
+                path: sysprobe,
+                keys: vec!["system_probe_config.enabled".into()],
+            }];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn fleet_infra_mode_change_retains_eud_agent_module_overrides() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(&fleet_dir, "datadog.yaml", "infrastructure_mode: full\n");
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "infrastructure_mode: end_user_device\nprocess_config:\n  process_collection:\n    enabled: false\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "discovery:\n  enabled: false\n",
+            );
+            let _fleet = EnvGuard::set(
+                "DD_FLEET_POLICIES_DIR",
+                fleet_dir.to_string_lossy().as_ref(),
+            );
+            let met = condition_config_any_met(&process_agent_windows_conditions(agent, sysprobe));
+            #[cfg(any(windows, target_os = "macos"))]
+            assert!(
+                met,
+                "pre-fleet EUD infra-mode overrides should survive a fleet infrastructure_mode change"
+            );
+            #[cfg(not(any(windows, target_os = "macos")))]
+            assert!(
+                !met,
+                "Linux has no EUD software_inventory / notable_events modules"
+            );
+        });
+    }
+
+    #[test]
+    fn fleet_can_disable_eud_software_inventory_override() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "datadog.yaml",
+                "infrastructure_mode: full\nsoftware_inventory:\n  enabled: false\n",
+            );
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "infrastructure_mode: end_user_device\nprocess_config:\n  process_collection:\n    enabled: false\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "discovery:\n  enabled: false\n",
+            );
+            let _fleet = EnvGuard::set(
+                "DD_FLEET_POLICIES_DIR",
+                fleet_dir.to_string_lossy().as_ref(),
+            );
+            let met = condition_config_any_met(&process_agent_windows_conditions(agent, sysprobe));
+            #[cfg(windows)]
+            assert!(
+                !met,
+                "fleet software_inventory.enabled=false should beat the retained EUD default"
+            );
+            #[cfg(target_os = "macos")]
+            assert!(
+                met,
+                "retained EUD notable_events should keep the gate open when fleet disables software_inventory only"
+            );
+            #[cfg(not(any(windows, target_os = "macos")))]
+            assert!(
+                !met,
+                "Linux has no EUD software_inventory / notable_events modules"
+            );
+        });
+    }
+
+    #[test]
+    fn derived_notable_events_matches_go_os_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\nnotable_events:\n  enabled: true\n",
+            );
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "discovery:\n  enabled: false\n",
+            );
+            let met = condition_config_any_met(&process_agent_windows_conditions(agent, sysprobe));
+            #[cfg(target_os = "macos")]
+            assert!(
+                met,
+                "notable_events.enabled should enable system-probe on macOS"
+            );
+            #[cfg(not(target_os = "macos"))]
+            assert!(
+                !met,
+                "notable_events.enabled should not enable system-probe off macOS"
+            );
+        });
+    }
+
+    #[test]
+    fn derived_logon_duration_matches_go_os_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\nlogon_duration:\n  enabled: true\n",
+            );
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "discovery:\n  enabled: false\n",
+            );
+            let met = condition_config_any_met(&process_agent_windows_conditions(agent, sysprobe));
+            #[cfg(target_os = "macos")]
+            assert!(
+                met,
+                "logon_duration.enabled in datadog.yaml should enable system-probe on macOS"
+            );
+            #[cfg(not(target_os = "macos"))]
+            assert!(
+                !met,
+                "logon_duration.enabled should not enable system-probe off macOS"
+            );
+        });
+    }
+
+    #[test]
+    fn derived_logon_duration_in_system_probe_yaml_does_not_enable() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "discovery:\n  enabled: false\nlogon_duration:\n  enabled: true\n",
+            );
+            assert!(
+                !condition_config_any_met(&process_agent_windows_conditions(agent, sysprobe)),
+                "logon_duration.enabled in system-probe.yaml should not enable the gate"
+            );
+        });
+    }
+
+    #[test]
+    fn derived_tcp_queue_length_enables_system_probe_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "system_probe_config:\n  enable_tcp_queue_length: true\n",
+            );
+            assert!(condition_config_any_met(&process_agent_windows_conditions(
+                agent, sysprobe
+            )));
+        });
+    }
+
+    #[test]
+    fn derived_module_beats_explicit_system_probe_disabled() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "system_probe_config:\n  enabled: false\n  enable_oom_kill: true\n",
+            );
+            assert!(condition_config_any_met(&process_agent_windows_conditions(
+                agent, sysprobe
+            )));
+        });
+    }
+
+    #[test]
+    fn derived_npm_env_disable_blocks_back_compat_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _network = EnvGuard::set("DD_SYSTEM_PROBE_NETWORK_ENABLED", "false");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", ALL_PROCESS_GATES_OFF);
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "system_probe_config:\n  enabled: true\ndiscovery:\n  enabled: false\n",
+            );
+            assert!(!condition_config_any_met(
+                &process_agent_windows_conditions(agent, sysprobe)
+            ));
+        });
+    }
+
+    #[test]
+    fn derived_npm_fleet_disable_blocks_back_compat_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "system-probe.yaml",
+                "network_config:\n  enabled: false\n",
+            );
+            let agent = write_config(dir.path(), "datadog.yaml", ALL_PROCESS_GATES_OFF);
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "system_probe_config:\n  enabled: true\ndiscovery:\n  enabled: false\n",
+            );
+            let _fleet = EnvGuard::set(
+                "DD_FLEET_POLICIES_DIR",
+                fleet_dir.to_string_lossy().as_ref(),
+            );
+            assert!(!condition_config_any_met(
+                &process_agent_windows_conditions(agent, sysprobe)
+            ));
+        });
+    }
+
+    #[test]
+    fn derived_npm_back_compat_with_usm_explicitly_disabled() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "system_probe_config:\n  enabled: true\nservice_monitoring_config:\n  enabled: false\n",
+            );
+            assert!(condition_config_any_met(&process_agent_windows_conditions(
+                agent, sysprobe
+            )));
+        });
+    }
+
+    #[test]
+    fn derived_npm_back_compat_ignores_valueless_network_config_enabled() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "system_probe_config:\n  enabled: true\nnetwork_config:\n  enabled:\nservice_monitoring_config:\n  enabled: false\n",
+            );
+            assert!(condition_config_any_met(&process_agent_windows_conditions(
+                agent, sysprobe
+            )));
+        });
+    }
+
+    #[test]
+    fn derived_sk_tracer_disables_usm_for_system_probe_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", ALL_PROCESS_GATES_OFF);
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "service_monitoring_config:\n  enabled: true\nnetwork_config:\n  enable_sk_tracer: true\ndiscovery:\n  enabled: false\n",
+            );
+            assert!(!condition_config_any_met(
+                &process_agent_windows_conditions(agent, sysprobe)
+            ));
+        });
+    }
+
+    #[test]
+    fn derived_sk_tracer_co_re_env_disables_sk_tracer_gating() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _co_re = EnvGuard::set("DD_ENABLE_CO_RE", "false");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", ALL_PROCESS_GATES_OFF);
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "service_monitoring_config:\n  enabled: true\nnetwork_config:\n  enable_sk_tracer: true\n",
+            );
+            assert!(condition_config_any_met(&process_agent_windows_conditions(
+                agent, sysprobe
+            )));
+        });
+    }
+
+    #[test]
+    fn derived_discovery_service_map_disabled_when_ebpfless() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", ALL_PROCESS_GATES_OFF);
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "discovery:\n  enabled: false\n  service_map:\n    enabled: true\nnetwork_config:\n  enable_ebpfless: true\n",
+            );
+            assert!(!condition_config_any_met(
+                &process_agent_windows_conditions(agent, sysprobe)
+            ));
+        });
+    }
+
+    #[test]
+    fn derived_discovery_service_map_disabled_when_sk_tracer() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", ALL_PROCESS_GATES_OFF);
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "discovery:\n  enabled: false\n  service_map:\n    enabled: true\nnetwork_config:\n  enable_sk_tracer: true\n",
+            );
+            assert!(!condition_config_any_met(
+                &process_agent_windows_conditions(agent, sysprobe)
+            ));
+        });
+    }
+
+    /// Linux default: empty system-probe.yaml enables discovery → system-probe gate open.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn derived_discovery_linux_default_enables_system_probe_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", ALL_PROCESS_GATES_OFF);
+            let sysprobe = write_config(dir.path(), "system-probe.yaml", "# empty\n");
+            assert!(condition_config_any_met(&process_agent_windows_conditions(
+                agent, sysprobe
+            )));
+        });
+    }
+
+    /// Fargate platform_default overrides Linux discovery default.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn derived_discovery_fargate_default_disables_system_probe_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _fargate = EnvGuard::set("AWS_EXECUTION_ENV", "AWS_ECS_FARGATE");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", ALL_PROCESS_GATES_OFF);
+            let sysprobe = write_config(dir.path(), "system-probe.yaml", "# empty\n");
+            assert!(!condition_config_any_met(
+                &process_agent_windows_conditions(agent, sysprobe)
+            ));
+        });
+    }
+
+    /// Explicit YAML false still disables discovery on Linux.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn derived_discovery_explicit_false_disables_on_linux() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", ALL_PROCESS_GATES_OFF);
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "discovery:\n  enabled: false\n",
+            );
+            assert!(!condition_config_any_met(
+                &process_agent_windows_conditions(agent, sysprobe)
+            ));
+        });
+    }
+
+    /// DD_DISCOVERY_ENABLED=false overrides Linux platform default.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn derived_discovery_env_disable_on_linux() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _discovery = EnvGuard::set("DD_DISCOVERY_ENABLED", "false");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(dir.path(), "datadog.yaml", ALL_PROCESS_GATES_OFF);
+            let sysprobe = write_config(dir.path(), "system-probe.yaml", "# empty\n");
+            assert!(!condition_config_any_met(
+                &process_agent_windows_conditions(agent, sysprobe)
+            ));
+        });
+    }
+
+    #[test]
+    fn derived_usm_env_enables_system_probe_gate() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+            let _usm = EnvGuard::set("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true");
+
+            let dir = tempfile::tempdir().unwrap();
+            let agent = write_config(
+                dir.path(),
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n",
+            );
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "service_monitoring_config:\n  enabled: false\n",
+            );
+            assert!(condition_config_any_met(&process_agent_windows_conditions(
+                agent, sysprobe
+            )));
+        });
+    }
+
+    #[test]
+    fn derived_fleet_beats_env_for_module_toggle() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let fleet_dir = dir.path().join("fleet");
+            std::fs::create_dir(&fleet_dir).unwrap();
+            write_config(
+                &fleet_dir,
+                "system-probe.yaml",
+                "service_monitoring_config:\n  enabled: false\n",
+            );
+            let agent = write_config(dir.path(), "datadog.yaml", ALL_PROCESS_GATES_OFF);
+            let sysprobe = write_config(
+                dir.path(),
+                "system-probe.yaml",
+                "discovery:\n  enabled: false\n",
+            );
+            let _fleet = EnvGuard::set(
+                "DD_FLEET_POLICIES_DIR",
+                fleet_dir.to_string_lossy().as_ref(),
+            );
+            let _usm = EnvGuard::set("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true");
+            assert!(!condition_config_any_met(
+                &process_agent_windows_conditions(agent, sysprobe)
+            ));
+        });
+    }
+
+    #[test]
+    fn condition_config_any_expands_dd_conf_dir_in_path() {
+        with_env_lock(|| {
+            clear_gated_env_vars();
+
+            let dir = tempfile::tempdir().unwrap();
+            let conf_dir = dir.path().join("agent-conf");
+            std::fs::create_dir_all(&conf_dir).unwrap();
+            write_config(
+                &conf_dir,
+                "datadog.yaml",
+                "process_config:\n  process_collection:\n    enabled: true\n",
+            );
+            let _conf = EnvGuard::set("DD_CONF_DIR", conf_dir.to_string_lossy().as_ref());
+            let conditions = vec![ConditionConfigFile {
+                path: "${DD_CONF_DIR}/datadog.yaml".into(),
+                keys: vec!["process_config.process_collection.enabled".into()],
+            }];
+            assert!(condition_config_any_met(&conditions));
+        });
+    }
+
+    #[test]
+    fn condition_config_summary_formats_paths() {
+        let conditions = vec![
+            ConditionConfigFile {
+                path: "/etc/datadog-agent/datadog.yaml".into(),
+                keys: vec![
+                    "process_config.enabled".into(),
+                    "process_config.process_collection.enabled".into(),
+                ],
+            },
+            ConditionConfigFile {
+                path: "/etc/datadog-agent/system-probe.yaml".into(),
+                keys: vec!["network_config.enabled".into()],
+            },
+        ];
+        assert_eq!(
+            condition_config_summary(&conditions),
+            "/etc/datadog-agent/datadog.yaml:process_config.enabled, /etc/datadog-agent/datadog.yaml:process_config.process_collection.enabled, /etc/datadog-agent/system-probe.yaml:network_config.enabled"
+        );
+    }
+}

--- a/pkg/procmgr/rust/src/config_gate/env_bindings.rs
+++ b/pkg/procmgr/rust/src/config_gate/env_bindings.rs
@@ -1,0 +1,186 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//! Config-key → environment-variable bindings for procmgr config gates.
+//!
+//! Source of truth: `env_vars` on each setting in `pkg/config/schema/yaml/`
+//! (merged via `dda inv schema.codegen` into generated Go init settings).
+//!
+//! Keys listed in [`ENV_BINDINGS`] use **only** the named env vars. All other
+//! keys use the agent convention `DD_<KEY_WITH_UNDERSCORES>`.
+//!
+//! This table covers only keys evaluated by config gates (`GATED_KEY_SPECS` in
+//! `config_gate.rs`). Keep it in sync with the schema `env_vars` for those keys.
+//!
+//! On Windows, config gates resolve `DD_*` from the core Agent SCM `Environment`
+//! registry first, then dd-procmgr's process environment, so service-local
+//! overrides match agent config resolution.
+
+struct EnvBinding {
+    key: &'static str,
+    env_vars: &'static [&'static str],
+}
+
+/// Non-default env bindings. Keys omitted here resolve via `DD_<KEY>`.
+const ENV_BINDINGS: &[EnvBinding] = &[
+    // process.go / process_settings.go
+    EnvBinding {
+        key: "process_config.enabled",
+        env_vars: &["DD_PROCESS_CONFIG_ENABLED", "DD_PROCESS_AGENT_ENABLED"],
+    },
+    EnvBinding {
+        key: "process_config.process_collection.enabled",
+        env_vars: &[
+            "DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED",
+            "DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED",
+        ],
+    },
+    EnvBinding {
+        key: "process_config.container_collection.enabled",
+        env_vars: &[
+            "DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED",
+            "DD_PROCESS_AGENT_CONTAINER_COLLECTION_ENABLED",
+        ],
+    },
+    EnvBinding {
+        key: "process_config.process_discovery.enabled",
+        env_vars: &[
+            "DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED",
+            "DD_PROCESS_AGENT_PROCESS_DISCOVERY_ENABLED",
+            "DD_PROCESS_CONFIG_DISCOVERY_ENABLED",
+            "DD_PROCESS_AGENT_DISCOVERY_ENABLED",
+        ],
+    },
+    // system_probe_settings.go
+    EnvBinding {
+        key: "network_config.enabled",
+        env_vars: &["DD_SYSTEM_PROBE_NETWORK_ENABLED"],
+    },
+    EnvBinding {
+        key: "system_probe_config.enabled",
+        env_vars: &["DD_SYSTEM_PROBE_ENABLED"],
+    },
+    EnvBinding {
+        key: "service_monitoring_config.enabled",
+        env_vars: &["DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED"],
+    },
+    EnvBinding {
+        key: "system_probe_config.enable_co_re",
+        env_vars: &["DD_ENABLE_CO_RE"],
+    },
+    EnvBinding {
+        key: "network_config.enable_ringbuffers",
+        env_vars: &["DD_SYSTEM_PROBE_NETWORK_ENABLE_RINGBUFFERS"],
+    },
+    EnvBinding {
+        key: "network_config.enable_ebpfless",
+        env_vars: &["DD_ENABLE_EBPFLESS", "DD_NETWORK_CONFIG_ENABLE_EBPFLESS"],
+    },
+    EnvBinding {
+        key: "system_probe_config.process_config.enabled",
+        env_vars: &["DD_SYSTEM_PROBE_PROCESS_ENABLED"],
+    },
+    EnvBinding {
+        key: "dynamic_instrumentation.enabled",
+        env_vars: &["DD_DYNAMIC_INSTRUMENTATION_ENABLED"],
+    },
+    // common_settings.go
+    EnvBinding {
+        key: "infrastructure_mode",
+        env_vars: &["DD_INFRASTRUCTURE_MODE"],
+    },
+];
+
+pub(super) fn env_vars_for_key(key: &str) -> &'static [&'static str] {
+    ENV_BINDINGS
+        .iter()
+        .find(|binding| binding.key == key)
+        .map(|binding| binding.env_vars)
+        .unwrap_or(&[])
+}
+
+pub(super) fn env_bool_for_config_key(key: &str) -> Option<bool> {
+    let names = env_vars_for_key(key);
+    if !names.is_empty() {
+        return env_bool_from_names(names);
+    }
+    let auto = auto_env_var_for_key(key);
+    env_bool_from_names(&[&auto])
+}
+
+/// Whether any env var bound to `key` is set to a non-empty value (mirrors Go `IsConfigured` env source).
+pub(super) fn env_configured_for_key(key: &str) -> bool {
+    let names = env_vars_for_key(key);
+    if !names.is_empty() {
+        return names.iter().any(|name| env_var_nonempty(name));
+    }
+    env_var_nonempty(&auto_env_var_for_key(key))
+}
+
+pub(super) fn env_string_for_config_key(key: &str) -> Option<String> {
+    let names = env_vars_for_key(key);
+    if !names.is_empty() {
+        for name in names {
+            if let Some(value) = env_var_value(name) {
+                return Some(value);
+            }
+        }
+        return None;
+    }
+    env_var_value(&auto_env_var_for_key(key))
+}
+
+/// Named env var with Agent SCM override first, then process env (Windows).
+pub(super) fn env_var_value_for_name(name: &str) -> Option<String> {
+    env_var_value(name)
+}
+
+#[cfg(test)]
+pub(super) fn all_bound_env_var_names() -> impl Iterator<Item = &'static str> {
+    ENV_BINDINGS
+        .iter()
+        .flat_map(|binding| binding.env_vars.iter().copied())
+}
+
+fn auto_env_var_for_key(key: &str) -> String {
+    format!("DD_{}", key.replace('.', "_").to_uppercase())
+}
+
+fn env_var_nonempty(name: &str) -> bool {
+    env_var_value(name).is_some()
+}
+
+fn env_bool_from_names(names: &[&str]) -> Option<bool> {
+    for name in names {
+        if let Some(value) = env_var_value(name) {
+            return Some(super::parse_agent_bool_string(&value).unwrap_or(false));
+        }
+    }
+    None
+}
+
+/// Core Agent SCM `Environment` overrides, then dd-procmgr process env.
+/// SCM wins when present so config gates match agent service-local resolution.
+fn env_var_value(name: &str) -> Option<String> {
+    if let Some(value) = agent_scm_env_var(name) {
+        return Some(value);
+    }
+    if let Ok(value) = std::env::var(name)
+        && !value.is_empty()
+    {
+        return Some(value);
+    }
+    None
+}
+
+#[cfg(windows)]
+fn agent_scm_env_var(name: &str) -> Option<String> {
+    crate::platform::core_agent_scm_env_var(name)
+}
+
+#[cfg(not(windows))]
+fn agent_scm_env_var(_name: &str) -> Option<String> {
+    None
+}

--- a/pkg/procmgr/rust/src/config_gate/system_probe.rs
+++ b/pkg/procmgr/rust/src/config_gate/system_probe.rs
@@ -1,0 +1,280 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//! Derived `system_probe_config.enabled` for process-manager config gates.
+//!
+//! # Keep in sync with Go
+//!
+//! Mirrors `load()` in `pkg/system-probe/config/config.go` and the NPM back-compat
+//! rule in `pkg/system-probe/config/adjust.go`. Sk-tracer disables USM in
+//! `pkg/system-probe/config/adjust_npm.go`; discovery conflicts in
+//! `pkg/system-probe/config/adjust_discovery.go`. Module knob resolution uses
+//! highest-priority configured source among fleet, env, and YAML
+//! ([`super::env_bindings`], `pkg/config/model/types.go` precedence). EUD
+//! infra-mode defaults for core-agent keys use pre-fleet `infrastructure_mode`
+//! because `applyInfrastructureModeOverrides` runs before `MergeFleetPolicy`.
+//!
+//! **When module enablement changes in Go, update `derived_enabled` below.**
+
+use std::path::Path;
+
+use super::YamlCache;
+use super::env_bindings::env_bool_for_config_key;
+
+const SYSPROBE_FLEET: &str = "system-probe.yaml";
+const AGENT_FLEET: &str = "datadog.yaml";
+
+/// Keys set to true by `applyInfrastructureModeOverrides` for `end_user_device`.
+const EUD_INFRA_MODE_AGENT_KEYS: &[&str] = &[
+    "software_inventory.enabled",
+    "notable_events.enabled",
+    "logon_duration.enabled",
+];
+
+/// Returns whether any system-probe module would be enabled at runtime (post-`Adjust`).
+pub(super) fn derived_enabled(sysprobe_path: &str, yaml: &mut YamlCache) -> anyhow::Result<bool> {
+    let agent = Path::new(sysprobe_path)
+        .parent()
+        .map(|dir| dir.join("datadog.yaml"))
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_else(|| sysprobe_path.to_owned());
+
+    let mut cfg = Cfg {
+        sysprobe: sysprobe_path,
+        agent: &agent,
+        yaml,
+    };
+
+    // config.go:123-131 — values reused below (post-Adjust; USM may be cleared by sk tracer).
+    let npm = cfg.npm_enabled()?;
+    let usm = cfg.effective_usm_enabled()?;
+    let ccm = cfg.sp_get_bool("ccm_network_config.enabled")?;
+    let eudm = cfg
+        .agent_string("infrastructure_mode")?
+        .is_some_and(|m| m == "end_user_device");
+    let csm = cfg.sp_get_bool("runtime_security_config.enabled")?;
+    let gpu = cfg.sp_get_bool("gpu_monitoring.enabled")?;
+    let di = cfg.sp_get_bool("dynamic_instrumentation.enabled")?;
+    let discovery_service_map = cfg.effective_discovery_service_map()?;
+
+    // config.go:133-135 — NetworkTracerModule
+    let network_tracer = npm
+        || usm
+        || ccm
+        || eudm
+        || discovery_service_map
+        || (csm && cfg.sp_get_bool("runtime_security_config.network_monitoring.enabled")?);
+    if network_tracer {
+        return Ok(true);
+    }
+
+    // config.go:136-141 — TCP queue length, OOM kill
+    if cfg.sp_get_bool("system_probe_config.enable_tcp_queue_length")?
+        || cfg.sp_get_bool("system_probe_config.enable_oom_kill")?
+    {
+        return Ok(true);
+    }
+
+    // config.go:142-150 — EventMonitorModule
+    // `network_process.enabled` needs NetworkTracerModule too (config.go:146); when that is on we
+    // already returned above.
+    if csm
+        || cfg.sp_get_bool("runtime_security_config.fim_enabled")?
+        || cfg.agent_get_bool("sbom.enrichment.usage.enabled")?
+        || (usm && cfg.sp_get_bool("service_monitoring_config.enable_event_stream")?)
+        || gpu
+        || di
+    {
+        return Ok(true);
+    }
+
+    // config.go:151-164 — ComplianceModule
+    if (cfg.agent_get_bool("compliance_config.enabled")?
+        && cfg.agent_get_bool("compliance_config.run_in_system_probe")?)
+        || cfg.sp_get_bool("compliance_config.database_benchmarks.enabled")?
+        || (csm && cfg.sp_get_bool("runtime_security_config.compliance_module.enabled")?)
+    {
+        return Ok(true);
+    }
+
+    // config.go:187-188 — DiscoveryModule (schema platform_default: linux true, fargate/other false)
+    if cfg.effective_discovery_enabled()? {
+        return Ok(true);
+    }
+
+    // config.go:165-194 — remaining modules with a single config knob each
+    for key in [
+        "system_probe_config.process_config.enabled",
+        "ebpf_check.enabled",
+        "system_probe_config.language_detection.enabled",
+        "ping.enabled",
+        "traceroute.enabled",
+        "privileged_logs.enabled",
+        "noisy_neighbor.enabled",
+        "windows_crash_detection.enabled",
+    ] {
+        if cfg.sp_get_bool(key)? {
+            return Ok(true);
+        }
+    }
+
+    // config.go:199-203: LogonDurationModule reads core datadog.yaml, not system-probe.yaml.
+    #[cfg(target_os = "macos")]
+    if cfg.agent_get_bool("logon_duration.enabled")? {
+        return Ok(true);
+    }
+
+    // config.go:221 — NotableEventsModule reads core datadog.yaml, not system-probe.yaml.
+    #[cfg(target_os = "macos")]
+    if cfg.agent_get_bool("notable_events.enabled")? {
+        return Ok(true);
+    }
+
+    // config.go:210-221 — Windows/macOS modules with their own knob.
+    // Injector default-on-when-other-modules-enabled is skipped: it cannot be the
+    // first module to turn system-probe on. Auto-enabled Windows crash detection
+    // likewise requires network tracer or event monitor, already handled above.
+    #[cfg(any(windows, target_os = "macos"))]
+    {
+        if cfg.agent_get_bool("software_inventory.enabled")?
+            || cfg.sp_get_bool("injector.enable_telemetry")?
+        {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+struct Cfg<'a> {
+    sysprobe: &'a str,
+    agent: &'a str,
+    yaml: &'a mut YamlCache,
+}
+
+impl<'a> Cfg<'a> {
+    fn sp_get_bool(&mut self, key: &str) -> anyhow::Result<bool> {
+        self.yaml
+            .resolve_get_bool(self.sysprobe, key, Some(SYSPROBE_FLEET))
+    }
+
+    fn sp_get_bool_default(&mut self, key: &str, default: bool) -> anyhow::Result<bool> {
+        self.yaml
+            .resolve_get_bool_with_default(self.sysprobe, key, Some(SYSPROBE_FLEET), default)
+    }
+
+    fn agent_get_bool(&mut self, key: &str) -> anyhow::Result<bool> {
+        if let Some(enabled) = self.agent_get_bool_if_set(key)? {
+            return Ok(enabled);
+        }
+        Ok(self.infra_mode_eud_agent_bool(key))
+    }
+
+    fn agent_get_bool_if_set(&mut self, key: &str) -> anyhow::Result<Option<bool>> {
+        if let Some(path) = self.yaml.fleet_policy_path(AGENT_FLEET, self.agent)?
+            && self.yaml.dotted_key_if_exists(&path, key)?.is_some()
+        {
+            return Ok(Some(self.yaml.get_bool_at(&path, key)?));
+        }
+        if let Some(enabled) = env_bool_for_config_key(key) {
+            return Ok(Some(enabled));
+        }
+        if self.yaml.dotted_key_if_exists(self.agent, key)?.is_some() {
+            return Ok(Some(self.yaml.get_bool_at(self.agent, key)?));
+        }
+        Ok(None)
+    }
+
+    /// `applyInfrastructureModeOverrides` runs before `MergeFleetPolicy` and is not
+    /// re-run after fleet merge, so retained EUD defaults use pre-fleet infra mode.
+    fn infra_mode_eud_agent_bool(&mut self, key: &str) -> bool {
+        if !EUD_INFRA_MODE_AGENT_KEYS.contains(&key) {
+            return false;
+        }
+        self.yaml
+            .resolve_string_pre_fleet(self.agent, "infrastructure_mode")
+            .ok()
+            .flatten()
+            .is_some_and(|mode| mode == "end_user_device")
+    }
+
+    fn agent_string(&mut self, key: &str) -> anyhow::Result<Option<String>> {
+        self.yaml.resolve_string(self.agent, key, Some(AGENT_FLEET))
+    }
+
+    fn sp_is_configured(&mut self, key: &str) -> anyhow::Result<bool> {
+        self.yaml
+            .is_configured(self.sysprobe, key, Some(SYSPROBE_FLEET))
+    }
+
+    /// adjust.go: `system_probe_config.enabled: true` with no NPM/USM block enables NPM.
+    fn npm_enabled(&mut self) -> anyhow::Result<bool> {
+        if self.sp_get_bool("network_config.enabled")? {
+            return Ok(true);
+        }
+        // Network: IsConfigured; USM: !GetBool. Back-compat runs before adjustNetwork (raw USM).
+        if self.sp_get_bool("system_probe_config.enabled")?
+            && !self.sp_is_configured("network_config.enabled")?
+            && !self.sp_get_bool("service_monitoring_config.enabled")?
+        {
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    fn effective_usm_enabled(&mut self) -> anyhow::Result<bool> {
+        // adjust_npm.go:123-135 — sk tracer disables USM when enabled.
+        let sk_tracer = self.sp_get_bool("network_config.enable_sk_tracer")?
+            && self.sp_get_bool_default("system_probe_config.enable_co_re", true)?
+            && self.sp_get_bool_default("network_config.enable_ringbuffers", true)?;
+        if sk_tracer {
+            return Ok(false);
+        }
+        self.sp_get_bool("service_monitoring_config.enabled")
+    }
+
+    fn effective_discovery_enabled(&mut self) -> anyhow::Result<bool> {
+        self.sp_get_bool_default("discovery.enabled", discovery_enabled_platform_default())
+    }
+
+    fn effective_discovery_service_map(&mut self) -> anyhow::Result<bool> {
+        if !self.sp_get_bool("discovery.service_map.enabled")? {
+            return Ok(false);
+        }
+        // adjust_discovery.go:48-52 — full USM makes discovery redundant (pre-adjustNetwork).
+        if self.sp_get_bool("service_monitoring_config.enabled")? {
+            return Ok(false);
+        }
+        // adjust_discovery.go:61-77 — raw sk_tracer / ebpfless (before adjustNetwork).
+        if self.sp_get_bool("network_config.enable_sk_tracer")?
+            || self.sp_get_bool("network_config.enable_ebpfless")?
+        {
+            return Ok(false);
+        }
+        Ok(true)
+    }
+}
+
+/// Schema `platform_default` for `discovery.enabled`.
+fn discovery_enabled_platform_default() -> bool {
+    #[cfg(not(target_os = "linux"))]
+    {
+        false
+    }
+    #[cfg(target_os = "linux")]
+    {
+        !is_ecs_fargate()
+    }
+}
+
+/// Mirrors `IsECSFargate` in `pkg/config/env/environment.go`.
+#[cfg(target_os = "linux")]
+fn is_ecs_fargate() -> bool {
+    std::env::var("ECS_FARGATE").is_ok_and(|v| !v.is_empty())
+        || matches!(
+            std::env::var("AWS_EXECUTION_ENV").ok().as_deref(),
+            Some("AWS_ECS_FARGATE")
+        )
+}

--- a/pkg/procmgr/rust/src/config_gate/yaml_load/mod.rs
+++ b/pkg/procmgr/rust/src/config_gate/yaml_load/mod.rs
@@ -1,0 +1,125 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//! YAML loading for config gates.
+//!
+//! Primary path uses [`saphyr_parser`] so plain-scalar YAML 1.1 bools (`yes`/`on`/…)
+//! are coerced at parse time, matching Go `gopkg.in/yaml.v2`. Quoted scalars stay strings.
+//!
+//! Duplicate mapping keys last-win (matching Go `yaml.Unmarshal`). On parse failure,
+//! falls back to permissive [`serde_yaml`] with the same last-win semantics.
+
+mod permissive;
+mod saphyr;
+
+use anyhow::{Context, Result};
+use log::debug;
+use serde_yaml::Value;
+
+/// Parse YAML for config-gate lookups, matching Agent config file semantics.
+pub(super) fn load_yaml(contents: &str) -> Result<Value> {
+    let mut root = match saphyr::load(contents) {
+        Ok(value) => value,
+        Err(err) => {
+            debug!("saphyr YAML parse failed, retrying serde_yaml permissive: {err}");
+            permissive::load(contents).with_context(|| err.to_string())?
+        }
+    };
+    root.apply_merge()
+        .context("apply YAML merge keys for config gate lookup")?;
+    Ok(root)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_yaml::Value;
+
+    use super::*;
+
+    fn dotted<'a>(root: &'a Value, path: &str) -> Option<&'a Value> {
+        let mut current = root;
+        for segment in path.split('.') {
+            current = current.get(segment)?;
+        }
+        Some(current)
+    }
+
+    #[test]
+    fn multi_document_stream_uses_first_document() {
+        let yaml = "process_config:\n  process_collection:\n    enabled: true\n---\nprocess_config:\n  process_collection:\n    enabled: false\n";
+        let root = load_yaml(yaml).unwrap();
+        assert_eq!(
+            dotted(&root, "process_config.process_collection.enabled"),
+            Some(&Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn strict_parse_used_when_no_duplicates() {
+        let root = load_yaml("process_config:\n  enabled: true\n").unwrap();
+        assert_eq!(
+            dotted(&root, "process_config.enabled"),
+            Some(&Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn permissive_parse_keeps_last_duplicate_key() {
+        let yaml = "process_config:\n  enabled: false\nprocess_config:\n  enabled: true\n";
+        let root = load_yaml(yaml).unwrap();
+        assert_eq!(
+            dotted(&root, "process_config.enabled"),
+            Some(&Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn permissive_parse_nested_duplicate_key_last_wins() {
+        let yaml = "process_config:\n  process_collection:\n    enabled: false\n  process_collection:\n    enabled: true\n";
+        let root = load_yaml(yaml).unwrap();
+        assert_eq!(
+            dotted(&root, "process_config.process_collection.enabled"),
+            Some(&Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn permissive_parse_accepts_null_with_duplicate_keys() {
+        let yaml = "network_config:\n  enabled:\nsystem_probe_config:\n  enabled: true\nprocess_config:\n  enabled: false\nprocess_config:\n  process_collection:\n    enabled: true\n";
+        let root = load_yaml(yaml).unwrap();
+        assert_eq!(dotted(&root, "network_config.enabled"), Some(&Value::Null));
+        assert_eq!(
+            dotted(&root, "system_probe_config.enabled"),
+            Some(&Value::Bool(true))
+        );
+        assert_eq!(
+            dotted(&root, "process_config.process_collection.enabled"),
+            Some(&Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn merge_keys_expand_disabled_process_config_defaults() {
+        let yaml = r#"
+disabled: &disabled
+  process_collection:
+    enabled: false
+  container_collection:
+    enabled: false
+
+process_config:
+  <<: *disabled
+"#;
+        let root = load_yaml(yaml).unwrap();
+        assert_eq!(
+            dotted(&root, "process_config.process_collection.enabled"),
+            Some(&Value::Bool(false))
+        );
+        assert_eq!(
+            dotted(&root, "process_config.container_collection.enabled"),
+            Some(&Value::Bool(false))
+        );
+    }
+}

--- a/pkg/procmgr/rust/src/config_gate/yaml_load/permissive.rs
+++ b/pkg/procmgr/rust/src/config_gate/yaml_load/permissive.rs
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//! Permissive [`serde_yaml`] fallback: duplicate mapping keys last-win via [`HashMap`].
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use serde::Deserialize;
+use serde_yaml::{Mapping, Number, Sequence, Value};
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum PermissiveValue {
+    Null,
+    Bool(bool),
+    Number(Number),
+    String(String),
+    Sequence(Vec<PermissiveValue>),
+    Mapping(HashMap<String, PermissiveValue>),
+}
+
+pub(super) fn load(contents: &str) -> Result<Value> {
+    let root: PermissiveValue = serde_yaml::from_str(contents)?;
+    Ok(to_value(root))
+}
+
+fn to_value(value: PermissiveValue) -> Value {
+    match value {
+        PermissiveValue::Null => Value::Null,
+        PermissiveValue::Bool(enabled) => Value::Bool(enabled),
+        PermissiveValue::Number(number) => Value::Number(number),
+        PermissiveValue::String(text) => Value::String(text),
+        PermissiveValue::Sequence(items) => {
+            Value::Sequence(Sequence::from_iter(items.into_iter().map(to_value)))
+        }
+        PermissiveValue::Mapping(items) => {
+            let mut map = Mapping::new();
+            for (key, item) in items {
+                map.insert(Value::String(key), to_value(item));
+            }
+            Value::Mapping(map)
+        }
+    }
+}

--- a/pkg/procmgr/rust/src/config_gate/yaml_load/saphyr.rs
+++ b/pkg/procmgr/rust/src/config_gate/yaml_load/saphyr.rs
@@ -1,0 +1,481 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//! Event-driven YAML loader with Go yaml.v2 plain-scalar bool coercion.
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result, bail};
+use saphyr_parser::{Event, Parser, ScalarStyle, Tag};
+use serde_yaml::{Mapping, Sequence, Value};
+
+pub(super) fn load(contents: &str) -> Result<Value> {
+    let parser = Parser::new_from_str(contents);
+    let mut builder = Builder::default();
+    for result in parser {
+        let (event, _) = result.context("parse YAML event")?;
+        builder.push(event)?;
+    }
+    builder.finish()
+}
+
+fn scalar_to_value(text: &str, style: ScalarStyle, tag: Option<&Tag>) -> Value {
+    if let Some(tag) = tag {
+        return tagged_scalar_to_value(text, tag);
+    }
+    if style == ScalarStyle::Plain {
+        plain_scalar_to_value(text)
+    } else {
+        Value::String(text.to_owned())
+    }
+}
+
+/// Explicit YAML tags disable implicit plain-scalar resolution (Go yaml.v2 parity).
+fn tagged_scalar_to_value(text: &str, tag: &Tag) -> Value {
+    if !tag.is_yaml_core_schema() {
+        return Value::String(text.to_owned());
+    }
+    match tag.suffix.as_str() {
+        "str" => Value::String(text.to_owned()),
+        "bool" => plain_scalar_to_value(text),
+        "int" | "float" => {
+            yaml_v2_plain_number(text).unwrap_or_else(|| Value::String(text.to_owned()))
+        }
+        "null" => Value::Null,
+        _ => Value::String(text.to_owned()),
+    }
+}
+
+/// Plain-scalar coercion aligned with Go yaml.v2 (YAML 1.1 bool/null spellings
+/// and numeric scalars, including floats such as `1.0`).
+fn plain_scalar_to_value(text: &str) -> Value {
+    match text.to_ascii_lowercase().as_str() {
+        "" | "~" | "null" => Value::Null,
+        "true" | "yes" | "on" | "y" => Value::Bool(true),
+        "false" | "no" | "off" | "n" => Value::Bool(false),
+        _ => yaml_v2_plain_number(text).unwrap_or_else(|| Value::String(text.to_owned())),
+    }
+}
+
+/// Integers first (decimal, then yaml.v2 `0x`/`0b`/`0o` prefixes), then YAML 1.1
+/// special floats (`.inf`, `-.inf`, `.nan`), then finite decimal/scientific floats.
+/// Matches yaml.v2 unmarshalling into `interface{}` so `cast.ToBoolE` can treat a
+/// non-zero number as true.
+fn yaml_v2_plain_number(text: &str) -> Option<Value> {
+    let plain: String = text.chars().filter(|c| *c != '_').collect();
+    if let Ok(n) = plain.parse::<i64>() {
+        return Some(Value::Number(n.into()));
+    }
+    if let Ok(n) = plain.parse::<u64>() {
+        return Some(Value::Number(n.into()));
+    }
+    if let Some(n) = parse_yaml_v2_prefixed_int(&plain) {
+        return Some(n);
+    }
+    if let Some(n) = parse_yaml_v2_special_float(&plain) {
+        return Some(Value::Number(n.into()));
+    }
+    if !looks_like_yaml_11_float(&plain) {
+        return None;
+    }
+    plain
+        .parse::<f64>()
+        .ok()
+        .filter(|n| n.is_finite())
+        .map(|n| Value::Number(n.into()))
+}
+
+/// YAML 1.1 special floats resolved by go.yaml.in/yaml/v2 (must include a leading `.`).
+fn parse_yaml_v2_special_float(text: &str) -> Option<f64> {
+    if let Some(rest) = text.strip_prefix('+') {
+        return parse_yaml_v2_special_float_unsigned(rest);
+    }
+    if let Some(rest) = text.strip_prefix('-') {
+        return parse_yaml_v2_special_float_unsigned(rest)
+            .and_then(|n| if n.is_infinite() { Some(-n) } else { None });
+    }
+    parse_yaml_v2_special_float_unsigned(text)
+}
+
+fn parse_yaml_v2_special_float_unsigned(text: &str) -> Option<f64> {
+    let suffix = text.strip_prefix('.')?;
+    if suffix.eq_ignore_ascii_case("inf") {
+        Some(f64::INFINITY)
+    } else if suffix.eq_ignore_ascii_case("nan") {
+        Some(f64::NAN)
+    } else {
+        None
+    }
+}
+
+/// `strconv.ParseInt`/`ParseUint` with base 0: `0x` hex, `0b` binary, `0o` octal.
+/// Leading-zero decimals stay decimal (`010` is 10) so `08` still parses as 8
+/// instead of failing octal and falling through to a string.
+fn parse_yaml_v2_prefixed_int(plain: &str) -> Option<Value> {
+    let (negative, rest) = match plain.as_bytes().first() {
+        Some(b'+') => (false, &plain[1..]),
+        Some(b'-') => (true, &plain[1..]),
+        _ => (false, plain),
+    };
+    let bytes = rest.as_bytes();
+    if bytes.len() < 3 || bytes[0] != b'0' {
+        return None;
+    }
+    let (base, digits) = match bytes[1] {
+        b'x' | b'X' => (16, &rest[2..]),
+        b'b' | b'B' => (2, &rest[2..]),
+        b'o' | b'O' => (8, &rest[2..]),
+        _ => return None,
+    };
+    if digits.is_empty() {
+        return None;
+    }
+    if negative {
+        if let Ok(n) = i64::from_str_radix(digits, base) {
+            return Some(Value::Number(n.checked_neg()?.into()));
+        }
+        // Magnitude 2^63 (e.g. 0x8000000000000000) exceeds i64::MAX but negates to i64::MIN.
+        let magnitude = u64::from_str_radix(digits, base).ok()?;
+        if magnitude == i64::MIN.unsigned_abs() {
+            return Some(Value::Number(i64::MIN.into()));
+        }
+        return None;
+    }
+    if let Ok(n) = i64::from_str_radix(digits, base) {
+        return Some(Value::Number(n.into()));
+    }
+    let n = u64::from_str_radix(digits, base).ok()?;
+    Some(Value::Number(n.into()))
+}
+
+/// Digit-based decimal or scientific form (`1.0`, `1e0`). Plain `inf` without a
+/// leading dot stays a string in yaml.v2.
+fn looks_like_yaml_11_float(text: &str) -> bool {
+    let mut rest = text.as_bytes();
+    if rest.first().is_some_and(|c| *c == b'+' || *c == b'-') {
+        rest = &rest[1..];
+    }
+    if rest.is_empty() {
+        return false;
+    }
+    let has_digit = rest.iter().any(u8::is_ascii_digit);
+    let has_dot_or_exp = rest.iter().any(|c| *c == b'.' || *c == b'e' || *c == b'E');
+    let all_float_chars = rest.iter().all(|c| {
+        c.is_ascii_digit() || *c == b'.' || *c == b'e' || *c == b'E' || *c == b'+' || *c == b'-'
+    });
+    has_digit && has_dot_or_exp && all_float_chars
+}
+
+fn mapping_from_pairs(pairs: HashMap<String, Value>) -> Value {
+    let mut map = Mapping::new();
+    for (key, value) in pairs {
+        map.insert(Value::String(key), value);
+    }
+    Value::Mapping(map)
+}
+
+fn scalar_as_key(value: Value) -> String {
+    match value {
+        Value::String(text) => text,
+        Value::Bool(enabled) => enabled.to_string(),
+        Value::Number(number) => number.to_string(),
+        Value::Null => "null".to_owned(),
+        _ => String::new(),
+    }
+}
+
+#[derive(Default)]
+struct Builder {
+    stack: Vec<Frame>,
+    anchors: HashMap<usize, Value>,
+    root: Option<Value>,
+    /// After the first document is parsed, ignore later `---` documents (Go yaml.v2 parity).
+    ignore_remaining_documents: bool,
+}
+
+enum Frame {
+    Mapping {
+        pairs: HashMap<String, Value>,
+        pending_key: Option<String>,
+        anchor: usize,
+    },
+    Sequence {
+        items: Vec<Value>,
+        anchor: usize,
+    },
+}
+
+impl Builder {
+    fn push(&mut self, event: Event<'_>) -> Result<()> {
+        if self.ignore_remaining_documents {
+            return Ok(());
+        }
+        match event {
+            Event::Nothing | Event::StreamStart | Event::StreamEnd | Event::DocumentEnd => {}
+            Event::DocumentStart(_) => {
+                if self.root.is_some() {
+                    self.ignore_remaining_documents = true;
+                    return Ok(());
+                }
+                self.stack.clear();
+                self.anchors.clear();
+            }
+            Event::MappingStart(anchor, _) => self.stack.push(Frame::Mapping {
+                pairs: HashMap::new(),
+                pending_key: None,
+                anchor,
+            }),
+            Event::MappingEnd => self.finish_mapping()?,
+            Event::SequenceStart(anchor, _) => self.stack.push(Frame::Sequence {
+                items: Vec::new(),
+                anchor,
+            }),
+            Event::SequenceEnd => self.finish_sequence()?,
+            Event::Scalar(text, style, anchor, tag) => {
+                let value = scalar_to_value(&text, style, tag.as_deref());
+                self.store_anchor(anchor, &value);
+                self.attach(value);
+            }
+            Event::Alias(anchor) => {
+                let value = self
+                    .anchors
+                    .get(&anchor)
+                    .with_context(|| format!("unknown YAML alias anchor {anchor}"))?
+                    .clone();
+                self.attach(value);
+            }
+        }
+        Ok(())
+    }
+
+    fn finish_mapping(&mut self) -> Result<()> {
+        let frame = self.stack.pop().context("unexpected YAML mapping end")?;
+        let (pairs, anchor) = match frame {
+            Frame::Mapping {
+                pairs,
+                pending_key: None,
+                anchor,
+            } => (pairs, anchor),
+            Frame::Mapping {
+                pending_key: Some(_),
+                ..
+            } => {
+                bail!("YAML mapping ended before value for key");
+            }
+            _ => bail!("YAML mapping end without matching start"),
+        };
+        self.attach_anchored(mapping_from_pairs(pairs), anchor);
+        Ok(())
+    }
+
+    fn finish_sequence(&mut self) -> Result<()> {
+        let frame = self.stack.pop().context("unexpected YAML sequence end")?;
+        let (items, anchor) = match frame {
+            Frame::Sequence { items, anchor } => (items, anchor),
+            _ => bail!("YAML sequence end without matching start"),
+        };
+        self.attach_anchored(Value::Sequence(Sequence::from(items)), anchor);
+        Ok(())
+    }
+
+    fn store_anchor(&mut self, anchor: usize, value: &Value) {
+        if anchor != 0 {
+            self.anchors.insert(anchor, value.clone());
+        }
+    }
+
+    fn attach_anchored(&mut self, value: Value, anchor: usize) {
+        self.store_anchor(anchor, &value);
+        self.attach(value);
+    }
+
+    fn attach(&mut self, value: Value) {
+        match self.stack.last_mut() {
+            None => self.root = Some(value),
+            Some(Frame::Mapping {
+                pairs, pending_key, ..
+            }) => {
+                if pending_key.is_none() {
+                    *pending_key = Some(scalar_as_key(value));
+                } else {
+                    pairs.insert(pending_key.take().expect("mapping key"), value);
+                }
+            }
+            Some(Frame::Sequence { items, .. }) => items.push(value),
+        }
+    }
+
+    fn finish(self) -> Result<Value> {
+        if !self.stack.is_empty() {
+            bail!("incomplete YAML document");
+        }
+        self.root.context("empty YAML document")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn multi_document_stream_uses_first_document() {
+        let yaml = "process_config:\n  process_collection:\n    enabled: true\n---\nprocess_config:\n  process_collection:\n    enabled: false\n";
+        let root = load(yaml).unwrap();
+        assert_eq!(
+            root.get("process_config")
+                .and_then(|pc| pc.get("process_collection"))
+                .and_then(|col| col.get("enabled"))
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn plain_yaml_11_bool_coerced_at_load() {
+        let root = load("enabled: yes\n").unwrap();
+        assert_eq!(root.get("enabled"), Some(&Value::Bool(true)));
+    }
+
+    #[test]
+    fn tagged_str_yaml_11_bool_stays_string() {
+        let root = load("enabled: !!str yes\n").unwrap();
+        assert_eq!(root.get("enabled"), Some(&Value::String("yes".into())));
+    }
+
+    #[test]
+    fn tagged_bool_yaml_11_bool_coerced_at_load() {
+        let root = load("enabled: !!bool yes\n").unwrap();
+        assert_eq!(root.get("enabled"), Some(&Value::Bool(true)));
+    }
+
+    #[test]
+    fn quoted_yaml_11_bool_stays_string() {
+        let root = load("enabled: \"yes\"\n").unwrap();
+        assert_eq!(root.get("enabled"), Some(&Value::String("yes".into())));
+    }
+
+    #[test]
+    fn single_quoted_yaml_11_bool_stays_string() {
+        let root = load("enabled: 'on'\n").unwrap();
+        assert_eq!(root.get("enabled"), Some(&Value::String("on".into())));
+    }
+
+    #[test]
+    fn plain_float_is_number() {
+        let root = load("enabled: 1.0\n").unwrap();
+        assert_eq!(root.get("enabled").and_then(Value::as_f64), Some(1.0));
+    }
+
+    #[test]
+    fn quoted_float_stays_string() {
+        let root = load("enabled: \"1.0\"\n").unwrap();
+        assert_eq!(root.get("enabled"), Some(&Value::String("1.0".into())));
+    }
+
+    #[test]
+    fn plain_dot_inf_is_number() {
+        let root = load("enabled: .inf\n").unwrap();
+        assert!(
+            root.get("enabled")
+                .and_then(Value::as_f64)
+                .unwrap()
+                .is_infinite()
+        );
+    }
+
+    #[test]
+    fn plain_dot_nan_is_number() {
+        let root = load("enabled: .nan\n").unwrap();
+        assert!(
+            root.get("enabled")
+                .and_then(Value::as_f64)
+                .unwrap()
+                .is_nan()
+        );
+    }
+
+    #[test]
+    fn negative_dot_nan_stays_string() {
+        let root = load("enabled: -.nan\n").unwrap();
+        assert_eq!(root.get("enabled"), Some(&Value::String("-.nan".into())));
+    }
+
+    #[test]
+    fn rust_inf_spelling_stays_string() {
+        let root = load("enabled: inf\n").unwrap();
+        assert_eq!(root.get("enabled"), Some(&Value::String("inf".into())));
+    }
+
+    #[test]
+    fn plain_u64_max_decimal_is_number() {
+        let root = load("enabled: 18446744073709551615\n").unwrap();
+        assert_eq!(root.get("enabled").and_then(Value::as_u64), Some(u64::MAX));
+    }
+
+    #[test]
+    fn plain_u64_max_hex_is_number() {
+        let root = load("enabled: 0xffffffffffffffff\n").unwrap();
+        assert_eq!(root.get("enabled").and_then(Value::as_u64), Some(u64::MAX));
+    }
+
+    #[test]
+    fn plain_prefixed_ints_are_numbers() {
+        assert_eq!(
+            load("enabled: 0x1\n")
+                .unwrap()
+                .get("enabled")
+                .and_then(Value::as_i64),
+            Some(1)
+        );
+        assert_eq!(
+            load("enabled: 0b1\n")
+                .unwrap()
+                .get("enabled")
+                .and_then(Value::as_i64),
+            Some(1)
+        );
+        assert_eq!(
+            load("enabled: 0o1\n")
+                .unwrap()
+                .get("enabled")
+                .and_then(Value::as_i64),
+            Some(1)
+        );
+        assert_eq!(
+            load("enabled: 0x0\n")
+                .unwrap()
+                .get("enabled")
+                .and_then(Value::as_i64),
+            Some(0)
+        );
+        assert_eq!(
+            load("enabled: -0x1\n")
+                .unwrap()
+                .get("enabled")
+                .and_then(Value::as_i64),
+            Some(-1)
+        );
+        assert_eq!(
+            load("enabled: -0x8000000000000000\n")
+                .unwrap()
+                .get("enabled")
+                .and_then(Value::as_i64),
+            Some(i64::MIN)
+        );
+        assert_eq!(
+            load("enabled: -0b1000000000000000000000000000000000000000000000000000000000000000\n")
+                .unwrap()
+                .get("enabled")
+                .and_then(Value::as_i64),
+            Some(i64::MIN)
+        );
+    }
+
+    #[test]
+    fn quoted_hex_int_stays_string() {
+        let root = load("enabled: \"0x1\"\n").unwrap();
+        assert_eq!(root.get("enabled"), Some(&Value::String("0x1".into())));
+    }
+}

--- a/pkg/procmgr/rust/src/lib.rs
+++ b/pkg/procmgr/rust/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod command;
 pub mod config;
+pub mod config_gate;
 pub mod env;
 pub mod grpc;
 pub mod handle;

--- a/pkg/procmgr/rust/src/manager.rs
+++ b/pkg/procmgr/rust/src/manager.rs
@@ -178,6 +178,10 @@ impl ProcessManager {
             info!("[{name}] already running, skipping queued restart");
             return;
         }
+        if !proc.may_respawn() {
+            info!("[{name}] restart skipped: start conditions not met");
+            return;
+        }
         match proc.spawn() {
             Ok(()) => spawn_watcher(proc, exit_tx.clone()),
             Err(e) => warn!("[{}] restart failed: {e:#}", proc.name()),
@@ -356,6 +360,24 @@ impl ProcessManager {
                     } else {
                         spawn_watcher(proc, exit_tx.clone());
                     }
+                }
+            }
+        }
+
+        {
+            let mut procs = self.processes.write().await;
+            for name in &unchanged {
+                let Some(proc) = procs.iter_mut().find(|p| p.name() == *name) else {
+                    continue;
+                };
+                if proc.is_running() || !proc.should_start() {
+                    continue;
+                }
+                info!("[{name}] config gate now met after reload, starting");
+                if let Err(e) = proc.spawn() {
+                    warn!("[{name}] failed to start after gate re-eval: {e:#}");
+                } else {
+                    spawn_watcher(proc, exit_tx.clone());
                 }
             }
         }
@@ -1005,5 +1027,129 @@ mod tests {
 
         // Clean up the spawned process.
         let _: Result<_, _> = mgr.handle_stop("aabbccdd-1").await;
+    }
+
+    #[cfg(not(windows))]
+    mod config_gate {
+        use super::*;
+        use crate::config::{ProcessConfig, RestartPolicy};
+        use crate::config_gate::ConditionConfigFile;
+        use std::io::Write;
+
+        fn gated_sleep_def(name: &str, agent_yaml: &str) -> ProcessDefinition {
+            let (cmd, args) = test_helpers::sleep_cmd(60);
+            ProcessDefinition {
+                name: name.to_string(),
+                config: ProcessConfig {
+                    command: cmd.to_string(),
+                    args,
+                    condition_config_any: vec![ConditionConfigFile {
+                        path: agent_yaml.to_string(),
+                        keys: vec!["process_config.process_collection.enabled".into()],
+                    }],
+                    ..Default::default()
+                },
+            }
+        }
+
+        fn write_agent_yaml(dir: &std::path::Path, process_collection_enabled: bool) -> String {
+            let path = dir.join("datadog.yaml");
+            let body = format!(
+                "process_config:\n  process_collection:\n    enabled: {process_collection_enabled}\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n"
+            );
+            let mut file = std::fs::File::create(&path).unwrap();
+            file.write_all(body.as_bytes()).unwrap();
+            path.to_string_lossy().into_owned()
+        }
+
+        fn gated_on_failure_sleep_def(name: &str, agent_yaml: &str) -> ProcessDefinition {
+            let (cmd, args) = test_helpers::sleep_cmd(60);
+            ProcessDefinition {
+                name: name.to_string(),
+                config: ProcessConfig {
+                    command: cmd.to_string(),
+                    args,
+                    restart: RestartPolicy::OnFailure,
+                    restart_sec: Some(2.0),
+                    condition_config_any: vec![ConditionConfigFile {
+                        path: agent_yaml.to_string(),
+                        keys: vec!["process_config.process_collection.enabled".into()],
+                    }],
+                    ..Default::default()
+                },
+            }
+        }
+
+        #[tokio::test]
+        async fn test_auto_start_runs_when_config_gate_open() -> anyhow::Result<()> {
+            let dir = tempfile::tempdir().unwrap();
+            let yaml = write_agent_yaml(dir.path(), true);
+            let mgr = ProcessManager::new(
+                loader(vec![gated_sleep_def("gated-svc", &yaml)]),
+                uuid_gen(),
+            );
+            let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(256);
+
+            mgr.start(&exit_tx).await;
+            assert!(
+                mgr.processes().await[0].is_running(),
+                "process should auto-start when condition_config_any is met"
+            );
+
+            test_helpers::cleanup_process(mgr.processes().await[0].pid().unwrap());
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_auto_start_skips_when_config_gate_closed() -> anyhow::Result<()> {
+            let dir = tempfile::tempdir().unwrap();
+            let yaml = write_agent_yaml(dir.path(), false);
+            let mgr = ProcessManager::new(
+                loader(vec![gated_sleep_def("gated-svc", &yaml)]),
+                uuid_gen(),
+            );
+            let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(256);
+
+            mgr.start(&exit_tx).await;
+            assert!(
+                !mgr.processes().await[0].is_running(),
+                "process should not auto-start when condition_config_any is not met"
+            );
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_on_failure_restart_skips_when_config_gate_closes() -> anyhow::Result<()> {
+            let dir = tempfile::tempdir().unwrap();
+            let yaml = write_agent_yaml(dir.path(), true);
+            let mgr = ProcessManager::new(
+                loader(vec![gated_on_failure_sleep_def("gated-svc", &yaml)]),
+                uuid_gen(),
+            );
+            let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(256);
+
+            mgr.start(&exit_tx).await;
+            let pid = {
+                let procs = mgr.processes().await;
+                assert!(procs[0].is_running());
+                procs[0].pid().unwrap()
+            };
+
+            write_agent_yaml(dir.path(), false);
+            {
+                let mut procs = mgr.processes.write().await;
+                let (cmd, args) = test_helpers::false_cmd();
+                let status = std::process::Command::new(cmd).args(args).status()?;
+                procs[0].set_last_status(status);
+            }
+            test_helpers::cleanup_process(pid);
+
+            mgr.complete_restart("gated-svc", &exit_tx).await;
+            assert!(
+                !mgr.processes().await[0].is_running(),
+                "on-failure restart should skip when the config gate is closed"
+            );
+            Ok(())
+        }
     }
 }

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -229,19 +229,47 @@ impl ManagedProcess {
     }
 
     #[must_use]
+    fn condition_path_exists_met(&self) -> bool {
+        let Some(raw) = &self.config.condition_path_exists else {
+            return true;
+        };
+        let path = expand_env_vars(raw);
+        if std::path::Path::new(&path).exists() {
+            return true;
+        }
+        info!("[{}] condition_path_exists not met: {path}", self.name);
+        false
+    }
+
+    fn config_gate_met(&self) -> bool {
+        if crate::config_gate::condition_config_any_met(&self.config.condition_config_any) {
+            return true;
+        }
+        info!(
+            "[{}] condition_config_any not met: {}",
+            self.name,
+            crate::config_gate::condition_config_summary(&self.config.condition_config_any)
+        );
+        false
+    }
+
+    #[must_use]
+    fn start_conditions_met(&self) -> bool {
+        self.condition_path_exists_met() && self.config_gate_met()
+    }
+
+    #[must_use]
+    pub(crate) fn may_respawn(&self) -> bool {
+        self.start_conditions_met()
+    }
+
+    #[must_use]
     pub fn should_start(&self) -> bool {
         if !self.config.auto_start {
             info!("[{}] auto_start=false, skipping", self.name);
             return false;
         }
-        if let Some(ref raw) = self.config.condition_path_exists {
-            let path = expand_env_vars(raw);
-            if !std::path::Path::new(&path).exists() {
-                info!("[{}] condition_path_exists not met: {path}", self.name);
-                return false;
-            }
-        }
-        true
+        self.start_conditions_met()
     }
 
     pub fn spawn(&mut self) -> Result<()> {
@@ -472,6 +500,11 @@ impl ManagedProcess {
                     self.name
                 );
             }
+            return None;
+        }
+
+        if !self.may_respawn() {
+            info!("[{}] start conditions not met, not restarting", self.name);
             return None;
         }
 

--- a/pkg/procmgr/rust/tests/e2e/config_gates.rs
+++ b/pkg/procmgr/rust/tests/e2e/config_gates.rs
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use crate::helpers::{ProcessExpect, ReloadExpect, TestEnv};
+use dd_procmgrd::test_helpers;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+fn write_agent_yaml(path: &Path, process_collection_enabled: bool) {
+    let body = format!(
+        "process_config:\n  process_collection:\n    enabled: {process_collection_enabled}\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n"
+    );
+    let mut file = fs::File::create(path).expect("create agent yaml");
+    file.write_all(body.as_bytes()).expect("write agent yaml");
+}
+
+fn gated_sleeper_yaml(agent_yaml: &str) -> String {
+    let (cmd, args) = test_helpers::sleep_cmd(300);
+    format!(
+        "command: {cmd}\nargs:\n{}condition_config_any:\n  - path: '{agent_yaml}'\n    keys:\n      - process_config.process_collection.enabled\nauto_start: true\n",
+        args.iter()
+            .map(|arg| format!("  - '{arg}'\n"))
+            .collect::<String>()
+    )
+}
+
+fn gated_env(process_collection_enabled: bool) -> TestEnv {
+    let env = TestEnv::new();
+    let agent_yaml = env.env_root().join("datadog.yaml");
+    write_agent_yaml(&agent_yaml, process_collection_enabled);
+    env.with_config(
+        "gated-sleeper",
+        &gated_sleeper_yaml(&agent_yaml.to_string_lossy()),
+    )
+}
+
+#[test]
+fn config_gate_open_auto_starts_process() {
+    let procmgr = gated_env(true).start();
+    procmgr
+        .wait_for_process_running("gated-sleeper")
+        .expect("expected gated-sleeper running when gate is open");
+    procmgr
+        .require_list()
+        .assert_process_state("gated-sleeper", ProcessExpect::Running);
+}
+
+#[test]
+fn config_gate_closed_stays_created() {
+    let procmgr = gated_env(false).start();
+    let list = procmgr.require_list();
+    list.assert_len(1);
+    list.assert_process_state("gated-sleeper", ProcessExpect::Created);
+    procmgr.assert_daemon_log_line_contains(&["gated-sleeper", "condition_config_any not met"]);
+}
+
+#[test]
+fn reload_restarts_created_process_when_gate_opens() {
+    let env = gated_env(false);
+    let agent_yaml = env.env_root().join("datadog.yaml");
+    let procmgr = env.start();
+
+    procmgr
+        .require_list()
+        .assert_process_state("gated-sleeper", ProcessExpect::Created);
+
+    write_agent_yaml(&agent_yaml, true);
+    procmgr.assert_reload_matches(ReloadExpect {
+        unchanged: Some(vec!["gated-sleeper".into()]),
+        ..Default::default()
+    });
+
+    procmgr
+        .wait_for_process_running("gated-sleeper")
+        .expect("expected gated-sleeper running after gate opens on reload");
+}

--- a/pkg/procmgr/rust/tests/e2e/main.rs
+++ b/pkg/procmgr/rust/tests/e2e/main.rs
@@ -8,6 +8,7 @@ mod helpers;
 
 mod catalog_list;
 mod cli_contracts;
+mod config_gates;
 mod config_status;
 mod create;
 mod daemon;


### PR DESCRIPTION
### What does this PR do?

Adds **`condition_config_any`** config gates for `processes.d` auto-start (YAML/env/fleet/system-probe derivations, Agent parity). Wires gates into auto-start, on-failure restart, and reload re-evaluation on the **monolithic `manager.rs`** from slim spawn profiles.

**Stack:** should base on [#54731](https://github.com/DataDog/datadog-agent/pull/54731) (`jose/procmgr-spawn-profiles`). Old manager-split head preserved locally at tag `config-gates-pre-slim` (`f76d78e7ef0`).

**Out of scope here:**
- Manager supervisor split ([#55505](https://github.com/DataDog/datadog-agent/pull/55505))
- Reload restore ([#55080](https://github.com/DataDog/datadog-agent/pull/55080)): slim already keeps reload; gates wire into existing reload
- Secret-backend `ENC[]` gates ([#54734](https://github.com/DataDog/datadog-agent/pull/54734))

### Motivation

Process-agent fleet YAML depends on `condition_config_any` to mirror legacy SCM start rules. This PR unblocks [#54735](https://github.com/DataDog/datadog-agent/pull/54735) on the slim stack.

### Describe how you validated your changes

- `cargo test -p dd-procmgrd` (274 unit tests, includes `config_gate` module tests)
- `cargo clippy -p dd-procmgrd --all-targets --features test-helpers -D warnings`
- Manager config gate tests (`#[cfg(not(windows))]`)
- TestEnv Slice C: `config_gates` e2e (gate open/closed, reload flip)
- Reload e2e charter tests still pass (11)
