### PR TITLE
packages: fix licenses install location

### DIFF
--- a/packages/agent/linux/BUILD.bazel
+++ b/packages/agent/linux/BUILD.bazel
@@ -39,7 +39,6 @@ pkg_filegroup(
         "//packages/install_dir:embedded",
         "//packages/install_dir:etc",
     ],
-    prefix = "/opt/datadog-agent",
 )
 
 # This is an intermediate node so that have a place to collect all
@@ -60,13 +59,23 @@ package_licenses(
     src = ":everything",
 )
 
+# Everything that gets installed under /opt/datadog-agent: the product
+# files plus the licenses gathered for them.
+pkg_filegroup(
+    name = "installed_distro",
+    srcs = [
+        ":everything",
+        ":license_files",
+    ],
+    prefix = "/opt/datadog-agent",
+)
+
 # Blend the dependencies, the license files and things that vary
 # a build time into the distribution.
 pkg_filegroup(
     name = "whole_distro",
     srcs = [
-        ":everything",
-        ":license_files",
+        ":installed_distro",
     ] + select({
         "//:is_standard_install": [
             ":datadog_agent_installer_symlinks",

--- a/packages/ddot/BUILD.bazel
+++ b/packages/ddot/BUILD.bazel
@@ -34,7 +34,6 @@ pkg_filegroup(
         # TODO: //packages/ddot/dependencies:all_files
         # TODO: //packages/install_dir:embedded (ddot-specific variant)
     ],
-    prefix = "/opt/datadog-agent",
 )
 
 # This is an intermediate node to collect all dependencies so we can walk
@@ -58,6 +57,7 @@ pkg_filegroup(
         ":everything",
         ":license_files",
     ],
+    prefix = "/opt/datadog-agent",
 )
 
 pkg_tar(

--- a/packages/dogstatsd/BUILD.bazel
+++ b/packages/dogstatsd/BUILD.bazel
@@ -26,7 +26,6 @@ pkg_filegroup(
         # TODO: //packages/dogstatsd/dependencies:all_files
         # TODO: //packages/install_dir:embedded (dogstatsd-specific variant)
     ],
-    prefix = "/opt/datadog-dogstatsd",
 )
 
 # This is an intermediate node to collect all dependencies so we can walk
@@ -50,6 +49,7 @@ pkg_filegroup(
         ":everything",
         ":license_files",
     ],
+    prefix = "/opt/datadog-dogstatsd",
 )
 
 pkg_tar(

--- a/packages/installer/linux/BUILD.bazel
+++ b/packages/installer/linux/BUILD.bazel
@@ -49,7 +49,7 @@ pkg_mkdirs(
 
 # Version manifest files.  The templates live in the parent package so they
 # can be shared if other platforms ever need them.
-# No prefix here — installer_components applies /opt/datadog-installer below.
+# No prefix here — whole_distro applies /opt/datadog-installer below.
 dd_agent_expand_template(
     name = "version_manifest_json",
     out = "version-manifest.json",
@@ -71,7 +71,6 @@ pkg_filegroup(
         ":version_manifest_json",
         ":version_manifest_txt",
     ],
-    prefix = "/opt/datadog-installer",
 )
 
 # Intermediate node for the license-gathering aspect.
@@ -95,6 +94,7 @@ pkg_filegroup(
         ":everything",
         ":license_files",
     ],
+    prefix = "/opt/datadog-installer",
     tags = ["manual"],
 )
 

--- a/packages/installer/macos/BUILD.bazel
+++ b/packages/installer/macos/BUILD.bazel
@@ -22,7 +22,6 @@ pkg_files(
 pkg_filegroup(
     name = "installer_components",
     srcs = [":installer_binary"],
-    prefix = "/opt/datadog-installer",
 )
 
 # Intermediate node for the license-gathering aspect.
@@ -36,12 +35,18 @@ package_licenses(
     src = ":everything",
 )
 
-pkg_tar(
-    name = "whole_distro_tar",
+pkg_filegroup(
+    name = "whole_distro",
     srcs = [
         ":everything",
         ":license_files",
     ],
+    prefix = "/opt/datadog-installer",
+)
+
+pkg_tar(
+    name = "whole_distro_tar",
+    srcs = [":whole_distro"],
     compression_level = get_compression_level(),
     extension = "tar.xz",
     owner = "0.0",

--- a/packages/iot/BUILD.bazel
+++ b/packages/iot/BUILD.bazel
@@ -26,7 +26,6 @@ pkg_filegroup(
         # TODO: //packages/iot/dependencies:all_files
         # TODO: //packages/install_dir:embedded (iot-specific variant)
     ],
-    prefix = "/opt/datadog-agent",
 )
 
 # This is an intermediate node to collect all dependencies so we can walk
@@ -50,6 +49,7 @@ pkg_filegroup(
         ":everything",
         ":license_files",
     ],
+    prefix = "/opt/datadog-agent",
 )
 
 pkg_tar(


### PR DESCRIPTION


<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Fix the license files install locations by refactoring the way we inject licenses in the package. 
We now have a single targets depending on all installed files & the collected licenses. That target gets passed a prefix, which fixes the licenses location without introducing another duplicated `prefix` parameter.

### Motivation

package_licenses previously defaulted to the package tar root instead of the product's actual install directory.

### Describe how you validated your changes

Local builds & CI runs on the originating PR linked just below

### Additional Notes

Extracted (and reworked) from https://github.com/DataDog/datadog-agent/pull/53907