### PR TITLE
ssi: allow OTEL_ prefixed tracer config env vars

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation/annotation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation/annotation.go
@@ -33,7 +33,7 @@ const (
 	// TracerConfigs sets tracer configuration options (injected as environment variables) during
 	// Local SDK Injection. It is the annotation-based equivalent of the targets[].ddTraceConfigs
 	// config option. The value is a JSON array of objects matching the ddTraceConfigs schema, and
-	// every entry's name must start with the DD_ prefix.
+	// every entry's name must start with the DD_ or OTEL_ prefix.
 	// Example value: [{"name":"DD_PROFILING_ENABLED","value":"true"}]
 	TracerConfigs = "admission.datadoghq.com/apm-inject.tracer-configs"
 	// LibraryVersion sets the library to use during Local SDK Injection.

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
@@ -38,6 +38,21 @@ const (
 	AppliedPolicyEnvVar = "DD_INSTRUMENTATION_APPLIED_POLICY"
 )
 
+// allowedTracerConfigPrefixes are the env var name prefixes accepted for tracer configs supplied
+// via Targets, remote-config policies, or the tracer-configs annotation. This keeps the mechanism
+// from being used as a generic env var injector while still allowing DD_* and OTel-native OTEL_*
+// configuration (e.g. activating a tracer's OTel mode with OTEL_TRACES_EXPORTER).
+var allowedTracerConfigPrefixes = []string{"DD_", "OTEL_"}
+
+func hasAllowedTracerConfigPrefix(name string) bool {
+	for _, prefix := range allowedTracerConfigPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // policySet is matcher.policies aligned with injection targets by index, so a
 // match resolves directly to its injection config. An empty set (no targets, no
 // policies) matches nothing.
@@ -175,13 +190,12 @@ func buildInternalTargets(config *Config, targets []Target, defaultLibVersions [
 			libVersions = pinnedLibraries.libs
 		}
 
-		// Convert the tracer configs to env vars. We check that the env var names start with the DD_ prefix to avoid
-		// this from being used as a generic env var injector. If there is a product requirement to allow arbitrary env
-		// vars in the future, we could relax this requirement.
+		// Convert the tracer configs to env vars. We only allow DD_ and OTEL_ prefixed names to avoid
+		// this from being used as a generic env var injector.
 		envVars := make([]corev1.EnvVar, len(t.TracerConfigs))
 		for j, tc := range t.TracerConfigs {
-			if !strings.HasPrefix(tc.Name, "DD_") {
-				return nil, fmt.Errorf("tracer config %q does not start with DD_", tc.Name)
+			if !hasAllowedTracerConfigPrefix(tc.Name) {
+				return nil, fmt.Errorf("tracer config %q does not start with DD_ or OTEL_", tc.Name)
 			}
 			envVars[j] = tc.AsEnvVar()
 		}
@@ -244,8 +258,8 @@ func buildInternalTargetsFromPolicies(config *Config, ps []policies.Policy, defa
 
 		envVars := make([]corev1.EnvVar, len(p.Outcome.TracerConfigs))
 		for j, tc := range p.Outcome.TracerConfigs {
-			if !strings.HasPrefix(tc.Name, "DD_") {
-				return nil, fmt.Errorf("tracer config %q does not start with DD_", tc.Name)
+			if !hasAllowedTracerConfigPrefix(tc.Name) {
+				return nil, fmt.Errorf("tracer config %q does not start with DD_ or OTEL_", tc.Name)
 			}
 			envVars[j] = corev1.EnvVar{Name: tc.Name, Value: tc.Value}
 		}
@@ -653,10 +667,10 @@ func extractTracerConfigsFromAnnotations(pod *corev1.Pod) []corev1.EnvVar {
 
 	envVars := make([]corev1.EnvVar, 0, len(tracerConfigs))
 	for _, tc := range tracerConfigs {
-		// Match the validation applied to config-based ddTraceConfigs: only allow DD_ prefixed names
-		// so this cannot be used as a generic env var injector.
-		if !strings.HasPrefix(tc.Name, "DD_") {
-			log.Errorf("tracer config %q from %q annotation does not start with DD_, skipping", tc.Name, annotation.TracerConfigs)
+		// Match the validation applied to config-based ddTraceConfigs: only allow DD_ or OTEL_
+		// prefixed names so this cannot be used as a generic env var injector.
+		if !hasAllowedTracerConfigPrefix(tc.Name) {
+			log.Errorf("tracer config %q from %q annotation does not start with DD_ or OTEL_, skipping", tc.Name, annotation.TracerConfigs)
 			continue
 		}
 		envVars = append(envVars, tc.AsEnvVar())

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
@@ -650,7 +650,7 @@ func containsVolume(pod *corev1.Pod, volumeName string) bool {
 
 // extractTracerConfigsFromAnnotations parses the tracer-configs annotation into env vars to inject
 // alongside the locally injected libraries. It is the annotation-based equivalent of a target's
-// ddTraceConfigs. Invalid input (malformed JSON or a non DD_ prefixed name) is logged and skipped
+// ddTraceConfigs. Invalid input (malformed JSON or a name without an allowed prefix) is logged and skipped
 // rather than failing the mutation, mirroring the lenient handling of the other local SDK
 // injection annotations.
 func extractTracerConfigsFromAnnotations(pod *corev1.Pod) []corev1.EnvVar {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -56,6 +56,45 @@ var (
 	imageResolver = imageresolver.NewNoOpResolver()
 )
 
+func TestHasAllowedTracerConfigPrefix(t *testing.T) {
+	require.True(t, hasAllowedTracerConfigPrefix("DD_PROFILING_ENABLED"))
+	require.True(t, hasAllowedTracerConfigPrefix("OTEL_TRACES_EXPORTER"))
+	require.False(t, hasAllowedTracerConfigPrefix("NOT_DD"))
+	require.False(t, hasAllowedTracerConfigPrefix(""))
+}
+
+func TestBuildInternalTargetsTracerConfigPrefix(t *testing.T) {
+	config := &Config{staticConfig: staticConfig{containerRegistry: "registry"}}
+
+	t.Run("DD_ and OTEL_ prefixed tracer configs are accepted", func(t *testing.T) {
+		targets, err := buildInternalTargets(config, []Target{
+			{
+				Name: "otel-mode",
+				TracerConfigs: []TracerConfig{
+					{Name: "DD_TRACE_OTEL_ENABLED", Value: "true"},
+					{Name: "OTEL_TRACES_EXPORTER", Value: "otlp"},
+				},
+			},
+		}, nil)
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+		require.Equal(t, []corev1.EnvVar{
+			{Name: "DD_TRACE_OTEL_ENABLED", Value: "true"},
+			{Name: "OTEL_TRACES_EXPORTER", Value: "otlp"},
+		}, targets[0].envVars)
+	})
+
+	t.Run("tracer config without an allowed prefix is rejected", func(t *testing.T) {
+		_, err := buildInternalTargets(config, []Target{
+			{
+				Name:          "bad-target",
+				TracerConfigs: []TracerConfig{{Name: "GENERIC_VAR", Value: "true"}},
+			},
+		}, nil)
+		require.Error(t, err)
+	})
+}
+
 func TestNewTargetMutator(t *testing.T) {
 	tests := map[string]struct {
 		configPath string
@@ -469,7 +508,7 @@ func TestGetTargetFromAnnotation(t *testing.T) {
 				},
 			},
 		},
-		"tracer-configs entries without a DD_ prefix are skipped": {
+		"tracer-configs entries without a DD_ or OTEL_ prefix are skipped": {
 			configPath: "testdata/filter_limited.yaml",
 			in: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -489,6 +528,30 @@ func TestGetTargetFromAnnotation(t *testing.T) {
 				},
 				envVars: []corev1.EnvVar{
 					{Name: "DD_PROFILING_ENABLED", Value: "true"},
+				},
+			},
+		},
+		"tracer-configs entries with an OTEL_ prefix are forwarded": {
+			configPath: "testdata/filter_limited.yaml",
+			in: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Labels: map[string]string{
+						common.EnabledLabelKey: "true",
+					},
+					Annotations: map[string]string{
+						"admission.datadoghq.com/python-lib.version":        "v3",
+						"admission.datadoghq.com/apm-inject.tracer-configs": `[{"name":"OTEL_TRACES_EXPORTER","value":"otlp"},{"name":"DD_TRACE_OTEL_ENABLED","value":"true"}]`,
+					},
+				},
+			},
+			expected: &targetInternal{
+				libVersions: []libInfo{
+					defaultLibInfoWithVersion(python, "v3"),
+				},
+				envVars: []corev1.EnvVar{
+					{Name: "OTEL_TRACES_EXPORTER", Value: "otlp"},
+					{Name: "DD_TRACE_OTEL_ENABLED", Value: "true"},
 				},
 			},
 		},

--- a/releasenotes/notes/ssi-otel-target-config-prefix-03b340d4c7104af1.yaml
+++ b/releasenotes/notes/ssi-otel-target-config-prefix-03b340d4c7104af1.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    Single Step Instrumentation's tracer config mechanisms (the ``ddTraceConfigs``
+    ``Targets`` field, remote-config policies, and the
+    ``admission.datadoghq.com/apm-inject.tracer-configs`` pod annotation) now also
+    accept ``OTEL_`` prefixed environment variable names, in addition to the
+    existing ``DD_`` prefix. This allows configuring a tracer's native OpenTelemetry
+    mode (e.g. ``OTEL_TRACES_EXPORTER``, ``OTEL_EXPORTER_OTLP_ENDPOINT``) through
+    SSI.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Relaxes the env var name validation induced in https://github.com/DataDog/datadog-agent/pull/33959/ applied to Single Step Instrumentation's tracer configs (via `Targets`' `ddTraceConfigs`, remote-config policies, and the `admission.datadoghq.com/apm-inject.tracer-configs` pod annotation) to also accept `OTEL_` prefixed names, in addition to the existing `DD_` prefix.

### Motivation

These tracer config mechanisms are how SSI lets users declare extra environment variables to inject alongside an auto-instrumented tracer. Today they reject anything that isn't `DD_` prefixed, which blocks a common use case: activating an APM tracer's built-in OTel mode requires setting native `OTEL_*` env vars (e.g. `OTEL_TRACES_EXPORTER`, `OTEL_EXPORTER_OTLP_ENDPOINT`) alongside the `DD_*` toggles (`DD_TRACE_OTEL_ENABLED`, etc.). Users configuring this today via the Datadog Operator/SSI hit an outright rejection for the `OTEL_*` half of that configuration.

This is a narrow relaxation of the existing prefix allowlist rather than a redesign — the mechanism still can't be used as a generic env var injector, it just also allows the `OTEL_` namespace.

### Describe how you validated your changes

Added/updated unit tests in `target_mutator_test.go` covering:
- `hasAllowedTracerConfigPrefix` accepting `DD_`/`OTEL_` and rejecting anything else
- `buildInternalTargets` accepting `OTEL_` prefixed `ddTraceConfigs` entries and still rejecting unprefixed ones
- the `tracer-configs` pod annotation forwarding `OTEL_` prefixed entries end to end

Ran `dda inv test --targets=./pkg/clusteragent/admission/mutate/autoinstrumentation/...` — all 495 tests pass.

### Additional Notes

Supersedes #55779, which took a different (equivalence-detection) approach to a related but distinct problem; this PR addresses the actual reported blocker of `OTEL_*` env vars being rejected outright by SSI's tracer-config mechanisms.
