### PR TITLE
Normalize metric and tag names prior to tag aggregation.

### DIFF
--- a/comp/filterlist/impl/filterlist.go
+++ b/comp/filterlist/impl/filterlist.go
@@ -251,20 +251,37 @@ func (fl *FilterList) setTagFilterList(metricTags tagMatcher) {
 	}
 }
 
+// normalizeMetricName normalizes a single filter list entry so it is in the name
+// space the filter lists compare in, i.e. the one the intake stores metric names
+// in. It reports false when the intake would reject the name outright (empty,
+// too long, or containing no ASCII letter); such an entry can never match
+// anything and callers drop it.
+func normalizeMetricName(name string) (string, bool) {
+	// Already normalized names, the common case, are returned as given.
+	if metricname.IsNormalized(name) {
+		return name, true
+	}
+
+	var buf [metricname.MaxLength]byte
+	key, ok := metricname.NormalizeAppend(buf[:0], name)
+	if !ok {
+		return "", false
+	}
+	return string(key), true
+}
+
 // normalizeMetricNames normalizes each entry so it matches the name space the
 // matcher compares in (see metricname.Matcher). Entries the intake would reject
 // outright (empty, too long, or containing no ASCII letter) are dropped.
 func normalizeMetricNames(names []string, log log.Component) []string {
 	normalized := make([]string, 0, len(names))
-	// Reuse this stack buffer for normalizing each metric.
-	var buf [metricname.MaxLength]byte
 	for _, name := range names {
-		key, ok := metricname.NormalizeAppend(buf[:0], name)
+		key, ok := normalizeMetricName(name)
 		if !ok {
 			log.Warnf("metric_filterlist: dropping entry %q that is not a storable metric name", name)
 			continue
 		}
-		normalized = append(normalized, string(key))
+		normalized = append(normalized, key)
 	}
 	return normalized
 }

--- a/comp/filterlist/impl/filterlist_test.go
+++ b/comp/filterlist/impl/filterlist_test.go
@@ -87,3 +87,92 @@ func TestNormalizeMetricNamesDropsUnstorable(t *testing.T) {
 
 	require.Equal([]string{"valid.metric", "another.valid"}, out)
 }
+
+// TestTagFilterListNormalizesEntries verifies that metric_tag_filterlist entries
+// loaded from the config are keyed on the normalized metric name, so an entry
+// written as the metric appears in Datadog strips tags from metrics submitted
+// with the raw name.
+func TestTagFilterListNormalizesEntries(t *testing.T) {
+	require := require.New(t)
+
+	cfg := map[string]interface{}{
+		"metric_tag_filterlist": []map[string]interface{}{
+			{
+				// `my metric-name` normalizes to this, the name a user sees.
+				"metric_name": "my_metric_name",
+				"action":      "exclude",
+				"tags":        []string{"env"},
+			},
+			{
+				// A raw entry is normalized at load time too.
+				"metric_name": "other metric-name",
+				"action":      "exclude",
+				"tags":        []string{"host"},
+			},
+			{
+				// Unstorable: no ASCII letter, so it can never match.
+				"metric_name": "123",
+				"action":      "exclude",
+				"tags":        []string{"pod"},
+			},
+		},
+	}
+
+	logComponent := logmock.New(t)
+	configComponent := config.NewMockWithOverrides(t, cfg)
+	telemetryComponent := fxutil.Test[telemetry.Component](t, telemetrynoop.Module())
+	filterList := NewFilterList(logComponent, configComponent, telemetryComponent)
+
+	matcher := filterList.GetTagFilterList()
+
+	// The raw submitted name normalizes to the configured entry, so its tags
+	// are stripped.
+	keepTag, shouldStrip := matcher.ShouldStripTags("my metric-name")
+	require.True(shouldStrip, "raw name should match its normalized filterlist entry")
+	require.False(keepTag("env:prod"))
+	require.True(keepTag("host:server1"))
+
+	keepTag, shouldStrip = matcher.ShouldStripTags("other_metric_name")
+	require.True(shouldStrip, "raw entry should have been normalized at load time")
+	require.False(keepTag("host:server1"))
+
+	_, shouldStrip = matcher.ShouldStripTags("123")
+	require.False(shouldStrip, "unstorable entry must not match")
+
+	_, shouldStrip = matcher.ShouldStripTags("unrelated.metric")
+	require.False(shouldStrip, "unrelated metric must not match")
+}
+
+// TestTagFilterListNormalizesTagNames verifies that the tag names of
+// metric_tag_filterlist entries loaded from the config are normalized, so an entry
+// written as the tag appears in Datadog strips the raw tag the Agent sees.
+func TestTagFilterListNormalizesTagNames(t *testing.T) {
+	require := require.New(t)
+
+	cfg := map[string]interface{}{
+		"metric_tag_filterlist": []map[string]interface{}{
+			{
+				"metric_name": "my.metric",
+				"action":      "exclude",
+				// As they appear in Datadog, plus one raw entry and one the
+				// intake would drop.
+				"tags": []string{"kube_namespace", "my-tag", "Raw Tag", "123"},
+			},
+		},
+	}
+
+	logComponent := logmock.New(t)
+	configComponent := config.NewMockWithOverrides(t, cfg)
+	telemetryComponent := fxutil.Test[telemetry.Component](t, telemetrynoop.Module())
+	filterList := NewFilterList(logComponent, configComponent, telemetryComponent)
+
+	keepTag, shouldStrip := filterList.GetTagFilterList().ShouldStripTags("my.metric")
+	require.True(shouldStrip)
+
+	require.False(keepTag("Kube Namespace:default"), "raw tag should match its normalized entry")
+	require.False(keepTag("kube_namespace:default"))
+	require.False(keepTag("My-Tag:value"))
+	require.False(keepTag("raw_tag:value"), "raw entry should have been normalized at load time")
+	require.True(keepTag("unrelated:value"))
+	require.True(keepTag("123:value"), "unstorable entry must not match")
+}

--- a/comp/filterlist/impl/rc.go
+++ b/comp/filterlist/impl/rc.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
-	"github.com/twmb/murmur3"
 )
 
 type statsdFilterListUpdate struct {
@@ -157,16 +156,33 @@ func (*FilterList) buildMetricFilterListConfig(metricFilterListUpdates []filtere
 // The first result contains the hashed tags that the filterlist uses, second result is the entry with unhashed tags
 // used to override the configuration file entry.
 //
+// Metric names are normalized, so that they are keyed on the name the intake
+// stores, which is the name the tag filterlist is queried with, and so are the tag
+// names they carry. Names the intake would reject outright are dropped.
+//
 // There is nothing stopping the tags for a given metric name being configured multiple times. Conflicts are handled
 // by the following rules:
 // - If the action is the same for both metrics, the list of tags is merged.
 // - If the action is different, always take the exclude list.
+//
+// Two names that normalize to the same stored name are a conflict too, and are
+// reconciled by those same rules.
 func (fl *FilterList) buildTagFilterListConfig(tagFilterListUpdates []filteredTags) (map[string]hashedMetricTagList, []MetricTagListEntry) {
 	tags := make(map[string]hashedMetricTagList)
 	tagEntries := make(map[string]MetricTagListEntry)
 
 	for _, update := range tagFilterListUpdates {
 		for _, metric := range update.ByName.Metrics {
+			name, storable := normalizeMetricName(metric.Name)
+			if !storable {
+				fl.log.Warnf("metric_tag_filterlist: dropping entry %q that is not a storable metric name", metric.Name)
+				continue
+			}
+			// metric is a copy, so the normalized names carry into the keys, the
+			// merge below and the config entry written back.
+			metric.Name = name
+			metric.Tags = normalizeTagNames(metric.Tags, fl.log)
+
 			currentHashed, ok := tags[metric.Name]
 			currentEntry := tagEntries[metric.Name]
 
@@ -213,8 +229,8 @@ func (fl *FilterList) buildTagFilterListConfig(tagFilterListUpdates []filteredTa
 func (fl *FilterList) mergeMetricTagListEntry(metric tagEntry, currentHashed hashedMetricTagList, currentEntry MetricTagListEntry) (hashedMetricTagList, MetricTagListEntry) {
 	if (currentHashed.action == exclude) == metric.ExcludeTag {
 		// Both metrics define the same action so we can just merge the list.
-		currentHashed.tags = append(currentHashed.tags, hashTags(metric.Tags)...)
-		slices.Sort(currentHashed.tags)
+		currentHashed = newHashedMetricTagList(currentHashed.action,
+			slices.Concat(currentHashed.tags, hashTags(metric.Tags)))
 
 		// Merge unhashed tags too
 		currentEntry.Tags = append(currentEntry.Tags, metric.Tags...)
@@ -239,13 +255,4 @@ func (fl *FilterList) mergeMetricTagListEntry(metric tagEntry, currentHashed has
 	// We always prefer the exclude tag, ignore this include tag configuration.
 	fl.log.Debugf("tag filterlist configures conflicting tags for metric %v", metric.Name)
 	return currentHashed, currentEntry
-}
-
-func hashTags(tags []string) []uint64 {
-	hashed := make([]uint64, 0, len(tags))
-	for _, tag := range tags {
-		hashed = append(hashed, murmur3.StringSum64(tag))
-	}
-
-	return hashed
 }

--- a/comp/filterlist/impl/rc_test.go
+++ b/comp/filterlist/impl/rc_test.go
@@ -934,3 +934,178 @@ func TestMergeMetricTagListEntry_ExcludeIgnoresInclude(t *testing.T) {
 		Tags:       []string{"env", "host"},
 	})
 }
+
+// TestFilterListUpdateNormalizesTagMetricNames verifies that metric names from a
+// remote tag filterlist configuration are normalized, both in the matcher used at
+// runtime and in the config written back for `agent config`. Names the intake
+// would reject outright are dropped.
+func TestFilterListUpdateNormalizesTagMetricNames(t *testing.T) {
+	require := require.New(t)
+
+	filterList, configComponent := newFilterList(t)
+
+	results := updateRes{}
+	callback := func(path string, status state.ApplyStatus) {
+		results[status.State] = append(results[status.State], path)
+	}
+
+	updates := map[string]state.RawConfig{
+		"config1": {Config: []byte(`{
+			"tag_filterlist": {
+				"by_name": {
+					"values": [
+						{
+							"metric_name": "test metric-name",
+							"exclude_tags_mode": true,
+							"tags": ["env"]
+						},
+						{
+							"metric_name": "123",
+							"exclude_tags_mode": true,
+							"tags": ["pod"]
+						}
+					]
+				}
+			}
+		}`)},
+	}
+
+	filterList.onFilterListUpdateCallback(updates, callback)
+	require.Len(results[state.ApplyStateAcknowledged], 1)
+	require.Len(results[state.ApplyStateError], 0)
+
+	// The raw submitted name normalizes to the configured one, so it is matched,
+	// and the unstorable entry was dropped.
+	matcher := filterList.GetTagFilterList()
+	keepTag, shouldStrip := matcher.ShouldStripTags("test metric-name")
+	require.True(shouldStrip)
+	require.False(keepTag("env:prod"))
+	require.True(keepTag("host:server1"))
+
+	_, shouldStrip = matcher.ShouldStripTags("123")
+	require.False(shouldStrip, "unstorable entry must not match")
+
+	// The config reflects the normalized name.
+	var tagEntries []MetricTagListEntry
+	err := structure.UnmarshalKey(configComponent, "metric_tag_filterlist", &tagEntries)
+	require.NoError(err)
+	require.Equal([]MetricTagListEntry{{
+		MetricName: "test_metric_name",
+		Action:     "exclude",
+		Tags:       []string{"env"},
+	}}, tagEntries)
+}
+
+// TestFilterListUpdateMergesTagNamesThatNormalizeTogether verifies that two
+// remote entries whose names normalize to the same stored name are reconciled
+// like duplicate entries, rather than one arbitrarily winning.
+func TestFilterListUpdateMergesTagNamesThatNormalizeTogether(t *testing.T) {
+	require := require.New(t)
+
+	filterList, configComponent := newFilterList(t)
+
+	results := updateRes{}
+	callback := func(path string, status state.ApplyStatus) {
+		results[status.State] = append(results[status.State], path)
+	}
+
+	updates := map[string]state.RawConfig{
+		"config1": {Config: []byte(`{
+			"tag_filterlist": {
+				"by_name": {
+					"values": [
+						{
+							"metric_name": "test metric-name",
+							"exclude_tags_mode": true,
+							"tags": ["env"]
+						},
+						{
+							"metric_name": "test_metric_name",
+							"exclude_tags_mode": true,
+							"tags": ["host"]
+						}
+					]
+				}
+			}
+		}`)},
+	}
+
+	filterList.onFilterListUpdateCallback(updates, callback)
+	require.Len(results[state.ApplyStateAcknowledged], 1)
+
+	matcher := filterList.GetTagFilterList()
+	keepTag, shouldStrip := matcher.ShouldStripTags("test metric-name")
+	require.True(shouldStrip)
+	require.False(keepTag("env:prod"))
+	require.False(keepTag("host:server1"))
+	require.True(keepTag("version:1.0"))
+
+	var tagEntries []MetricTagListEntry
+	err := structure.UnmarshalKey(configComponent, "metric_tag_filterlist", &tagEntries)
+	require.NoError(err)
+	require.Len(tagEntries, 1)
+	slices.Sort(tagEntries[0].Tags)
+	require.Equal(MetricTagListEntry{
+		MetricName: "test_metric_name",
+		Action:     "exclude",
+		Tags:       []string{"env", "host"},
+	}, tagEntries[0])
+}
+
+// TestFilterListUpdateNormalizesTagNames verifies that tag names from a remote tag
+// filterlist configuration are normalized, both in the matcher used at runtime and
+// in the config written back for `agent config`. Tag names the intake would drop
+// outright are dropped.
+func TestFilterListUpdateNormalizesTagNames(t *testing.T) {
+	require := require.New(t)
+
+	filterList, configComponent := newFilterList(t)
+
+	results := updateRes{}
+	callback := func(path string, status state.ApplyStatus) {
+		results[status.State] = append(results[status.State], path)
+	}
+
+	updates := map[string]state.RawConfig{
+		"config1": {Config: []byte(`{
+			"tag_filterlist": {
+				"by_name": {
+					"values": [
+						{
+							"metric_name": "test.metric",
+							"exclude_tags_mode": true,
+							"tags": ["Kube Namespace", "My-Tag", "123"]
+						}
+					]
+				}
+			}
+		}`)},
+	}
+
+	filterList.onFilterListUpdateCallback(updates, callback)
+	require.Len(results[state.ApplyStateAcknowledged], 1)
+	require.Len(results[state.ApplyStateError], 0)
+
+	// The raw tags the Agent sees normalize to the configured names, so they are
+	// stripped.
+	matcher := filterList.GetTagFilterList()
+	keepTag, shouldStrip := matcher.ShouldStripTags("test.metric")
+	require.True(shouldStrip)
+	require.False(keepTag("Kube Namespace:default"))
+	require.False(keepTag("kube_namespace:default"))
+	require.False(keepTag("My-Tag:value"))
+	require.True(keepTag("other:value"))
+	require.True(keepTag("123:value"), "an unstorable tag name cannot have been configured")
+
+	// The config reflects the normalized tag names, with the unstorable one dropped.
+	var tagEntries []MetricTagListEntry
+	err := structure.UnmarshalKey(configComponent, "metric_tag_filterlist", &tagEntries)
+	require.NoError(err)
+	require.Len(tagEntries, 1)
+	slices.Sort(tagEntries[0].Tags)
+	require.Equal(MetricTagListEntry{
+		MetricName: "test.metric",
+		Action:     "exclude",
+		Tags:       []string{"kube_namespace", "my-tag"},
+	}, tagEntries[0])
+}

--- a/comp/filterlist/impl/tagfilterlist.go
+++ b/comp/filterlist/impl/tagfilterlist.go
@@ -11,10 +11,18 @@ import (
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/def"
+	"github.com/DataDog/datadog-agent/pkg/util/metricname"
 	"github.com/twmb/murmur3"
 )
 
 // TagMatcher manages removing tags from metrics with a given name.
+//
+// Both halves work in normalized names, the names the intake stores and displays
+// and therefore the names users configure: MetricTags is keyed on the normalized
+// metric name and holds hashes of normalized tag names, and ShouldStripTags
+// normalizes the metric name and each tag name it is given before looking them
+// up. See metricname, and note that metric names and tag names normalize by
+// different rules.
 type tagMatcher struct {
 	MetricTags map[string]hashedMetricTagList
 }
@@ -48,11 +56,107 @@ type hashedMetricTagList struct {
 func newHashedMetricTagList(action action, tags []uint64) hashedMetricTagList {
 	// The tags must be sorted as we do a binary search to test membership.
 	slices.Sort(tags)
+	// Distinct configured names can normalize to the same one, and merging two
+	// lists can bring the same name in twice; either way a duplicate carries no
+	// information.
+	tags = slices.Compact(tags)
 
 	return hashedMetricTagList{
 		action: action,
 		tags:   tags,
 	}
+}
+
+// hashTags hashes the given tag names, which must already be normalized (see
+// normalizeTagNames).
+func hashTags(tags []string) []uint64 {
+	hashed := make([]uint64, 0, len(tags))
+	for _, tag := range tags {
+		hashed = append(hashed, murmur3.StringSum64(tag))
+	}
+
+	return hashed
+}
+
+// normalizeTagNames normalizes each configured tag name so it is in the name space
+// the intake stores tag names in, which is the one ShouldStripTags compares in.
+// Names the intake would drop outright can never match and are dropped here.
+//
+// A configured name is a name on its own, never a whole tag, so a trailing
+// underscore is kept: an entry of `my_tag_` means the name stored as `my_tag_`.
+// See hashTagName for the valueless tag that loses it.
+func normalizeTagNames(names []string, log log.Component) []string {
+	normalized := make([]string, 0, len(names))
+	// Reuse this stack buffer for normalizing each name.
+	var buf [metricname.MaxNormalizedTagLength]byte
+	for _, name := range names {
+		if metricname.IsNormalizedASCIITagName(name) {
+			normalized = append(normalized, name)
+			continue
+		}
+
+		key, ok := metricname.NormalizeTagNameAppend(buf[:0], name)
+		if !ok {
+			log.Warnf("metric_tag_filterlist: dropping tag %q that is not a storable tag name", name)
+			continue
+		}
+		normalized = append(normalized, string(key))
+	}
+	return normalized
+}
+
+// hashTagName hashes the name of the given tag the way the configured names were
+// hashed, normalizing it first. The Agent sees tags exactly as they were
+// submitted, so a tag submitted as `My-Tag:value` has to be found under the
+// `my-tag` entry the user configured. It reports false when the intake would drop
+// the tag outright, in which case no configured name can match it.
+//
+// It takes the whole tag rather than just its name because one rule depends on
+// what follows the name: the intake strips a trailing underscore from the end of
+// the tag, so `my_tag_:value` keeps it and a valueless `my_tag_` does not.
+//
+// It never allocates: an already normalized ASCII name is hashed as given, and the
+// rest are normalized into a stack buffer.
+func hashTagName(tag string) (uint64, bool) {
+	name := tagName(tag)
+	// The name ends the tag when the tag carries no value, and only then is its
+	// trailing underscore at the end of the tag.
+	valueless := len(name) == len(tag)
+
+	if metricname.IsNormalizedASCIITagName(name) &&
+		!(valueless && name[len(name)-1] == '_') {
+		return murmur3.StringSum64(name), true
+	}
+
+	var buf [metricname.MaxNormalizedTagLength]byte
+	key, ok := metricname.NormalizeTagNameAppend(buf[:0], name)
+	if !ok {
+		return 0, false
+	}
+	if valueless && key[len(key)-1] == '_' {
+		// Normalizing never leaves a run of underscores, so dropping one is
+		// enough. It cannot empty the name either, since a normalized name
+		// starts with a letter.
+		key = key[:len(key)-1]
+	}
+	// murmur3.Sum64 and murmur3.StringSum64 hash the same bytes to the same
+	// value, so this matches how the configured names were hashed.
+	return murmur3.Sum64(key), true
+}
+
+// mergeHashedMetricTagLists reconciles two tag configurations that apply to the
+// same metric name, following the same rules as duplicate configuration entries:
+// tags are merged when both agree on the action, and an exclude list always wins
+// over an include one.
+func mergeHashedMetricTagLists(a, b hashedMetricTagList) hashedMetricTagList {
+	if a.action == b.action {
+		return newHashedMetricTagList(a.action, slices.Concat(a.tags, b.tags))
+	}
+
+	if a.action == exclude {
+		return a
+	}
+	return b
 }
 
 func NewEmptyTagMatcher() filterlist.TagMatcher {
@@ -69,15 +173,23 @@ func NewTagMatcher(metrics map[string]MetricTagList, log log.Component) filterli
 // a list of metric names and tags. Those tags are hashed using murmur3.
 // The hashed value is then used to query whether a tag should be removed
 // from a given metric.
+//
+// Metric and tag names are normalized, so an entry written as the metric and its
+// tags appear in Datadog matches the raw names the Agent sees on the wire. Names
+// the intake would reject outright are dropped, and two metric names that
+// normalize to the same stored name have their configurations merged.
 func newTagMatcher(metrics map[string]MetricTagList, log log.Component) tagMatcher {
 	// Store a hashed version of the tag list since that will take up
 	// less space and be faster to query.
 	hashed := make(map[string]hashedMetricTagList, len(metrics))
 	for k, v := range metrics {
-		tags := make([]uint64, 0, len(v.Tags))
-		for _, tag := range v.Tags {
-			tags = append(tags, murmur3.StringSum64(tag))
+		name, storable := normalizeMetricName(k)
+		if !storable {
+			log.Warnf("metric_tag_filterlist: dropping entry %q that is not a storable metric name", k)
+			continue
 		}
+
+		tags := hashTags(normalizeTagNames(v.Tags, log))
 
 		var act action
 		switch v.Action {
@@ -91,7 +203,13 @@ func newTagMatcher(metrics map[string]MetricTagList, log log.Component) tagMatch
 			log.Warnf("`metric_tag_filterlist.%s.action` configuration value %q should be either `include` or `exclude`. Defaulting to `exclude`.", k, v.Action)
 			act = exclude
 		}
-		hashed[k] = newHashedMetricTagList(act, tags)
+
+		entry := newHashedMetricTagList(act, tags)
+		if existing, dup := hashed[name]; dup {
+			log.Debugf("metric_tag_filterlist configures conflicting tags for metric %v, which is stored as %v", k, name)
+			entry = mergeHashedMetricTagLists(existing, entry)
+		}
+		hashed[name] = entry
 	}
 
 	return tagMatcher{
@@ -113,18 +231,50 @@ func tagName(tag string) string {
 // from the given metric name. The returned tag list will be used to query
 // the tag.
 func (m tagMatcher) ShouldStripTags(metricName string) (func(tag string) bool, bool) {
-	tm, ok := m.MetricTags[metricName]
+	tm, ok := m.lookup(metricName)
 	if !ok {
 		return nil, false
 	}
 
 	keepTag := func(tag string) bool {
-		hashedTag := murmur3.StringSum64(tagName(tag))
-		_, found := slices.BinarySearch(tm.tags, hashedTag)
+		// A tag name the intake drops outright cannot have been configured, so it
+		// is simply not in the list, which include and exclude read differently.
+		found := false
+		if hashedTag, ok := hashTagName(tag); ok {
+			_, found = slices.BinarySearch(tm.tags, hashedTag)
+		}
 		keep := found != bool(tm.action)
 
 		return keep
 	}
 
 	return keepTag, ok
+}
+
+// lookup returns the tag configuration for the given metric name.
+//
+// The name is normalized before being looked up, since MetricTags is keyed on
+// the name the intake stores. The Agent sees names exactly as they were
+// submitted, so a metric submitted as `my metric-name` has to be found under the
+// `my_metric_name` entry the user configured. Names the intake would reject are
+// never found.
+//
+// lookup never allocates: already normalized names are used as given, and the
+// rest are normalized into a stack buffer.
+func (m tagMatcher) lookup(metricName string) (hashedMetricTagList, bool) {
+	if metricname.IsNormalized(metricName) {
+		tm, ok := m.MetricTags[metricName]
+		return tm, ok
+	}
+
+	var buf [metricname.MaxLength]byte
+	key, ok := metricname.NormalizeAppend(buf[:0], metricName)
+	if !ok {
+		return hashedMetricTagList{}, false
+	}
+
+	// The compiler elides the copy for a map lookup on a []byte to string
+	// conversion, so this does not allocate.
+	tm, ok := m.MetricTags[string(key)]
+	return tm, ok
 }

--- a/comp/filterlist/impl/tagfilterlist_test.go
+++ b/comp/filterlist/impl/tagfilterlist_test.go
@@ -8,10 +8,12 @@
 package filterlistimpl
 
 import (
+	"maps"
 	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/twmb/murmur3"
 
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
@@ -135,4 +137,303 @@ func TestTagMatcher(t *testing.T) {
 	// metric5 is not configured
 	_, shouldStrip = matcher.ShouldStripTags("metric5")
 	assert.False(t, shouldStrip)
+}
+
+// TestTagMatcherNormalizesMetricNames verifies that metric_tag_filterlist entries
+// are keyed on the normalized metric name and looked up by it, so an entry using
+// the name as it appears in Datadog strips tags from metrics submitted with the
+// raw name the Agent sees.
+func TestTagMatcherNormalizesMetricNames(t *testing.T) {
+	matcher := newTagMatcher(map[string]MetricTagList{
+		// The intake stores this as `my_metric_name`, which is what a user
+		// configures, but the Agent sees `my metric-name` on the wire.
+		"my_metric_name": {
+			Tags:   []string{"env"},
+			Action: "exclude",
+		},
+		// A raw entry is normalized at load time, so it matches too.
+		"other metric-name": {
+			Tags:   []string{"host"},
+			Action: "exclude",
+		},
+		// Unstorable: no ASCII letter, so it can never match anything.
+		"123": {
+			Tags:   []string{"pod"},
+			Action: "exclude",
+		},
+	}, logmock.New(t))
+
+	assert.ElementsMatch(t,
+		[]string{"my_metric_name", "other_metric_name"},
+		slices.Collect(maps.Keys(matcher.MetricTags)),
+		"entries should be keyed on the normalized name, dropping unstorable ones")
+
+	// Every name that normalizes to a configured entry strips its tags.
+	for _, name := range []string{"my metric-name", "my_metric_name", "my/metric*name"} {
+		keepTag, shouldStrip := matcher.ShouldStripTags(name)
+		if assert.True(t, shouldStrip, "%q should match its normalized entry", name) {
+			assert.False(t, keepTag("env:prod"))
+			assert.True(t, keepTag("host:server1"))
+		}
+	}
+
+	keepTag, shouldStrip := matcher.ShouldStripTags("other metric-name")
+	if assert.True(t, shouldStrip, "raw entry should have been normalized at load time") {
+		assert.False(t, keepTag("host:server1"))
+		assert.True(t, keepTag("env:prod"))
+	}
+
+	// Names that normalize to something else are left alone. Periods survive
+	// normalization, so this is a different metric entirely.
+	_, shouldStrip = matcher.ShouldStripTags("my.metric.name")
+	assert.False(t, shouldStrip, "a name that normalizes to a different metric must not match")
+
+	_, shouldStrip = matcher.ShouldStripTags("123")
+	assert.False(t, shouldStrip, "unstorable entry must not match")
+}
+
+// TestTagMatcherMergesNamesThatNormalizeTogether verifies that entries whose
+// names normalize to the same stored name are reconciled the same way duplicate
+// entries are, rather than one of them arbitrarily winning.
+func TestTagMatcherMergesNamesThatNormalizeTogether(t *testing.T) {
+	t.Run("same action merges tags", func(t *testing.T) {
+		matcher := newTagMatcher(map[string]MetricTagList{
+			"my metric-name": {Tags: []string{"env"}, Action: "exclude"},
+			"my_metric_name": {Tags: []string{"host"}, Action: "exclude"},
+		}, logmock.New(t))
+
+		require.Len(t, matcher.MetricTags, 1)
+
+		keepTag, shouldStrip := matcher.ShouldStripTags("my metric-name")
+		require.True(t, shouldStrip)
+		assert.False(t, keepTag("env:prod"))
+		assert.False(t, keepTag("host:server1"))
+		assert.True(t, keepTag("version:1.0"))
+	})
+
+	t.Run("exclude wins over include", func(t *testing.T) {
+		for _, metrics := range []map[string]MetricTagList{
+			{
+				"my metric-name": {Tags: []string{"env"}, Action: "exclude"},
+				"my_metric_name": {Tags: []string{"host"}, Action: "include"},
+			},
+			{
+				"my metric-name": {Tags: []string{"host"}, Action: "include"},
+				"my_metric_name": {Tags: []string{"env"}, Action: "exclude"},
+			},
+		} {
+			matcher := newTagMatcher(metrics, logmock.New(t))
+			require.Len(t, matcher.MetricTags, 1)
+
+			keepTag, shouldStrip := matcher.ShouldStripTags("my_metric_name")
+			require.True(t, shouldStrip)
+			assert.False(t, keepTag("env:prod"), "the exclude list should be the one in effect")
+			assert.True(t, keepTag("host:server1"))
+		}
+	})
+}
+
+// TestTagMatcherLookupDoesNotAllocate pins that normalizing the queried name
+// stays allocation free, since the lookup runs for every sample.
+func TestTagMatcherLookupDoesNotAllocate(t *testing.T) {
+	matcher := newTagMatcher(map[string]MetricTagList{
+		"my_metric_name": {Tags: []string{"env"}, Action: "exclude"},
+	}, logmock.New(t))
+
+	for _, name := range []string{"my_metric_name", "my metric-name", "unconfigured metric"} {
+		t.Run(name, func(t *testing.T) {
+			allocs := testing.AllocsPerRun(100, func() {
+				matcher.lookup(name)
+			})
+			assert.Zero(t, allocs)
+		})
+	}
+}
+
+// TestTagMatcherNormalizesTagNames verifies that configured tag names are hashed
+// in the same name space as the tags the Agent sees on the wire, so an entry
+// written as the tag appears in Datadog (lowercased, `-` and `/` kept) strips the
+// raw tag.
+func TestTagMatcherNormalizesTagNames(t *testing.T) {
+	matcher := newTagMatcher(map[string]MetricTagList{
+		"my.metric": {
+			// As they appear in Datadog: the Agent sees `My-Tag`,
+			// `Kube Namespace` and `Env` on the wire.
+			Tags:   []string{"my-tag", "kube_namespace", "env"},
+			Action: "exclude",
+		},
+	}, logmock.New(t))
+
+	keepTag, shouldStrip := matcher.ShouldStripTags("my.metric")
+	require.True(t, shouldStrip)
+
+	for _, tag := range []string{
+		"My-Tag:value", "my-tag:value", "MY-TAG:value",
+		"Kube Namespace:default", "kube_namespace:default", "kube namespace:default",
+		"Env:prod", "env:prod",
+	} {
+		assert.False(t, keepTag(tag), "%q should match its normalized filterlist entry", tag)
+	}
+
+	// Tags that normalize to something else are left alone. `-` and `/` survive
+	// normalization, so they are not interchangeable with `_`.
+	for _, tag := range []string{"my_tag:value", "my.tag:value", "kube-namespace:default", "other:value"} {
+		assert.True(t, keepTag(tag), "%q must not match", tag)
+	}
+}
+
+// TestTagMatcherNormalizesConfiguredTagNames verifies that a raw configured tag
+// name is normalized at load time, so it matches too.
+func TestTagMatcherNormalizesConfiguredTagNames(t *testing.T) {
+	matcher := newTagMatcher(map[string]MetricTagList{
+		"my.metric": {
+			// `Kube Namespace` normalizes to `kube_namespace`, and `123` is not a
+			// storable tag name so it is dropped.
+			Tags:   []string{"Kube Namespace", "123"},
+			Action: "exclude",
+		},
+	}, logmock.New(t))
+
+	require.Len(t, matcher.MetricTags["my.metric"].tags, 1, "the unstorable tag name should have been dropped")
+
+	keepTag, shouldStrip := matcher.ShouldStripTags("my.metric")
+	require.True(t, shouldStrip)
+	assert.False(t, keepTag("kube_namespace:default"))
+	assert.False(t, keepTag("Kube Namespace:default"))
+	assert.True(t, keepTag("123:whatever"), "a tag the intake drops cannot have been configured")
+}
+
+// TestTagMatcherUnstorableTagNameIsNotInTheList verifies that a tag name the intake
+// drops is treated as absent from the list, which include and exclude read
+// differently, rather than as a blanket keep or strip.
+func TestTagMatcherUnstorableTagNameIsNotInTheList(t *testing.T) {
+	metrics := map[string]MetricTagList{
+		"excluded": {Tags: []string{"env"}, Action: "exclude"},
+		"included": {Tags: []string{"env"}, Action: "include"},
+	}
+	matcher := newTagMatcher(metrics, logmock.New(t))
+
+	keepTag, shouldStrip := matcher.ShouldStripTags("excluded")
+	require.True(t, shouldStrip)
+	assert.True(t, keepTag("123:x"), "an unconfigurable tag is not excluded")
+
+	keepTag, shouldStrip = matcher.ShouldStripTags("included")
+	require.True(t, shouldStrip)
+	assert.False(t, keepTag("123:x"), "an unconfigurable tag is not included either")
+}
+
+// TestHashTagNameMatchesStringHash pins the assumption hashTagName relies on: the
+// byte and string forms of the murmur3 hash agree, so a name hashed after being
+// normalized into a buffer matches the same name hashed as a string.
+func TestHashTagNameMatchesStringHash(t *testing.T) {
+	for _, name := range []string{"env", "my-tag", "kube_namespace", "café"} {
+		hashed, ok := hashTagName(name + ":value")
+		require.True(t, ok)
+		assert.Equal(t, murmur3.StringSum64(name), hashed)
+		assert.Equal(t, murmur3.Sum64([]byte(name)), hashed)
+	}
+
+	// A name that needs a rewrite hashes to the same value as its normalized form.
+	hashed, ok := hashTagName("My Tag:value")
+	require.True(t, ok)
+	assert.Equal(t, murmur3.StringSum64("my_tag"), hashed)
+
+	_, ok = hashTagName("123:value")
+	assert.False(t, ok)
+}
+
+// TestHashTagNameTrailingUnderscore pins where the trailing underscore of a tag
+// name survives: the intake strips one only from the very end of a tag, so
+// `my_tag_:value` is stored with the name `my_tag_`, while the valueless tag
+// `my_tag_` is stored as `my_tag`.
+func TestHashTagNameTrailingUnderscore(t *testing.T) {
+	kept := murmur3.StringSum64("my_tag_")
+	stripped := murmur3.StringSum64("my_tag")
+
+	// A value follows the name, so the underscore is part of the name. Both the
+	// already normalized name and one that needs a rewrite must agree.
+	for _, tag := range []string{"my_tag_:value", "My Tag :value", "my_tag_*:value"} {
+		hashed, ok := hashTagName(tag)
+		require.True(t, ok, tag)
+		assert.Equal(t, kept, hashed, "%q keeps the trailing underscore", tag)
+	}
+
+	// The tag carries no value, so the name ends the tag and loses it.
+	for _, tag := range []string{"my_tag_", "My Tag ", "my_tag_*"} {
+		hashed, ok := hashTagName(tag)
+		require.True(t, ok, tag)
+		assert.Equal(t, stripped, hashed, "%q loses the trailing underscore", tag)
+	}
+}
+
+// TestTagMatcherTrailingUnderscore checks the same rule end to end: an entry
+// written as the name appears in Datadog strips the tag that carries a value, and
+// the valueless form of that tag is a different, unconfigured name.
+func TestTagMatcherTrailingUnderscore(t *testing.T) {
+	matcher := newTagMatcher(map[string]MetricTagList{
+		"my.metric": {Tags: []string{"my_tag_"}, Action: "exclude"},
+	}, logmock.New(t))
+
+	keepTag, shouldStrip := matcher.ShouldStripTags("my.metric")
+	require.True(t, shouldStrip)
+
+	assert.False(t, keepTag("my_tag_:value"), "the configured name should match")
+	assert.False(t, keepTag("My Tag :value"), "the raw form of the configured name should match")
+	assert.True(t, keepTag("my_tag:value"), "a different name must not match")
+	assert.True(t, keepTag("my_tag_"), "the intake stores this valueless tag as my_tag")
+
+	// Configuring the name of that valueless tag works the other way round.
+	matcher = newTagMatcher(map[string]MetricTagList{
+		"my.metric": {Tags: []string{"my_tag"}, Action: "exclude"},
+	}, logmock.New(t))
+
+	keepTag, shouldStrip = matcher.ShouldStripTags("my.metric")
+	require.True(t, shouldStrip)
+	assert.False(t, keepTag("my_tag_"), "a valueless tag loses its trailing underscore")
+	assert.True(t, keepTag("my_tag_:value"))
+}
+
+// TestHashTagNameDoesNotAllocate pins that hashing an observed tag name stays
+// allocation free, since it runs for every tag of every sample.
+func TestHashTagNameDoesNotAllocate(t *testing.T) {
+	for _, tag := range []string{"kube_namespace:default", "Kube Namespace:default", "123:x", "my_tag_", "bare"} {
+		t.Run(tag, func(t *testing.T) {
+			allocs := testing.AllocsPerRun(100, func() {
+				hashTagName(tag)
+			})
+			assert.Zero(t, allocs)
+		})
+	}
+}
+
+// benchmarkKeepTag measures the per-tag cost of the filter, which runs for every
+// tag of every sample whose metric is configured.
+func benchmarkKeepTag(b *testing.B, tags []string) {
+	matcher := newTagMatcher(map[string]MetricTagList{
+		"my.metric": {
+			Tags:   []string{"env", "kube_namespace", "my-tag", "host"},
+			Action: "exclude",
+		},
+	}, logmock.New(b))
+
+	keepTag, shouldStrip := matcher.ShouldStripTags("my.metric")
+	if !shouldStrip {
+		b.Fatal("expected the metric to be configured")
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		for _, tag := range tags {
+			keepTag(tag)
+		}
+	}
+}
+
+func BenchmarkKeepTagNormalized(b *testing.B) {
+	benchmarkKeepTag(b, []string{"env:prod", "kube_namespace:default", "service:billing", "version:1.2.3"})
+}
+
+func BenchmarkKeepTagNeedsRewrite(b *testing.B) {
+	benchmarkKeepTag(b, []string{"Env:prod", "Kube Namespace:default", "Service:billing", "Version:1.2.3"})
 }

--- a/pkg/util/metricname/BUILD.bazel
+++ b/pkg/util/metricname/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "matcher.go",
         "normalize.go",
+        "tagname.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/util/metricname",
     visibility = ["//visibility:public"],
@@ -16,6 +17,7 @@ dd_agent_go_test(
     srcs = [
         "matcher_test.go",
         "normalize_test.go",
+        "tagname_test.go",
     ],
     embed = [":metricname"],
     deps = [

--- a/pkg/util/metricname/matcher.go
+++ b/pkg/util/metricname/matcher.go
@@ -80,7 +80,7 @@ func (m *Matcher) Test(name string) bool {
 	}
 
 	// Fast path: already normalized, so compare the name as given.
-	if isNormalized(name) {
+	if IsNormalized(name) {
 		return m.search(name)
 	}
 

--- a/pkg/util/metricname/normalize.go
+++ b/pkg/util/metricname/normalize.go
@@ -3,17 +3,23 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package metricname matches metric names against a list, in the name space the
-// Datadog metrics intake stores them in.
+// Package metricname matches metric and tag names against a list, in the name
+// space the Datadog metrics intake stores them in.
 //
-// The Agent submits metric names verbatim; the backend rewrites them on ingest.
-// Any Agent-side decision that has to agree with what the backend stores (for
-// example matching a metric filter list) must therefore compare normalized
+// The Agent submits metric and tag names verbatim; the backend rewrites them on
+// ingest. Any Agent-side decision that has to agree with what the backend stores
+// (for example matching a metric filter list) must therefore compare normalized
 // names rather than the raw names seen on the wire.
 //
+// Metric names and tag names are normalized by different rules, so this package
+// keeps them apart: NormalizeAppend and IsNormalized for metric names,
+// NormalizeTagNameAppend and IsNormalizedASCIITagName for tag names. See
+// NormalizeTagNameAppend for how the two differ.
+//
 // This is a faithful port of `NormMetricNameParse` / `ValidateMetricName` in
-// dd-go (`model/metric.go`). Keep the two in sync: a divergence here silently
-// changes which metrics get filtered.
+// dd-go (`model/metric.go`), and of `NormalizeTag` in `model/tags.go`. Keep them
+// in sync: a divergence here silently changes which metrics and tags get
+// filtered.
 package metricname
 
 // MaxLength is the maximum allowed length of a metric name in bytes.
@@ -55,17 +61,18 @@ func firstAlpha(name string) (int, bool) {
 	return 0, false
 }
 
-// isNormalized reports whether name is a name the intake would store unchanged,
+// IsNormalized reports whether name is a name the intake would store unchanged,
 // i.e. whether normalizing it would be the identity.
 //
 // It performs a single pass and never allocates, which is what lets filter list
 // matching skip the rewrite entirely for the overwhelmingly common case of an
-// already-normalized name. See Matcher.Test.
+// already-normalized name. See Matcher.Test, and tagMatcher.lookup in
+// comp/filterlist/impl for a lookup keyed on normalized names.
 //
-// The predicate is exact: isNormalized(s) is true if and only if normalizing s
+// The predicate is exact: IsNormalized(s) is true if and only if normalizing s
 // yields s unchanged. TestIsNormalizedMatchesNormalize and the fuzz target
 // beside it assert that equivalence.
-func isNormalized(name string) bool {
+func IsNormalized(name string) bool {
 	if len(name) == 0 || len(name) > MaxLength {
 		return false
 	}
@@ -120,7 +127,7 @@ func isNormalized(name string) bool {
 // Because step 4 works on bytes, each byte of a multi-byte UTF-8 sequence is
 // treated separately and the sequence collapses to a single underscore.
 //
-// Normalizing is idempotent: the output always satisfies isNormalized.
+// Normalizing is idempotent: the output always satisfies IsNormalized.
 //
 // A normalized name is never longer than its input, and firstAlpha rejects
 // anything longer than MaxLength, so a dst with MaxLength spare capacity is

--- a/pkg/util/metricname/normalize_test.go
+++ b/pkg/util/metricname/normalize_test.go
@@ -143,19 +143,19 @@ func TestNormalizeMaxLength(t *testing.T) {
 func TestIsNormalized(t *testing.T) {
 	for input, expected := range normalizedNames {
 		t.Run(input, func(t *testing.T) {
-			assert.Equal(t, input == expected, isNormalized(input))
+			assert.Equal(t, input == expected, IsNormalized(input))
 		})
 	}
 
 	for _, input := range unstorableNames {
 		t.Run(input, func(t *testing.T) {
-			assert.False(t, isNormalized(input))
+			assert.False(t, IsNormalized(input))
 		})
 	}
 }
 
 // TestIsNormalizedMatchesNormalize asserts the property the fast path in
-// Normalize relies on: isNormalized(s) is true exactly when normalize(s)
+// Normalize relies on: IsNormalized(s) is true exactly when normalize(s)
 // returns s unchanged.
 func TestIsNormalizedMatchesNormalize(t *testing.T) {
 	inputs := []string{
@@ -167,7 +167,7 @@ func TestIsNormalizedMatchesNormalize(t *testing.T) {
 	for _, input := range inputs {
 		t.Run(input, func(t *testing.T) {
 			normalized, ok := normalize(input)
-			assert.Equal(t, ok && normalized == input, isNormalized(input))
+			assert.Equal(t, ok && normalized == input, IsNormalized(input))
 		})
 	}
 }
@@ -183,8 +183,8 @@ func FuzzIsNormalizedMatchesNormalize(f *testing.F) {
 	f.Fuzz(func(t *testing.T, name string) {
 		normalized, ok := normalize(name)
 
-		assert.Equal(t, ok && normalized == name, isNormalized(name),
-			"isNormalized disagrees with Normalize for %q", name)
+		assert.Equal(t, ok && normalized == name, IsNormalized(name),
+			"IsNormalized disagrees with Normalize for %q", name)
 
 		if !ok {
 			assert.Equal(t, name, normalized)
@@ -192,7 +192,7 @@ func FuzzIsNormalizedMatchesNormalize(f *testing.F) {
 		}
 
 		// Normalization must always produce a storable, stable name.
-		assert.True(t, isNormalized(normalized),
+		assert.True(t, IsNormalized(normalized),
 			"Normalize produced a non-normalized name %q from %q", normalized, name)
 
 		again, ok := normalize(normalized)
@@ -275,7 +275,7 @@ func referenceNormalize(name string) (string, bool) {
 // replay their seed corpus. Exhaustive enumeration is the coverage that actually
 // runs in CI.
 //
-// It also pins the equivalence that isNormalized's fast path depends on, since a
+// It also pins the equivalence that IsNormalized's fast path depends on, since a
 // name reported as already normalized must normalise to itself.
 func TestNormalizationMatchesReferenceExhaustive(t *testing.T) {
 	alphabet := []byte{'a', 'B', '1', '.', '_', '-', 0xC3}
@@ -299,12 +299,12 @@ func TestNormalizationMatchesReferenceExhaustive(t *testing.T) {
 					name, wantStr, gotStr)
 			}
 			// The fast path in Matcher.Test skips the rewrite entirely for names
-			// isNormalized accepts, so that must imply the rewrite is a no-op.
-			if isNormalized(name) && gotStr != name {
+			// IsNormalized accepts, so that must imply the rewrite is a no-op.
+			if IsNormalized(name) && gotStr != name {
 				t.Fatalf("%q is reported normalized but normalises to %q", name, gotStr)
 			}
 			// And the output must itself be a fixed point.
-			if !isNormalized(gotStr) {
+			if !IsNormalized(gotStr) {
 				t.Fatalf("normalising %q produced %q, which is not normalized",
 					name, gotStr)
 			}

--- a/pkg/util/metricname/tagname.go
+++ b/pkg/util/metricname/tagname.go
@@ -1,0 +1,188 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metricname
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// MaxTagLength is the maximum length of a tag in bytes.
+//
+// Unlike a metric name, a tag over this length is truncated by the intake rather
+// than rejected. Mirrors `model.MaxTagLength` in dd-go.
+//
+// Note that the intake applies this limit to the whole `name:value` tag, so a
+// tag name is never longer than this either. Tags submitted with the long tag
+// option get a much larger budget (`model.MaxLongTagLength`, 5 KiB), which is
+// deliberately not mirrored here: it only ever lets a *longer* name through, and
+// a name that long cannot be typed into a filter list by hand anyway.
+const MaxTagLength = 200
+
+// MaxNormalizedTagLength is the maximum length in bytes of a normalized tag
+// name, and therefore the buffer size NormalizeTagNameAppend needs to never
+// reallocate.
+//
+// It exceeds MaxTagLength because the length is checked before appending a code
+// point rather than after, so the last one can straddle the limit. dd-go has the
+// same overshoot, documented as a bug on `model.MaxTagLength`; matching it
+// matters, because the intake stores the overshooting name.
+const MaxNormalizedTagLength = MaxTagLength + utf8.UTFMax - 1
+
+// isLowerAlpha reports whether b is a lowercase ASCII letter.
+func isLowerAlpha(b byte) bool {
+	return b >= 'a' && b <= 'z'
+}
+
+// isDigit reports whether b is an ASCII digit.
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}
+
+// IsNormalizedASCIITagName reports whether name is an all-ASCII tag name that the
+// intake would store unchanged. See NormalizeTagNameAppend for the trailing
+// underscore, which is part of a normalized name.
+//
+// Like IsNormalized it exists to let callers skip the rewrite for the
+// overwhelmingly common case, and it performs a single pass and never allocates.
+//
+// Unlike IsNormalized the predicate is one-sided, mirroring
+// `model.IsNormalizedASCIITag` in dd-go: true guarantees that normalizing name
+// is the identity, but false does not guarantee the opposite. A name containing
+// non-ASCII bytes is always reported as not normalized, even when it is already
+// a fixed point (`café` is stored as `café`), because deciding that needs the
+// Unicode tables that the fast path exists to avoid. Such a name simply takes
+// the slow path, which returns it unchanged.
+//
+// The one-sidedness is why callers must use the result only to skip work, never
+// to decide that a name is unstorable.
+func IsNormalizedASCIITagName(name string) bool {
+	if len(name) == 0 || len(name) > MaxTagLength {
+		return false
+	}
+
+	// A normalized tag name always starts with a lowercase ASCII letter (or a
+	// non-ASCII letter, which this fast path does not accept): everything before
+	// the first letter is stripped, and letters are lowercased.
+	if !isLowerAlpha(name[0]) {
+		return false
+	}
+
+	for i := 1; i < len(name); i++ {
+		switch c := name[i]; {
+		case isLowerAlpha(c) || isDigit(c) || c == '.' || c == '/' || c == '-':
+			// Kept verbatim.
+		case c == '_':
+			// Runs of underscores collapse to one. Note that, unlike in a metric
+			// name, an underscore next to a period or at the end of the name is
+			// left alone.
+			if name[i-1] == '_' {
+				return false
+			}
+		default:
+			// Anything else, including a colon and any non-ASCII byte, means the
+			// name is either rewritten or not a tag name at all.
+			return false
+		}
+	}
+
+	return true
+}
+
+// NormalizeTagNameAppend appends the tag name as the Datadog intake will store it
+// to dst, and returns the extended slice.
+//
+// The bool is false when the name normalizes to nothing, which happens when it is
+// empty or contains no letter at all: the intake drops such a tag. In that case
+// dst is returned unmodified.
+//
+// name must be a tag name, i.e. the part of a tag before the first colon. A colon
+// is not expected and, like any other invalid byte, becomes an underscore --
+// callers holding a whole `name:value` tag must split it first.
+//
+// The rules, applied per code point:
+//
+//  1. Everything before the first letter is discarded.
+//  2. Letters are lowercased.
+//  3. Digits and `.`, `/` and `-` are kept verbatim.
+//  4. Every other code point becomes an underscore, and an underscore is not
+//     emitted directly after another one. Note that this applies to literal
+//     underscores in the input too, so `a__b` becomes `a_b`.
+//  5. The name is truncated to MaxTagLength.
+//
+// A trailing underscore is deliberately *kept*: the intake strips one only from
+// the very end of the whole tag, so the name in `my_tag_:value` is stored as
+// `my_tag_`. A caller holding a tag that carries no value, where the name does end
+// the tag, has to drop that underscore itself.
+//
+// These are *not* the metric name rules in NormalizeAppend: tag names are
+// lowercased, keep `-` and `/`, keep an underscore next to a period, are
+// Unicode-aware rather than byte-wise, and are truncated instead of rejected when
+// too long. Use the right one for the name at hand.
+//
+// Normalizing is idempotent, and the output of an all-ASCII input satisfies
+// IsNormalizedASCIITagName.
+//
+// A dst with MaxNormalizedTagLength spare capacity is enough for append never to
+// reallocate, which is what lets callers normalize into a stack buffer.
+//
+// This is a port of `NormalizeTag` in dd-go (`model/tags.go`), restricted to the
+// tag name. Keep the two in sync: a divergence here silently changes which tags
+// get stripped. Note that `NormalizeTagArbTagValue`, the path taken only when a
+// payload opts in with `allow_arbitrary_tags`, normalizes the name slightly
+// differently: it strips a trailing underscore from the name even when a value
+// follows. This follows the default path.
+func NormalizeTagNameAppend(dst []byte, name string) ([]byte, bool) {
+	start := len(dst)
+	lastWasUnderscore := false
+
+	for i, c := range name {
+		if len(dst)-start >= MaxTagLength {
+			break
+		}
+		// Bound the work done on a very long name that is mostly garbage: past
+		// this point it cannot contribute to the truncated result anyway. dd-go
+		// bounds it the same way, on the byte offset rather than the count of
+		// code points read.
+		if i > 2*MaxTagLength {
+			break
+		}
+
+		switch {
+		// Fast path for the ASCII alphabet.
+		case c >= 'a' && c <= 'z':
+			dst = append(dst, byte(c))
+			lastWasUnderscore = false
+		case c >= 'A' && c <= 'Z':
+			dst = append(dst, byte(c)+('a'-'A'))
+			lastWasUnderscore = false
+		case unicode.IsLetter(c):
+			dst = utf8.AppendRune(dst, unicode.ToLower(c))
+			lastWasUnderscore = false
+		// Skip anything that cannot start the name. Reached only while nothing
+		// has been emitted yet, so only until the first letter.
+		case len(dst) == start:
+		// Valid, but cannot start the name.
+		case c == '.' || c == '/' || c == '-':
+			dst = append(dst, byte(c))
+			lastWasUnderscore = false
+		case unicode.IsDigit(c):
+			dst = utf8.AppendRune(dst, c)
+			lastWasUnderscore = false
+		// Convert anything else to an underscore, including a literal
+		// underscore, but only one in a row.
+		case !lastWasUnderscore:
+			dst = append(dst, '_')
+			lastWasUnderscore = true
+		}
+	}
+
+	if len(dst) == start {
+		return dst, false
+	}
+
+	return dst, true
+}

--- a/pkg/util/metricname/tagname_test.go
+++ b/pkg/util/metricname/tagname_test.go
@@ -1,0 +1,437 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metricname
+
+import (
+	"strings"
+	"testing"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// normalizeTagName is the string-returning form of NormalizeTagNameAppend, for
+// tests that assert on the normalized name. Production code normalizes into a
+// stack buffer instead.
+func normalizeTagName(name string) (string, bool) {
+	got, ok := NormalizeTagNameAppend(make([]byte, 0, MaxNormalizedTagLength), name)
+	if !ok {
+		return "", false
+	}
+	return string(got), true
+}
+
+// normalizedTagNames covers the tag name rules. Expectations are the *name* the
+// intake stores, so where an input also happens to be a whole valueless tag they
+// differ from dd-go's tables by the trailing underscore that dd-go strips from the
+// end of a tag; ddgoValuelessTagNames below covers that composition.
+var normalizedTagNames = map[string]string{
+	// Already normalized, must be returned untouched.
+	"env":            "env",
+	"kube_namespace": "kube_namespace",
+	"host-name":      "host-name",
+	"my.tag":         "my.tag",
+	"path/to":        "path/to",
+	"tag1":           "tag1",
+
+	// Lowercased, unlike a metric name.
+	"Env":     "env",
+	"MyTag":   "mytag",
+	"KUBE_NS": "kube_ns",
+
+	// Hyphens and slashes survive, unlike in a metric name.
+	"my-tag":    "my-tag",
+	"My-Tag":    "my-tag",
+	"a/b-c.d":   "a/b-c.d",
+	"kube-app":  "kube-app",
+	"foo_-_bar": "foo_-_bar",
+
+	// Anything else becomes a single underscore, including literal underscores.
+	"foo bar":         "foo_bar",
+	"foo  bar":        "foo_bar",
+	"foo__bar":        "foo_bar",
+	"foo_%bar":        "foo_bar",
+	"foo_=bar":        "foo_bar",
+	"foo_@(bar":       "foo_bar",
+	"foo_(bar_+_baz)": "foo_bar_baz_",
+
+	// A trailing underscore is kept, because the intake only strips one from the
+	// very end of the whole tag: the name in `foo_:value` is stored as `foo_`.
+	"foo!":     "foo_",
+	"foo_*":    "foo_",
+	"foo_":     "foo_",
+	"foo__":    "foo_",
+	"foo bar ": "foo_bar_",
+	"tag🍣":     "tag_",
+
+	// An underscore next to a period is kept, unlike in a metric name.
+	"a._b": "a._b",
+	"a_.b": "a_.b",
+
+	// Everything before the first letter is dropped, including digits.
+	"1tag":     "tag",
+	"...tag":   "tag",
+	"_tag":     "tag",
+	"-tag":     "tag",
+	"5-2 tags": "tags",
+
+	// Non-ASCII letters are lowercased and kept.
+	"café":   "café",
+	"CAFÉ":   "café",
+	"Straße": "straße",
+	// Non-letters are still underscores.
+	"tag🍣end": "tag_end",
+}
+
+// ddgoValuelessTagNames mirrors entries of the `normalizeTagTests` table in dd-go
+// (`model/tags_test.go`) whose input is a whole tag with no value, so a divergence
+// between the two implementations shows up as a failure here. These expectations
+// include the trailing underscore strip dd-go applies at the end of a tag, which
+// is why they go through normalizeValuelessTagName.
+var ddgoValuelessTagNames = map[string]string{
+	"foo_%bar":        "foo_bar",
+	"foo_=bar":        "foo_bar",
+	"foo_'bar":        "foo_bar",
+	"foo_\"bar":       "foo_bar",
+	"foo_\\bar":       "foo_bar",
+	"foo_@(bar":       "foo_bar",
+	"foo_*":           "foo",
+	"foo_(bar_+_baz)": "foo_bar_baz",
+	"FOO":             "foo",
+	"foo bar":         "foo_bar",
+}
+
+// unstorableTagNames are names that normalize to nothing, so the intake drops the
+// tag entirely.
+var unstorableTagNames = []string{
+	"",
+	"_",
+	"...",
+	"123",
+	"127.0.0.0",
+	"🍣",
+	"-",
+	"1.2-3/4",
+}
+
+func TestNormalizeTagName(t *testing.T) {
+	for input, expected := range normalizedTagNames {
+		t.Run(input, func(t *testing.T) {
+			actual, ok := normalizeTagName(input)
+			require.True(t, ok)
+			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
+// normalizeValuelessTagName composes the name rules with the rule a caller holding
+// a tag that carries no value has to apply, since the name then ends the tag: see
+// NormalizeTagNameAppend, and hashTagName in comp/filterlist/impl for the caller
+// that does it. It exists so this package can be checked against dd-go's whole-tag
+// expectations.
+func normalizeValuelessTagName(tag string) (string, bool) {
+	name, ok := normalizeTagName(tag)
+	if !ok {
+		return "", false
+	}
+	return strings.TrimSuffix(name, "_"), true
+}
+
+// TestNormalizeValuelessTagNameMatchesDDGo checks the composed rules against dd-go's
+// own expectations for whole tags without a value.
+func TestNormalizeValuelessTagNameMatchesDDGo(t *testing.T) {
+	for input, expected := range ddgoValuelessTagNames {
+		t.Run(input, func(t *testing.T) {
+			actual, ok := normalizeValuelessTagName(input)
+			require.True(t, ok)
+			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
+// TestNormalizeTagNameKeepsTrailingUnderscore pins the rule that the name of a tag
+// carrying a value keeps its trailing underscore, because the intake only strips
+// one from the very end of a tag: `my_tag_:value` is stored with the name
+// `my_tag_`, while the valueless tag `my_tag_` is stored as `my_tag`.
+func TestNormalizeTagNameKeepsTrailingUnderscore(t *testing.T) {
+	for _, name := range []string{"my_tag_", "my tag ", "my_tag_*"} {
+		t.Run(name, func(t *testing.T) {
+			actual, ok := normalizeTagName(name)
+			require.True(t, ok)
+			assert.Equal(t, "my_tag_", actual)
+			assert.True(t, IsNormalizedASCIITagName(actual),
+				"a name ending in an underscore is normalized")
+
+			valueless, ok := normalizeValuelessTagName(name)
+			require.True(t, ok)
+			assert.Equal(t, "my_tag", valueless)
+		})
+	}
+}
+
+func TestNormalizeTagNameUnstorable(t *testing.T) {
+	for _, input := range unstorableTagNames {
+		t.Run(input, func(t *testing.T) {
+			_, ok := normalizeTagName(input)
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestNormalizeTagNameIsIdempotent(t *testing.T) {
+	for input := range normalizedTagNames {
+		t.Run(input, func(t *testing.T) {
+			once, ok := normalizeTagName(input)
+			require.True(t, ok)
+			twice, ok := normalizeTagName(once)
+			require.True(t, ok)
+			assert.Equal(t, once, twice)
+		})
+	}
+}
+
+// TestNormalizeTagNameColon documents that a colon is not special here: callers
+// are expected to have split the tag already, and a name still holding one is
+// rewritten rather than truncated at it.
+func TestNormalizeTagNameColon(t *testing.T) {
+	actual, ok := normalizeTagName("env:prod")
+	require.True(t, ok)
+	assert.Equal(t, "env_prod", actual)
+}
+
+// TestNormalizeTagNameTruncates checks the length rule, which differs from metric
+// names: an over-long tag name is cut down rather than rejected.
+func TestNormalizeTagNameTruncates(t *testing.T) {
+	atLimit := strings.Repeat("a", MaxTagLength)
+
+	actual, ok := normalizeTagName(atLimit)
+	require.True(t, ok)
+	assert.Equal(t, atLimit, actual)
+
+	actual, ok = normalizeTagName(atLimit + "bbb")
+	require.True(t, ok)
+	assert.Equal(t, atLimit, actual, "an over-long name is truncated, not rejected")
+
+	// Truncation can leave a trailing underscore, which is kept like any other.
+	actual, ok = normalizeTagName(strings.Repeat("a", MaxTagLength-1) + "_bbb")
+	require.True(t, ok)
+	assert.Equal(t, strings.Repeat("a", MaxTagLength-1)+"_", actual)
+
+	// A multi-byte code point straddling the limit overshoots it, as it does in
+	// the intake, but never past MaxNormalizedTagLength.
+	actual, ok = normalizeTagName(strings.Repeat("a", MaxTagLength-1) + "é" + "b")
+	require.True(t, ok)
+	assert.Equal(t, strings.Repeat("a", MaxTagLength-1)+"é", actual)
+	assert.LessOrEqual(t, len(actual), MaxNormalizedTagLength)
+}
+
+// TestNormalizeTagNameAppendReusesBuffer pins the two properties callers depend on
+// for the stack buffer: existing content is left alone, and a buffer with
+// MaxNormalizedTagLength spare capacity is never grown.
+func TestNormalizeTagNameAppendReusesBuffer(t *testing.T) {
+	buf := make([]byte, 0, MaxNormalizedTagLength)
+	buf = append(buf, "keep:"...)
+
+	got, ok := NormalizeTagNameAppend(buf, "My Tag")
+	require.True(t, ok)
+	assert.Equal(t, "keep:my_tag", string(got))
+
+	// An unstorable name leaves the buffer untouched.
+	got, ok = NormalizeTagNameAppend(buf, "123")
+	require.False(t, ok)
+	assert.Equal(t, "keep:", string(got))
+
+	var stack [MaxNormalizedTagLength]byte
+	long := strings.Repeat("a-", MaxTagLength)
+	allocs := testing.AllocsPerRun(100, func() {
+		NormalizeTagNameAppend(stack[:0], long)
+	})
+	assert.Zero(t, allocs, "normalizing into a MaxNormalizedTagLength buffer must not reallocate")
+}
+
+func TestIsNormalizedASCIITagName(t *testing.T) {
+	for input, expected := range normalizedTagNames {
+		t.Run(input, func(t *testing.T) {
+			if !isASCII(input) {
+				// The predicate is one-sided: a non-ASCII name is always
+				// reported as not normalized, even when it is a fixed point.
+				assert.False(t, IsNormalizedASCIITagName(input))
+				return
+			}
+			assert.Equal(t, input == expected, IsNormalizedASCIITagName(input))
+		})
+	}
+
+	for _, input := range unstorableTagNames {
+		t.Run(input, func(t *testing.T) {
+			assert.False(t, IsNormalizedASCIITagName(input))
+		})
+	}
+
+	// A colon means the caller has not split the tag, so it is never a
+	// normalized tag name.
+	assert.False(t, IsNormalizedASCIITagName("env:prod"))
+	assert.False(t, IsNormalizedASCIITagName("env"+strings.Repeat("a", MaxTagLength)))
+}
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
+}
+
+// referenceNormalizeTagName is an independent transcription of `NormalizeTag` in
+// dd-go `model/tags.go`, restricted to a name with no colon (see
+// NormalizeTagNameAppend) and deliberately written without a fast path. It is the
+// oracle for TestTagNameNormalizationMatchesReferenceExhaustive, so that test pins
+// this package against dd-go's behaviour rather than against itself.
+//
+// dd-go's trailing underscore strip is deliberately not transcribed: it applies to
+// the end of the whole tag, which a name followed by a value is not. Callers
+// holding a valueless tag apply it themselves, and that is covered where they do.
+func referenceNormalizeTagName(name string) (string, bool) {
+	var buf []byte
+	lastWasUnderscore := false
+
+	for i, c := range name {
+		if len(buf) >= MaxTagLength {
+			break
+		}
+		if i > 2*MaxTagLength {
+			break
+		}
+
+		switch {
+		case unicode.IsLetter(c):
+			buf = utf8.AppendRune(buf, unicode.ToLower(c))
+			lastWasUnderscore = false
+		case len(buf) == 0:
+			// Dropped: nothing can start the name but a letter.
+		case unicode.IsDigit(c) || c == '.' || c == '/' || c == '-':
+			buf = utf8.AppendRune(buf, c)
+			lastWasUnderscore = false
+		case !lastWasUnderscore:
+			buf = append(buf, '_')
+			lastWasUnderscore = true
+		}
+	}
+
+	if len(buf) == 0 {
+		return "", false
+	}
+	return string(buf), true
+}
+
+// TestTagNameNormalizationMatchesReferenceExhaustive checks this package against
+// the dd-go transcription above over every string up to length 5 drawn from an
+// alphabet that reaches every branch: lower and upper ASCII letters, a digit, the
+// three punctuation characters that survive, an underscore, a byte that becomes an
+// underscore, and a byte of a multi-byte rune. 108,801 cases, a few milliseconds.
+//
+// This is the counterpart of TestNormalizationMatchesReferenceExhaustive for
+// metric names, and exists for the same reason: `bazel test` cannot run fuzz
+// targets, so enumeration is the coverage that actually runs in CI.
+//
+// It also pins the one-sided guarantee IsNormalizedASCIITagName makes, since a
+// name it accepts must normalize to itself.
+func TestTagNameNormalizationMatchesReferenceExhaustive(t *testing.T) {
+	alphabet := []byte{'a', 'B', '1', '.', '/', '-', '_', ' ', 0xC3}
+
+	var buf []byte
+	checked := 0
+	var rec func(depth int)
+	rec = func(depth int) {
+		name := string(buf)
+		checked++
+
+		wantStr, wantOK := referenceNormalizeTagName(name)
+		gotStr, gotOK := normalizeTagName(name)
+		if wantOK != gotOK {
+			t.Fatalf("storability disagrees for %q: reference %v, package %v",
+				name, wantOK, gotOK)
+		}
+		if wantOK {
+			if wantStr != gotStr {
+				t.Fatalf("normalisation disagrees for %q: reference %q, package %q",
+					name, wantStr, gotStr)
+			}
+			// Callers skip the rewrite for names the predicate accepts, so that
+			// must imply the rewrite is a no-op.
+			if IsNormalizedASCIITagName(name) && gotStr != name {
+				t.Fatalf("%q is reported normalized but normalises to %q", name, gotStr)
+			}
+			// And an all-ASCII output must itself be a fixed point, otherwise
+			// the two sides of a comparison could disagree.
+			if isASCII(gotStr) && !IsNormalizedASCIITagName(gotStr) {
+				t.Fatalf("normalising %q produced %q, which is not normalized",
+					name, gotStr)
+			}
+		}
+
+		if depth == 0 {
+			return
+		}
+		for _, c := range alphabet {
+			buf = append(buf, c)
+			rec(depth - 1)
+			buf = buf[:len(buf)-1]
+		}
+	}
+	rec(5)
+	t.Logf("checked %d strings against the dd-go transcription", checked)
+}
+
+func FuzzNormalizeTagName(f *testing.F) {
+	for input := range normalizedTagNames {
+		f.Add(input)
+	}
+	for _, input := range unstorableTagNames {
+		f.Add(input)
+	}
+
+	f.Fuzz(func(t *testing.T, name string) {
+		wantStr, wantOK := referenceNormalizeTagName(name)
+		gotStr, gotOK := normalizeTagName(name)
+
+		assert.Equal(t, wantOK, gotOK, "storability disagrees for %q", name)
+		if !gotOK {
+			return
+		}
+		assert.Equal(t, wantStr, gotStr, "normalisation disagrees for %q", name)
+
+		if IsNormalizedASCIITagName(name) {
+			assert.Equal(t, name, gotStr, "%q is reported normalized but was rewritten", name)
+		}
+
+		again, ok := normalizeTagName(gotStr)
+		assert.True(t, ok)
+		assert.Equal(t, gotStr, again, "normalizing is not idempotent for %q", name)
+		assert.LessOrEqual(t, len(gotStr), MaxNormalizedTagLength)
+	})
+}
+
+func BenchmarkNormalizeTagNameAlreadyNormalized(b *testing.B) {
+	name := "kube_namespace"
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		normalizeTagName(name)
+	}
+}
+
+func BenchmarkNormalizeTagNameNeedsRewrite(b *testing.B) {
+	name := "Kube Namespace"
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		normalizeTagName(name)
+	}
+}


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Follow on from #55599 

This normalizes metric and tag names prior to checking for tag aggregation.

### Motivation

The datadog backend normalizes metric and tag names according to the rules outlined [here](https://datadoghq.atlassian.net/wiki/spaces/AMCC/pages/edit-v2/7140312254). The user will configure the normalized names for tag aggregation. The agent receives the raw names and will not match them with the configured rules unless it normalizes these values first.

### Describe how you validated your changes

### Additional Notes
