### PR TITLE
Fix support for parsing DD_NETWORK_PATH_COLLECTOR_FILTERS into network path filters.

### DIFF
--- a/comp/networkpath/npcollector/impl/config_test.go
+++ b/comp/networkpath/npcollector/impl/config_test.go
@@ -194,3 +194,30 @@ func TestNewConfigInvalidFilters(t *testing.T) {
 
 	assert.Empty(t, result.filterConfig)
 }
+
+func TestNewConfigFiltersFromEnv(t *testing.T) {
+	t.Setenv("DD_NETWORK_PATH_COLLECTOR_FILTERS", `[
+		{"match_domain":"*.example.com","type":"exclude"},
+		{"match_domain":"^api-[0-9]+\\.example\\.com$","match_domain_strategy":"regex","type":"include"},
+		{"match_ip":"10.0.0.0/8","type":"exclude"}
+	]`)
+
+	mockConfig := config.NewMock(t)
+	result := newConfig(mockConfig, logmock.New(t))
+
+	require.Equal(t, []connfilter.Config{
+		{
+			Type:        connfilter.FilterTypeExclude,
+			MatchDomain: "*.example.com",
+		},
+		{
+			Type:                connfilter.FilterTypeInclude,
+			MatchDomain:         `^api-[0-9]+\.example\.com$`,
+			MatchDomainStrategy: connfilter.MatchDomainStrategyRegex,
+		},
+		{
+			Type:    connfilter.FilterTypeExclude,
+			MatchIP: "10.0.0.0/8",
+		},
+	}, result.filterConfig)
+}

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -1786,6 +1786,7 @@ properties:
             node_type: setting
             type: array
             default: []
+            env_parser: json
             items:
               additionalProperties:
                 type: string

--- a/releasenotes/notes/parse-network-path-filters-env-91decb190a98345e.yaml
+++ b/releasenotes/notes/parse-network-path-filters-env-91decb190a98345e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix ``DD_NETWORK_PATH_COLLECTOR_FILTERS`` so JSON-encoded Network Path
+    collector filters are parsed and applied correctly.


### PR DESCRIPTION
### What does this PR do?

Adds support for parsing `DD_NETWORK_PATH_COLLECTOR_FILTERS` from environment variables.

### Motivation

Add support for Helm configuration to inject env variables to configure network path dynamic test filters.

### Describe how you validated your changes

1. Added a new test to `comp/networkpath/npcollector/impl/config_test.go` and verified it failed
2. Ran live agent with `DD_NETWORK_PATH_COLLECTOR_FILTERS='[{"match_domain":"*.example.com","type":"exclude"}]'` passed in as env variable
    * noted the failure `Error unmarshalling network_path.collector.filters: decoding failed due to the following error(s): '[0]' expected a map or struct, got "string"`
4. Added the one-line fix to `pkg/config/schema/yaml/core_schema.yaml` 
5. Verified the test now passed, with the fix
6. Verified the live agent run no longer had a config parsing issue, with the fix 

### Additional Notes

This PR adds fix + test for env var-based ingestion. For YAML-based ingestion, see relevant [test here](https://github.com/DataDog/datadog-agent/blob/main/comp/networkpath/npcollector/impl/npcollector_test.go#L2296).