### PR TITLE
bazel: packages: inject the real versions

### DIFF
--- a/packages/agent/linux/BUILD.bazel
+++ b/packages/agent/linux/BUILD.bazel
@@ -13,7 +13,7 @@ load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//bazel/rules:compression.bzl", "get_compression_level")
 load("//bazel/rules:dd_agent_pkg_mklink.bzl", "dd_agent_pkg_mklink")
 load("//compliance:package_licenses.bzl", "package_licenses")
-load("//packages/rules:package_naming.bzl", "package_name_variables")
+load("//packages/rules:package_naming.bzl", "make_version", "package_name_variables")
 
 package(default_visibility = ["//packages:__subpackages__"])
 
@@ -115,7 +115,7 @@ pkg_deb(
     priority = "extra",
     recommends = ["datadog-signing-keys (>= 1:1.4.0)"],
     section = "utils",
-    version = "7",
+    version = "1:" + make_version() + "-1",
 
     # TODO: pull in target_cpu as arch.
     # architecture = "$(COMPILATION_MODE)",
@@ -158,7 +158,7 @@ pkg_rpm(
     },
     summary = "Datadog Monitoring Agent",
     url = "http://www.datadoghq.com",
-    version = "7",
+    version = make_version(),
 )
 
 # Replacement for datadog-agent-installer-symlinks.rb

--- a/packages/ddot/BUILD.bazel
+++ b/packages/ddot/BUILD.bazel
@@ -9,7 +9,7 @@ load("@rules_pkg//pkg:rpm.bzl", "pkg_rpm")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//bazel/rules:compression.bzl", "get_compression_level")
 load("//compliance:package_licenses.bzl", "package_licenses")
-load("//packages/rules:package_naming.bzl", "package_name_variables")
+load("//packages/rules:package_naming.bzl", "make_version", "package_name_variables")
 
 package(default_visibility = ["//packages:__subpackages__"])
 
@@ -92,8 +92,7 @@ pkg_deb(
     priority = "extra",
     recommends = ["datadog-signing-keys (>= 1:1.4.0)"],
     section = "utils",
-    # TODO: Stamp in pipeline: 1:7.77.0~devel.git.394.fe0d0bb.pipeline.95313893-1
-    version = "7",
+    version = "1:" + make_version() + "-1",
 )
 
 pkg_rpm(
@@ -109,7 +108,6 @@ pkg_rpm(
     posttrans_scriptlet_file = "//omnibus:package-scripts/ddot-rpm/posttrans",
     pre_scriptlet_file = "//omnibus:package-scripts/ddot-rpm/preinst",
     preun_scriptlet_file = "//omnibus:package-scripts/ddot-rpm/prerm",
-    # TODO: Stamp in pipeline: 7.77.0~devel.git.394.fe0d0bb.pipeline.95313893
     release = "1",
     # datadog-agent version dependency is stamped at build time; the version
     # must match exactly (epoch 1, same version, release 1).
@@ -118,5 +116,5 @@ pkg_rpm(
     requires = ["datadog-agent"],
     summary = "Datadog Distribution of OpenTelemetry Collector",
     url = "http://www.datadoghq.com",
-    version = "7",
+    version = make_version(),
 )

--- a/packages/dogstatsd/BUILD.bazel
+++ b/packages/dogstatsd/BUILD.bazel
@@ -9,7 +9,7 @@ load("@rules_pkg//pkg:rpm.bzl", "pkg_rpm")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//bazel/rules:compression.bzl", "get_compression_level")
 load("//compliance:package_licenses.bzl", "package_licenses")
-load("//packages/rules:package_naming.bzl", "package_name_variables")
+load("//packages/rules:package_naming.bzl", "make_version", "package_name_variables")
 
 package(default_visibility = ["//packages:__subpackages__"])
 
@@ -88,8 +88,7 @@ pkg_deb(
     priority = "extra",
     recommends = ["datadog-signing-keys (>= 1:1.4.0)"],
     section = "utils",
-    # TODO: Stamp in pipeline: 1:7.77.0~devel.git.394.fe0d0bb.pipeline.95313893-1
-    version = "7",
+    version = "1:" + make_version() + "-1",
 )
 
 pkg_rpm(
@@ -107,7 +106,6 @@ pkg_rpm(
     postun_scriptlet_file = "//omnibus:package-scripts/dogstatsd-rpm/postrm",
     pre_scriptlet_file = "//omnibus:package-scripts/dogstatsd-rpm/preinst",
     preun_scriptlet_file = "//omnibus:package-scripts/dogstatsd-rpm/prerm",
-    # TODO: Stamp in pipeline: 7.77.0~devel.git.394.fe0d0bb.pipeline.95313893
     release = "1",
     # Packages needed during %pre scriptlet execution (from dogstatsd.rb ).
     # coreutils and grep are common to RHEL and SUSE.
@@ -123,5 +121,5 @@ pkg_rpm(
     },
     summary = "Datadog dogstatsd agent",
     url = "http://www.datadoghq.com",
-    version = "7",
+    version = make_version(),
 )

--- a/packages/installer/linux/BUILD.bazel
+++ b/packages/installer/linux/BUILD.bazel
@@ -19,7 +19,7 @@ load("//bazel/rules:dd_agent_expand_template.bzl", "dd_agent_expand_template")
 load("//compliance:package_licenses.bzl", "package_licenses")
 load("//compliance/rules:version_manifest.bzl", "version_manifest")
 load("//packages/rules:dd_pkg_deb.bzl", "dd_pkg_deb")
-load("//packages/rules:package_naming.bzl", "package_name_variables")
+load("//packages/rules:package_naming.bzl", "make_version", "package_name_variables")
 
 package(default_visibility = ["//packages:__subpackages__"])
 
@@ -175,7 +175,7 @@ dd_pkg_deb(
     recommends = ["datadog-signing-keys (>= 1:1.4.0)"],
     section = "utils",
     tags = ["manual"],
-    version = "7",  # TODO: stamp from pipeline (ABLD-364)
+    version = "1:" + make_version() + "-1",
 )
 
 pkg_rpm(
@@ -207,7 +207,7 @@ pkg_rpm(
     summary = "Datadog Installer",
     tags = ["manual"],
     url = "http://www.datadoghq.com",
-    version = "7",  # TODO: pick up from pipeline
+    version = make_version(),
 )
 
 # Version manifests approximating the omnibus <artifact>.metadata.json sidecar,

--- a/packages/iot/BUILD.bazel
+++ b/packages/iot/BUILD.bazel
@@ -9,7 +9,7 @@ load("@rules_pkg//pkg:rpm.bzl", "pkg_rpm")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//bazel/rules:compression.bzl", "get_compression_level")
 load("//compliance:package_licenses.bzl", "package_licenses")
-load("//packages/rules:package_naming.bzl", "package_name_variables")
+load("//packages/rules:package_naming.bzl", "make_version", "package_name_variables")
 
 package(default_visibility = ["//packages:__subpackages__"])
 
@@ -89,8 +89,7 @@ pkg_deb(
     priority = "extra",
     recommends = ["datadog-signing-keys (>= 1:1.4.0)"],
     section = "utils",
-    # TODO: Stamp in pipeline: 1:7.77.0~devel.git.394.fe0d0bb.pipeline.95313893-1
-    version = "7",
+    version = "1:" + make_version() + "-1",
 )
 
 pkg_rpm(
@@ -109,7 +108,6 @@ pkg_rpm(
     postun_scriptlet_file = "//omnibus:package-scripts/iot-agent-rpm/postrm",
     pre_scriptlet_file = "//omnibus:package-scripts/iot-agent-rpm/preinst",
     preun_scriptlet_file = "//omnibus:package-scripts/iot-agent-rpm/prerm",
-    # TODO: Stamp in pipeline: 7.77.0~devel.git.394.fe0d0bb.pipeline.95313893
     release = "1",
     # Packages needed during %pre scriptlet execution (from iot-agent.rb runtime_script_dependency).
     # coreutils and grep are common to RHEL and SUSE.
@@ -125,5 +123,5 @@ pkg_rpm(
     },
     summary = "Datadog IoT Agent",
     url = "http://www.datadoghq.com",
-    version = "7",
+    version = make_version(),
 )

--- a/packages/rules/package_naming.bzl
+++ b/packages/rules/package_naming.bzl
@@ -59,7 +59,7 @@ And other thing which might be useful:
 - milestone: Next product milestone version.
 """
 
-def _make_version():
+def make_version():
     """Make the version component of the file name.
 
     Use PACKAGE_VERSION, if it is availble, otherwise guess from release.json
@@ -111,7 +111,7 @@ def _package_name_variables_impl(ctx):
 
     flavor = ctx.attr._flavor[BuildSettingInfo].value
     values["product_name"] = _inject_flavor(ctx.attr.product_name, flavor)
-    values["version"] = _make_version()
+    values["version"] = make_version()
     values["base_branch"] = release_json.get("base_branch")
     values["milestone"] = release_json.get("current_milestone")
 

--- a/packages/rules/package_naming.bzl
+++ b/packages/rules/package_naming.bzl
@@ -73,7 +73,7 @@ def make_version():
     milestone = release_json.get("current_milestone")
 
     # 'localbuild' is just a placeholder choice for now.
-    return milestone + "-localbuild"
+    return milestone + "~localbuild"
 
 def _extract_arch(ctx, cpu, style):
     """Extract the arch part from a os/arch pair."""

--- a/packages/rules/package_naming_test.bzl
+++ b/packages/rules/package_naming_test.bzl
@@ -228,9 +228,9 @@ def _test_arch_values_impl(env, target):
     env.expect.that_str(pvi.values.get("arch_deb")).equals(env.ctx.attr.expect_arch_deb)
     env.expect.that_str(pvi.values.get("arch_rpm")).equals(env.ctx.attr.expect_arch_rpm)
 
-# -- Test 8: version begins with "7" and contains "-localbuild" --------------
+# -- Test 8: version begins with "7" and contains "~localbuild" --------------
 # The exact value depends on CI env vars / release.json, but without
-# PACKAGE_VERSION set the fallback path produces "<milestone>-localbuild"
+# PACKAGE_VERSION set the fallback path produces "<milestone>~localbuild"
 # where milestone is a "7.x.y" string from release.json.
 
 def _test_version_nonempty(name):
@@ -248,7 +248,7 @@ def _test_version_nonempty_impl(env, target):
     pvi = target[PackageVariablesInfo]
     version = pvi.values.get("version")
     env.expect.that_str(version[:2]).equals("7.")
-    env.expect.that_str(version).contains("-localbuild")
+    env.expect.that_str(version).contains("~localbuild")
 
 # -- Suite -------------------------------------------------------------------
 


### PR DESCRIPTION
### What does this PR do?

Start injecting the a fully formatted Debian version string into the `control` file of bazel generated packages

### Motivation

Replicating the same metadata as the omnibus based packages

### Describe how you validated your changes

Local builds and CI (dd-pkg linting) while working on https://github.com/DataDog/datadog-agent/pull/53907

### Additional Notes
