### PR TITLE
fix(e2e): make the e2e test framework tasks work from a Datadog workspace

### DIFF
--- a/docs/public/how-to/test/e2e/index.md
+++ b/docs/public/how-to/test/e2e/index.md
@@ -58,6 +58,17 @@ dda inv e2e.setup --with-azure --with-gcp
 
 The configuration is persisted to `~/.test_infra_config.yaml` (chmod `0600`, since it contains the auto-generated Pulumi passphrase). Re-running `dda inv e2e.setup` is idempotent — it prints `✓ already configured` checks and exits.
 
+### Caveats
+
+**Only `us-east-1` regions.** Every AWS resource the framework depends on is pinned to `us-east-1`: the AMIs and subnets, the ECR registries, the KMS keys and the fakeintake ECS cluster (see `test/e2e-framework/resources/aws/environmentDefaults.go`), plus `us-east-1a`/`us-east-1b` for macOS hosts. There is no supported way to run against another region, so a dev machine in, say, `eu-west-3` won't work.
+
+**Only `zsh` and `bash`.** `fish` is not supported. Both the docs and several tasks emit POSIX shell syntax for you to paste — inline `VAR=value cmd` assignments and `export VAR=…` lines (for instance the `KUBECONFIG` line printed by `dda inv aws.create-kind`) — none of which `fish` accepts.
+
+**Running from a Datadog workspace** works, with two things worth knowing:
+
+- Stacks, EC2 key pairs and SSH keys are named after `$REAL_USER` and `$WORKSPACE_NAME`, not the OS user (which is `bits` for everyone on a workspace). Two workspaces owned by the same developer therefore get their own key pair and their own stacks, and `dda inv aws.destroy-vm` only ever sees the stacks created from that workspace.
+- Workspaces are headless, so desktop notifications and the "copy to clipboard" prompts are skipped automatically. The connection command or password is printed instead.
+
 ## See Also
 
 - [Test Categories](../../../guidelines/testing/test-categories.md) - Understanding different test types

--- a/docs/public/how-to/test/e2e/index.md
+++ b/docs/public/how-to/test/e2e/index.md
@@ -58,13 +58,15 @@ dda inv e2e.setup --with-azure --with-gcp
 
 The configuration is persisted to `~/.test_infra_config.yaml` (chmod `0600`, since it contains the auto-generated Pulumi passphrase). Re-running `dda inv e2e.setup` is idempotent — it prints `✓ already configured` checks and exits.
 
-### Caveats
-
-**Only `us-east-1` regions.** Every AWS resource the framework depends on is pinned to `us-east-1`: the AMIs and subnets, the ECR registries, the KMS keys and the fakeintake ECS cluster (see `test/e2e-framework/resources/aws/environmentDefaults.go`), plus `us-east-1a`/`us-east-1b` for macOS hosts. There is no supported way to run against another region, so a dev machine in, say, `eu-west-3` won't work.
-
-**Only `zsh` and `bash`.** `fish` is not supported. Both the docs and several tasks emit POSIX shell syntax for you to paste — inline `VAR=value cmd` assignments and `export VAR=…` lines (for instance the `KUBECONFIG` line printed by `dda inv aws.create-kind`) — none of which `fish` accepts.
-
-**Running from a Datadog workspace** works, with two things worth knowing:
+### Workspace support
+The e2e test framework tooling supports being run from Datadog workspaces just like developer laptops. 
+/// warning | Workspace compatibility of the e2e tooling
+- **The workspace must be in the `us-east-1` region**. The VPN bridging the AWS account holding the workspace machines and the `datadog-agent-qa` account actually running the tests only exists in `us-east-1`.
+- **You must use `zsh` in the workspace**. The `fish`-based workspace config lacks some setup that is required for the e2e tooling.
+///
+/// danger
+The `e2e.*` Invoke tasks will **NOT WORK** in a workspace provisioned in `eu-west-3`.
+///
 
 - Stacks, EC2 key pairs and SSH keys are named after `$REAL_USER` and `$WORKSPACE_NAME`, not the OS user (which is `bits` for everyone on a workspace). Two workspaces owned by the same developer therefore get their own key pair and their own stacks, and `dda inv aws.destroy-vm` only ever sees the stacks created from that workspace.
 - Workspaces are headless, so desktop notifications and the "copy to clipboard" prompts are skipped automatically. The connection command or password is printed instead.

--- a/tasks/AGENTS.md
+++ b/tasks/AGENTS.md
@@ -70,6 +70,30 @@ Release, packaging, tooling, and developer-experience tasks. Examples:
 
 To test either branch on any platform, patch `tasks.libs.common.utils.is_windows`.
 
+## Shelling Out to Pulumi
+
+Every pulumi invocation outside `kernel_matrix_testing/` (which owns its own backend
+convention) goes through `run_pulumi` / `pulumi_json` / `pulumi_stack_names` in
+`tasks/e2e_framework/tool.py`. Do not add a bare `ctx.run("pulumi …")` or
+`subprocess.run(["pulumi", …])`.
+
+The helper is what makes the tasks work on machines that do not look like a dev laptop —
+a Datadog workspace, for instance, where the OS user is `bits` for everyone and
+`PULUMI_CONFIG_PASSPHRASE` is never exported. It resolves the project directory, the
+passphrase (from `~/.test_infra_config.yaml` when the environment has none) and the
+`--ci` backend in one place:
+
+- **Secrets travel in `env=`, never in the command string** — argv is visible in `/proc`
+  and in `echo=True` traces. Invoke merges `env=` into the parent environment, so this
+  composes with ambient variables instead of replacing them.
+- **Cloud resource names come from `get_resource_owner_id()`**, not `getpass.getuser()`.
+  It prefers `$REAL_USER` and appends `$WORKSPACE_NAME`, so two remote dev VMs owned by
+  the same developer do not collide on stack or EC2 keypair names in the shared account.
+  The Go equivalent is `localProfile.NamePrefix()`.
+- **A capability that a headless box lacks must degrade, not crash** — see
+  `notify_linux` and `copy_to_clipboard_if_supported`, which probe for `notify-send` and
+  a clipboard before use. Probe *before* any blocking prompt.
+
 ## Incremental Refactoring: Making Task Logic Bazel-Callable
 
 We are incrementally splitting invoke-coupled code from pure logic so that the

--- a/tasks/ai_sandbox.py
+++ b/tasks/ai_sandbox.py
@@ -23,16 +23,6 @@ CLI_PACKAGE = "./cmd/ai-sandbox"
 CLI_BIN = "bin/ai-sandbox"
 
 
-def _load_e2e_local_config():
-    """Load ~/.test_infra_config.yaml lazily; return the Config or None."""
-    try:
-        from tasks.e2e_framework import config as e2e_config
-
-        return e2e_config.get_local_config()
-    except Exception:
-        return None
-
-
 @task(
     auto_shortflags=False,
     help={
@@ -96,15 +86,12 @@ def run(
         joined = " or ".join(cred_vars)
         print(color_message(f"WARNING: none of {joined} is set; {tool} will likely fail to authenticate", Color.ORANGE))
 
-    env_vars = {}
-    # Export PULUMI_CONFIG_PASSPHRASE from local config when not already set, mirroring
-    # new-e2e-tests.run, so developers don't need it in their shell rc.
-    if "PULUMI_CONFIG_PASSPHRASE" not in os.environ:
-        from tasks.e2e_framework.config import get_pulumi_passphrase
+    # Pulls PULUMI_CONFIG_PASSPHRASE out of the local config when the environment doesn't
+    # already carry one, mirroring new-e2e-tests.run, so developers don't need it in
+    # their shell rc.
+    from tasks.e2e_framework import tool as e2e_tool
 
-        passphrase = get_pulumi_passphrase(_load_e2e_local_config())
-        if passphrase:
-            env_vars["PULUMI_CONFIG_PASSPHRASE"] = passphrase
+    env_vars = e2e_tool.pulumi_env(skip_update_check=False)
 
     # Resolve paths to absolute so they are independent of the binary's working directory.
     local_output_dir = str(Path(local_output_dir).expanduser().absolute())

--- a/tasks/e2e_framework/aws/common.py
+++ b/tasks/e2e_framework/aws/common.py
@@ -117,10 +117,7 @@ def show_eks_connection_message(
     print(f"\nYou can run the following command to connect to the EKS cluster\n\n{command}\n")
 
     if interactive:
-        import pyperclip
-
-        input("Press a key to copy command to clipboard...")
-        pyperclip.copy(command)
+        tool.copy_to_clipboard_if_supported(command, prompt="Press a key to copy command to clipboard...")
 
 
 def get_image_description(ctx: Context, ami_id: str) -> Any:

--- a/tasks/e2e_framework/aws/docker.py
+++ b/tasks/e2e_framework/aws/docker.py
@@ -87,10 +87,7 @@ def _show_connection_message(ctx: Context, full_stack_name: str, copy_to_clipboa
     print(f"If you want to use docker context, you can run the following commands \n\n{command}")
 
     if copy_to_clipboard:
-        import pyperclip
-
-        input("Press a key to copy command to clipboard...")
-        pyperclip.copy(command)
+        tool.copy_to_clipboard_if_supported(command, prompt="Press a key to copy command to clipboard...")
 
 
 @task(

--- a/tasks/e2e_framework/aws/ecs.py
+++ b/tasks/e2e_framework/aws/ecs.py
@@ -99,10 +99,7 @@ def _show_connection_message(
     print(f"\nYou can run the following command to list tasks on the ECS cluster\n\n{command}\n")
 
     if interactive:
-        import pyperclip
-
-        input("Press a key to copy command to clipboard...")
-        pyperclip.copy(command)
+        tool.copy_to_clipboard_if_supported(command, prompt="Press a key to copy command to clipboard...")
 
 
 @task(help={"stack_name": doc.stack_name})

--- a/tasks/e2e_framework/aws/kind.py
+++ b/tasks/e2e_framework/aws/kind.py
@@ -108,10 +108,7 @@ def _show_connection_message(ctx: Context, full_stack_name: str, copy_to_clipboa
     tool.info(f"kubectl configured — run the following to use it in other terminals:\n\n  {export_cmd}\n")
 
     if copy_to_clipboard:
-        import pyperclip
-
-        input("Press a key to copy command to clipboard...")
-        pyperclip.copy(export_cmd)
+        tool.copy_to_clipboard_if_supported(export_cmd, prompt="Press a key to copy command to clipboard...")
 
 
 @task(

--- a/tasks/e2e_framework/aws/vm.py
+++ b/tasks/e2e_framework/aws/vm.py
@@ -1,4 +1,3 @@
-import contextlib
 import json
 
 from invoke.context import Context
@@ -282,8 +281,7 @@ def rdp_vm(
     if not stack_name:
         raise Exit("Please provide a stack name to connect to.")
 
-    with tool.use_ci_pulumi_backend(ctx) if ci else contextlib.nullcontext():
-        out = tool.get_stack_json_outputs(ctx, stack_name)
+    out = tool.get_stack_json_outputs(ctx, stack_name, config_path=config_path, ci=ci)
     if not out:
         raise Exit("No VM found in the stack.")
 

--- a/tasks/e2e_framework/aws/vm.py
+++ b/tasks/e2e_framework/aws/vm.py
@@ -286,14 +286,13 @@ def rdp_vm(
         raise Exit("No VM found in the stack.")
 
     for vm_id, vm in out.items():
-        import pyperclip
-
         if "address" not in vm:
             continue
         vm_ip = vm["address"]
         password = vm["password"]
         tool.rdp(ctx, vm_ip)
         print(f"Password for VM {vm_id} ({vm_ip}): {password}")
-        print("Username is Administrator, password has been copied to clipboard")
-
-        pyperclip.copy(password)
+        if tool.copy_to_clipboard_if_supported(password):
+            print("Username is Administrator, password has been copied to clipboard")
+        else:
+            print("Username is Administrator")

--- a/tasks/e2e_framework/azure/aks.py
+++ b/tasks/e2e_framework/azure/aks.py
@@ -106,7 +106,4 @@ def _show_connection_message(ctx: Context, full_stack_name: str, copy_to_clipboa
 
     print(f"\nYou can run the following command to connect to the AKS cluster\n\n{command}\n")
     if copy_to_clipboard:
-        import pyperclip
-
-        input("Press a key to copy command to clipboard...")
-        pyperclip.copy(command)
+        tool.copy_to_clipboard_if_supported(command, prompt="Press a key to copy command to clipboard...")

--- a/tasks/e2e_framework/config.py
+++ b/tasks/e2e_framework/config.py
@@ -1,4 +1,3 @@
-import contextlib
 import os
 from collections.abc import Callable
 from pathlib import Path
@@ -188,28 +187,6 @@ def get_pulumi_passphrase(cfg: Config | None) -> str | None:
     if passphrase:
         return passphrase
     return None
-
-
-@contextlib.contextmanager
-def use_local_pulumi_passphrase(profile_path: str | None = None):
-    """
-    Temporarily export the Pulumi passphrase persisted in the local config
-    (~/.test_infra_config.yaml by default) as PULUMI_CONFIG_PASSPHRASE, so pulumi CLI
-    commands can decrypt secrets (e.g. a VM password) non-interactively even if the
-    passphrase isn't already exported in the caller's shell. Restores the previous
-    value on exit. No-op if the config has no passphrase recorded.
-    """
-    passphrase = get_pulumi_passphrase(get_local_config(profile_path))
-    previous = os.environ.get("PULUMI_CONFIG_PASSPHRASE")
-    if passphrase:
-        os.environ["PULUMI_CONFIG_PASSPHRASE"] = passphrase
-    try:
-        yield
-    finally:
-        if previous is None:
-            os.environ.pop("PULUMI_CONFIG_PASSPHRASE", None)
-        else:
-            os.environ["PULUMI_CONFIG_PASSPHRASE"] = previous
 
 
 def get_api_key(cfg: Config | None) -> str:

--- a/tasks/e2e_framework/deploy.py
+++ b/tasks/e2e_framework/deploy.py
@@ -223,9 +223,8 @@ def _deploy(
     pulumi_extra_args: str = "",
     pulumi_env: dict[str, str] | None = None,
 ) -> str:
+    # get_stack_name normalizes the name, so destroy looks for the one deployed here
     stack_name = tool.get_stack_name(stack_name, flags["scenario"])
-    # make sure the stack name is safe
-    stack_name = stack_name.replace(" ", "-").lower()
     log_flags_array: list[str] = []
     up_flags = ""
 

--- a/tasks/e2e_framework/deploy.py
+++ b/tasks/e2e_framework/deploy.py
@@ -157,6 +157,7 @@ def deploy(
         debug,
         cfg.get_pulumi().logLevel,
         cfg.get_pulumi().logToStdErr,
+        config_path=config_path,
         pulumi_extra_args=pulumi_extra_args,
         pulumi_env=pulumi_env,
     )
@@ -204,19 +205,11 @@ def check_s3_image_exists(_, pipeline_id: str, deploy_job: str):
 
 
 # creates a stack with the given stack_name if it doesn't already exists
-def _create_stack(ctx: Context, stack_name: str, global_flags: str):
-    result = ctx.run(f"pulumi {global_flags} stack ls --all", hide="stdout")
-    if not result:
+def _create_stack(ctx: Context, stack_name: str, log_flags: str, config_path: str | None):
+    if stack_name in tool.pulumi_stack_names(ctx, config_path=config_path):
         return
 
-    stacks = result.stdout.splitlines()[1:]  # skip header
-    for stack in stacks:
-        # the stack has an asterisk if it is currently selected
-        ls_stack_name = stack.split(" ")[0].rstrip("*")
-        if ls_stack_name == stack_name:
-            return
-
-    ctx.run(f"pulumi {global_flags} stack init --no-select {stack_name}")
+    tool.run_pulumi(ctx, f"{log_flags} stack init --no-select {stack_name}", config_path=config_path)
 
 
 def _deploy(
@@ -226,17 +219,15 @@ def _deploy(
     debug: bool | None,
     log_level: int | None,
     log_to_stderr: bool | None,
+    config_path: str | None = None,
     pulumi_extra_args: str = "",
     pulumi_env: dict[str, str] | None = None,
 ) -> str:
     stack_name = tool.get_stack_name(stack_name, flags["scenario"])
     # make sure the stack name is safe
     stack_name = stack_name.replace(" ", "-").lower()
-    global_flags_array: list[str] = []
+    log_flags_array: list[str] = []
     up_flags = ""
-
-    # Check we are in a pulumi project
-    global_flags_array.append(tool.get_pulumi_dir_flag())
 
     # Building run func parameters
     for key, value in flags.items():
@@ -251,20 +242,22 @@ def _deploy(
         log_to_stderr = debug
     if should_log:
         if log_to_stderr:
-            global_flags_array.append("--logtostderr")
-        global_flags_array.append(f"-v {log_level}")
+            log_flags_array.append("--logtostderr")
+        log_flags_array.append(f"-v {log_level}")
         if debug:
             up_flags += " --debug"
 
-    global_flags = " ".join(global_flags_array)
-    _create_stack(ctx, stack_name, global_flags)
+    log_flags = " ".join(log_flags_array)
+    _create_stack(ctx, stack_name, log_flags, config_path)
     extra = f" {pulumi_extra_args}" if pulumi_extra_args else ""
-    env_prefix = " ".join(f"{k}={v}" for k, v in (pulumi_env or {}).items())
-    env_prefix = f"{env_prefix} " if env_prefix else ""
-    cmd = f"{env_prefix}pulumi {global_flags} up --yes{extra} -s {stack_name} {up_flags}"
 
-    pty = not pulumi_extra_args  # disable pty when extra args are set (e.g. --non-interactive)
-    if tool.is_windows():
-        pty = False
-    ctx.run(cmd, pty=pty)
+    tool.run_pulumi(
+        ctx,
+        f"{log_flags} up --yes{extra} {up_flags}",
+        stack=stack_name,
+        config_path=config_path,
+        env=pulumi_env,
+        # disable pty when extra args are set (e.g. --non-interactive)
+        pty=not pulumi_extra_args,
+    )
     return stack_name

--- a/tasks/e2e_framework/destroy.py
+++ b/tasks/e2e_framework/destroy.py
@@ -1,5 +1,3 @@
-import subprocess
-
 from invoke.context import Context
 from invoke.exceptions import Exit
 
@@ -23,9 +21,8 @@ def destroy(
     from tasks.e2e_framework import config
 
     full_stack_name = get_stack_name(stack, scenario_name)
-    pulumi_dir_flag = tool.get_pulumi_dir_flag()
 
-    short_stack_names, full_stack_names = _get_existing_stacks(pulumi_dir_flag.split(" "))
+    short_stack_names, full_stack_names = _get_existing_stacks(tool.pulumi_stack_names(ctx, config_path=config_path))
     if len(short_stack_names) == 0:
         info("No stack to destroy")
         return
@@ -51,30 +48,23 @@ def destroy(
         for stack_name in short_stack_names:
             error(f" {stack_name}")
     else:
-        cmd = f"pulumi {pulumi_dir_flag} destroy --remove --yes --skip-preview -s {full_stack_name}"
-        pty = True
-        if tool.is_windows():
-            pty = False
-        ret = ctx.run(cmd, pty=pty, warn=True)
+        args = "destroy --remove --yes --skip-preview"
+        ret = tool.run_pulumi(ctx, args, stack=full_stack_name, config_path=config_path, pty=True, warn=True)
         if ret is not None and ret.exited != 0:
             # run with refresh on first destroy attempt failure
-            cmd += " --refresh"
-            ctx.run(cmd, pty=pty)
+            tool.run_pulumi(ctx, f"{args} --refresh", stack=full_stack_name, config_path=config_path, pty=True)
 
 
-def _get_existing_stacks(pulumi_dir_flag: list[str]) -> tuple[list[str], list[str]]:
-    output = subprocess.check_output(["pulumi", *pulumi_dir_flag, "stack", "ls", "--all"])
-    output = output.decode("utf-8")
-    lines = output.splitlines()
-    lines = lines[1:]  # skip headers
+def _get_existing_stacks(stack_names: list[str]) -> tuple[list[str], list[str]]:
+    """
+    Split the stacks belonging to the current user out of `stack_names`, as both their
+    short (prefix stripped) and full names.
+    """
     stacks: list[str] = []
     full_stacks: list[str] = []
     stack_name_prefix = get_stack_name_prefix()
-    for line in lines:
-        # the stack has an asterisk if it is currently selected
-        stack_name = line.split(" ")[0].rstrip("*")
+    for stack_name in stack_names:
         if stack_name.startswith(stack_name_prefix):
             full_stacks.append(stack_name)
-            stack_name = stack_name[len(stack_name_prefix) :]
-            stacks.append(stack_name)
+            stacks.append(stack_name[len(stack_name_prefix) :])
     return stacks, full_stacks

--- a/tasks/e2e_framework/gcp/gke.py
+++ b/tasks/e2e_framework/gcp/gke.py
@@ -121,7 +121,4 @@ def _show_connection_message(ctx: Context, full_stack_name: str, copy_to_clipboa
 
     print(f"\nYou can run the following command to connect to the GKE cluster\n\n{command}\n")
     if copy_to_clipboard:
-        import pyperclip
-
-        input("Press a key to copy command to clipboard...")
-        pyperclip.copy(command)
+        tool.copy_to_clipboard_if_supported(command, prompt="Press a key to copy command to clipboard...")

--- a/tasks/e2e_framework/setup/aws.py
+++ b/tasks/e2e_framework/setup/aws.py
@@ -1,4 +1,3 @@
-import getpass
 import json
 import os
 import secrets
@@ -18,6 +17,7 @@ from tasks.e2e_framework.tool import (
     ask_yesno,
     error,
     get_aws_cmd,
+    get_resource_owner_id,
     info,
     warn,
     write_secret_file,
@@ -48,7 +48,7 @@ def setup_aws_config(ctx: Context, config: Config, account: str | None = None):
         config.configParams.aws = Config.Params.Aws(keyPairName=None, publicKeyPath=None, account=None, teamTag=None)
 
     aws = config.configParams.aws
-    user = getpass.getuser()
+    user = get_resource_owner_id()
 
     # Account
     if account:
@@ -401,7 +401,7 @@ def aws_resolve_keypair_opts(
     if awsConf.keyPairName:
         default_keypair_name = awsConf.keyPairName
     else:
-        default_keypair_name = getpass.getuser()
+        default_keypair_name = get_resource_owner_id()
     if awsConf.privateKeyPath:
         default_private_key_path = awsConf.privateKeyPath
     else:

--- a/tasks/e2e_framework/setup/aws.py
+++ b/tasks/e2e_framework/setup/aws.py
@@ -26,6 +26,9 @@ from tasks.e2e_framework.tool import (
 SUPPORTED_KEY_TYPES = ["rsa", "ed25519"]
 AVAILABLE_AWS_ACCOUNTS = ["agent-sandbox", "sandbox", "tse-playground"]
 DEFAULT_AWS_ACCOUNT = "agent-sandbox"
+# Every resource the E2E framework relies on -- AMIs, subnets, ECR registries, KMS keys,
+# the fakeintake ECS cluster -- is pinned to this region.
+DEFAULT_AWS_REGION = "us-east-1"
 DEFAULT_KEY_TYPE = "rsa"
 # Accounts not listed here default to 'account-admin'. Keep in sync with the
 # `profile:` entries in test/e2e-framework/resources/aws/environmentDefaults.go.
@@ -189,7 +192,7 @@ def setup_aws_sso_config(config: Config, interactive: bool = True):
     role = ACCOUNT_ADMIN_ROLE_BY_ACCOUNT.get(aws.account, 'account-admin')
     acct_id = 376334461865
     start_url = 'https://d-906757b57c.awsapps.com/start/#'
-    region = 'us-east-1'
+    region = DEFAULT_AWS_REGION
 
     aws_conf_path = Path.home().joinpath(".aws", "config")
     profile_name = f'sso-{aws.account}-{role}'

--- a/tasks/e2e_framework/setup/azure.py
+++ b/tasks/e2e_framework/setup/azure.py
@@ -1,4 +1,3 @@
-import getpass
 from pathlib import Path
 
 from invoke.context import Context
@@ -10,7 +9,7 @@ from tasks.e2e_framework.setup.ssh_keys import (
     discard_key_without_passphrase,
     generate_keypair_with_passphrase,
 )
-from tasks.e2e_framework.tool import info
+from tasks.e2e_framework.tool import get_resource_owner_id, info
 
 
 def setup_azure_config(ctx: Context, config: Config):
@@ -18,7 +17,7 @@ def setup_azure_config(ctx: Context, config: Config):
         config.configParams.azure = Config.Params.Azure(publicKeyPath=None)
 
     azure = config.configParams.azure
-    user = getpass.getuser()
+    user = get_resource_owner_id()
 
     if not azure.account:
         azure.account = "agent-sandbox"

--- a/tasks/e2e_framework/setup/gcp.py
+++ b/tasks/e2e_framework/setup/gcp.py
@@ -1,4 +1,3 @@
-import getpass
 import json
 from pathlib import Path
 
@@ -12,7 +11,7 @@ from tasks.e2e_framework.setup.ssh_keys import (
     discard_key_without_passphrase,
     generate_keypair_with_passphrase,
 )
-from tasks.e2e_framework.tool import info
+from tasks.e2e_framework.tool import get_resource_owner_id, info
 
 
 def setup_gcp_config(ctx: Context, config: Config):
@@ -20,7 +19,7 @@ def setup_gcp_config(ctx: Context, config: Config):
         config.configParams.gcp = Config.Params.GCP(publicKeyPath=None)
 
     gcp = config.configParams.gcp
-    user = getpass.getuser()
+    user = get_resource_owner_id()
 
     if not gcp.account:
         gcp.account = "agent-sandbox"

--- a/tasks/e2e_framework/setup/pulumi.py
+++ b/tasks/e2e_framework/setup/pulumi.py
@@ -7,7 +7,7 @@ from invoke.context import Context
 from invoke.exceptions import UnexpectedExit
 
 from tasks.e2e_framework.config import Config
-from tasks.e2e_framework.tool import info, is_linux, is_windows, warn
+from tasks.e2e_framework.tool import info, is_linux, is_windows, run_pulumi, warn
 
 # Length matches Pulumi cloud-generated passphrases. token_urlsafe yields ~43 chars from 32 bytes.
 _PASSPHRASE_BYTES = 32
@@ -46,7 +46,9 @@ def pulumi_version(ctx: Context) -> tuple[str, bool]:
     Will return True if PULUMI_SKIP_UPDATE_CHECK=1
     """
     try:
-        out = ctx.run("pulumi version --logtostderr", hide=True)
+        # skip_update_check must stay off here: the update notice on stderr is what tells
+        # us whether pulumi is up to date.
+        out = run_pulumi(ctx, "version --logtostderr", project_dir=False, skip_update_check=False, hide=True)
     except UnexpectedExit:
         # likely pulumi command not found
         return "", False

--- a/tasks/e2e_framework/setup/setup.py
+++ b/tasks/e2e_framework/setup/setup.py
@@ -186,7 +186,7 @@ def setup(
         debug_env(ctx, config_path=config_path)
 
     if interactive:
-        info("\n✓ Setup complete. Try: dda inv new-e2e-tests.run --targets=./test/new-e2e/examples\n")
+        info("\n✓ Setup complete. Try: dda inv new-e2e-tests.run --targets=./examples\n")
 
 
 @task

--- a/tasks/e2e_framework/setup/setup.py
+++ b/tasks/e2e_framework/setup/setup.py
@@ -14,6 +14,7 @@ from tasks.e2e_framework.tool import (
     error,
     get_aws_cmd,
     get_pulumi_run_folder,
+    get_resource_owner_id,
     info,
     is_windows,
     run_pulumi,
@@ -36,8 +37,6 @@ def _force_cleanup(
     Uses computed default paths — not the existing config — so it targets exactly
     what the next setup run would create.
     """
-    import getpass
-
     from tasks.e2e_framework.config import get_full_profile_path
     from tasks.e2e_framework.setup.aws import DEFAULT_AWS_ACCOUNT, _default_keypair_name
     from tasks.e2e_framework.setup.ssh_keys import default_key_paths, ssh_agent_supported
@@ -57,7 +56,7 @@ def _force_cleanup(
                 p.unlink()
                 info(f"✓ Deleted {p}")
 
-    user = getpass.getuser()
+    user = get_resource_owner_id()
     effective_account = account or DEFAULT_AWS_ACCOUNT
 
     # AWS: remove from agent, delete local files, then delete EC2 keypair

--- a/tasks/e2e_framework/setup/setup.py
+++ b/tasks/e2e_framework/setup/setup.py
@@ -452,6 +452,8 @@ def debug_env(ctx, config_path: str | None = None):
     """
     Debug E2E and test-infra-definitions required tools and configuration
     """
+    from tasks.e2e_framework.setup.aws import DEFAULT_AWS_REGION
+
     # check pulumi found
     try:
         out = run_pulumi(ctx, "version", project_dir=False, skip_update_check=False, hide=True)
@@ -507,18 +509,24 @@ def debug_env(ctx, config_path: str | None = None):
 
     # Show AWS account info
     info("Logged-in aws account info:")
+    # AWS_REGION being unset is not fatal: every resource the E2E framework uses lives in
+    # us-east-1, which is also what the SSO profile sets. Some setups (aws-vault on a
+    # Datadog workspace, for one) simply don't export it.
+    region = os.environ.get("AWS_REGION")
     if os.environ.get("AWS_PROFILE"):
         info(f"\tAWS_PROFILE={os.environ.get('AWS_PROFILE')}")
-        region = os.environ.get("AWS_REGION")
-        if not region:
-            raise Exit("Missing env var AWS_REGION, please set var", 1)
-        info(f"\tAWS_REGION={region}")
     else:
-        for env in ["AWS_VAULT", "AWS_REGION"]:
-            val = os.environ.get(env, None)
-            if val is None:
-                raise Exit(f"Missing env var {env}, please login with awscli/aws-vault or set AWS_PROFILE", 1)
-            info(f"\t{env}={val}")
+        aws_vault = os.environ.get("AWS_VAULT")
+        if aws_vault is None:
+            raise Exit("Missing env var AWS_VAULT, please login with awscli/aws-vault or set AWS_PROFILE", 1)
+        info(f"\tAWS_VAULT={aws_vault}")
+
+    if region:
+        info(f"\tAWS_REGION={region}")
+        if region != DEFAULT_AWS_REGION:
+            warn(f"\tAWS_REGION is {region}, but the E2E resources only exist in {DEFAULT_AWS_REGION}")
+    else:
+        info(f"\tAWS_REGION is unset, {DEFAULT_AWS_REGION} will be used")
 
     # Check if aws creds are valid
     try:

--- a/tasks/e2e_framework/setup/setup.py
+++ b/tasks/e2e_framework/setup/setup.py
@@ -16,6 +16,7 @@ from tasks.e2e_framework.tool import (
     get_pulumi_run_folder,
     info,
     is_windows,
+    run_pulumi,
     warn,
 )
 
@@ -150,9 +151,8 @@ def setup(
     else:
         install_pulumi(ctx)
 
-    with ctx.cd(get_pulumi_run_folder()):
-        ctx.run("pulumi --non-interactive plugin install", hide=True)
-        ctx.run("pulumi login --local", hide=True)
+    run_pulumi(ctx, "--non-interactive plugin install", project_dir=get_pulumi_run_folder(), hide=True)
+    run_pulumi(ctx, "login --local", project_dir=False, hide=True)
     info("✓ Pulumi plugins installed; local backend configured")
 
     try:
@@ -455,7 +455,7 @@ def debug_env(ctx, config_path: str | None = None):
     """
     # check pulumi found
     try:
-        out = ctx.run("pulumi version", hide=True)
+        out = run_pulumi(ctx, "version", project_dir=False, skip_update_check=False, hide=True)
     except UnexpectedExit as e:
         error(f"{e}")
         error("Pulumi CLI not found, please install it: https://www.pulumi.com/docs/get-started/install/")
@@ -464,7 +464,7 @@ def debug_env(ctx, config_path: str | None = None):
 
     # Check pulumi credentials
     try:
-        out = ctx.run("pulumi whoami", hide=True)
+        out = run_pulumi(ctx, "whoami", project_dir=False, hide=True)
     except UnexpectedExit as e:
         error("No pulumi credentials found")
         info("Please login, e.g. pulumi login --local")

--- a/tasks/e2e_framework/tool.py
+++ b/tasks/e2e_framework/tool.py
@@ -4,6 +4,7 @@ import json
 import os
 import pathlib
 import platform
+import shlex
 import subprocess
 import tempfile
 from io import StringIO
@@ -11,6 +12,7 @@ from typing import Any
 
 from invoke.context import Context
 from invoke.exceptions import Exit
+from invoke.runners import Result
 
 try:
     from termcolor import colored
@@ -158,56 +160,171 @@ CI_PULUMI_BACKEND_URL = "s3://dd-pulumi-state"
 CI_PULUMI_PASSPHRASE_SSM_PARAM = "ci.datadog-agent.pulumi_password"
 
 
-@contextlib.contextmanager
-def use_ci_pulumi_backend(ctx: Context):
+def _ci_pulumi_env() -> dict[str, str]:
     """
-    Temporarily point the local Pulumi CLI at CI's S3 state backend and export
-    the CI Pulumi secrets passphrase (read from SSM), so a CI-created stack
-    (absent from the local file backend) can be queried. Always restores the
-    local backend on exit, even if an error occurs.
+    Point the Pulumi CLI at CI's S3 state backend and supply the CI secrets passphrase
+    (read from SSM), so a CI-created stack -- absent from the local file backend -- can be
+    queried.
 
-    Must be run with AWS credentials that can read CI_PULUMI_BACKEND_URL and
-    decrypt CI_PULUMI_PASSPHRASE_SSM_PARAM, e.g.:
+    Must be run with AWS credentials that can read CI_PULUMI_BACKEND_URL and decrypt
+    CI_PULUMI_PASSPHRASE_SSM_PARAM, e.g.:
         aws-vault exec sso-agent-qa-read-only -- dda inv aws.rdp-vm --stack-name=<ci-stack-name> --ci
     """
     import boto3
 
-    previous_passphrase = os.environ.get("PULUMI_CONFIG_PASSPHRASE")
-    ctx.run(f"pulumi login {CI_PULUMI_BACKEND_URL}", hide=True)
+    ssm = boto3.client("ssm", region_name="us-east-1")
+    passphrase = ssm.get_parameter(Name=CI_PULUMI_PASSPHRASE_SSM_PARAM, WithDecryption=True)["Parameter"]["Value"]
+    # Selecting the backend through the environment rather than `pulumi login` keeps the
+    # dev machine's own login untouched: there is no global state to restore if the
+    # command fails.
+    return {
+        "PULUMI_BACKEND_URL": CI_PULUMI_BACKEND_URL,
+        "PULUMI_CONFIG_PASSPHRASE": passphrase,
+    }
+
+
+def _local_pulumi_passphrase(config_path: str | None) -> str | None:
+    # Imported here because config imports this module.
+    from . import config as e2e_config
+
     try:
-        ssm = boto3.client("ssm", region_name="us-east-1")
-        passphrase = ssm.get_parameter(Name=CI_PULUMI_PASSPHRASE_SSM_PARAM, WithDecryption=True)["Parameter"]["Value"]
-        os.environ["PULUMI_CONFIG_PASSPHRASE"] = passphrase
-        yield
-    finally:
-        # Always restore the local backend and passphrase env var, even if login, the
-        # SSM lookup, or the wrapped call failed, so a CI lookup never leaves the dev
-        # environment pointed at CI's S3 state or holding the CI passphrase.
-        if previous_passphrase is None:
-            os.environ.pop("PULUMI_CONFIG_PASSPHRASE", None)
-        else:
-            os.environ["PULUMI_CONFIG_PASSPHRASE"] = previous_passphrase
-        ctx.run("pulumi login --local", hide=True)
+        return e2e_config.get_pulumi_passphrase(e2e_config.get_local_config(config_path))
+    except Exception:
+        # A broken config file shouldn't stop `pulumi version` or `pulumi login` from
+        # running. Commands that do need the passphrase still prompt, as they did before.
+        return None
 
 
-def get_stack_json_outputs(ctx: Context, full_stack_name: str) -> Any:
-    buffer = StringIO()
+def pulumi_env(
+    *,
+    config_path: str | None = None,
+    ci: bool = False,
+    skip_update_check: bool = True,
+    overrides: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """
+    Build the environment overrides that every Pulumi invocation needs.
 
-    cmd_parts: list[str] = [
-        "pulumi",
-        "stack",
-        "output",
-        "--json",
-        "--show-secrets",
-        "-s",
-        full_stack_name,
-        get_pulumi_dir_flag(),
-    ]
-    ctx.run(
+    The passphrase is read from the local config file (~/.test_infra_config.yaml) unless
+    the caller's environment already carries one, so the tasks work on a machine where it
+    was never exported -- a Datadog workspace, for instance.
+    """
+    env: dict[str, str] = {}
+    if skip_update_check:
+        env["PULUMI_SKIP_UPDATE_CHECK"] = "true"
+
+    # Membership rather than truthiness: an empty passphrase is a valid Pulumi setup.
+    if "PULUMI_CONFIG_PASSPHRASE" not in os.environ and "PULUMI_CONFIG_PASSPHRASE_FILE" not in os.environ:
+        passphrase = _local_pulumi_passphrase(config_path)
+        if passphrase:
+            env["PULUMI_CONFIG_PASSPHRASE"] = passphrase
+
+    if ci:
+        env.update(_ci_pulumi_env())
+    if overrides:
+        env.update(overrides)
+    return env
+
+
+def run_pulumi(
+    ctx: Context,
+    args: str,
+    *,
+    stack: str | None = None,
+    project_dir: bool | str = True,
+    config_path: str | None = None,
+    ci: bool = False,
+    env: dict[str, str] | None = None,
+    skip_update_check: bool = True,
+    pty: bool = False,
+    hide: str | bool | None = None,
+    warn: bool = False,
+) -> Result | None:
+    """
+    Run a Pulumi command.
+
+    Every Pulumi invocation in the e2e tasks goes through here, so the project directory,
+    the passphrase and the rest of the environment are resolved in a single place.
+
+    `project_dir` drives the -C flag: True picks the e2e-framework Pulumi project, False
+    omits it (for commands that aren't project scoped, such as `login` or `version`), and
+    a path uses that directory.
+    """
+    cmd_parts = ["pulumi"]
+    if project_dir is True:
+        dir_flag = get_pulumi_dir_flag()
+        if dir_flag:
+            cmd_parts.append(dir_flag)
+    elif project_dir is not False:
+        cmd_parts.append(f"-C {shlex.quote(str(project_dir))}")
+    # Callers build args by interpolating optional flag groups, so it can come with
+    # leading or trailing blanks when a group is empty.
+    if args.strip():
+        cmd_parts.append(args.strip())
+    if stack is not None:
+        cmd_parts.append(f"-s {stack}")
+
+    return ctx.run(
         " ".join(cmd_parts),
-        out_stream=buffer,
+        env=pulumi_env(config_path=config_path, ci=ci, skip_update_check=skip_update_check, overrides=env),
+        # A pty is only ever useful for the commands whose progress the user watches, and
+        # invoke can't allocate one on Windows.
+        pty=pty and not is_windows(),
+        hide=hide,
+        warn=warn,
     )
-    return json.loads(buffer.getvalue())
+
+
+def pulumi_json(
+    ctx: Context,
+    args: str,
+    *,
+    stack: str | None = None,
+    project_dir: bool | str = True,
+    config_path: str | None = None,
+    ci: bool = False,
+    warn: bool = False,
+) -> Any:
+    """
+    Run a Pulumi command that prints JSON and return the parsed output, or None when the
+    command failed and `warn` is set.
+
+    stdout is captured instead of echoed; stderr keeps streaming so Pulumi's own error
+    message stays visible when the command fails.
+    """
+    result = run_pulumi(
+        ctx, args, stack=stack, project_dir=project_dir, config_path=config_path, ci=ci, hide="stdout", warn=warn
+    )
+    if result is None or result.exited != 0:
+        return None
+    return json.loads(result.stdout)
+
+
+def pulumi_stack_names(
+    ctx: Context,
+    *,
+    project: str | None = None,
+    project_dir: bool | str = True,
+    config_path: str | None = None,
+) -> list[str]:
+    """
+    Names of every stack the current backend knows about.
+    """
+    args = "stack ls --all --json"
+    if project:
+        args += f" --project {project}"
+    stacks = pulumi_json(ctx, args, project_dir=project_dir, config_path=config_path) or []
+    return [stack["name"] for stack in stacks if "name" in stack]
+
+
+def get_stack_json_outputs(ctx: Context, full_stack_name: str, config_path: str | None = None, ci: bool = False) -> Any:
+    return pulumi_json(
+        ctx,
+        "stack output --json --show-secrets",
+        stack=full_stack_name,
+        config_path=config_path,
+        ci=ci,
+    )
 
 
 def get_aws_wrapper(
@@ -303,7 +420,7 @@ def get_pulumi_dir_flag():
     root_path = get_pulumi_run_folder()
     current_path = os.getcwd()
     if not os.path.isfile(os.path.join(current_path, "Pulumi.yaml")):
-        return f"-C {root_path}"
+        return f"-C {shlex.quote(root_path)}"
     return ""
 
 

--- a/tasks/e2e_framework/tool.py
+++ b/tasks/e2e_framework/tool.py
@@ -142,18 +142,43 @@ def get_default_workload_install() -> bool:
     return True
 
 
+def get_local_user() -> str:
+    """
+    The developer's login.
+
+    On a shared dev VM (a Datadog workspace) the OS user is `bits` for everyone, so the
+    real identity comes from $REAL_USER.
+    """
+    return os.getenv("REAL_USER") or getpass.getuser()
+
+
+def get_resource_owner_id() -> str:
+    """
+    The identity used to name cloud resources: Pulumi stacks, EC2 key pairs and SSH keys.
+
+    The workspace name is part of it so that several workspaces owned by the same
+    developer don't fight over the same key pair or stack names in a shared account.
+    """
+    parts = [get_local_user()]
+    workspace = os.getenv("WORKSPACE_NAME")
+    if workspace:
+        parts.append(workspace)
+    # EKS doesn't support '.' and spaces in the user name could be problematic on Windows
+    return "-".join(parts).replace(".", "-").replace(" ", "-").lower()
+
+
 def get_stack_name(stack_name: str | None, scenario_name: str) -> str:
     if stack_name is None:
         stack_name = scenario_name.replace("/", "-")
     # The scenario name cannot start with the stack name because ECS
-    # stack name cannot start with 'ecs' or 'aws'
-    return f"{get_stack_name_prefix()}{stack_name}"
+    # stack name cannot start with 'ecs' or 'aws'.
+    # Normalizing here rather than in the caller keeps deploy and destroy looking for the
+    # same name: they used to disagree on the casing of a --stack-name.
+    return f"{get_stack_name_prefix()}{stack_name}".replace(" ", "-").lower()
 
 
 def get_stack_name_prefix() -> str:
-    user_name = f"{getpass.getuser()}-"
-    # EKS doesn't support '.' and spaces in the user name could be problematic on Windows
-    return user_name.replace(".", "-").replace(" ", "-")
+    return f"{get_resource_owner_id()}-"
 
 
 CI_PULUMI_BACKEND_URL = "s3://dd-pulumi-state"

--- a/tasks/e2e_framework/tool.py
+++ b/tasks/e2e_framework/tool.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import platform
 import shlex
+import shutil
 import subprocess
 import tempfile
 from io import StringIO
@@ -431,12 +432,37 @@ def notify_macos(ctx, text):
 
 
 def notify_linux(ctx, text):
+    # Headless Linux boxes -- Datadog workspaces among them -- have no libnotify and no
+    # D-Bus session, so there is nothing to notify.
+    if shutil.which("notify-send") is None:
+        return
     ctx.run(f"notify-send 'test/e2e-framework' '{text}'")
 
 
 def notify_windows():
     # TODO: Implenent notification on windows. Would require windows computer (with desktop) to test
     return
+
+
+def copy_to_clipboard_if_supported(text: str, prompt: str | None = None) -> bool:
+    """
+    Copy `text` to the clipboard, and return whether that worked.
+
+    Headless machines -- Datadog workspaces among them -- have no clipboard, so the copy
+    is probed before `prompt` is shown: asking the user to press a key and only then
+    failing would be worse than not offering the copy at all.
+    """
+    try:
+        import pyperclip
+
+        pyperclip.copy("")
+    except Exception:
+        return False
+
+    if prompt:
+        input(prompt)
+    pyperclip.copy(text)
+    return True
 
 
 # ensure we run pulumi from a directory with a Pulumi.yaml file
@@ -482,10 +508,7 @@ def show_connection_message(
 
     print(f"\nYou can run the following command to connect to the host `{command}`.\n")
     if copy_to_clipboard:
-        import pyperclip
-
-        input("Press a key to copy command to clipboard...")
-        pyperclip.copy(command)
+        copy_to_clipboard_if_supported(command, prompt="Press a key to copy command to clipboard...")
 
 
 def add_known_host(ctx: Context, address: str) -> None:

--- a/tasks/e2e_framework/tool.py
+++ b/tasks/e2e_framework/tool.py
@@ -210,10 +210,11 @@ def _ci_pulumi_env() -> dict[str, str]:
 
 
 def _local_pulumi_passphrase(config_path: str | None) -> str | None:
-    # Imported here because config imports this module.
-    from . import config as e2e_config
-
     try:
+        # Imported here, and inside the try: config imports this module, and pulls in
+        # pydantic, which isn't installed in every environment that calls run_pulumi.
+        from . import config as e2e_config
+
         return e2e_config.get_pulumi_passphrase(e2e_config.get_local_config(config_path))
     except Exception:
         # A broken config file shouldn't stop `pulumi version` or `pulumi login` from

--- a/tasks/e2e_framework/vm.py
+++ b/tasks/e2e_framework/vm.py
@@ -27,14 +27,12 @@ def get_vm_password(
     outputs (the same value RemoteHost.Password uses in-process), so it
     works for any provisioner that exports a password (AWS, Azure, ...).
     """
-    from tasks.e2e_framework import config, tool
+    from tasks.e2e_framework import tool
 
     if not stack_name:
         raise Exit("Please provide a stack name to connect to.")
 
-    passphrase_ctx = tool.use_ci_pulumi_backend(ctx) if ci else config.use_local_pulumi_passphrase(config_path)
-    with passphrase_ctx:
-        out = tool.get_stack_json_outputs(ctx, stack_name)
+    out = tool.get_stack_json_outputs(ctx, stack_name, config_path=config_path, ci=ci)
     if not out:
         raise Exit("No VM found in the stack.")
 

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -23,6 +23,7 @@ from invoke.context import Context
 from invoke.exceptions import Exit
 from invoke.tasks import task
 
+from tasks.e2e_framework import tool
 from tasks.e2e_framework.deploy import get_pipeline_commit_sha
 from tasks.flavor import AgentFlavor
 from tasks.gotest import process_test_result, test_flavor
@@ -605,7 +606,6 @@ def run(
         )
 
     _check_e2e_local_config_or_exit(profile)
-    local_e2e_cfg = _load_e2e_local_config()
 
     e2e_module = get_default_modules()[module_name]
 
@@ -638,14 +638,9 @@ def run(
     if profile:
         env_vars["E2E_PROFILE"] = profile
 
-    # Export PULUMI_CONFIG_PASSPHRASE from local config when not already set in the
-    # environment. Lets developers run E2E without putting the passphrase in their rc.
-    if "PULUMI_CONFIG_PASSPHRASE" not in os.environ and local_e2e_cfg is not None:
-        from tasks.e2e_framework.config import get_pulumi_passphrase
-
-        passphrase = get_pulumi_passphrase(local_e2e_cfg)
-        if passphrase:
-            env_vars["PULUMI_CONFIG_PASSPHRASE"] = passphrase
+    # Pulls PULUMI_CONFIG_PASSPHRASE out of the local config when the environment doesn't
+    # already carry one, so developers don't have to put the passphrase in their rc file.
+    env_vars.update(tool.pulumi_env(skip_update_check=False))
 
     parsed_params = {}
 
@@ -1031,19 +1026,13 @@ def _get_pulumi_backend_url(ctx: Context) -> str | None:
     Get the Pulumi backend URL using 'pulumi whoami --json'.
     Returns the backend URL or None if it cannot be determined.
     """
-    res = ctx.run(
-        "pulumi whoami --json",
-        hide=True,
-        warn=True,
-        env=_get_default_env(),
-    )
-    if res is None or res.exited != 0:
-        return None
     try:
-        whoami = json.loads(res.stdout)
-        return whoami.get("url")
+        whoami = tool.pulumi_json(ctx, "whoami --json", project_dir=False, warn=True)
     except json.JSONDecodeError:
         return None
+    if whoami is None:
+        return None
+    return whoami.get("url")
 
 
 def _list_stacks_from_s3(backend_url: str, project: str = "e2eci") -> list[dict]:
@@ -1118,14 +1107,7 @@ def list_stacks(ctx: Context, project: str = "e2eci") -> list[dict]:
         return _list_stacks_from_s3(backend_url, project)
 
     # Fallback to pulumi CLI for non-S3 backends (local, etc.)
-    res = ctx.run(
-        "pulumi stack ls --all --json",
-        hide=True,
-        warn=True,
-    )
-    if res is None or res.exited != 0:
-        return []
-    return json.loads(res.stdout)
+    return tool.pulumi_json(ctx, "stack ls --all --json", project_dir=False, warn=True) or []
 
 
 @task
@@ -1348,12 +1330,6 @@ def deps(ctx, verbose=False):
     download_go_dependencies(ctx, paths=["test/new-e2e"], verbose=verbose, max_retry=3)
 
 
-def _get_default_env():
-    return {
-        "PULUMI_SKIP_UPDATE_CHECK": "true",
-    }
-
-
 def _get_home_dir():
     # TODO: Go os.UserHomeDir() uses a different algorithm than Python Path.home()
     #       so a different directory may be returned in some cases.
@@ -1472,22 +1448,9 @@ def _prompt_select_stacks(stacks: list[str]) -> list[str]:
 
 
 def _get_existing_stacks(ctx: Context) -> list[str]:
-    e2e_stacks: list[str] = []
-    output = ctx.run(
-        "pulumi stack ls --all --project e2elocal --json",
-        hide=True,
-        env=_get_default_env(),
-    )
-    if output is None or not output:
-        return []
-    stacks_data = json.loads(output.stdout)
-    for stack in stacks_data:
-        if "name" not in stack:
-            print(f"Skipping stack {stack} as it does not have a name")
-            continue
-        stack_name = stack["name"]
+    e2e_stacks = tool.pulumi_stack_names(ctx, project="e2elocal", project_dir=False)
+    for stack_name in e2e_stacks:
         print(f"Adding stack {stack_name}")
-        e2e_stacks.append(stack_name)
     return e2e_stacks
 
 
@@ -1496,42 +1459,46 @@ def _destroy_stack(ctx: Context, stack: str):
     # stacks are stored. It is expected to fail on stacks existing locally
     # with resources removed by agent-sandbox clean up job
 
-    destroy_env = _get_default_env()
-    destroy_env["PULUMI_K8S_DELETE_UNREACHABLE"] = "true"
+    destroy_env = {"PULUMI_K8S_DELETE_UNREACHABLE": "true"}
+    tmp_dir = tempfile.gettempdir()
 
-    with ctx.cd(tempfile.gettempdir()):
-        ret = ctx.run(
-            f"pulumi destroy --stack {stack} --yes --remove --skip-preview",
+    ret = tool.run_pulumi(
+        ctx,
+        f"destroy --stack {stack} --yes --remove --skip-preview",
+        project_dir=tmp_dir,
+        env=destroy_env,
+        warn=True,
+        hide=True,
+    )
+    if ret is not None and ret.exited != 0:
+        if "No valid credential sources found" in ret.stdout:
+            raise Exception(
+                f"no valid credentials sources found for stack {stack}, if you set the AWS_PROFILE environment variable ensure it is valid"
+            )
+        if "no previous deployment" in ret.stderr:
+            # Stack was created but never had a successful up; no resources to destroy.
+            print(f"Stack {stack} has no previous deployment, skipping destroy")
+            return
+        # run with refresh on first destroy attempt failure
+        ret = tool.run_pulumi(
+            ctx,
+            f"destroy --stack {stack} -r --yes --remove --skip-preview",
+            project_dir=tmp_dir,
+            env=destroy_env,
             warn=True,
             hide=True,
-            env=destroy_env,
         )
-        if ret is not None and ret.exited != 0:
-            if "No valid credential sources found" in ret.stdout:
-                raise Exception(
-                    f"no valid credentials sources found for stack {stack}, if you set the AWS_PROFILE environment variable ensure it is valid"
-                )
-            if "no previous deployment" in ret.stderr:
-                # Stack was created but never had a successful up; no resources to destroy.
-                print(f"Stack {stack} has no previous deployment, skipping destroy")
-                return
-            # run with refresh on first destroy attempt failure
-            ret = ctx.run(
-                f"pulumi destroy --stack {stack} -r --yes --remove --skip-preview",
-                warn=True,
-                hide=True,
-                env=destroy_env,
-            )
-        if ret is not None and ret.exited != 0:
-            raise Exception(f"{ret.stdout, ret.stderr}")
+    if ret is not None and ret.exited != 0:
+        raise Exception(f"{ret.stdout, ret.stderr}")
 
 
 def _remove_stack(ctx: Context, stack: str):
-    ret = ctx.run(
-        f"pulumi stack rm --force --yes --stack {stack}",
+    ret = tool.run_pulumi(
+        ctx,
+        f"stack rm --force --yes --stack {stack}",
+        project_dir=False,
         warn=True,
         hide=True,
-        env=_get_default_env(),
     )
     if ret is not None and ret.exited != 0:
         if "no stack named" in ret.stderr:
@@ -1541,10 +1508,7 @@ def _remove_stack(ctx: Context, stack: str):
 
 
 def _get_pulumi_about(ctx: Context) -> dict:
-    output = ctx.run("pulumi about --json", hide=True, env=_get_default_env())
-    if output is None or not output:
-        return {}
-    return json.loads(output.stdout)
+    return tool.pulumi_json(ctx, "about --json", project_dir=False) or {}
 
 
 def _is_local_state(pulumi_about: dict) -> bool:

--- a/tasks/tools/e2e_stacks.py
+++ b/tasks/tools/e2e_stacks.py
@@ -1,14 +1,26 @@
 import os
-import subprocess
 
 from invoke import Context
 
 from tasks.agent_ci_api import run
+from tasks.e2e_framework import tool
 
 
-def destroy_remote_stack_local(stack: str):
-    res = subprocess.run(["pulumi", "destroy", "--remove", "--yes", "--stack", stack], capture_output=True, text=True)
-    return res.returncode, res.stdout, res.stderr, stack
+def destroy_remote_stack_local(stack: str, ctx: Context | None = None):
+    # Runs in a multiprocessing pool, which only hands over the stack name, so the
+    # context is built here rather than passed in.
+    ctx = ctx or Context()
+
+    res = tool.run_pulumi(
+        ctx,
+        f"destroy --remove --yes --stack {stack}",
+        project_dir=False,
+        warn=True,
+        hide=True,
+    )
+    if res is None:
+        return 1, "", "pulumi destroy produced no result", stack
+    return res.exited, res.stdout, res.stderr, stack
 
 
 def destroy_remote_stack_api(stack: str, ctx: Context | None = None):

--- a/tasks/unit_tests/e2e_framework_tool_tests.py
+++ b/tasks/unit_tests/e2e_framework_tool_tests.py
@@ -1,0 +1,150 @@
+import unittest
+from unittest import mock
+
+from invoke.runners import Result
+
+from tasks.e2e_framework import destroy, tool
+
+
+def _run_mock(stdout: str = "", exited: int = 0):
+    """A context whose `run` records its call and returns a canned Result."""
+    ctx = mock.MagicMock()
+    ctx.run.return_value = Result(stdout=stdout, exited=exited)
+    return ctx
+
+
+def _command(ctx) -> str:
+    return ctx.run.call_args.args[0]
+
+
+def _env(ctx) -> dict:
+    return ctx.run.call_args.kwargs["env"]
+
+
+class TestRunPulumi(unittest.TestCase):
+    def setUp(self):
+        # Neither the caller's shell nor a real config file should leak into the assertions.
+        patcher = mock.patch.dict("os.environ", {}, clear=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        passphrase = mock.patch.object(tool, "_local_pulumi_passphrase", return_value=None)
+        passphrase.start()
+        self.addCleanup(passphrase.stop)
+
+    def test_project_dir_default_uses_the_e2e_framework_project(self):
+        ctx = _run_mock()
+        with mock.patch.object(tool, "get_pulumi_dir_flag", return_value="-C /repo/test/e2e-framework/run"):
+            tool.run_pulumi(ctx, "up --yes", stack="user-aws-vm")
+        self.assertEqual(_command(ctx), "pulumi -C /repo/test/e2e-framework/run up --yes -s user-aws-vm")
+
+    def test_project_dir_false_omits_the_flag(self):
+        ctx = _run_mock()
+        tool.run_pulumi(ctx, "login --local", project_dir=False)
+        self.assertEqual(_command(ctx), "pulumi login --local")
+
+    def test_project_dir_path_is_quoted(self):
+        ctx = _run_mock()
+        tool.run_pulumi(ctx, "version", project_dir="/tmp/a dir")
+        self.assertEqual(_command(ctx), "pulumi -C '/tmp/a dir' version")
+
+    def test_empty_flag_groups_do_not_leave_blanks(self):
+        # deploy interpolates a log-flags group that is empty unless logging is on.
+        ctx = _run_mock()
+        tool.run_pulumi(ctx, " stack init --no-select s ", project_dir=False)
+        self.assertEqual(_command(ctx), "pulumi stack init --no-select s")
+
+    def test_pty_is_disabled_on_windows(self):
+        ctx = _run_mock()
+        with mock.patch.object(tool, "is_windows", return_value=True):
+            tool.run_pulumi(ctx, "up --yes", project_dir=False, pty=True)
+        self.assertFalse(ctx.run.call_args.kwargs["pty"])
+
+    def test_pty_is_kept_elsewhere(self):
+        ctx = _run_mock()
+        with mock.patch.object(tool, "is_windows", return_value=False):
+            tool.run_pulumi(ctx, "up --yes", project_dir=False, pty=True)
+        self.assertTrue(ctx.run.call_args.kwargs["pty"])
+
+
+class TestPulumiEnv(unittest.TestCase):
+    def setUp(self):
+        patcher = mock.patch.dict("os.environ", {}, clear=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_passphrase_comes_from_the_local_config(self):
+        with mock.patch.object(tool, "_local_pulumi_passphrase", return_value="from-config"):
+            env = tool.pulumi_env()
+        self.assertEqual(env, {"PULUMI_SKIP_UPDATE_CHECK": "true", "PULUMI_CONFIG_PASSPHRASE": "from-config"})
+
+    def test_ambient_passphrase_wins(self):
+        # Empty is a valid passphrase, so presence -- not truthiness -- is what counts.
+        for ambient in ({"PULUMI_CONFIG_PASSPHRASE": ""}, {"PULUMI_CONFIG_PASSPHRASE_FILE": "/tmp/pass"}):
+            with self.subTest(ambient=ambient), mock.patch.dict("os.environ", ambient, clear=True):
+                with mock.patch.object(tool, "_local_pulumi_passphrase", return_value="from-config") as read:
+                    env = tool.pulumi_env()
+                self.assertNotIn("PULUMI_CONFIG_PASSPHRASE", env)
+                read.assert_not_called()
+
+    def test_skip_update_check_can_be_turned_off(self):
+        # pulumi_version() reads the upgrade banner off stderr, so it must not be skipped.
+        with mock.patch.object(tool, "_local_pulumi_passphrase", return_value=None):
+            env = tool.pulumi_env(skip_update_check=False)
+        self.assertEqual(env, {})
+
+    def test_overrides_win(self):
+        with mock.patch.object(tool, "_local_pulumi_passphrase", return_value="from-config"):
+            env = tool.pulumi_env(
+                overrides={"PULUMI_CONFIG_PASSPHRASE": "explicit", "PULUMI_K8S_DELETE_UNREACHABLE": "true"}
+            )
+        self.assertEqual(env["PULUMI_CONFIG_PASSPHRASE"], "explicit")
+        self.assertEqual(env["PULUMI_K8S_DELETE_UNREACHABLE"], "true")
+
+    def test_caller_env_reaches_run_without_a_shell_prefix(self):
+        ctx = _run_mock()
+        with mock.patch.object(tool, "_local_pulumi_passphrase", return_value=None):
+            tool.run_pulumi(ctx, "up --yes", project_dir=False, env={"PULUMI_K8S_DELETE_UNREACHABLE": "true"})
+        self.assertEqual(_command(ctx), "pulumi up --yes")
+        self.assertEqual(_env(ctx)["PULUMI_K8S_DELETE_UNREACHABLE"], "true")
+
+    def test_ci_selects_the_ci_backend(self):
+        with (
+            mock.patch.object(tool, "_local_pulumi_passphrase", return_value=None),
+            mock.patch.object(tool, "_ci_pulumi_env", return_value={"PULUMI_BACKEND_URL": tool.CI_PULUMI_BACKEND_URL}),
+        ):
+            self.assertEqual(tool.pulumi_env(ci=True)["PULUMI_BACKEND_URL"], tool.CI_PULUMI_BACKEND_URL)
+            self.assertNotIn("PULUMI_BACKEND_URL", tool.pulumi_env())
+
+    def test_a_broken_config_does_not_break_pulumi(self):
+        with mock.patch("tasks.e2e_framework.config.get_local_config", side_effect=ValueError("bad yaml")):
+            self.assertIsNone(tool._local_pulumi_passphrase(None))
+
+
+class TestPulumiStackNames(unittest.TestCase):
+    def setUp(self):
+        patcher = mock.patch.object(tool, "_local_pulumi_passphrase", return_value=None)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_names_are_read_from_json(self):
+        ctx = _run_mock(stdout='[{"name": "a"}, {"name": "b"}, {"current": true}]')
+        self.assertEqual(tool.pulumi_stack_names(ctx, project_dir=False), ["a", "b"])
+        self.assertEqual(_command(ctx), "pulumi stack ls --all --json")
+        self.assertEqual(ctx.run.call_args.kwargs["hide"], "stdout")
+
+    def test_project_is_forwarded(self):
+        ctx = _run_mock(stdout="[]")
+        tool.pulumi_stack_names(ctx, project="e2elocal", project_dir=False)
+        self.assertEqual(_command(ctx), "pulumi stack ls --all --json --project e2elocal")
+
+
+class TestExistingStacks(unittest.TestCase):
+    def test_only_the_current_user_stacks_are_returned(self):
+        with mock.patch.object(destroy, "get_stack_name_prefix", return_value="jdoe-"):
+            shorts, fulls = destroy._get_existing_stacks(["jdoe-aws-vm", "jdoe-eks", "other-aws-vm"])
+        self.assertEqual(shorts, ["aws-vm", "eks"])
+        self.assertEqual(fulls, ["jdoe-aws-vm", "jdoe-eks"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tasks/unit_tests/e2e_framework_tool_tests.py
+++ b/tasks/unit_tests/e2e_framework_tool_tests.py
@@ -146,5 +146,29 @@ class TestExistingStacks(unittest.TestCase):
         self.assertEqual(fulls, ["jdoe-aws-vm", "jdoe-eks"])
 
 
+class TestResourceOwnerID(unittest.TestCase):
+    def test_falls_back_to_the_os_user(self):
+        with mock.patch.dict("os.environ", {}, clear=True), mock.patch("getpass.getuser", return_value="John.Doe"):
+            self.assertEqual(tool.get_resource_owner_id(), "john-doe")
+
+    def test_real_user_wins_over_the_os_user(self):
+        env = {"REAL_USER": "john.doe"}
+        with mock.patch.dict("os.environ", env, clear=True), mock.patch("getpass.getuser", return_value="bits"):
+            self.assertEqual(tool.get_resource_owner_id(), "john-doe")
+
+    def test_workspace_name_disambiguates_two_workspaces(self):
+        env = {"REAL_USER": "john.doe", "WORKSPACE_NAME": "test-e2e"}
+        with mock.patch.dict("os.environ", env, clear=True), mock.patch("getpass.getuser", return_value="bits"):
+            self.assertEqual(tool.get_resource_owner_id(), "john-doe-test-e2e")
+            self.assertEqual(tool.get_stack_name(None, "aws/vm"), "john-doe-test-e2e-aws-vm")
+
+    def test_an_explicit_stack_name_is_normalized(self):
+        # deploy used to lowercase the full name while destroy did not, so a --stack-name
+        # with uppercase deployed under a name destroy could never find again.
+        env = {"REAL_USER": "john.doe"}
+        with mock.patch.dict("os.environ", env, clear=True):
+            self.assertEqual(tool.get_stack_name("My Stack", "aws/vm"), "john-doe-my-stack")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/e2e-framework/testing/runner/BUILD.bazel
+++ b/test/e2e-framework/testing/runner/BUILD.bazel
@@ -28,6 +28,7 @@ dd_agent_go_test(
     name = "runner_test",
     srcs = [
         "configmap_test.go",
+        "local_profile_test.go",
         "profile_test.go",
     ],
     embed = [":runner"],

--- a/test/e2e-framework/testing/runner/local_profile.go
+++ b/test/e2e-framework/testing/runner/local_profile.go
@@ -91,10 +91,14 @@ var _ Profile = localProfile{}
 func (p localProfile) NamePrefix() string {
 	// Stack names may only contain alphanumeric characters, hyphens, underscores, or periods.
 	// As NamePrefix is used as stack name, we sanitize the user name.
-	var username string
-	user, err := user.Current()
-	if err == nil {
-		username = user.Username
+	// On a shared dev VM (a Datadog workspace) the OS user is the same for everyone, so
+	// REAL_USER carries the developer's identity.
+	username := os.Getenv("REAL_USER")
+	if username == "" {
+		user, err := user.Current()
+		if err == nil {
+			username = user.Username
+		}
 	}
 
 	if username == "" || username == "root" {
@@ -117,6 +121,13 @@ func (p localProfile) NamePrefix() string {
 
 	username = strings.ToLower(username)
 	username = strings.ReplaceAll(username, " ", "-")
+
+	// Several workspaces owned by the same developer would otherwise name their stacks
+	// and cloud resources identically in the shared account.
+	if workspace := os.Getenv("WORKSPACE_NAME"); workspace != "" {
+		workspace = strings.ReplaceAll(strings.ToLower(workspace), " ", "-")
+		username = fmt.Sprintf("%s-%s", username, workspace)
+	}
 
 	return username
 }

--- a/test/e2e-framework/testing/runner/local_profile_test.go
+++ b/test/e2e-framework/testing/runner/local_profile_test.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package runner
+
+import (
+	"testing"
+)
+
+func TestNamePrefix(t *testing.T) {
+	tests := []struct {
+		name      string
+		realUser  string
+		workspace string
+		want      string
+	}{
+		{
+			name:     "real user collapses first.last",
+			realUser: "john.doe",
+			want:     "jdoe",
+		},
+		{
+			name:      "workspace name disambiguates two workspaces of the same developer",
+			realUser:  "john.doe",
+			workspace: "test-e2e",
+			want:      "jdoe-test-e2e",
+		},
+		{
+			name:      "workspace name is sanitized",
+			realUser:  "john.doe",
+			workspace: "Test E2E",
+			want:      "jdoe-test-e2e",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("REAL_USER", tt.realUser)
+			t.Setenv("WORKSPACE_NAME", tt.workspace)
+
+			if got := (localProfile{}).NamePrefix(); got != tt.want {
+				t.Errorf("localProfile.NamePrefix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Without REAL_USER the prefix must keep coming from the OS user, so laptops are
+// unaffected by the workspace support.
+func TestNamePrefixWithoutRealUser(t *testing.T) {
+	t.Setenv("REAL_USER", "")
+	t.Setenv("WORKSPACE_NAME", "")
+
+	if got := (localProfile{}).NamePrefix(); got == "" {
+		t.Error("localProfile.NamePrefix() = \"\", want the sanitized OS user")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Makes the `dda inv e2e.*` / `aws.*` / `azure.*` / `gcp.*` tasks work when run from inside a Datadog workspace instead of a regular dev laptop:
- Cloud resources (Pulumi stacks, EC2 key pairs, SSH keys) are named from `$REAL_USER` + `$WORKSPACE_NAME` instead of the OS user, which is `bits` for everyone on a workspace.
- Desktop notifications and "copy to clipboard" prompts probe for `notify-send`/a clipboard first and degrade gracefully instead of failing on a headless box.
- `e2e.setup.debug` no longer aborts when `AWS_REGION` is unset (workspaces using `aws-vault` don't export it; every E2E resource lives in `us-east-1` regardless).
- Fixes the example command `e2e.setup` prints on success.
- Every remaining raw `pulumi` shell-out is routed through a single `run_pulumi`/`pulumi_env` helper in `tool.py`, so the passphrase/backend/project-dir resolution lives in one place instead of being duplicated per call site.
- Documents the workspace caveats (region pinning, shell support, resource naming) and the pulumi-helper convention in `docs/public/how-to/test/e2e.md` and `tasks/AGENTS.md`.

### Motivation

Running the e2e framework from a Datadog workspace failed in several ways: stack/key names collided because everyone shares the OS user `bits`, `notify-send`/clipboard calls crashed on the headless box, and `e2e.setup.debug` aborted on a missing `AWS_REGION`. Jira: ACIX-1792.

### Describe how you validated your changes

Ran `dda inv e2e.setup` on a blank workspace, ran an example test, and created/destroyed an AWS VM from the workspace.