### PR TITLE
Bump `rules_go` to tentatively fix fingerprint mismatches

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -115,9 +115,9 @@ archive_override(
     patches = [
         "//bazel/patches:rules_go-windows-symlink-workaround.patch",  # bazel-contrib/rules_go#3977
     ],
-    sha256 = "8cb73cffdaac70d1f1c8430b2dfe892251c69a223d8b878d9648eecd648cb233",
-    strip_prefix = "rules_go-3798bb5f3bbb61e36285705ab12d8b2aa78cf2cd",
-    urls = ["https://github.com/bazel-contrib/rules_go/archive/3798bb5f3bbb61e36285705ab12d8b2aa78cf2cd.tar.gz"],  # master as of September 1, 2026
+    sha256 = "9f066d4ad363d049b7b6c3c7f64d73e5ba36caf065fab51848a540a49ab1bb49",
+    strip_prefix = "rules_go-f6afe7478c645595839adc211644e6e5474d9fd3",
+    urls = ["https://github.com/bazel-contrib/rules_go/archive/f6afe7478c645595839adc211644e6e5474d9fd3.tar.gz"],  # master as of September 3, 2026
 )
 
 # Temporary until rules_pkg > 1.2.0 is in BCR


### PR DESCRIPTION
### What does this PR do?
Bump the `rules_go` `archive_override` pin in `MODULE.bazel` to its latest upstream master commit: bazel-contrib/rules_go@f6afe7478c645595839adc211644e6e5474d9fd3.

### Motivation
`bazel:coverage:*` jobs intermittently fail with a Go linker fingerprint mismatch, for example job https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/2010657193, where `comp/snmptraps/config/def` and `comp/core/tagger/common` get compiled twice, each with a different fingerprint.

bazel-contrib/rules_go#4706 stopped propagating `go_binary`/`go_test`'s `static` attribute through `go_transition`, since that transition forked a private configuration for every dependency reachable from a target that sets it.

Its own description names exactly this failure mode:
> - Two binaries that only differed in this attribute landed in two configurations.

Bumping past it, together with the related config-forking fix in bazel-contrib/rules_go#4704 for `linkmode`, is a **plausible, though unconfirmed, mitigation worth trying**.

### Describe how you validated your changes
Ran `bazel mod deps --lockfile_mode=update` after the pin change, which resolved cleanly.

Built `//pkg/util/common:common` and `//pkg/network/go/bininspect:bininspect_test`, the repo's only target setting `static = "on"`, both succeeded.

### Additional Notes
[Slack thread](https://dd.slack.com/archives/C08SK4B0FK8/p1788430633256749) (internal).