### PR TITLE
[CWS] Account for two expected ways a TC classifier attachment can fail

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -208,7 +208,7 @@ require (
 	github.com/DataDog/dd-policy-engine/go v0.0.0-20260730181922-c5e419a4ec7d
 	github.com/DataDog/dd-trace-go/v2 v2.9.2
 	github.com/DataDog/ddtrivy v0.0.0-20260519164847-bf6bcaf2f9b7
-	github.com/DataDog/ebpf-manager v0.8.3
+	github.com/DataDog/ebpf-manager v0.8.4
 	github.com/DataDog/go-acl v1.0.1
 	github.com/DataDog/go-sqllexer v0.2.4
 	github.com/DataDog/jsonapi v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -2552,8 +2552,8 @@ github.com/DataDog/dd-trace-go/v2 v2.9.2 h1:JoYZ9lZLCyBeRE6sRvaBXSe8AGrGySfbnB/B
 github.com/DataDog/dd-trace-go/v2 v2.9.2/go.mod h1:SdMkCESSBc2knx56Xol2pO7jhMDPi7MxyNj6vRYMW48=
 github.com/DataDog/ddtrivy v0.0.0-20260519164847-bf6bcaf2f9b7 h1:N9Ufc+tRU6BaVpxw0D60bvhqwsJ90r5ygXNIbx/kucg=
 github.com/DataDog/ddtrivy v0.0.0-20260519164847-bf6bcaf2f9b7/go.mod h1:cy6fMTy/g9yD4GxWUXTTDzKKJE9ZbONxcwiQfpPrv/M=
-github.com/DataDog/ebpf-manager v0.8.3 h1:aaMiJit2cHkxQXcHxxumm+PC+PvC0f0nryT6GTdpabo=
-github.com/DataDog/ebpf-manager v0.8.3/go.mod h1:zlmQH/xpl87sWLv2k0ek5Nw1PsAOEfDYc8+AYd7lYxw=
+github.com/DataDog/ebpf-manager v0.8.4 h1:JDY0PWXwG8lirC/9QX7iq5Klc0ftK0t232rk1iY+qJM=
+github.com/DataDog/ebpf-manager v0.8.4/go.mod h1:zlmQH/xpl87sWLv2k0ek5Nw1PsAOEfDYc8+AYd7lYxw=
 github.com/DataDog/go-acl v1.0.1 h1:uRbp98YmlVZYqNNyTBFNI3Y6bnziBLyCIR4nRu0bIpU=
 github.com/DataDog/go-acl v1.0.1/go.mod h1:YJx333qSb3GUqCLIbqKeGaZS2pUYh2IYGI7+FsX18CU=
 github.com/DataDog/go-cmp v0.0.0-20250605161605-8f326bf2ab9d h1:ErpIQikDqtpE21afk2ExlJn0wg7gGWyUVu/RY4rBlMI=

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -404,8 +404,8 @@ var (
 	MetricNamespaceResolverLonelyNetworkNamespace = newRuntimeMetric(".namespace_resolver.lonely_netns")
 	// MetricNamespaceResolverError is the name of the metric used to report the count of errors hit by the
 	// NamespaceResolver, mostly while attaching TC classifiers to network devices.
-	// Tags: error_type ('link_not_found', 'no_such_device', 'classifier_exists', 'queue_full', 'netlink_socket',
-	// 'link_list', 'unknown')
+	// Tags: error_type ('link_not_found', 'no_such_device', 'filter_not_found', 'classifier_exists',
+	// 'queue_full', 'netlink_socket', 'link_list', 'unknown')
 	MetricNamespaceResolverError = newRuntimeMetric(".namespace_resolver.error")
 
 	// Policies

--- a/pkg/security/resolvers/netns/errors.go
+++ b/pkg/security/resolvers/netns/errors.go
@@ -9,6 +9,7 @@ package netns
 
 import (
 	"errors"
+	"strings"
 
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/vishvananda/netlink"
@@ -26,6 +27,8 @@ const (
 	errorClassLinkNotFound = "link_not_found"
 	// errorClassNoSuchDevice is reported when an interface is gone while its classifier is attached
 	errorClassNoSuchDevice = "no_such_device"
+	// errorClassFilterNotFound is reported when the filter of an interface is gone right after being added
+	errorClassFilterNotFound = "filter_not_found"
 	// errorClassClassifierExists is reported when the eBPF manager already holds a classifier for an interface
 	errorClassClassifierExists = "classifier_exists"
 	// errorClassQueueFull is reported when a classifier request is dropped because the queue is full
@@ -43,6 +46,7 @@ const (
 var errorClasses = []string{
 	errorClassLinkNotFound,
 	errorClassNoSuchDevice,
+	errorClassFilterNotFound,
 	errorClassClassifierExists,
 	errorClassQueueFull,
 	errorClassNetlinkSocket,
@@ -74,6 +78,10 @@ func (nr *Resolver) sendErrorStats() {
 	}
 }
 
+// tcFilterNotFoundMsg ends the failure the eBPF manager returns when the filter it just added is
+// already missing from the interface it reads back. That one carries no cause to match it on.
+const tcFilterNotFoundMsg = "filter not found"
+
 // classifyTCClassifierError returns the class of a TC classifier setup failure.
 func classifyTCClassifierError(err error) string {
 	var linkNotFound netlink.LinkNotFoundError
@@ -85,6 +93,8 @@ func classifyTCClassifierError(err error) string {
 		return errorClassNoSuchDevice
 	case errors.Is(err, manager.ErrIdentificationPairInUse):
 		return errorClassClassifierExists
+	case strings.Contains(err.Error(), tcFilterNotFoundMsg):
+		return errorClassFilterNotFound
 	default:
 		return errorClassUnknown
 	}

--- a/pkg/security/resolvers/netns/errors_test.go
+++ b/pkg/security/resolvers/netns/errors_test.go
@@ -70,6 +70,22 @@ func TestClassifyTCClassifierError(t *testing.T) {
 			expected: errorClassNoSuchDevice,
 		},
 		{
+			name: "missing device on filter add",
+			err: multierror.Append(nil, cloneErr(
+				fmt.Errorf("failed to attach new probe %v: %w", pip,
+					fmt.Errorf("couldn't start probe %v: %w", pip,
+						fmt.Errorf("couldn't add a %v filter to interface %s[%d]: %w", "ingress", "tmpc255a", 145, unix.ENODEV))))).ErrorOrNil(),
+			expected: errorClassNoSuchDevice,
+		},
+		{
+			name: "filter not found",
+			err: multierror.Append(nil, cloneErr(
+				fmt.Errorf("failed to attach new probe %v: %w", pip,
+					fmt.Errorf("couldn't start probe %v: %w", pip,
+						fmt.Errorf("couldn't create TC filter for %v: filter not found", pip))))).ErrorOrNil(),
+			expected: errorClassFilterNotFound,
+		},
+		{
 			name:     "unknown",
 			err:      multierror.Append(nil, cloneErr(errors.New("something else"))).ErrorOrNil(),
 			expected: errorClassUnknown,


### PR DESCRIPTION
### What does this PR do?

Accounts for two failures of the network namespace resolver that were reported as unclassified.

### Motivation

Container runtimes move network interfaces to the network namespace of the container as soon as they create them, so errors such as "no such device" or "filter not found" midway into attaching new TC filters are expected.

Since interfaces are tracked by the `dev_change_net_namespace` hook, the TC filter attachments are retried after the interface move is done.

### Describe how you validated your changes

Unit test on the error classification.

### Additional Notes

The `ebpf-manager` dependency bump brings in [this change](https://github.com/DataDog/ebpf-manager/pull/287) and allows properly classifying "no such device" errors occurring when an interface is moved from one network namespace to another.
