### PR TITLE
[WP] Fix TestRemediationCustomEventNotTriggered corrupted by another test

### DIFF
--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -10,6 +10,7 @@ package tests
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -1748,6 +1749,19 @@ func TestRemediationCustomEvents(t *testing.T) {
 
 }
 
+func remediationStatusSourceRuleID(data []byte) string {
+	var obj interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return ""
+	}
+	if el, err := jsonpath.JsonPathLookup(obj, `$.rule_tags.rule_id`); err == nil {
+		if ruleID, ok := el.(string); ok {
+			return ruleID
+		}
+	}
+	return ""
+}
+
 func TestRemediationCustomEventNotTriggered(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -1791,7 +1805,7 @@ func TestRemediationCustomEventNotTriggered(t *testing.T) {
 	}
 	noEventRule := &rules.RuleDefinition{
 
-		ID:         "kill_remediation_not_triggering",
+		ID:         "kill_remediation_not_triggering_no_remediation_tag",
 		Expression: `exec.file.name == "there-is-again-no-file-like-that"`,
 		Actions: []*rules.ActionDefinition{
 			{
@@ -1800,6 +1814,9 @@ func TestRemediationCustomEventNotTriggered(t *testing.T) {
 					Scope:  "process",
 				},
 			},
+		},
+		Tags: map[string]string{
+			"rule_id": "kill_remediation_not_triggering_no_remediation_tag",
 		},
 	}
 
@@ -1881,6 +1898,11 @@ func TestRemediationCustomEventNotTriggered(t *testing.T) {
 
 			msg := test.msgSender.getMsg("remediation_status")
 			if msg != nil {
+				if sourceRuleID := remediationStatusSourceRuleID(msg.Data); sourceRuleID != noEventRule.ID {
+					// Stale remediation_status from another test still in the queue.
+					test.msgSender.flush()
+					return errors.New("retry")
+				}
 				t.Error("should not find remediation_status message, got event : " + string(msg.Data))
 				return nil
 			}


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
`TestRemediationCustomEventNotTriggered` checks if we receive no event when the action does not triggered, which is the expected behavior for automated responses. 
Another test corrupts the test `TestRemediationCustomEventNotTriggered` that fails because he was receiving an event from a previous test.
We now check the ID of the rule.