### PR TITLE
default CNM direct send to true

### DIFF
--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -620,7 +620,7 @@ properties:
       direct_send:
         node_type: setting
         type: boolean
-        default: false
+        default: true
       dns_recorded_query_types:
         node_type: setting
         type: array

--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -620,7 +620,10 @@ properties:
       direct_send:
         node_type: setting
         type: boolean
-        default: true
+        platform_default:
+          linux: true
+          windows: true
+          other: false
       dns_recorded_query_types:
         node_type: setting
         type: array

--- a/releasenotes/notes/sysprobe-direct-send-default-ceb993833bec3b26.yaml
+++ b/releasenotes/notes/sysprobe-direct-send-default-ceb993833bec3b26.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Send CNM/USM data directly to Datadog from system-probe on Linux and Windows.
+    This eliminates the need to run process-agent in certain configurations.
+    Customers with tight memory limits on system-probe may need to increase
+    the limit by 50-100MiB, but an equal amount can be removed from the process-agent memory limit.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Defaults CNM direct send to `true`.

### Motivation

Removing the need to run `process-agent` on Linux.

### Describe how you validated your changes

### Additional Notes

This default has already been applied at the operator and helm chart level.