### PR TITLE
chore: remove disabling of jemalloc stats

### DIFF
--- a/deps/jemalloc.BUILD.bazel
+++ b/deps/jemalloc.BUILD.bazel
@@ -58,7 +58,6 @@ configure_make(
     configure_in_place = True,
     configure_options = [
         "--disable-debug",
-        "--disable-stats",
         "--disable-fill",
         "--disable-prof",
         "--disable-static",


### PR DESCRIPTION
## What does this PR do?

Removes `--disable-stats` from jemalloc build to allow for detailed investigation of jemalloc performance in the agent.

### Motivation

### Describe how you validated your changes

* CI is green ✅ 
