### PR TITLE
feat(delegated-auth): add credential provider registry

### DIFF
--- a/comp/core/delegatedauth/def/component.go
+++ b/comp/core/delegatedauth/def/component.go
@@ -10,6 +10,7 @@ package delegatedauth
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/DataDog/datadog-agent/comp/core/delegatedauth/common"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
@@ -17,35 +18,61 @@ import (
 
 // team: credential-management delegated-auth-login
 
+// Provider supplies a delegated credential for one destination.
+type Provider interface {
+	// Authorize stamps the current credential onto h. A false return means the caller must
+	// retain the payload and retry after the first exchange or a refresh completes.
+	Authorize(h http.Header) bool
+
+	// Refresh stops use of a rejected credential and requests an immediate re-exchange.
+	// It returns false when no refresh mechanism is available.
+	Refresh() bool
+}
+
 // InstanceParams configures a single API key instance.
+//
+// There are two usage shapes, distinguished by SkipConfigWriteback:
+//
+//   - Flat-key (write-back): the resolved key is written into the config slot named by
+//     APIKeyConfigKey, and consumers pick it up via config OnUpdate callbacks. This is
+//     the original delivery path used by the delegated_auth.* config sections.
+//
+//   - Directive (provider): the key is delivered through a Provider returned by
+//     AddInstance, and nothing is written to config. SkipConfigWriteback must be true.
+//     ConfigKey + Destination identify the provider so consumers can find it via
+//     Component.ProvidersFor, and Directive disambiguates multiple orgs on one host.
+//
+// Fields marked [flat] are only used when SkipConfigWriteback is false.
+// Fields marked [directive] are only used when SkipConfigWriteback is true.
+// Fields marked [shared] are used in both paths.
 type InstanceParams struct {
-	// Config is used to read settings and write API keys. Only the Config from
+	// [shared] Config is used to read settings and write API keys. Only the Config from
 	// the first AddInstance call is used; later calls must pass the same instance.
 	Config pkgconfigmodel.ReaderWriter
 
-	// OrgUUID is the Datadog organization UUID. Required.
+	// [shared] OrgUUID is the Datadog organization UUID. Required.
 	OrgUUID string
 
-	// RefreshInterval in minutes. Defaults to 60 if not specified.
+	// [shared] RefreshInterval in minutes. Defaults to 60 if not specified.
 	RefreshInterval int
 
-	// APIKeyConfigKey is where to write the API key (e.g. "api_key",
-	// "logs_config.api_key"). Required. In additional-endpoints mode it serves
-	// as an internal bookkeeping/status key; the key itself is written elsewhere.
+	// [shared] APIKeyConfigKey is a unique identifier for this instance. In flat-key mode it is
+	// also where the resolved key is written (e.g. "api_key", "logs_config.api_key"). In
+	// directive mode it is bookkeeping only — the key is delivered via Provider. Required.
 	APIKeyConfigKey string
 
-	// AdditionalEndpointDomain, if set, routes the fetched key into the map-shape
+	// [flat] AdditionalEndpointDomain, if set, routes the fetched key into the map-shape
 	// config at AdditionalEndpointsConfigKey under this domain, replacing the
 	// DELA(...) directive. Mutually exclusive with AdditionalEndpointsListConfigKey.
 	// Requires AdditionalEndpointsConfigKey and AdditionalEndpointDirective.
 	AdditionalEndpointDomain string
 
-	// AdditionalEndpointsConfigKey is the config path of the map-shape
+	// [flat] AdditionalEndpointsConfigKey is the config path of the map-shape
 	// additional_endpoints value (domain -> []keys). Required when
 	// AdditionalEndpointDomain is set.
 	AdditionalEndpointsConfigKey string
 
-	// AdditionalEndpointKeyIndex is this entry's position in the domain's key list at
+	// [flat] AdditionalEndpointKeyIndex is this entry's position in the domain's key list at
 	// AdditionalEndpointsConfigKey. Optional, but recommended when set alongside
 	// AdditionalEndpointDomain: it disambiguates this instance's own entry from another entry
 	// under the same domain that happens to share the same value (e.g. a fallback API key that
@@ -53,37 +80,83 @@ type InstanceParams struct {
 	// doesn't point at a matching entry (e.g. the list was reordered).
 	AdditionalEndpointKeyIndex int
 
-	// AdditionalEndpointsListConfigKey, if set, routes the fetched key into the
+	// [flat] AdditionalEndpointsListConfigKey, if set, routes the fetched key into the
 	// list-shape config at this path, replacing the entry whose api_key holds the
 	// DELA(...) directive. Mutually exclusive with AdditionalEndpointDomain.
 	// Requires AdditionalEndpointDirective and ListEntryIndex.
 	AdditionalEndpointsListConfigKey string
 
-	// ListEntryIndex is this entry's position in the list at
+	// [flat] ListEntryIndex is this entry's position in the list at
 	// AdditionalEndpointsListConfigKey. Required when that field is set.
 	ListEntryIndex int
-
-	// AdditionalEndpointIdentity fingerprints the list entry without its API key.
-	// Writeback is refused if the endpoint route changes.
+	// [flat] AdditionalEndpointIdentity fingerprints the list entry without its api_key.
+	// Writeback is refused if routing or transport fields change.
+	// Required when AdditionalEndpointsListConfigKey is set.
 	AdditionalEndpointIdentity string
 
-	// AdditionalEndpointDirective is the literal DELA(...) directive text to
+	// [flat] AdditionalEndpointDirective is the literal DELA(...) directive text to
 	// replace with the real key once fetched. Used only when
 	// AdditionalEndpointDomain or AdditionalEndpointsListConfigKey is set.
 	AdditionalEndpointDirective string
 
-	// TargetSite is the Datadog site to exchange the auth proof against.
+	// [shared] TargetSite is the Datadog site to exchange the auth proof against.
 	// Falls back to AdditionalEndpointDomain, then to the agent's primary site.
 	TargetSite string
 
-	// FallbackAPIKey, if set, is written when no delegated-auth key can be
+	// [shared] FallbackAPIKey, if set, is written when no delegated-auth key can be
 	// obtained so dual-shipping still works. A later successful fetch replaces it.
-	// Current DELA(...) discovery does not populate this field.
+	// It is caller-supplied; current directive discovery does not populate it.
 	FallbackAPIKey string
 
-	// ProviderConfig contains provider-specific configuration.
-	// A non-nil value overrides the detected configuration for this instance.
+	// [shared] ProviderConfig contains provider-specific configuration.
+	// A non-nil value overrides the shared detected configuration for this instance.
 	ProviderConfig common.ProviderConfig
+
+	// [directive] SkipConfigWriteback stops the component writing the resolved key back into
+	// the config slot named by APIKeyConfigKey / AdditionalEndpoint*. Set it when the consumer
+	// takes the credential from the returned Provider instead, which keeps the key out of the
+	// config tree entirely.
+	//
+	// Defaults to false so existing callers keep the write-back delivery path. Both at once would
+	// double-deliver: the consumer would see a provider-backed credential AND a static key
+	// appearing in config for the same destination.
+	SkipConfigWriteback bool
+
+	// [directive] Directive is the raw DELA(...) text this instance was created from. It identifies the
+	// instance among several sharing one destination, which Destination alone cannot do: two
+	// orgs may legitimately dual-ship to the same domain.
+	Directive string
+
+	// [directive] ConfigKey is the setting the credential belongs to (e.g. "additional_endpoints"), forming
+	// the other half of the Component.ProvidersFor lookup. Leave it empty for a flat key, where
+	// APIKeyConfigKey already identifies the slot.
+	ConfigKey string
+
+	// [directive] Destination identifies what this credential is for, so consumers can look up the provider
+	// they need via Component.ProvidersFor. For an additional endpoint it is the domain or host;
+	// for a flat key it may be left empty.
+	Destination string
+}
+
+// ProviderKey is the (configKey, destination) pair this instance's Provider is registered under,
+// and the pair a consumer must pass to Component.ProvidersFor to find it. Both the component and
+// its mock derive the key here so they cannot disagree about where a provider lives.
+//
+// In directive mode the caller sets ConfigKey (the setting path, e.g. "additional_endpoints").
+// In flat-key mode ConfigKey is empty, so we fall back through the write-back fields and
+// ultimately to APIKeyConfigKey, which is always set.
+func (p InstanceParams) ProviderKey() (configKey, destination string) {
+	configKey = p.ConfigKey
+	if configKey == "" {
+		configKey = p.AdditionalEndpointsConfigKey
+	}
+	if configKey == "" {
+		configKey = p.AdditionalEndpointsListConfigKey
+	}
+	if configKey == "" {
+		configKey = p.APIKeyConfigKey
+	}
+	return configKey, p.Destination
 }
 
 // Component manages cloud-based delegated authentication.
@@ -94,5 +167,26 @@ type Component interface {
 	// The context is used for the initial fetch and provider detection;
 	// background refresh uses its own cancellable context.
 	// Returns an error if Config or OrgUUID is empty.
-	AddInstance(ctx context.Context, params InstanceParams) error
+	//
+	// The returned Provider tracks this instance's credential for the life of the process. It is
+	// non-nil whenever the error is nil, and reports "no credential yet" until the first exchange
+	// succeeds (or fails and a FallbackAPIKey is configured).
+	AddInstance(ctx context.Context, params InstanceParams) (Provider, error)
+
+	// ProvidersFor returns the providers registered for a config setting and destination. It lets
+	// future provider-integrated consumers look up credentials after discovery has run.
+	//
+	// A destination can legitimately have more than one provider (one per org), which is why this
+	// returns a slice rather than a single provider keyed by name.
+	ProvidersFor(configKey, destination string) []Provider
+
+	// ProviderForDirective returns the provider registered for one specific DELA(...) directive,
+	// for consumers that create one destination per directive and so must not mix them up.
+	// Returns nil when no instance was registered for that directive, e.g. because it named an
+	// unsupported provider - the caller must then refuse to send rather than send unauthenticated.
+	ProviderForDirective(configKey, destination, directive string) Provider
+
+	// RefreshFor requests an immediate refresh for the provider currently serving credential at
+	// configKey and destination. It returns false when no matching provider can be refreshed.
+	RefreshFor(configKey, destination, credential string) bool
 }

--- a/comp/core/delegatedauth/impl/BUILD.bazel
+++ b/comp/core/delegatedauth/impl/BUILD.bazel
@@ -3,7 +3,10 @@ load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "impl",
-    srcs = ["delegatedauth.go"],
+    srcs = [
+        "delegatedauth.go",
+        "provider.go",
+    ],
     embedsrcs = [
         "status_templates/delegatedauth.tmpl",
         "status_templates/delegatedauthHTML.tmpl",
@@ -27,7 +30,10 @@ go_library(
 
 dd_agent_go_test(
     name = "impl_test",
-    srcs = ["delegatedauth_test.go"],
+    srcs = [
+        "delegatedauth_test.go",
+        "provider_test.go",
+    ],
     embed = [":impl"],
     deps = [
         "//comp/core/delegatedauth/api/cloudauth/config",

--- a/comp/core/delegatedauth/impl/delegatedauth.go
+++ b/comp/core/delegatedauth/impl/delegatedauth.go
@@ -434,8 +434,27 @@ func (d *delegatedAuthComponent) replaceInstance(ctx context.Context, key string
 				if replacement != nil && replacement.refreshCancel != nil {
 					replacement.refreshCancel()
 				}
-				return ctx.Err()
 			}
+		}
+		if err := ctx.Err(); err != nil {
+			if replacement != nil && replacement.refreshCancel != nil {
+				replacement.refreshCancel()
+				if replacement.done != nil {
+					close(replacement.done)
+				}
+			}
+			if existing.credProvider != nil {
+				existing.credProvider.invalidate()
+			}
+			d.mu.Lock()
+			if d.instances[key] == existing {
+				d.removeProviderRegistrationLocked(key)
+			}
+			d.mu.Unlock()
+			return err
+		}
+		if existing.credProvider != nil {
+			existing.credProvider.invalidate()
 		}
 	}
 	if err := ctx.Err(); err != nil {
@@ -457,12 +476,24 @@ func (d *delegatedAuthComponent) replaceInstance(ctx context.Context, key string
 }
 
 func (d *delegatedAuthComponent) deliverAPIKey(instance *authInstance, apiKey string) {
-	instance.credProvider.setResolved(apiKey)
+	if !instance.credProvider.setResolved(apiKey) {
+		return
+	}
 	if !instance.skipConfigWriteback {
 		d.updateConfigWithAPIKey(instance, apiKey)
 	}
 }
 
+func (d *delegatedAuthComponent) deliverFallbackAPIKey(instance *authInstance) {
+	if !instance.credProvider.setFallback(instance.fallbackAPIKey) {
+		return
+	}
+	if !instance.skipConfigWriteback {
+		d.writeAPIKeyToTarget(instance, instance.fallbackAPIKey, true)
+	}
+}
+
+// registerProvider indexes a provider so consumers constructed after discovery can find it.
 func (d *delegatedAuthComponent) registerProvider(params delegatedauth.InstanceParams, p delegatedauth.Provider) {
 	configKey, destination := params.ProviderKey()
 	key := providerKey{configKey: configKey, destination: destination}
@@ -623,7 +654,7 @@ func (d *delegatedAuthComponent) startBackgroundRefresh(instance *authInstance) 
 func (d *delegatedAuthComponent) doRefresh(instance *authInstance, ticker *time.Ticker) {
 	credentials, updated, refreshErr := d.refreshAndGetAPIKey(instance.refreshCtx, instance, true)
 	var apiKey string
-	var fallbackActivated bool
+	var shouldDeliverFallback bool
 
 	d.mu.Lock()
 	if refreshErr != nil {
@@ -633,7 +664,7 @@ func (d *delegatedAuthComponent) doRefresh(instance *authInstance, ticker *time.
 		}
 		instance.consecutiveFailures++
 		instance.lastError = refreshErr
-		fallbackActivated = instance.credProvider.setFallback(instance.fallbackAPIKey)
+		shouldDeliverFallback = true
 		nextInterval := instance.backoff.NextBackOff()
 		instance.nextRefresh = time.Now().Add(nextInterval)
 		ticker.Reset(nextInterval)
@@ -653,8 +684,8 @@ func (d *delegatedAuthComponent) doRefresh(instance *authInstance, ticker *time.
 
 	if apiKey != "" {
 		d.deliverAPIKey(instance, apiKey)
-	} else if fallbackActivated && !instance.skipConfigWriteback {
-		d.writeAPIKeyToTarget(instance, instance.fallbackAPIKey, true)
+	} else if shouldDeliverFallback {
+		d.deliverFallbackAPIKey(instance)
 	}
 }
 

--- a/comp/core/delegatedauth/impl/delegatedauth.go
+++ b/comp/core/delegatedauth/impl/delegatedauth.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"maps"
 	"reflect"
+	"slices"
 	"sync"
 	"time"
 
@@ -93,6 +94,13 @@ type authInstance struct {
 	// consecutiveFailures tracks failures for status reporting
 	consecutiveFailures int
 
+	// credProvider exposes the resolved credential to request-path consumers.
+	credProvider *instanceProvider
+	// fallbackAPIKey is used only after credential resolution fails.
+	fallbackAPIKey string
+	// skipConfigWriteback serves consumers directly through credProvider.
+	skipConfigWriteback bool
+
 	// lastRefresh, nextRefresh, and lastError are for status reporting only.
 	lastRefresh time.Time
 	nextRefresh time.Time
@@ -123,10 +131,24 @@ type delegatedAuthComponent struct {
 	resolvedProvider string                   // Resolved provider name (e.g., "aws") - for status display
 	// disabledReason explains why no provider was resolved, for status display.
 	disabledReason string
+	// providers indexes credentials by config setting and destination.
+	providers map[providerKey][]registeredProvider
 
 	// additionalEndpointsMu serializes read-modify-write access to additional_endpoints config
 	// values across concurrent instances. Separate from mu to avoid deadlocking with OnUpdate callbacks.
 	additionalEndpointsMu sync.Mutex
+}
+
+type providerKey struct {
+	configKey   string
+	destination string
+}
+
+// registeredProvider retains the directive needed to disambiguate credentials.
+type registeredProvider struct {
+	instanceKey string
+	directive   string
+	provider    delegatedauth.Provider
 }
 
 // Provides list the provided interfaces from the delegatedauth Component
@@ -139,6 +161,7 @@ type Provides struct {
 func NewComponent() Provides {
 	comp := &delegatedAuthComponent{
 		instances: make(map[string]*authInstance),
+		providers: make(map[providerKey][]registeredProvider),
 	}
 
 	return Provides{
@@ -232,43 +255,43 @@ func (d *delegatedAuthComponent) initializeIfNeeded(ctx context.Context, params 
 // AddInstance configures delegated auth for a specific API key.
 // On the first call, it detects the cloud provider and initializes the component.
 // The context is used for the initial API key fetch and cloud provider detection.
-func (d *delegatedAuthComponent) AddInstance(ctx context.Context, params delegatedauth.InstanceParams) error {
+func (d *delegatedAuthComponent) AddInstance(ctx context.Context, params delegatedauth.InstanceParams) (delegatedauth.Provider, error) {
 	// Validate required parameters first
 	if params.Config == nil {
-		return errors.New("config is required")
+		return nil, errors.New("config is required")
 	}
 	if params.OrgUUID == "" {
-		return errors.New("org_uuid is required")
+		return nil, errors.New("org_uuid is required")
 	}
 	if params.APIKeyConfigKey == "" {
-		return errors.New("api_key_config_key is required")
+		return nil, errors.New("api_key_config_key is required")
 	}
 	if params.AdditionalEndpointDomain != "" {
 		if params.AdditionalEndpointDirective == "" {
-			return errors.New("additional_endpoint_directive is required when additional_endpoint_domain is set")
+			return nil, errors.New("additional_endpoint_directive is required when additional_endpoint_domain is set")
 		}
 		if params.AdditionalEndpointsConfigKey == "" {
-			return errors.New("additional_endpoints_config_key is required when additional_endpoint_domain is set")
+			return nil, errors.New("additional_endpoints_config_key is required when additional_endpoint_domain is set")
 		}
 	}
 	if params.AdditionalEndpointsListConfigKey != "" && params.AdditionalEndpointDirective == "" {
-		return errors.New("additional_endpoint_directive is required when additional_endpoints_list_config_key is set")
+		return nil, errors.New("additional_endpoint_directive is required when additional_endpoints_list_config_key is set")
 	}
 	if params.AdditionalEndpointsListConfigKey != "" && params.AdditionalEndpointIdentity == "" {
-		return errors.New("additional_endpoint_identity is required when additional_endpoints_list_config_key is set")
+		return nil, errors.New("additional_endpoint_identity is required when additional_endpoints_list_config_key is set")
 	}
 	if params.AdditionalEndpointDomain != "" && params.AdditionalEndpointsListConfigKey != "" {
-		return errors.New("additional_endpoint_domain and additional_endpoints_list_config_key are mutually exclusive")
+		return nil, errors.New("additional_endpoint_domain and additional_endpoints_list_config_key are mutually exclusive")
 	}
 
 	if err := ctx.Err(); err != nil {
-		return err
+		return nil, err
 	}
 
 	d.addInstanceMu.Lock()
 	defer d.addInstanceMu.Unlock()
 	if err := ctx.Err(); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Initialize on first call - this detects cloud provider without holding locks.
@@ -276,21 +299,32 @@ func (d *delegatedAuthComponent) AddInstance(ctx context.Context, params delegat
 	// the process-wide detected/default configuration.
 	providerConfig, err := d.initializeIfNeeded(ctx, params)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	providerConfig = providerConfigForInstance(providerConfig, params.ProviderConfig)
 
-	// No provider: skip this instance and keep the statically configured key. Write the fallback
-	// now if set, so dual-shipping still works. No retry — detection only runs once.
+	// No provider is terminal because detection only runs once. Expose fallback state to consumers.
 	if providerConfig == nil {
 		log.Warnf("Delegated auth is not available on this host, so '%s' will keep its statically configured value", params.APIKeyConfigKey)
-		if err := d.replaceInstance(ctx, params.APIKeyConfigKey, nil); err != nil {
-			return err
+		credProvider := newInstanceProvider()
+		credProvider.setFallback(params.FallbackAPIKey)
+		instance := fallbackTargetInstance(params)
+		instance.refreshInterval = 60 * time.Minute
+		instance.credProvider = credProvider
+		instance.fallbackAPIKey = params.FallbackAPIKey
+		instance.skipConfigWriteback = params.SkipConfigWriteback
+		instance.consecutiveFailures = 1
+		instance.lastError = errors.New("no delegated auth provider is available on this host")
+		instance.done = make(chan struct{})
+		close(instance.done)
+		if err := d.replaceInstance(ctx, params.APIKeyConfigKey, instance); err != nil {
+			return nil, err
 		}
-		if params.FallbackAPIKey != "" {
-			d.writeAPIKeyToTarget(fallbackTargetInstance(params), params.FallbackAPIKey, true)
+		if params.FallbackAPIKey != "" && !params.SkipConfigWriteback {
+			d.writeAPIKeyToTarget(instance, params.FallbackAPIKey, true)
 		}
-		return nil
+		d.registerProvider(params, credProvider)
+		return credProvider, nil
 	}
 
 	apiKeyConfigKey := params.APIKeyConfigKey
@@ -309,13 +343,15 @@ func (d *delegatedAuthComponent) AddInstance(ctx context.Context, params delegat
 	case *cloudauthconfig.AWSProviderConfig:
 		tokenProvider = aws.NewAWSAuth(cfg)
 	default:
-		return fmt.Errorf("unsupported delegated auth provider config type: %T", providerConfig)
+		return nil, fmt.Errorf("unsupported delegated auth provider config type: %T", providerConfig)
 	}
 
 	authConfig := &common.AuthConfig{
 		OrgUUID: params.OrgUUID,
 	}
 	providerName, providerRegion := providerStatus(providerConfig)
+	credProvider := newInstanceProvider()
+	credProvider.setRefreshTrigger(make(chan struct{}, 1))
 
 	// Create a context for the background refresh goroutine
 	refreshCtx, refreshCancel := context.WithCancel(context.Background())
@@ -338,6 +374,9 @@ func (d *delegatedAuthComponent) AddInstance(ctx context.Context, params delegat
 		lastWrittenValue:                 params.AdditionalEndpointDirective,
 		originalDirective:                params.AdditionalEndpointDirective,
 		backoff:                          newBackoff(refreshInterval),
+		credProvider:                     credProvider,
+		fallbackAPIKey:                   params.FallbackAPIKey,
+		skipConfigWriteback:              params.SkipConfigWriteback,
 		refreshCtx:                       refreshCtx,
 		refreshCancel:                    refreshCancel,
 		done:                             make(chan struct{}),
@@ -345,7 +384,7 @@ func (d *delegatedAuthComponent) AddInstance(ctx context.Context, params delegat
 
 	if err := d.replaceInstance(ctx, apiKeyConfigKey, instance); err != nil {
 		refreshCancel()
-		return err
+		return nil, err
 	}
 
 	log.Infof("Delegated authentication is enabled for '%s', fetching initial API key...", apiKeyConfigKey)
@@ -354,9 +393,9 @@ func (d *delegatedAuthComponent) AddInstance(ctx context.Context, params delegat
 	apiKey, _, err := d.refreshAndGetAPIKey(ctx, instance, false)
 	if err != nil {
 		log.Errorf("Failed to get initial delegated API key for '%s': %v", apiKeyConfigKey, err)
-		// Write the fallback now so the target ships with a static key while retries continue.
-		if params.FallbackAPIKey != "" {
-			d.writeAPIKeyToTarget(instance, params.FallbackAPIKey, true)
+		instance.credProvider.setFallback(instance.fallbackAPIKey)
+		if instance.fallbackAPIKey != "" && !instance.skipConfigWriteback {
+			d.writeAPIKeyToTarget(instance, instance.fallbackAPIKey, true)
 		}
 		// Record the failure so the status page shows it immediately.
 		d.mu.Lock()
@@ -364,8 +403,7 @@ func (d *delegatedAuthComponent) AddInstance(ctx context.Context, params delegat
 		instance.lastError = err
 		d.mu.Unlock()
 	} else {
-		// Update the config with the initial API key
-		d.updateConfigWithAPIKey(instance, *apiKey)
+		d.deliverAPIKey(instance, *apiKey)
 		log.Infof("Successfully fetched and set initial delegated API key for '%s'", apiKeyConfigKey)
 	}
 
@@ -373,7 +411,8 @@ func (d *delegatedAuthComponent) AddInstance(ctx context.Context, params delegat
 	// This ensures retries will happen with exponential backoff
 	d.startBackgroundRefresh(instance)
 
-	return nil
+	d.registerProvider(params, instance.credProvider)
+	return instance.credProvider, nil
 }
 
 // replaceInstance stops the old refresh loop before publishing its replacement.
@@ -407,13 +446,92 @@ func (d *delegatedAuthComponent) replaceInstance(ctx context.Context, key string
 	}
 
 	d.mu.Lock()
-	defer d.mu.Unlock()
+	d.removeProviderRegistrationLocked(key)
 	if replacement == nil {
 		delete(d.instances, key)
 	} else {
 		d.instances[key] = replacement
 	}
+	d.mu.Unlock()
 	return nil
+}
+
+func (d *delegatedAuthComponent) deliverAPIKey(instance *authInstance, apiKey string) {
+	instance.credProvider.setResolved(apiKey)
+	if !instance.skipConfigWriteback {
+		d.updateConfigWithAPIKey(instance, apiKey)
+	}
+}
+
+func (d *delegatedAuthComponent) registerProvider(params delegatedauth.InstanceParams, p delegatedauth.Provider) {
+	configKey, destination := params.ProviderKey()
+	key := providerKey{configKey: configKey, destination: destination}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.providers == nil {
+		d.providers = make(map[providerKey][]registeredProvider)
+	}
+	d.removeProviderRegistrationLocked(params.APIKeyConfigKey)
+	d.providers[key] = append(d.providers[key], registeredProvider{
+		instanceKey: params.APIKeyConfigKey,
+		directive:   params.Directive,
+		provider:    p,
+	})
+}
+
+func (d *delegatedAuthComponent) removeProviderRegistrationLocked(instanceKey string) {
+	for key, registered := range d.providers {
+		kept := registered[:0]
+		for _, candidate := range registered {
+			if candidate.instanceKey != instanceKey {
+				kept = append(kept, candidate)
+			}
+		}
+		if len(kept) == 0 {
+			delete(d.providers, key)
+		} else {
+			d.providers[key] = kept
+		}
+	}
+}
+
+// ProvidersFor returns all credentials registered for a destination.
+func (d *delegatedAuthComponent) ProvidersFor(configKey, destination string) []delegatedauth.Provider {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	found := d.providers[providerKey{configKey: configKey, destination: destination}]
+	out := make([]delegatedauth.Provider, len(found))
+	for i, registered := range found {
+		out[i] = registered.provider
+	}
+	return out
+}
+
+// ProviderForDirective returns the credential owned by one directive.
+func (d *delegatedAuthComponent) ProviderForDirective(configKey, destination, directive string) delegatedauth.Provider {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	for _, registered := range d.providers[providerKey{configKey: configKey, destination: destination}] {
+		if registered.directive == directive {
+			return registered.provider
+		}
+	}
+	return nil
+}
+
+// RefreshFor requests an immediate refresh for the matching credential.
+func (d *delegatedAuthComponent) RefreshFor(configKey, destination, credential string) bool {
+	d.mu.RLock()
+	registered := slices.Clone(d.providers[providerKey{configKey: configKey, destination: destination}])
+	d.mu.RUnlock()
+	for _, entry := range registered {
+		provider, ok := entry.provider.(*instanceProvider)
+		if ok && provider.matches(credential) {
+			return provider.Refresh()
+		}
+	}
+	return false
 }
 
 // providerConfigForInstance applies a directive-specific provider configuration after shared
@@ -478,82 +596,66 @@ func (d *delegatedAuthComponent) refreshAndGetAPIKey(ctx context.Context, instan
 	return apiKey, true, nil
 }
 
-// startBackgroundRefresh starts the background goroutine that periodically refreshes the API key
-// with exponential backoff on failures
+// startBackgroundRefresh periodically refreshes the key and accepts immediate refresh requests.
 func (d *delegatedAuthComponent) startBackgroundRefresh(instance *authInstance) {
 	go func() {
-		// Signal goroutine exit when we return
 		defer close(instance.done)
-
-		// Get initial interval with jitter from backoff
 		d.mu.Lock()
 		nextInterval := instance.backoff.NextBackOff()
 		instance.nextRefresh = time.Now().Add(nextInterval)
 		d.mu.Unlock()
-
 		ticker := time.NewTicker(nextInterval)
 		defer ticker.Stop()
-
 		for {
 			select {
 			case <-instance.refreshCtx.Done():
 				log.Debugf("Background refresh goroutine for '%s' exiting due to context cancellation", instance.apiKeyConfigKey)
 				return
 			case <-ticker.C:
-				lCreds, updated, lErr := d.refreshAndGetAPIKey(instance.refreshCtx, instance, true)
-
-				// Variables to capture state updates
-				var shouldUpdateConfig bool
-				var apiKeyToUpdate string
-
-				d.mu.Lock()
-				if lErr != nil {
-					// Check if the error is due to context cancellation
-					if instance.refreshCtx.Err() != nil {
-						d.mu.Unlock()
-						log.Debugf("Refresh for '%s' failed due to context cancellation, exiting", instance.apiKeyConfigKey)
-						return
-					}
-
-					// Track failures for status reporting
-					instance.consecutiveFailures++
-					instance.lastError = lErr
-
-					// Get next backoff interval (exponentially increasing with jitter)
-					nextInterval := instance.backoff.NextBackOff()
-					instance.nextRefresh = time.Now().Add(nextInterval)
-					log.Errorf("Failed to refresh delegated API key for '%s' (attempt %d): %v. Next retry in %v",
-						instance.apiKeyConfigKey, instance.consecutiveFailures, lErr, nextInterval)
-					ticker.Reset(nextInterval)
-				} else {
-					// Success - reset backoff and failure counter
-					if instance.consecutiveFailures > 0 {
-						log.Infof("Successfully refreshed delegated API key for '%s' after %d failed attempts",
-							instance.apiKeyConfigKey, instance.consecutiveFailures)
-					}
-					instance.consecutiveFailures = 0
-					instance.backoff.Reset()
-					nextInterval := instance.backoff.NextBackOff()
-					instance.nextRefresh = time.Now().Add(nextInterval)
-
-					// Capture the API key to update config outside the lock
-					if updated && lCreds != nil {
-						shouldUpdateConfig = true
-						apiKeyToUpdate = *lCreds
-					}
-
-					ticker.Reset(nextInterval)
-				}
-				d.mu.Unlock()
-
-				// Update the config OUTSIDE the lock to avoid potential deadlocks
-				// with config callbacks that might try to acquire locks
-				if shouldUpdateConfig {
-					d.updateConfigWithAPIKey(instance, apiKeyToUpdate)
-				}
+				d.doRefresh(instance, ticker)
+			case <-instance.credProvider.refreshTrigger:
+				d.doRefresh(instance, ticker)
 			}
 		}
 	}()
+}
+
+func (d *delegatedAuthComponent) doRefresh(instance *authInstance, ticker *time.Ticker) {
+	credentials, updated, refreshErr := d.refreshAndGetAPIKey(instance.refreshCtx, instance, true)
+	var apiKey string
+	var fallbackActivated bool
+
+	d.mu.Lock()
+	if refreshErr != nil {
+		if instance.refreshCtx.Err() != nil {
+			d.mu.Unlock()
+			return
+		}
+		instance.consecutiveFailures++
+		instance.lastError = refreshErr
+		fallbackActivated = instance.credProvider.setFallback(instance.fallbackAPIKey)
+		nextInterval := instance.backoff.NextBackOff()
+		instance.nextRefresh = time.Now().Add(nextInterval)
+		ticker.Reset(nextInterval)
+		log.Errorf("Failed to refresh delegated API key for '%s' (attempt %d): %v. Next retry in %v",
+			instance.apiKeyConfigKey, instance.consecutiveFailures, refreshErr, nextInterval)
+	} else {
+		instance.consecutiveFailures = 0
+		instance.backoff.Reset()
+		nextInterval := instance.backoff.NextBackOff()
+		instance.nextRefresh = time.Now().Add(nextInterval)
+		ticker.Reset(nextInterval)
+		if updated && credentials != nil {
+			apiKey = *credentials
+		}
+	}
+	d.mu.Unlock()
+
+	if apiKey != "" {
+		d.deliverAPIKey(instance, apiKey)
+	} else if fallbackActivated && !instance.skipConfigWriteback {
+		d.writeAPIKeyToTarget(instance, instance.fallbackAPIKey, true)
+	}
 }
 
 // authenticate uses the configured provider to generate an auth proof, then exchanges it for an API key
@@ -897,8 +999,11 @@ func (d *delegatedAuthComponent) populateStatusInfo(stats map[string]interface{}
 			instanceInfo["AWSRegion"] = instance.providerRegion
 		}
 
-		// Status
-		if instance.apiKey != nil {
+		active := instance.apiKey != nil
+		if instance.credProvider != nil {
+			active = instance.credProvider.hasCredential()
+		}
+		if active {
 			instanceInfo["Status"] = "Active"
 		} else {
 			instanceInfo["Status"] = "Pending"

--- a/comp/core/delegatedauth/impl/delegatedauth_test.go
+++ b/comp/core/delegatedauth/impl/delegatedauth_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -275,6 +276,26 @@ func TestStatusJSON_EnabledWithInstances(t *testing.T) {
 	assert.Equal(t, "3 consecutive failures", logsInstance["Error"])
 }
 
+func TestStatusJSON_FallbackIsActive(t *testing.T) {
+	provider := newInstanceProvider()
+	provider.setFallback("fallback-key")
+	comp := &delegatedAuthComponent{
+		instances: map[string]*authInstance{
+			"additional_endpoints[1]": {
+				credProvider:        provider,
+				refreshInterval:     time.Hour,
+				apiKeyConfigKey:     "additional_endpoints[1]",
+				consecutiveFailures: 1,
+			},
+		},
+	}
+
+	stats := make(map[string]interface{})
+	require.NoError(t, comp.JSON(false, stats))
+	instances := stats["instances"].(map[string]map[string]interface{})
+	assert.Equal(t, "Active", instances["additional_endpoints[1]"]["Status"])
+}
+
 func TestStatusText_NotEnabled(t *testing.T) {
 	comp := &delegatedAuthComponent{
 		instances: make(map[string]*authInstance),
@@ -532,7 +553,7 @@ func TestAddInstanceRespectsContextCancellation(t *testing.T) {
 	mockConfig := mock.New(t)
 
 	// AddInstance should return context.Canceled error after validating params
-	err := comp.AddInstance(ctx, delegatedauth.InstanceParams{
+	_, err := comp.AddInstance(ctx, delegatedauth.InstanceParams{
 		Config:          mockConfig,
 		OrgUUID:         "test-org",
 		APIKeyConfigKey: "api_key",
@@ -1494,7 +1515,7 @@ func TestAddInstanceWritesFallbackWhenNoCloudProviderDetected(t *testing.T) {
 		config:      mockConfig,
 	}
 
-	err := comp.AddInstance(context.Background(), delegatedauth.InstanceParams{
+	_, err := comp.AddInstance(context.Background(), delegatedauth.InstanceParams{
 		Config:                       mockConfig,
 		OrgUUID:                      "second-org-uuid",
 		APIKeyConfigKey:              "additional_endpoints[https://second-org.datadoghq.com][second-org-uuid]",
@@ -1509,8 +1530,43 @@ func TestAddInstanceWritesFallbackWhenNoCloudProviderDetected(t *testing.T) {
 	assert.Equal(t, []string{"static-fallback-key"}, got["https://second-org.datadoghq.com"],
 		"with no cloud provider detected, the fallback key should be written instead of leaving the domain with zero keys")
 
-	// No instance/retry loop should be created for the no-provider case.
-	assert.Empty(t, comp.instances)
+	// Keep a terminal status instance without starting a retry loop.
+	instanceKey := "additional_endpoints[https://second-org.datadoghq.com][second-org-uuid]"
+	require.Contains(t, comp.instances, instanceKey)
+	select {
+	case <-comp.instances[instanceKey].done:
+	default:
+		t.Fatal("unavailable instance is not terminal")
+	}
+}
+
+func TestAddInstanceDoesNotWriteProviderFallbackWhenNoCloudProviderDetected(t *testing.T) {
+	mockConfig := mock.New(t)
+	mockConfig.SetDefault("provider_slot", "original")
+	mockConfig.Set("provider_slot", "original", pkgconfigmodel.SourceFile)
+
+	comp := &delegatedAuthComponent{
+		instances:   make(map[string]*authInstance),
+		initialized: true,
+		config:      mockConfig,
+	}
+
+	provider, err := comp.AddInstance(context.Background(), delegatedauth.InstanceParams{
+		Config:              mockConfig,
+		OrgUUID:             "second-org-uuid",
+		APIKeyConfigKey:     "provider_slot",
+		ConfigKey:           "additional_endpoints",
+		Destination:         "https://second-org.datadoghq.com",
+		Directive:           "DELA(second-org-uuid, aws)",
+		FallbackAPIKey:      "static-fallback-key",
+		SkipConfigWriteback: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "original", mockConfig.GetString("provider_slot"))
+
+	header := http.Header{}
+	require.True(t, provider.Authorize(header))
+	assert.Equal(t, "static-fallback-key", header.Get(apiKeyHeader))
 }
 
 func TestAddInstanceWithoutFallbackSkipsSilentlyWhenNoCloudProviderDetected(t *testing.T) {
@@ -1525,7 +1581,7 @@ func TestAddInstanceWithoutFallbackSkipsSilentlyWhenNoCloudProviderDetected(t *t
 		config:      mockConfig,
 	}
 
-	err := comp.AddInstance(context.Background(), delegatedauth.InstanceParams{
+	_, err := comp.AddInstance(context.Background(), delegatedauth.InstanceParams{
 		Config:                       mockConfig,
 		OrgUUID:                      "second-org-uuid",
 		APIKeyConfigKey:              "additional_endpoints[https://second-org.datadoghq.com][second-org-uuid]",
@@ -1556,7 +1612,7 @@ func TestAddInstanceWritesFallbackWhenInitialFetchFails(t *testing.T) {
 	comp := &delegatedAuthComponent{instances: make(map[string]*authInstance)}
 
 	apiKeyConfigKey := "additional_endpoints[https://second-org.datadoghq.com][second-org-uuid]"
-	err := comp.AddInstance(context.Background(), delegatedauth.InstanceParams{
+	_, err := comp.AddInstance(context.Background(), delegatedauth.InstanceParams{
 		Config:                       mockConfig,
 		ProviderConfig:               &cloudauthconfig.AWSProviderConfig{Region: "us-east-1"},
 		OrgUUID:                      "second-org-uuid",

--- a/comp/core/delegatedauth/impl/provider.go
+++ b/comp/core/delegatedauth/impl/provider.go
@@ -1,0 +1,143 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package delegatedauthimpl
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"sync/atomic"
+)
+
+// apiKeyHeader is the header a resolved delegated-auth credential is stamped onto.
+//
+// It lives here, inside the provider, rather than at each consumer's send site. That is the point
+// of the Provider interface: when delegated auth moves from API keys to stateless tokens, the
+// header name and credential format change here and nowhere else.
+const apiKeyHeader = "DD-Api-Key"
+
+// credential is an immutable snapshot of what a provider currently has to offer. It is swapped
+// atomically so Authorize stays lock-free on the request path.
+type credential struct {
+	// value is the credential to send. Only meaningful when usable is true.
+	value string
+	// usable reports whether the caller may send. False means "still resolving, buffer" - never
+	// "send without a credential".
+	usable bool
+}
+
+// buffering is the credential state before the first exchange completes, and after a failure when
+// no fallback key is configured.
+var buffering = &credential{usable: false}
+
+// instanceProvider is the Provider for a single delegated-auth instance.
+//
+// Credential lifecycle:
+//
+//	                 ┌──────────────────────────────────────────┐
+//	start ──────────▶│ resolving        Authorize -> false      │  caller buffers
+//	                 └───────────┬──────────────────┬───────────┘
+//	         exchange succeeded  │                  │  exchange failed
+//	                             ▼                  ▼
+//	        ┌────────────────────────────┐   ┌──────────────────────────────────┐
+//	        │ resolved                   │   │ fallback configured?             │
+//	        │ Authorize -> true (real)   │   │  yes -> Authorize -> true (static)│
+//	        └────────────────────────────┘   │  no  -> Authorize -> false        │
+//	                     ▲                   └──────────────┬───────────────────┘
+//	                     └──────────────────────────────────┘
+//	                            a later refresh succeeds
+//
+// A fallback is only ever used after an attempt has actually failed. While the very first exchange
+// is still in flight the provider reports "not yet", so callers hold their payloads instead of
+// shipping them under a key the operator only meant as a safety net.
+type instanceProvider struct {
+	cred atomic.Pointer[credential]
+	// refreshTrigger is a buffered channel (capacity 1) that Refresh() sends to in order to
+	// nudge the background goroutine into an immediate re-exchange. nil when no background
+	// refresh goroutine is running (no cloud provider detected), in which case Refresh()
+	// returns false.
+	refreshTrigger chan struct{}
+}
+
+func newInstanceProvider() *instanceProvider {
+	p := &instanceProvider{}
+	p.cred.Store(buffering)
+	return p
+}
+
+// setRefreshTrigger attaches the channel that Refresh() uses to nudge the background goroutine.
+// Called by the component only when a background refresh goroutine is about to start; when no
+// cloud provider was detected the channel stays nil and Refresh() returns false.
+func (p *instanceProvider) setRefreshTrigger(ch chan struct{}) {
+	p.refreshTrigger = ch
+}
+
+// Authorize implements delegatedauth.Provider.
+func (p *instanceProvider) Authorize(h http.Header) bool {
+	c := p.cred.Load()
+	if c == nil || !c.usable {
+		return false
+	}
+	h.Set(apiKeyHeader, c.value)
+	return true
+}
+
+// Refresh implements delegatedauth.Provider. It resets the credential to buffering so Authorize
+// returns false (no further sends under the stale key) and nudges the background goroutine to
+// re-exchange as soon as possible.
+//
+// The send is non-blocking and the channel has capacity 1, so a burst of 403s from many
+// in-flight transactions coalesces into a single refresh — no storm.
+func (p *instanceProvider) Refresh() bool {
+	if p.refreshTrigger == nil {
+		return false
+	}
+	// Stop further sends under the stale key. A concurrent Authorize that already loaded the
+	// old credential will still use it, but the next call will see buffering.
+	p.cred.Store(buffering)
+	select {
+	case p.refreshTrigger <- struct{}{}:
+	default:
+		// A refresh is already queued or in progress; this call coalesces into it.
+	}
+	return true
+}
+
+// setResolved records a credential fetched from the cloud provider. It always wins over a
+// fallback, including when a refresh recovers after earlier failures.
+func (p *instanceProvider) setResolved(key string) {
+	p.cred.Store(&credential{value: key, usable: true})
+}
+
+// setFallback records the operator-supplied static key after an exchange has failed. It does not
+// overwrite an already-resolved credential: a transient refresh failure should keep using the last
+// known-good key rather than regress to the fallback.
+func (p *instanceProvider) setFallback(key string) bool {
+	if key == "" {
+		// Nothing to fall back to - keep buffering and let retries continue.
+		return false
+	}
+	for {
+		current := p.cred.Load()
+		if current != nil && current.usable {
+			return false
+		}
+		if p.cred.CompareAndSwap(current, &credential{value: key, usable: true}) {
+			return true
+		}
+	}
+}
+
+// hasCredential reports whether the provider can currently authorize a request. For status
+// reporting and tests.
+func (p *instanceProvider) hasCredential() bool {
+	c := p.cred.Load()
+	return c != nil && c.usable
+}
+
+func (p *instanceProvider) matches(value string) bool {
+	c := p.cred.Load()
+	return c != nil && c.usable && subtle.ConstantTimeCompare([]byte(c.value), []byte(value)) == 1
+}

--- a/comp/core/delegatedauth/impl/provider.go
+++ b/comp/core/delegatedauth/impl/provider.go
@@ -26,11 +26,15 @@ type credential struct {
 	// usable reports whether the caller may send. False means "still resolving, buffer" - never
 	// "send without a credential".
 	usable bool
+	// invalid is terminal. Resolution and fallback updates cannot replace it.
+	invalid bool
 }
 
 // buffering is the credential state before the first exchange completes, and after a failure when
 // no fallback key is configured.
 var buffering = &credential{usable: false}
+
+var invalidCredential = &credential{invalid: true}
 
 // instanceProvider is the Provider for a single delegated-auth instance.
 //
@@ -77,7 +81,7 @@ func (p *instanceProvider) setRefreshTrigger(ch chan struct{}) {
 // Authorize implements delegatedauth.Provider.
 func (p *instanceProvider) Authorize(h http.Header) bool {
 	c := p.cred.Load()
-	if c == nil || !c.usable {
+	if c == nil || c.invalid || !c.usable {
 		return false
 	}
 	h.Set(apiKeyHeader, c.value)
@@ -94,9 +98,15 @@ func (p *instanceProvider) Refresh() bool {
 	if p.refreshTrigger == nil {
 		return false
 	}
-	// Stop further sends under the stale key. A concurrent Authorize that already loaded the
-	// old credential will still use it, but the next call will see buffering.
-	p.cred.Store(buffering)
+	for {
+		current := p.cred.Load()
+		if current == nil || current.invalid {
+			return false
+		}
+		if p.cred.CompareAndSwap(current, buffering) {
+			break
+		}
+	}
 	select {
 	case p.refreshTrigger <- struct{}{}:
 	default:
@@ -107,8 +117,21 @@ func (p *instanceProvider) Refresh() bool {
 
 // setResolved records a credential fetched from the cloud provider. It always wins over a
 // fallback, including when a refresh recovers after earlier failures.
-func (p *instanceProvider) setResolved(key string) {
-	p.cred.Store(&credential{value: key, usable: true})
+func (p *instanceProvider) setResolved(key string) bool {
+	for {
+		current := p.cred.Load()
+		if current != nil && current.invalid {
+			return false
+		}
+		if p.cred.CompareAndSwap(current, &credential{value: key, usable: true}) {
+			return true
+		}
+	}
+}
+
+// invalidate stops new requests from using this provider.
+func (p *instanceProvider) invalidate() {
+	p.cred.Store(invalidCredential)
 }
 
 // setFallback records the operator-supplied static key after an exchange has failed. It does not
@@ -121,7 +144,7 @@ func (p *instanceProvider) setFallback(key string) bool {
 	}
 	for {
 		current := p.cred.Load()
-		if current != nil && current.usable {
+		if current != nil && (current.invalid || current.usable) {
 			return false
 		}
 		if p.cred.CompareAndSwap(current, &credential{value: key, usable: true}) {
@@ -134,10 +157,10 @@ func (p *instanceProvider) setFallback(key string) bool {
 // reporting and tests.
 func (p *instanceProvider) hasCredential() bool {
 	c := p.cred.Load()
-	return c != nil && c.usable
+	return c != nil && !c.invalid && c.usable
 }
 
 func (p *instanceProvider) matches(value string) bool {
 	c := p.cred.Load()
-	return c != nil && c.usable && subtle.ConstantTimeCompare([]byte(c.value), []byte(value)) == 1
+	return c != nil && !c.invalid && c.usable && subtle.ConstantTimeCompare([]byte(c.value), []byte(value)) == 1
 }

--- a/comp/core/delegatedauth/impl/provider_test.go
+++ b/comp/core/delegatedauth/impl/provider_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
 )
 
 // A provider that has never resolved must report "no credential" so the caller buffers. Shipping
@@ -193,12 +194,15 @@ func TestReplaceInstanceRemovesOldProviderRoute(t *testing.T) {
 	const instanceKey = "additional_endpoints[old][org]"
 	oldDone := make(chan struct{})
 	close(oldDone)
+	oldProvider := newInstanceProvider()
+	oldProvider.setResolved("old-key")
 	d := &delegatedAuthComponent{
-		instances: map[string]*authInstance{instanceKey: {done: oldDone}},
+		instances: map[string]*authInstance{instanceKey: {
+			credProvider: oldProvider,
+			done:         oldDone,
+		}},
 		providers: make(map[providerKey][]registeredProvider),
 	}
-
-	oldProvider := newInstanceProvider()
 	d.registerProvider(delegatedauth.InstanceParams{
 		APIKeyConfigKey: instanceKey,
 		ConfigKey:       "additional_endpoints",
@@ -209,6 +213,7 @@ func TestReplaceInstanceRemovesOldProviderRoute(t *testing.T) {
 
 	require.NoError(t, d.replaceInstance(context.Background(), instanceKey, &authInstance{done: make(chan struct{})}))
 	assert.Nil(t, d.ProviderForDirective("additional_endpoints", "https://old.datadoghq.com", "DELA(old-org, aws)"))
+	assert.False(t, oldProvider.Authorize(http.Header{}))
 
 	newProvider := newInstanceProvider()
 	d.registerProvider(delegatedauth.InstanceParams{
@@ -218,6 +223,98 @@ func TestReplaceInstanceRemovesOldProviderRoute(t *testing.T) {
 		Directive:       "DELA(new-org, aws)",
 	}, newProvider)
 	require.Same(t, newProvider, d.ProviderForDirective("additional_endpoints", "https://new.datadoghq.com", "DELA(new-org, aws)"))
+}
+
+func TestCanceledReplacementInvalidatesOldProvider(t *testing.T) {
+	const instanceKey = "additional_endpoints[org-a]"
+	config := mock.New(t)
+	config.SetDefault("api_key", "original-key")
+	d := &delegatedAuthComponent{
+		instances: make(map[string]*authInstance),
+		providers: make(map[providerKey][]registeredProvider),
+		config:    config,
+	}
+	oldProvider := newInstanceProvider()
+	oldProvider.setResolved("old-key")
+	old := &authInstance{
+		apiKeyConfigKey: "api_key",
+		credProvider:    oldProvider,
+		fallbackAPIKey:  "fallback-key",
+		refreshCancel:   func() {},
+		done:            make(chan struct{}),
+	}
+	d.instances[instanceKey] = old
+	d.registerProvider(delegatedauth.InstanceParams{
+		APIKeyConfigKey: instanceKey,
+		ConfigKey:       "additional_endpoints",
+		Destination:     "https://old.datadoghq.com",
+		Directive:       "DELA(old-org, aws)",
+	}, oldProvider)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	replacementDone := make(chan struct{})
+	require.ErrorIs(t, d.replaceInstance(ctx, instanceKey, &authInstance{
+		refreshCancel: func() {},
+		done:          replacementDone,
+	}), context.Canceled)
+
+	assert.Nil(t, d.ProviderForDirective("additional_endpoints", "https://old.datadoghq.com", "DELA(old-org, aws)"))
+	assert.False(t, oldProvider.Authorize(http.Header{}))
+	oldProvider.setResolved("late-key")
+	assert.False(t, oldProvider.Authorize(http.Header{}))
+	assert.False(t, oldProvider.Refresh())
+	d.deliverFallbackAPIKey(old)
+	assert.Equal(t, "original-key", config.GetString("api_key"))
+	assert.Same(t, old, d.instances[instanceKey])
+	select {
+	case <-replacementDone:
+	default:
+		t.Fatal("replacement was not stopped")
+	}
+}
+
+func TestCanceledReplacementWithStoppedInstanceIsNotPublished(t *testing.T) {
+	oldDone := make(chan struct{})
+	close(oldDone)
+	oldProvider := newInstanceProvider()
+	oldProvider.setResolved("old-key")
+	d := &delegatedAuthComponent{
+		instances: map[string]*authInstance{"api_key": {
+			credProvider:  oldProvider,
+			refreshCancel: func() {},
+			done:          oldDone,
+		}},
+		providers: make(map[providerKey][]registeredProvider),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	replacementDone := make(chan struct{})
+	require.ErrorIs(t, d.replaceInstance(ctx, "api_key", &authInstance{
+		refreshCancel: func() {},
+		done:          replacementDone,
+	}), context.Canceled)
+
+	assert.NotNil(t, d.instances["api_key"])
+	assert.False(t, oldProvider.Authorize(http.Header{}))
+}
+
+func TestInvalidatedProviderRejectsLateConfigDelivery(t *testing.T) {
+	config := mock.New(t)
+	config.SetDefault("api_key", "original-key")
+	provider := newInstanceProvider()
+	instance := &authInstance{
+		apiKeyConfigKey: "api_key",
+		credProvider:    provider,
+	}
+	d := &delegatedAuthComponent{config: config}
+
+	provider.invalidate()
+	d.deliverAPIKey(instance, "late-key")
+
+	assert.Equal(t, "original-key", config.GetString("api_key"))
+	assert.False(t, provider.Authorize(http.Header{}))
 }
 
 // Refresh returns false when no background refresh goroutine is running (no trigger channel),

--- a/comp/core/delegatedauth/impl/provider_test.go
+++ b/comp/core/delegatedauth/impl/provider_test.go
@@ -1,0 +1,289 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package delegatedauthimpl
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
+)
+
+// A provider that has never resolved must report "no credential" so the caller buffers. Shipping
+// under no credential, or silently under the fallback before an attempt has even failed, are both
+// wrong: the fallback is a failure path, not a startup path.
+func TestProviderBuffersBeforeFirstExchange(t *testing.T) {
+	p := newInstanceProvider()
+
+	h := http.Header{}
+	assert.False(t, p.Authorize(h), "must not authorize before the first exchange completes")
+	assert.Empty(t, h, "must not stamp any header when it cannot authorize")
+	assert.False(t, p.hasCredential())
+}
+
+func TestProviderAuthorizesOnceResolved(t *testing.T) {
+	p := newInstanceProvider()
+	p.setResolved("resolved-key")
+
+	h := http.Header{}
+	require.True(t, p.Authorize(h))
+	assert.Equal(t, "resolved-key", h.Get(apiKeyHeader))
+}
+
+// The fallback is applied only after an exchange has actually failed - that is what setFallback
+// being called from the failure paths encodes. Before that the provider buffers even though a
+// fallback is configured.
+func TestProviderUsesFallbackOnlyAfterFailure(t *testing.T) {
+	p := newInstanceProvider()
+
+	h := http.Header{}
+	require.False(t, p.Authorize(h), "a configured fallback must not be used before a failure")
+
+	p.setFallback("static-fallback")
+
+	h = http.Header{}
+	require.True(t, p.Authorize(h))
+	assert.Equal(t, "static-fallback", h.Get(apiKeyHeader))
+}
+
+// With no fallback configured, a failure leaves the provider buffering rather than authorizing
+// with nothing. Retries continue in the background.
+func TestProviderKeepsBufferingWhenFailureHasNoFallback(t *testing.T) {
+	p := newInstanceProvider()
+	p.setFallback("")
+
+	h := http.Header{}
+	assert.False(t, p.Authorize(h))
+	assert.Empty(t, h)
+}
+
+// A later successful refresh must replace the fallback: the real credential always wins.
+func TestProviderResolvedReplacesFallback(t *testing.T) {
+	p := newInstanceProvider()
+	p.setFallback("static-fallback")
+	p.setResolved("resolved-key")
+
+	h := http.Header{}
+	require.True(t, p.Authorize(h))
+	assert.Equal(t, "resolved-key", h.Get(apiKeyHeader))
+}
+
+// A transient refresh failure after a successful resolve must NOT regress to the fallback - the
+// last known-good credential is better than a static key the operator supplied as a safety net.
+func TestProviderFallbackDoesNotRegressAResolvedCredential(t *testing.T) {
+	p := newInstanceProvider()
+	p.setResolved("resolved-key")
+	p.setFallback("static-fallback")
+
+	h := http.Header{}
+	require.True(t, p.Authorize(h))
+	assert.Equal(t, "resolved-key", h.Get(apiKeyHeader),
+		"a refresh failure must keep the last resolved key, not fall back")
+}
+
+func TestProviderUsesFallbackAfterRejectedCredentialRefreshFails(t *testing.T) {
+	p := newInstanceProvider()
+	p.setRefreshTrigger(make(chan struct{}, 1))
+	p.setResolved("rejected-key")
+
+	require.True(t, p.Refresh())
+	require.True(t, p.setFallback("static-fallback"))
+
+	h := http.Header{}
+	require.True(t, p.Authorize(h))
+	assert.Equal(t, "static-fallback", h.Get(apiKeyHeader))
+}
+
+// Authorize runs on the request path while the refresh goroutine swaps credentials. Exercised
+// under -race in CI; without the atomic swap this is a data race.
+func TestProviderConcurrentAuthorizeAndUpdate(t *testing.T) {
+	p := newInstanceProvider()
+
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					p.Authorize(http.Header{})
+				}
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(done)
+		for i := range 500 {
+			if i%2 == 0 {
+				p.setResolved("k")
+			} else {
+				p.setFallback("f")
+			}
+		}
+	}()
+
+	wg.Wait()
+	assert.True(t, p.hasCredential())
+}
+
+// Two orgs dual-shipping to one domain is the case this feature exists for. Looking a provider up
+// by destination alone cannot tell them apart, so consumers that own one directive each must be
+// able to find their own credential - otherwise both ship under the first org's key and the second
+// org receives nothing.
+func TestProviderForDirectiveDistinguishesTwoOrgsOnOneDestination(t *testing.T) {
+	d := &delegatedAuthComponent{}
+	const key, dest = "additional_endpoints", "https://app.datadoghq.com"
+
+	orgA := newInstanceProvider()
+	orgB := newInstanceProvider()
+	orgA.setResolved("org-a-key")
+	orgB.setResolved("org-b-key")
+
+	d.registerProvider(delegatedauth.InstanceParams{
+		APIKeyConfigKey: "org-a", ConfigKey: key, Destination: dest, Directive: "DELA(org-a, aws)",
+	}, orgA)
+	d.registerProvider(delegatedauth.InstanceParams{
+		APIKeyConfigKey: "org-b", ConfigKey: key, Destination: dest, Directive: "DELA(org-b, aws)",
+	}, orgB)
+
+	for _, tc := range []struct{ directive, want string }{
+		{"DELA(org-a, aws)", "org-a-key"},
+		{"DELA(org-b, aws)", "org-b-key"},
+	} {
+		p := d.ProviderForDirective(key, dest, tc.directive)
+		require.NotNil(t, p, "each directive must resolve to its own instance")
+
+		h := http.Header{}
+		require.True(t, p.Authorize(h))
+		assert.Equal(t, tc.want, h.Get("DD-Api-Key"), "directive %q got the wrong org's credential", tc.directive)
+	}
+
+	// The forwarder still sees both, because it fans one payload out to every slot on the domain.
+	assert.Len(t, d.ProvidersFor(key, dest), 2)
+}
+
+// An unknown directive must resolve to nothing so the caller refuses to send, rather than falling
+// back to some other org's credential that happens to share the destination.
+func TestProviderForDirectiveReturnsNilForAnUnregisteredDirective(t *testing.T) {
+	d := &delegatedAuthComponent{}
+	d.registerProvider(delegatedauth.InstanceParams{
+		APIKeyConfigKey: "org-a", ConfigKey: "additional_endpoints", Destination: "https://app.datadoghq.com", Directive: "DELA(org-a, aws)",
+	}, newInstanceProvider())
+
+	assert.Nil(t, d.ProviderForDirective("additional_endpoints", "https://app.datadoghq.com", "DELA(org-z, aws)"))
+}
+
+func TestReplaceInstanceRemovesOldProviderRoute(t *testing.T) {
+	const instanceKey = "additional_endpoints[old][org]"
+	oldDone := make(chan struct{})
+	close(oldDone)
+	d := &delegatedAuthComponent{
+		instances: map[string]*authInstance{instanceKey: {done: oldDone}},
+		providers: make(map[providerKey][]registeredProvider),
+	}
+
+	oldProvider := newInstanceProvider()
+	d.registerProvider(delegatedauth.InstanceParams{
+		APIKeyConfigKey: instanceKey,
+		ConfigKey:       "additional_endpoints",
+		Destination:     "https://old.datadoghq.com",
+		Directive:       "DELA(old-org, aws)",
+	}, oldProvider)
+	require.Same(t, oldProvider, d.ProviderForDirective("additional_endpoints", "https://old.datadoghq.com", "DELA(old-org, aws)"))
+
+	require.NoError(t, d.replaceInstance(context.Background(), instanceKey, &authInstance{done: make(chan struct{})}))
+	assert.Nil(t, d.ProviderForDirective("additional_endpoints", "https://old.datadoghq.com", "DELA(old-org, aws)"))
+
+	newProvider := newInstanceProvider()
+	d.registerProvider(delegatedauth.InstanceParams{
+		APIKeyConfigKey: instanceKey,
+		ConfigKey:       "additional_endpoints",
+		Destination:     "https://new.datadoghq.com",
+		Directive:       "DELA(new-org, aws)",
+	}, newProvider)
+	require.Same(t, newProvider, d.ProviderForDirective("additional_endpoints", "https://new.datadoghq.com", "DELA(new-org, aws)"))
+}
+
+// Refresh returns false when no background refresh goroutine is running (no trigger channel),
+// so the caller knows to drop the transaction rather than reschedule it.
+func TestProviderRefreshReturnsFalseWithoutTrigger(t *testing.T) {
+	p := newInstanceProvider()
+	assert.False(t, p.Refresh(), "Refresh must return false when no background goroutine is configured")
+}
+
+// Refresh resets the credential to buffering so Authorize returns false — no further sends under
+// the stale key — and sends a non-blocking signal to the trigger channel. A burst of calls
+// coalesces: the channel has capacity 1, so a second Refresh while the first signal is still
+// pending is silently dropped.
+func TestProviderRefreshResetsToBufferingAndSignals(t *testing.T) {
+	p := newInstanceProvider()
+	p.setResolved("stale-key")
+	p.setRefreshTrigger(make(chan struct{}, 1))
+
+	// Before Refresh, the provider authorizes.
+	h := http.Header{}
+	require.True(t, p.Authorize(h))
+	assert.Equal(t, "stale-key", h.Get(apiKeyHeader))
+
+	// After Refresh, it buffers and the trigger channel has one pending signal.
+	require.True(t, p.Refresh())
+	h = http.Header{}
+	assert.False(t, p.Authorize(h), "Authorize must return false after Refresh resets to buffering")
+	assert.Empty(t, h)
+
+	// A second Refresh coalesces: the channel is full, so the non-blocking send is dropped.
+	require.True(t, p.Refresh())
+
+	// Exactly one signal in the channel, not two.
+	select {
+	case <-p.refreshTrigger:
+		// expected: the first signal
+	default:
+		t.Fatal("Refresh must send to the trigger channel")
+	}
+	select {
+	case <-p.refreshTrigger:
+		t.Fatal("second Refresh must not add a second signal to a full channel")
+	default:
+		// expected: channel is empty, the second Refresh was dropped
+	}
+}
+
+func TestRefreshForTargetsMatchingCredential(t *testing.T) {
+	d := &delegatedAuthComponent{providers: make(map[providerKey][]registeredProvider)}
+	first := newInstanceProvider()
+	first.setResolved("first-key")
+	firstTrigger := make(chan struct{}, 1)
+	first.setRefreshTrigger(firstTrigger)
+	second := newInstanceProvider()
+	second.setResolved("second-key")
+	secondTrigger := make(chan struct{}, 1)
+	second.setRefreshTrigger(secondTrigger)
+
+	params := delegatedauth.InstanceParams{APIKeyConfigKey: "first", ConfigKey: "additional_endpoints", Destination: "https://example.com"}
+	d.registerProvider(params, first)
+	params.APIKeyConfigKey = "second"
+	params.Directive = "DELA(second, aws)"
+	d.registerProvider(params, second)
+
+	require.True(t, d.RefreshFor("additional_endpoints", "https://example.com", "second-key"))
+	assert.Empty(t, firstTrigger)
+	assert.Len(t, secondTrigger, 1)
+	assert.False(t, d.RefreshFor("additional_endpoints", "https://example.com", "unknown-key"))
+}

--- a/comp/core/delegatedauth/mock/BUILD.bazel
+++ b/comp/core/delegatedauth/mock/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "mock",
-    srcs = ["mock.go"],
+    srcs = [
+        "mock.go",
+        "stub_provider.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock",
     visibility = ["//visibility:public"],
     deps = ["//comp/core/delegatedauth/def"],

--- a/comp/core/delegatedauth/mock/BUILD.bazel
+++ b/comp/core/delegatedauth/mock/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "mock",
@@ -9,4 +10,15 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock",
     visibility = ["//visibility:public"],
     deps = ["//comp/core/delegatedauth/def"],
+)
+
+dd_agent_go_test(
+    name = "mock_test",
+    srcs = ["mock_test.go"],
+    embed = [":mock"],
+    deps = [
+        "//comp/core/delegatedauth/def",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/comp/core/delegatedauth/mock/mock.go
+++ b/comp/core/delegatedauth/mock/mock.go
@@ -8,6 +8,8 @@ package mock
 
 import (
 	"context"
+	"crypto/subtle"
+	"net/http"
 	"testing"
 
 	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
@@ -16,7 +18,45 @@ import (
 // Mock is a mock implementation of the delegatedauth.Component interface
 type Mock struct {
 	AddInstanceFunc func(context.Context, delegatedauth.InstanceParams) error
+	// ProvidersForFunc overrides ProvidersFor. When nil, providers returned from AddInstance are
+	// indexed the same way the real component indexes them, so a test can wire a consumer without
+	// standing up the whole component.
+	ProvidersForFunc func(configKey, destination string) []delegatedauth.Provider
+
+	// ProviderForInstanceFunc, when set, is called by AddInstance to obtain the provider for
+	// each instance. When nil, AddInstance uses PendingProvider (the original behavior). This
+	// lets a test return distinct providers per directive so "two orgs" tests prove real
+	// separation rather than just bookkeeping.
+	ProviderForInstanceFunc func(params delegatedauth.InstanceParams) delegatedauth.Provider
+
+	providers  map[[2]string][]delegatedauth.Provider
+	directives map[[3]string]delegatedauth.Provider
 }
+
+// StaticProvider is a Provider that always authorizes with a fixed key, for tests that only care
+// that a consumer stamps what it is given.
+type StaticProvider struct {
+	Key string
+}
+
+// Authorize implements delegatedauth.Provider.
+func (p StaticProvider) Authorize(h http.Header) bool {
+	h.Set("DD-Api-Key", p.Key)
+	return true
+}
+
+// Refresh implements delegatedauth.Provider.
+func (StaticProvider) Refresh() bool { return false }
+
+// PendingProvider is a Provider that never has a credential, for tests that exercise the
+// buffer-until-resolved path.
+type PendingProvider struct{}
+
+// Authorize implements delegatedauth.Provider and always reports "no credential yet".
+func (PendingProvider) Authorize(_ http.Header) bool { return false }
+
+// Refresh implements delegatedauth.Provider. A pending provider has no background refresh.
+func (PendingProvider) Refresh() bool { return false }
 
 var _ delegatedauth.Component = (*Mock)(nil)
 
@@ -30,10 +70,58 @@ func New(_ testing.TB) delegatedauth.Component {
 	return &Mock{}
 }
 
-// AddInstance calls the mock function if set, otherwise returns nil
-func (m *Mock) AddInstance(ctx context.Context, params delegatedauth.InstanceParams) error {
+// AddInstance calls the mock function if set, then registers a provider for the params so
+// ProvidersFor can find it. The returned provider is pending (no credential) unless the test
+// supplies its own via ProvidersForFunc.
+func (m *Mock) AddInstance(ctx context.Context, params delegatedauth.InstanceParams) (delegatedauth.Provider, error) {
+	var err error
 	if m.AddInstanceFunc != nil {
-		return m.AddInstanceFunc(ctx, params)
+		err = m.AddInstanceFunc(ctx, params)
 	}
-	return nil
+	if err != nil {
+		return nil, err
+	}
+
+	p := delegatedauth.Provider(PendingProvider{})
+	if m.ProviderForInstanceFunc != nil {
+		p = m.ProviderForInstanceFunc(params)
+	}
+	if m.providers == nil {
+		m.providers = map[[2]string][]delegatedauth.Provider{}
+	}
+	configKey, destination := params.ProviderKey()
+	if m.directives == nil {
+		m.directives = map[[3]string]delegatedauth.Provider{}
+	}
+	dkey := [3]string{configKey, destination, params.Directive}
+	if _, seen := m.directives[dkey]; !seen {
+		m.directives[dkey] = p
+	}
+	key := [2]string{configKey, destination}
+	m.providers[key] = append(m.providers[key], p)
+	return p, nil
+}
+
+// ProvidersFor implements delegatedauth.Component.
+func (m *Mock) ProvidersFor(configKey, destination string) []delegatedauth.Provider {
+	if m.ProvidersForFunc != nil {
+		return m.ProvidersForFunc(configKey, destination)
+	}
+	return m.providers[[2]string{configKey, destination}]
+}
+
+// ProviderForDirective implements delegatedauth.Component.
+func (m *Mock) ProviderForDirective(configKey, destination, directive string) delegatedauth.Provider {
+	return m.directives[[3]string{configKey, destination, directive}]
+}
+
+// RefreshFor implements delegatedauth.Component.
+func (m *Mock) RefreshFor(configKey, destination, credential string) bool {
+	for _, provider := range m.ProvidersFor(configKey, destination) {
+		header := http.Header{}
+		if provider.Authorize(header) && subtle.ConstantTimeCompare([]byte(header.Get("DD-Api-Key")), []byte(credential)) == 1 {
+			return provider.Refresh()
+		}
+	}
+	return false
 }

--- a/comp/core/delegatedauth/mock/mock.go
+++ b/comp/core/delegatedauth/mock/mock.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"net/http"
+	"sync"
 	"testing"
 
 	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
@@ -17,6 +18,8 @@ import (
 
 // Mock is a mock implementation of the delegatedauth.Component interface
 type Mock struct {
+	mu sync.RWMutex
+
 	AddInstanceFunc func(context.Context, delegatedauth.InstanceParams) error
 	// ProvidersForFunc overrides ProvidersFor. When nil, providers returned from AddInstance are
 	// indexed the same way the real component indexes them, so a test can wire a consumer without
@@ -29,8 +32,13 @@ type Mock struct {
 	// separation rather than just bookkeeping.
 	ProviderForInstanceFunc func(params delegatedauth.InstanceParams) delegatedauth.Provider
 
-	providers  map[[2]string][]delegatedauth.Provider
-	directives map[[3]string]delegatedauth.Provider
+	providers map[[2]string][]registeredProvider
+}
+
+type registeredProvider struct {
+	instanceKey string
+	directive   string
+	provider    delegatedauth.Provider
 }
 
 // StaticProvider is a Provider that always authorizes with a fixed key, for tests that only care
@@ -70,9 +78,8 @@ func New(_ testing.TB) delegatedauth.Component {
 	return &Mock{}
 }
 
-// AddInstance calls the mock function if set, then registers a provider for the params so
-// ProvidersFor can find it. The returned provider is pending (no credential) unless the test
-// supplies its own via ProvidersForFunc.
+// AddInstance calls the mock function if set, then registers a provider for the params.
+// ProviderForInstanceFunc can supply a custom provider; the default is pending.
 func (m *Mock) AddInstance(ctx context.Context, params delegatedauth.InstanceParams) (delegatedauth.Provider, error) {
 	var err error
 	if m.AddInstanceFunc != nil {
@@ -86,20 +93,36 @@ func (m *Mock) AddInstance(ctx context.Context, params delegatedauth.InstancePar
 	if m.ProviderForInstanceFunc != nil {
 		p = m.ProviderForInstanceFunc(params)
 	}
-	if m.providers == nil {
-		m.providers = map[[2]string][]delegatedauth.Provider{}
-	}
 	configKey, destination := params.ProviderKey()
-	if m.directives == nil {
-		m.directives = map[[3]string]delegatedauth.Provider{}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.providers == nil {
+		m.providers = map[[2]string][]registeredProvider{}
 	}
-	dkey := [3]string{configKey, destination, params.Directive}
-	if _, seen := m.directives[dkey]; !seen {
-		m.directives[dkey] = p
-	}
+	m.removeProviderLocked(params.APIKeyConfigKey)
 	key := [2]string{configKey, destination}
-	m.providers[key] = append(m.providers[key], p)
+	m.providers[key] = append(m.providers[key], registeredProvider{
+		instanceKey: params.APIKeyConfigKey,
+		directive:   params.Directive,
+		provider:    p,
+	})
 	return p, nil
+}
+
+func (m *Mock) removeProviderLocked(instanceKey string) {
+	for key, registered := range m.providers {
+		kept := registered[:0]
+		for _, candidate := range registered {
+			if candidate.instanceKey != instanceKey {
+				kept = append(kept, candidate)
+			}
+		}
+		if len(kept) == 0 {
+			delete(m.providers, key)
+		} else {
+			m.providers[key] = kept
+		}
+	}
 }
 
 // ProvidersFor implements delegatedauth.Component.
@@ -107,12 +130,26 @@ func (m *Mock) ProvidersFor(configKey, destination string) []delegatedauth.Provi
 	if m.ProvidersForFunc != nil {
 		return m.ProvidersForFunc(configKey, destination)
 	}
-	return m.providers[[2]string{configKey, destination}]
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	registered := m.providers[[2]string{configKey, destination}]
+	providers := make([]delegatedauth.Provider, len(registered))
+	for i, candidate := range registered {
+		providers[i] = candidate.provider
+	}
+	return providers
 }
 
 // ProviderForDirective implements delegatedauth.Component.
 func (m *Mock) ProviderForDirective(configKey, destination, directive string) delegatedauth.Provider {
-	return m.directives[[3]string{configKey, destination, directive}]
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, candidate := range m.providers[[2]string{configKey, destination}] {
+		if candidate.directive == directive {
+			return candidate.provider
+		}
+	}
+	return nil
 }
 
 // RefreshFor implements delegatedauth.Component.

--- a/comp/core/delegatedauth/mock/mock_test.go
+++ b/comp/core/delegatedauth/mock/mock_test.go
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package mock
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddInstanceReplacesProviderRegistration(t *testing.T) {
+	m := &Mock{
+		ProviderForInstanceFunc: func(params delegatedauth.InstanceParams) delegatedauth.Provider {
+			return StaticProvider{Key: params.Directive}
+		},
+	}
+	const instanceKey = "additional_endpoints[org-a]"
+
+	_, err := m.AddInstance(context.Background(), delegatedauth.InstanceParams{
+		APIKeyConfigKey: instanceKey,
+		ConfigKey:       "additional_endpoints",
+		Destination:     "https://old.datadoghq.com",
+		Directive:       "DELA(old-org, aws)",
+	})
+	require.NoError(t, err)
+
+	_, err = m.AddInstance(context.Background(), delegatedauth.InstanceParams{
+		APIKeyConfigKey: instanceKey,
+		ConfigKey:       "additional_endpoints",
+		Destination:     "https://new.datadoghq.com",
+		Directive:       "DELA(new-org, aws)",
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, m.ProvidersFor("additional_endpoints", "https://old.datadoghq.com"))
+	assert.Nil(t, m.ProviderForDirective("additional_endpoints", "https://old.datadoghq.com", "DELA(old-org, aws)"))
+	assert.Len(t, m.ProvidersFor("additional_endpoints", "https://new.datadoghq.com"), 1)
+	assert.NotNil(t, m.ProviderForDirective("additional_endpoints", "https://new.datadoghq.com", "DELA(new-org, aws)"))
+}
+
+func TestProvidersForReturnsCopy(t *testing.T) {
+	m := &Mock{}
+	_, err := m.AddInstance(context.Background(), delegatedauth.InstanceParams{
+		APIKeyConfigKey: "api_key",
+		ConfigKey:       "api_key",
+	})
+	require.NoError(t, err)
+
+	providers := m.ProvidersFor("api_key", "")
+	require.Len(t, providers, 1)
+	providers[0] = nil
+
+	assert.NotNil(t, m.ProvidersFor("api_key", "")[0])
+}
+
+func TestConcurrentRegistrationAndLookup(t *testing.T) {
+	m := &Mock{}
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			directive := fmt.Sprintf("DELA(org-%d, aws)", i)
+			_, err := m.AddInstance(context.Background(), delegatedauth.InstanceParams{
+				APIKeyConfigKey: fmt.Sprintf("instance-%d", i),
+				ConfigKey:       "additional_endpoints",
+				Destination:     "https://app.datadoghq.com",
+				Directive:       directive,
+			})
+			assert.NoError(t, err)
+			m.ProvidersFor("additional_endpoints", "https://app.datadoghq.com")
+			m.ProviderForDirective("additional_endpoints", "https://app.datadoghq.com", directive)
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Len(t, m.ProvidersFor("additional_endpoints", "https://app.datadoghq.com"), 50)
+}

--- a/comp/core/delegatedauth/mock/stub_provider.go
+++ b/comp/core/delegatedauth/mock/stub_provider.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package mock
+
+import (
+	"net/http"
+	"sync/atomic"
+)
+
+// StubProvider is a test Provider whose readiness the test controls. It is the shared
+// equivalent of the per-package stubProvider copies that were duplicated across the
+// resolver, logs, trace writer, and trace API tests.
+//
+// Set Ready to true (or call SetReady) to make Authorize stamp Key onto the header;
+// leave it false to simulate "credential not yet resolved".
+type StubProvider struct {
+	Key   string
+	Ready atomic.Bool
+}
+
+// SetReady sets the provider's readiness state.
+func (p *StubProvider) SetReady(ready bool) {
+	p.Ready.Store(ready)
+}
+
+// Authorize implements delegatedauth.Provider.
+func (p *StubProvider) Authorize(h http.Header) bool {
+	if !p.Ready.Load() {
+		return false
+	}
+	h.Set("DD-Api-Key", p.Key)
+	return true
+}
+
+// Refresh implements delegatedauth.Provider.
+func (p *StubProvider) Refresh() bool { return false }

--- a/comp/core/delegatedauth/noop-impl/delegatedauth_noop.go
+++ b/comp/core/delegatedauth/noop-impl/delegatedauth_noop.go
@@ -9,6 +9,7 @@ package delegatedauthimpl
 import (
 	"context"
 	"io"
+	"net/http"
 
 	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 	"github.com/DataDog/datadog-agent/comp/core/status"
@@ -34,10 +35,34 @@ func NewComponent() Provides {
 	}
 }
 
-// AddInstance does nothing in the noop implementation
-func (d *DelegatedAuthNoop) AddInstance(_ context.Context, _ delegatedauth.InstanceParams) error {
+// AddInstance is a no-op. It returns a provider that never has a credential, so a consumer that
+// buffers on "no credential yet" would never ship. That is intentional: this impl is wired in
+// where delegated auth is compiled out, and nothing registers DELA destinations there.
+func (d *DelegatedAuthNoop) AddInstance(_ context.Context, _ delegatedauth.InstanceParams) (delegatedauth.Provider, error) {
+	return noopProvider{}, nil
+}
+
+// ProvidersFor is a no-op and never has providers to return.
+func (d *DelegatedAuthNoop) ProvidersFor(_, _ string) []delegatedauth.Provider {
 	return nil
 }
+
+// ProviderForDirective implements delegatedauth.Component and never has a credential.
+func (d *DelegatedAuthNoop) ProviderForDirective(_, _, _ string) delegatedauth.Provider {
+	return nil
+}
+
+// RefreshFor is a no-op and never finds a provider.
+func (d *DelegatedAuthNoop) RefreshFor(_, _, _ string) bool { return false }
+
+// noopProvider never holds a credential.
+type noopProvider struct{}
+
+// Authorize implements delegatedauth.Provider and never authorizes.
+func (noopProvider) Authorize(_ http.Header) bool { return false }
+
+// Refresh implements delegatedauth.Provider. No background refresh in the noop impl.
+func (noopProvider) Refresh() bool { return false }
 
 // Status Provider implementation for noop
 

--- a/comp/core/delegatedauth/noop-impl/delegatedauth_noop_test.go
+++ b/comp/core/delegatedauth/noop-impl/delegatedauth_noop_test.go
@@ -8,6 +8,7 @@ package delegatedauthimpl
 import (
 	"bytes"
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,12 +19,18 @@ import (
 
 func TestNoopAddInstance(t *testing.T) {
 	noop := &DelegatedAuthNoop{}
-	err := noop.AddInstance(context.Background(), delegatedauth.InstanceParams{
+	provider, err := noop.AddInstance(context.Background(), delegatedauth.InstanceParams{
 		OrgUUID:         "test-org-uuid",
 		RefreshInterval: 60,
 		APIKeyConfigKey: "api_key",
 	})
 	assert.NoError(t, err)
+
+	// The noop returns a usable Provider rather than nil so callers never have to nil-check, but
+	// it never holds a credential.
+	require.NotNil(t, provider)
+	assert.False(t, provider.Authorize(http.Header{}))
+	assert.Nil(t, noop.ProvidersFor("api_key", ""))
 }
 
 func TestNoopStatusProviderName(t *testing.T) {

--- a/comp/core/delegatedauth/noop-impl/types/types.go
+++ b/comp/core/delegatedauth/noop-impl/types/types.go
@@ -8,6 +8,7 @@ package types
 
 import (
 	"context"
+	"net/http"
 
 	delegatedauth "github.com/DataDog/datadog-agent/comp/core/delegatedauth/def"
 )
@@ -18,6 +19,31 @@ type DelegatedAuthNoop struct{}
 var _ delegatedauth.Component = (*DelegatedAuthNoop)(nil)
 
 // AddInstance does nothing in the noop implementation
-func (r *DelegatedAuthNoop) AddInstance(_ context.Context, _ delegatedauth.InstanceParams) error {
+// AddInstance is a no-op. It returns a provider that never has a credential, so a consumer that
+// buffers on "no credential yet" would never ship. That is intentional: this impl is wired in
+// where delegated auth is compiled out, and nothing registers DELA destinations there.
+func (r *DelegatedAuthNoop) AddInstance(_ context.Context, _ delegatedauth.InstanceParams) (delegatedauth.Provider, error) {
+	return noopProvider{}, nil
+}
+
+// ProvidersFor is a no-op and never has providers to return.
+func (r *DelegatedAuthNoop) ProvidersFor(_, _ string) []delegatedauth.Provider {
 	return nil
 }
+
+// ProviderForDirective implements delegatedauth.Component and never has a credential.
+func (r *DelegatedAuthNoop) ProviderForDirective(_, _, _ string) delegatedauth.Provider {
+	return nil
+}
+
+// RefreshFor is a no-op and never finds a provider.
+func (r *DelegatedAuthNoop) RefreshFor(_, _, _ string) bool { return false }
+
+// noopProvider never holds a credential.
+type noopProvider struct{}
+
+// Authorize implements delegatedauth.Provider and never authorizes.
+func (noopProvider) Authorize(_ http.Header) bool { return false }
+
+// Refresh implements delegatedauth.Provider. No background refresh in the noop impl.
+func (noopProvider) Refresh() bool { return false }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -524,14 +524,14 @@ func configureDelegatedAuth(ctx context.Context, config pkgconfigmodel.Config, d
 
 // addDelegatedAuthInstance lets startup continue when synchronous initialization times out.
 func addDelegatedAuthInstance(ctx context.Context, delegatedAuthComp delegatedauth.Component, params delegatedauth.InstanceParams) error {
-	err := delegatedAuthComp.AddInstance(ctx, params)
+	_, err := delegatedAuthComp.AddInstance(ctx, params)
 	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
 		return err
 	}
 
 	log.Warnf("Delegated auth startup timed out for '%s'; continuing in the background", params.APIKeyConfigKey)
 	go func() {
-		if retryErr := delegatedAuthComp.AddInstance(context.Background(), params); retryErr != nil {
+		if _, retryErr := delegatedAuthComp.AddInstance(context.Background(), params); retryErr != nil {
 			log.Errorf("Failed to configure delegated auth for '%s' in the background: %v", params.APIKeyConfigKey, retryErr)
 		}
 	}()


### PR DESCRIPTION
### What does this PR do?

Adds a request-path credential provider API to delegated auth.

```text
AddInstance
    ├── existing config writeback
    └── Provider
          ├── lookup by config key, destination, and directive
          ├── atomic credential snapshots
          └── refresh after credential rejection
```

Provider registrations are replaced with their owning delegated-auth instance, preventing stale routes from surviving configuration changes. Consumers can opt out of config writeback when they use the provider directly. Replacement invalidates retained providers, and terminal invalidation cannot be overwritten by a late refresh or fallback.

### Motivation

The provider API is not required for the config-writeback dual shipping in #55791. Keeping it in a separate PR lets that work proceed without importing delegated auth into sender modules and gives provider-based consumers an independently reviewable foundation.

### Describe how you validated your changes

- `dda inv test --targets=./comp/core/delegatedauth/... --coverage --race --rerun-fails=2`
- `dda inv test --targets=./pkg/config/setup --coverage --rerun-fails=2`
- `bazel test //comp/core/delegatedauth/mock:mock_test //comp/core/delegatedauth/impl:impl_test`

### Additional Notes

Stacked on #55479. #55480 remains unchanged.

WIF-48
