### PR TITLE
fix(admission): distinguish missing admission webhook from network failures in probe health reporting

### DIFF
--- a/comp/healthplatform/issues/admissionprobe/issue.go
+++ b/comp/healthplatform/issues/admissionprobe/issue.go
@@ -40,11 +40,12 @@ func (t *AdmissionProbeIssue) BuildIssue(context map[string]string) (*healthplat
 	}
 
 	steps := []*healthplatform.RemediationStep{
-		{Order: 1, Text: "Check the cluster agent logs for admission controller errors"},
-		{Order: 2, Text: "Verify the cluster agent service is reachable from the Kubernetes API server on port 8000"},
+		{Order: 1, Text: "Run 'datadog-cluster-agent status' and check the 'Webhook running' line in the admissionWebhook section — if it is false, the webhook was never created (often because the certificate secret is missing or unreadable) and this is not a network issue"},
+		{Order: 2, Text: "Check the cluster agent logs for admission controller errors"},
 		{Order: 3, Text: "Verify the MutatingWebhookConfiguration exists and has the correct service reference: kubectl get mutatingwebhookconfigurations"},
-		{Order: 4, Text: remediation},
-		{Order: 5, Text: "See docs: https://dtdg.co/4eZW0g4"},
+		{Order: 4, Text: "If the webhook is confirmed running, verify the cluster agent service is reachable from the Kubernetes API server on port 8000"},
+		{Order: 5, Text: remediation},
+		{Order: 6, Text: "See docs: https://dtdg.co/4eZW0g4"},
 	}
 
 	extra, err := structpb.NewStruct(map[string]any{

--- a/comp/healthplatform/issues/admissionprobe/issue.go
+++ b/comp/healthplatform/issues/admissionprobe/issue.go
@@ -40,7 +40,7 @@ func (t *AdmissionProbeIssue) BuildIssue(context map[string]string) (*healthplat
 	}
 
 	steps := []*healthplatform.RemediationStep{
-		{Order: 1, Text: "Run 'datadog-cluster-agent status' and check the 'Webhook running' line in the admissionWebhook section — if it is false, the webhook was never created (often because the certificate secret is missing or unreadable) and this is not a network issue"},
+		{Order: 1, Text: "Run 'datadog-cluster-agent status' and check the 'Webhook running' line in the admissionWebhook section — if it is false, check the ValidatingWebhookError/MutatingWebhookError/SecretError fields there to see why (e.g. the webhook configuration does not exist, an RBAC error prevented the lookup, or the certificate secret is missing or unreadable)"},
 		{Order: 2, Text: "Check the cluster agent logs for admission controller errors"},
 		{Order: 3, Text: "Verify the MutatingWebhookConfiguration exists and has the correct service reference: kubectl get mutatingwebhookconfigurations"},
 		{Order: 4, Text: "If the webhook is confirmed running, verify the cluster agent service is reachable from the Kubernetes API server on port 8000"},

--- a/comp/healthplatform/issues/admissionprobe/issue.go
+++ b/comp/healthplatform/issues/admissionprobe/issue.go
@@ -21,6 +21,39 @@ const (
 	source    = "cluster-agent"
 )
 
+// Cause values for the "cause" context key. They select which remediation
+// steps are the most useful, since the probe usually knows more about the
+// root cause than "something is wrong" by the time it reports an issue.
+const (
+	// CauseSecretControllerFailed means the cluster agent's own certificate
+	// controller reported an error on its last reconciliation attempt, for a
+	// reason other than an RBAC denial.
+	CauseSecretControllerFailed = "secret_controller_failed"
+	// CauseSecretControllerForbidden means the certificate controller's last
+	// reconciliation attempt failed because the Kubernetes API server denied
+	// the request (RBAC).
+	CauseSecretControllerForbidden = "secret_controller_forbidden"
+	// CauseWebhookControllerFailed means the cluster agent's own webhook
+	// registration controller reported an error on its last reconciliation
+	// attempt, for a reason other than an RBAC denial.
+	CauseWebhookControllerFailed = "webhook_controller_failed"
+	// CauseWebhookControllerForbidden means the webhook registration
+	// controller's last reconciliation attempt failed because the
+	// Kubernetes API server denied the request (RBAC).
+	CauseWebhookControllerForbidden = "webhook_controller_forbidden"
+	// CauseWebhookMissing means the webhook configuration was confirmed absent
+	// from the Kubernetes API (not merely unreachable).
+	CauseWebhookMissing = "webhook_missing"
+	// CauseIndeterminate means the probe could not determine whether the
+	// webhook configuration exists (e.g. an RBAC error on the lookup).
+	CauseIndeterminate = "indeterminate"
+	// CauseProbeConfigForbidden means the probe itself could not create its
+	// dry-run ConfigMap because the Kubernetes API server denied the request
+	// (RBAC). The probe cannot determine whether the webhook is reachable in
+	// this case, but the cause is still known and actionable.
+	CauseProbeConfigForbidden = "probe_config_forbidden"
+)
+
 // AdmissionProbeIssue builds a complete issue for admission webhook connectivity failures.
 type AdmissionProbeIssue struct{}
 
@@ -28,6 +61,14 @@ type AdmissionProbeIssue struct{}
 // Expected context keys:
 //   - "issue": a human-readable description of the problem
 //   - "remediation": a provider-specific hint for remediation
+//   - "cause": one of the Cause* constants, selecting more targeted remediation
+//     steps than the generic "webhook missing or network failure" checklist
+//   - "fix_hint": a specific, actionable diagnosis of the underlying
+//     Kubernetes API error — the exact RBAC permission that was denied for
+//     the *Forbidden causes, or a classification of the API error (timeout,
+//     conflict, invalid, etc.) for the *Failed causes — so the remediation
+//     states precisely what's wrong instead of asking the user to go find
+//     information already known
 func (t *AdmissionProbeIssue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
 	issue := context["issue"]
 	if issue == "" {
@@ -39,14 +80,7 @@ func (t *AdmissionProbeIssue) BuildIssue(context map[string]string) (*healthplat
 		remediation = "Ensure proper inbound network connectivity to the cluster agent's node on port 8000."
 	}
 
-	steps := []*healthplatform.RemediationStep{
-		{Order: 1, Text: "Run 'datadog-cluster-agent status' and check the 'Webhook running' line in the admissionWebhook section — if it is false, check the ValidatingWebhookError/MutatingWebhookError/SecretError fields there to see why (e.g. the webhook configuration does not exist, an RBAC error prevented the lookup, or the certificate secret is missing or unreadable)"},
-		{Order: 2, Text: "Check the cluster agent logs for admission controller errors"},
-		{Order: 3, Text: "Verify the MutatingWebhookConfiguration exists and has the correct service reference: kubectl get mutatingwebhookconfigurations"},
-		{Order: 4, Text: "If the webhook is confirmed running, verify the cluster agent service is reachable from the Kubernetes API server on port 8000"},
-		{Order: 5, Text: remediation},
-		{Order: 6, Text: "See docs: https://dtdg.co/4eZW0g4"},
-	}
+	steps := remediationSteps(context["cause"], remediation, context["fix_hint"])
 
 	extra, err := structpb.NewStruct(map[string]any{
 		"impact": "Pod mutations (config injection, library injection, standard tags) may not be applied to new pods",
@@ -72,4 +106,97 @@ func (t *AdmissionProbeIssue) BuildIssue(context map[string]string) (*healthplat
 		},
 		Tags: []string{"admission-controller", "connectivity", "cluster-agent"},
 	}, nil
+}
+
+// remediationSteps returns the remediation steps for the given cause. When
+// the probe knows the specific reason the webhook is unreachable, the steps
+// point directly at that reason instead of asking users to check things the
+// probe has already ruled out. fixHint, when set, is that specific diagnosis
+// — the exact RBAC permission denied for the *Forbidden causes, or a
+// classification of the underlying Kubernetes API error for the *Failed
+// causes — and replaces a generic "go check the logs" step with the real
+// answer.
+func remediationSteps(cause, remediation, fixHint string) []*healthplatform.RemediationStep {
+	switch cause {
+	case CauseSecretControllerForbidden:
+		grant := fixHint
+		if grant == "" {
+			grant = "Grant the cluster agent's Kubernetes service account get/create/update permissions on Secrets in its namespace"
+		}
+		return []*healthplatform.RemediationStep{
+			{Order: 1, Text: grant},
+			{Order: 2, Text: "The secret controller will retry automatically once permissions are fixed; restart the cluster agent to force an immediate retry"},
+			{Order: 3, Text: "See docs: https://dtdg.co/4eZW0g4"},
+		}
+	case CauseSecretControllerFailed:
+		diagnosis := fixHint
+		if diagnosis == "" {
+			diagnosis = "The specific secret controller error is included in the issue description above"
+		}
+		return []*healthplatform.RemediationStep{
+			{Order: 1, Text: diagnosis},
+			{Order: 2, Text: "The secret controller will retry automatically once the underlying issue is fixed; restart the cluster agent to force an immediate retry"},
+			{Order: 3, Text: "See docs: https://dtdg.co/4eZW0g4"},
+		}
+	case CauseWebhookControllerForbidden:
+		grant := fixHint
+		if grant == "" {
+			grant = "Grant the cluster agent's Kubernetes service account get/create/update permissions on MutatingWebhookConfigurations and ValidatingWebhookConfigurations"
+		}
+		return []*healthplatform.RemediationStep{
+			{Order: 1, Text: grant},
+			{Order: 2, Text: "The webhook controller will retry automatically once permissions are fixed; restart the cluster agent to force an immediate retry"},
+			{Order: 3, Text: "See docs: https://dtdg.co/4eZW0g4"},
+		}
+	case CauseWebhookControllerFailed:
+		diagnosis := fixHint
+		if diagnosis == "" {
+			diagnosis = "The specific webhook controller error is included in the issue description above"
+		}
+		return []*healthplatform.RemediationStep{
+			{Order: 1, Text: diagnosis},
+			{Order: 2, Text: "The webhook controller will retry automatically once the underlying issue is fixed; restart the cluster agent to force an immediate retry"},
+			{Order: 3, Text: "See docs: https://dtdg.co/4eZW0g4"},
+		}
+	case CauseWebhookMissing:
+		// The issue description already names the missing webhook configuration
+		// and states that both controllers last reconciled without error, so the
+		// object was most likely deleted after being created rather than never
+		// created — there's nothing left to "go check", only to recreate it.
+		return []*healthplatform.RemediationStep{
+			{Order: 1, Text: "The webhook configuration named in the issue description above was deleted after being created; nothing else in the cluster agent detected an error, so this is most likely an external deletion (e.g. by another controller, an admission policy, or a manual kubectl delete)"},
+			{Order: 2, Text: "Restart the cluster agent to force the webhook controller to recreate the webhook configuration immediately, rather than waiting for its next reconcile"},
+			{Order: 3, Text: "See docs: https://dtdg.co/4eZW0g4"},
+		}
+	case CauseProbeConfigForbidden:
+		grant := fixHint
+		if grant == "" {
+			grant = "Grant the cluster agent's Kubernetes service account \"create\" permission on ConfigMaps in its own namespace"
+		}
+		return []*healthplatform.RemediationStep{
+			{Order: 1, Text: grant},
+			{Order: 2, Text: "This does not mean the admission webhook itself is broken — the probe cannot verify webhook connectivity until this permission is restored"},
+			{Order: 3, Text: "See docs: https://dtdg.co/4eZW0g4"},
+		}
+	case CauseIndeterminate:
+		diagnosis := fixHint
+		if diagnosis == "" {
+			diagnosis = "The specific error encountered while looking up the webhook configuration is included in the issue description above"
+		}
+		return []*healthplatform.RemediationStep{
+			{Order: 1, Text: diagnosis},
+			{Order: 2, Text: "See docs: https://dtdg.co/4eZW0g4"},
+		}
+	default:
+		// The webhook configuration is confirmed registered and the cluster
+		// agent's own controllers report no errors, so the most likely
+		// explanation is a network problem between the API server and the
+		// cluster agent's admission webhook endpoint.
+		return []*healthplatform.RemediationStep{
+			{Order: 1, Text: "The webhook configuration is registered and the secret/webhook controllers report no error, so the API server is reaching the endpoint incorrectly or not at all; run 'datadog-cluster-agent status' and check the 'Webhook running' line in the admissionWebhook section for the ValidatingWebhookError/MutatingWebhookError/SecretError fields"},
+			{Order: 2, Text: "Verify the cluster agent service is reachable from the Kubernetes API server on port 8000 (network policies, firewalls, or a misconfigured service/endpoint are the most common causes)"},
+			{Order: 3, Text: remediation},
+			{Order: 4, Text: "See docs: https://dtdg.co/4eZW0g4"},
+		}
+	}
 }

--- a/comp/healthplatform/issues/admissionprobe/issue_test.go
+++ b/comp/healthplatform/issues/admissionprobe/issue_test.go
@@ -47,12 +47,12 @@ func TestBuildIssue_Remediation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, issue.Remediation)
 	assert.NotEmpty(t, issue.Remediation.Summary)
-	assert.Len(t, issue.Remediation.Steps, 5)
+	assert.Len(t, issue.Remediation.Steps, 6)
 
 	lastStep := issue.Remediation.Steps[len(issue.Remediation.Steps)-1]
 	assert.Contains(t, lastStep.Text, "dtdg.co")
 
-	assert.Equal(t, "check network", issue.Remediation.Steps[3].Text)
+	assert.Equal(t, "check network", issue.Remediation.Steps[4].Text)
 }
 
 func TestBuildIssue_Defaults(t *testing.T) {
@@ -61,7 +61,7 @@ func TestBuildIssue_Defaults(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Contains(t, issue.Description, "unreachable from the Kubernetes API server")
-	assert.Contains(t, issue.Remediation.Steps[3].Text, "port 8000")
+	assert.Contains(t, issue.Remediation.Steps[4].Text, "port 8000")
 }
 
 func TestBuildIssue_Extra(t *testing.T) {

--- a/comp/healthplatform/issues/admissionprobe/issue_test.go
+++ b/comp/healthplatform/issues/admissionprobe/issue_test.go
@@ -47,12 +47,12 @@ func TestBuildIssue_Remediation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, issue.Remediation)
 	assert.NotEmpty(t, issue.Remediation.Summary)
-	assert.Len(t, issue.Remediation.Steps, 6)
+	assert.Len(t, issue.Remediation.Steps, 4)
 
 	lastStep := issue.Remediation.Steps[len(issue.Remediation.Steps)-1]
 	assert.Contains(t, lastStep.Text, "dtdg.co")
 
-	assert.Equal(t, "check network", issue.Remediation.Steps[4].Text)
+	assert.Equal(t, "check network", issue.Remediation.Steps[2].Text)
 }
 
 func TestBuildIssue_Defaults(t *testing.T) {
@@ -61,7 +61,7 @@ func TestBuildIssue_Defaults(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Contains(t, issue.Description, "unreachable from the Kubernetes API server")
-	assert.Contains(t, issue.Remediation.Steps[4].Text, "port 8000")
+	assert.Contains(t, issue.Remediation.Steps[1].Text, "port 8000")
 }
 
 func TestBuildIssue_Extra(t *testing.T) {
@@ -74,6 +74,200 @@ func TestBuildIssue_Extra(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, issue.Extra)
 	assert.NotEmpty(t, issue.Extra.Fields["impact"].GetStringValue())
+}
+
+func TestBuildIssue_CauseSecretControllerForbidden(t *testing.T) {
+	template := &AdmissionProbeIssue{}
+	issue, err := template.BuildIssue(map[string]string{
+		"issue":    "the cluster agent failed to create the TLS certificate Secret: forbidden",
+		"cause":    CauseSecretControllerForbidden,
+		"fix_hint": `Grant the cluster agent's Kubernetes service account "create" permission on secrets "datadog-webhook-certificate" in namespace "datadog"`,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, issue.Remediation)
+	for _, step := range issue.Remediation.Steps {
+		assert.NotContains(t, step.Text, "port 8000", "steps should not ask the user to check network connectivity when the secret controller already reported the root cause")
+	}
+	assert.Equal(t, `Grant the cluster agent's Kubernetes service account "create" permission on secrets "datadog-webhook-certificate" in namespace "datadog"`, issue.Remediation.Steps[0].Text)
+}
+
+func TestBuildIssue_CauseSecretControllerForbidden_NoRBACFixFallsBackToGenericGrant(t *testing.T) {
+	template := &AdmissionProbeIssue{}
+	issue, err := template.BuildIssue(map[string]string{
+		"issue": "the cluster agent failed to create the TLS certificate Secret: forbidden",
+		"cause": CauseSecretControllerForbidden,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, issue.Remediation)
+	assert.Contains(t, issue.Remediation.Steps[0].Text, "Secrets")
+}
+
+func TestBuildIssue_CauseSecretControllerFailed(t *testing.T) {
+	template := &AdmissionProbeIssue{}
+	issue, err := template.BuildIssue(map[string]string{
+		"issue":    "the cluster agent failed to create the TLS certificate Secret: connection refused",
+		"cause":    CauseSecretControllerFailed,
+		"fix_hint": "The Kubernetes API server timed out handling the request; check network connectivity and API server load between the cluster agent and the control plane",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, issue.Remediation)
+	for _, step := range issue.Remediation.Steps {
+		assert.NotContains(t, step.Text, "port 8000", "steps should not ask the user to check network connectivity when the secret controller already reported the root cause")
+		assert.NotContains(t, step.Text, "RBAC", "steps should not guess RBAC as the cause when the error is not a Forbidden error")
+	}
+	assert.Equal(t, "The Kubernetes API server timed out handling the request; check network connectivity and API server load between the cluster agent and the control plane", issue.Remediation.Steps[0].Text)
+}
+
+func TestBuildIssue_CauseSecretControllerFailed_NoFixHintPointsAtDescriptionInsteadOfLogs(t *testing.T) {
+	template := &AdmissionProbeIssue{}
+	issue, err := template.BuildIssue(map[string]string{
+		"issue": "the cluster agent failed to create the TLS certificate Secret: connection refused",
+		"cause": CauseSecretControllerFailed,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, issue.Remediation)
+	assert.NotContains(t, issue.Remediation.Steps[0].Text, "logs", "the error is already in the issue description, so the fallback shouldn't ask the user to go find it again in the logs")
+}
+
+func TestBuildIssue_CauseWebhookControllerForbidden(t *testing.T) {
+	template := &AdmissionProbeIssue{}
+	issue, err := template.BuildIssue(map[string]string{
+		"issue":    "the cluster agent failed to register the webhook configuration: forbidden",
+		"cause":    CauseWebhookControllerForbidden,
+		"fix_hint": `Grant the cluster agent's Kubernetes service account "create" permission on the cluster-scoped mutatingwebhookconfigurations "datadog-webhook"`,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, issue.Remediation)
+	for _, step := range issue.Remediation.Steps {
+		assert.NotContains(t, step.Text, "port 8000", "steps should not ask the user to check network connectivity when the webhook controller already reported the root cause")
+	}
+	assert.Equal(t, `Grant the cluster agent's Kubernetes service account "create" permission on the cluster-scoped mutatingwebhookconfigurations "datadog-webhook"`, issue.Remediation.Steps[0].Text)
+}
+
+func TestBuildIssue_CauseWebhookControllerForbidden_NoRBACFixFallsBackToGenericGrant(t *testing.T) {
+	template := &AdmissionProbeIssue{}
+	issue, err := template.BuildIssue(map[string]string{
+		"issue": "the cluster agent failed to register the webhook configuration: forbidden",
+		"cause": CauseWebhookControllerForbidden,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, issue.Remediation)
+	assert.Contains(t, issue.Remediation.Steps[0].Text, "WebhookConfigurations")
+}
+
+func TestBuildIssue_CauseWebhookControllerFailed(t *testing.T) {
+	template := &AdmissionProbeIssue{}
+	issue, err := template.BuildIssue(map[string]string{
+		"issue":    "the cluster agent failed to register the webhook configuration: connection refused",
+		"cause":    CauseWebhookControllerFailed,
+		"fix_hint": "The Kubernetes API server timed out handling the request; check network connectivity and API server load between the cluster agent and the control plane",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, issue.Remediation)
+	for _, step := range issue.Remediation.Steps {
+		assert.NotContains(t, step.Text, "port 8000", "steps should not ask the user to check network connectivity when the webhook controller already reported the root cause")
+		assert.NotContains(t, step.Text, "RBAC", "steps should not guess RBAC as the cause when the error is not a Forbidden error")
+	}
+	assert.Equal(t, "The Kubernetes API server timed out handling the request; check network connectivity and API server load between the cluster agent and the control plane", issue.Remediation.Steps[0].Text)
+}
+
+func TestBuildIssue_CauseWebhookControllerFailed_NoFixHintPointsAtDescriptionInsteadOfLogs(t *testing.T) {
+	template := &AdmissionProbeIssue{}
+	issue, err := template.BuildIssue(map[string]string{
+		"issue": "the cluster agent failed to register the webhook configuration: connection refused",
+		"cause": CauseWebhookControllerFailed,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, issue.Remediation)
+	assert.NotContains(t, issue.Remediation.Steps[0].Text, "logs", "the error is already in the issue description, so the fallback shouldn't ask the user to go find it again in the logs")
+}
+
+func TestBuildIssue_CauseWebhookMissing(t *testing.T) {
+	template := &AdmissionProbeIssue{}
+	issue, err := template.BuildIssue(map[string]string{
+		"issue": `The admission webhook configuration "datadog-webhook" does not exist in the cluster. Both the secret controller and the webhook controller last reconciled successfully, so the object was most likely deleted after being created rather than never created.`,
+		"cause": CauseWebhookMissing,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, issue.Remediation)
+	for _, step := range issue.Remediation.Steps {
+		assert.NotContains(t, step.Text, "port 8000", "steps should not ask the user to check network connectivity when the webhook is confirmed missing")
+		assert.NotContains(t, step.Text, "kubectl get", "the probe already confirmed the webhook is absent; steps shouldn't ask the user to re-verify that")
+	}
+	assert.Contains(t, issue.Remediation.Steps[0].Text, "deleted after being created")
+}
+
+func TestBuildIssue_CauseIndeterminate(t *testing.T) {
+	template := &AdmissionProbeIssue{}
+	issue, err := template.BuildIssue(map[string]string{
+		"issue":    `Could not determine whether the admission webhook configuration "datadog-webhook" exists: checking mutating webhook configuration: "system:serviceaccount:datadog:datadog-cluster-agent" is missing "get" permission on mutatingwebhookconfigurations "datadog-webhook": forbidden.`,
+		"cause":    CauseIndeterminate,
+		"fix_hint": `Grant service account "system:serviceaccount:datadog:datadog-cluster-agent" "get" permission on the cluster-scoped mutatingwebhookconfigurations "datadog-webhook"`,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, issue.Remediation)
+	for _, step := range issue.Remediation.Steps {
+		assert.NotContains(t, step.Text, "port 8000", "steps should not claim a network diagnosis when existence could not be determined")
+	}
+	assert.Equal(t, `Grant service account "system:serviceaccount:datadog:datadog-cluster-agent" "get" permission on the cluster-scoped mutatingwebhookconfigurations "datadog-webhook"`, issue.Remediation.Steps[0].Text)
+}
+
+func TestBuildIssue_CauseIndeterminate_NoFixHintPointsAtDescriptionInsteadOfLogs(t *testing.T) {
+	template := &AdmissionProbeIssue{}
+	issue, err := template.BuildIssue(map[string]string{
+		"issue": "could not determine whether the webhook configuration exists",
+		"cause": CauseIndeterminate,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, issue.Remediation)
+	assert.NotContains(t, issue.Remediation.Steps[0].Text, "logs", "the error is already in the issue description, so the fallback shouldn't ask the user to go find it again in the logs")
+}
+
+func TestBuildIssue_CauseProbeConfigForbidden(t *testing.T) {
+	template := &AdmissionProbeIssue{}
+	issue, err := template.BuildIssue(map[string]string{
+		"issue":    "the cluster agent cannot verify admission webhook connectivity: forbidden",
+		"cause":    CauseProbeConfigForbidden,
+		"fix_hint": `Grant service account "system:serviceaccount:datadog:datadog-cluster-agent" "create" permission on configmaps "" in namespace "datadog"`,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, issue.Remediation)
+	assert.Equal(t, `Grant service account "system:serviceaccount:datadog:datadog-cluster-agent" "create" permission on configmaps "" in namespace "datadog"`, issue.Remediation.Steps[0].Text)
+	assert.Contains(t, issue.Remediation.Steps[1].Text, "does not mean the admission webhook itself is broken")
+}
+
+func TestBuildIssue_CauseProbeConfigForbidden_NoRBACFixFallsBackToGenericGrant(t *testing.T) {
+	template := &AdmissionProbeIssue{}
+	issue, err := template.BuildIssue(map[string]string{
+		"issue": "the cluster agent cannot verify admission webhook connectivity: forbidden",
+		"cause": CauseProbeConfigForbidden,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, issue.Remediation)
+	assert.Contains(t, issue.Remediation.Steps[0].Text, "ConfigMaps")
+}
+
+func TestBuildIssue_UnknownCauseFallsBackToDefaultSteps(t *testing.T) {
+	template := &AdmissionProbeIssue{}
+	issue, err := template.BuildIssue(map[string]string{
+		"cause": "not_a_real_cause",
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, issue.Remediation.Steps, 4)
 }
 
 func TestNewModule(t *testing.T) {

--- a/pkg/clusteragent/admission/BUILD.bazel
+++ b/pkg/clusteragent/admission/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//comp/core/workloadfilter/def",
         "//comp/core/workloadmeta/def",
         "//comp/healthplatform/store/def",
+        "//pkg/clusteragent/admission/common",
         "//pkg/clusteragent/admission/controllers/secret",
         "//pkg/clusteragent/admission/controllers/webhook",
         "//pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection",

--- a/pkg/clusteragent/admission/common/BUILD.bazel
+++ b/pkg/clusteragent/admission/common/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "global.go",
         "label_selectors.go",
         "lib_config.go",
+        "webhook_status.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common",
     visibility = ["//visibility:public"],
@@ -17,6 +18,7 @@ go_library(
         "@io_k8s_api//admission/v1:admission",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_client_go//kubernetes",
     ],
 )
 
@@ -25,6 +27,7 @@ dd_agent_go_test(
     srcs = [
         "label_selectors_test.go",
         "lib_config_test.go",
+        "webhook_status_test.go",
     ],
     embed = [":common"],
     gotags_sets = [[
@@ -40,7 +43,14 @@ dd_agent_go_test(
         "//pkg/util/pointer",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_k8s_api//admissionregistration/v1:admissionregistration",
+        "@io_k8s_api//admissionregistration/v1beta1",
         "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/errors",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/runtime",
+        "@io_k8s_apimachinery//pkg/runtime/schema",
+        "@io_k8s_client_go//kubernetes/fake",
+        "@io_k8s_client_go//testing",
     ],
 )

--- a/pkg/clusteragent/admission/common/rbac_error.go
+++ b/pkg/clusteragent/admission/common/rbac_error.go
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package common
+
+import (
+	"fmt"
+	"regexp"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// deniedUserPattern extracts the requesting identity from a Kubernetes API
+// server RBAC denial message, e.g. `User "system:serviceaccount:datadog:
+// datadog-cluster-agent" cannot create resource "secrets" ...`. The API
+// server embeds this in the error message; there is no structured field for
+// it in metav1.Status.
+var deniedUserPattern = regexp.MustCompile(`[Uu]ser\s+"([^"]+)"`)
+
+// RBACError wraps a Kubernetes API "forbidden" error with the verb and
+// resource the caller was denied, so that callers can report exactly which
+// RBAC permission is missing instead of guessing.
+type RBACError struct {
+	// Verb is the Kubernetes API verb that was denied, e.g. "create" or "update".
+	Verb string
+	// Resource is the plural resource name, e.g. "secrets" or "mutatingwebhookconfigurations".
+	Resource string
+	// Namespace is the namespace of the request, empty for cluster-scoped resources.
+	Namespace string
+	// Name is the name of the object the request targeted.
+	Name string
+	// Username is the identity the API server denied, e.g.
+	// "system:serviceaccount:datadog:datadog-cluster-agent", extracted from
+	// the API server's own denial message. Empty if the message didn't
+	// contain a recognizable identity (e.g. an older or non-standard
+	// API server response).
+	Username string
+
+	*apierrors.StatusError
+}
+
+// Error implements the error interface.
+func (e *RBACError) Error() string {
+	target := fmt.Sprintf("%s %q", e.Resource, e.Name)
+	if e.Namespace != "" {
+		target = fmt.Sprintf("%s in namespace %q", target, e.Namespace)
+	}
+	who := "the caller"
+	if e.Username != "" {
+		who = fmt.Sprintf("%q", e.Username)
+	}
+	return fmt.Sprintf("%s is missing %q permission on %s: %s", who, e.Verb, target, e.StatusError.Error())
+}
+
+// Unwrap allows errors.Is/errors.As to reach the underlying StatusError.
+func (e *RBACError) Unwrap() error {
+	return e.StatusError
+}
+
+// WrapIfForbidden wraps err with verb/resource/namespace/name context when
+// err is a Kubernetes "forbidden" error, so the RBAC permission that is
+// missing can be reported precisely. It returns err unchanged otherwise.
+func WrapIfForbidden(err error, verb, resource, namespace, name string) error {
+	if err == nil {
+		return nil
+	}
+	statusErr, ok := err.(*apierrors.StatusError)
+	if !ok || !apierrors.IsForbidden(statusErr) {
+		return err
+	}
+	var username string
+	if m := deniedUserPattern.FindStringSubmatch(statusErr.Status().Message); len(m) == 2 {
+		username = m[1]
+	}
+	return &RBACError{
+		Verb:        verb,
+		Resource:    resource,
+		Namespace:   namespace,
+		Name:        name,
+		Username:    username,
+		StatusError: statusErr,
+	}
+}

--- a/pkg/clusteragent/admission/common/rbac_error_test.go
+++ b/pkg/clusteragent/admission/common/rbac_error_test.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package common
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestWrapIfForbidden_Nil(t *testing.T) {
+	assert.Nil(t, WrapIfForbidden(nil, "create", "secrets", "ns", "name"))
+}
+
+func TestWrapIfForbidden_NonForbiddenErrorIsUnchanged(t *testing.T) {
+	err := errors.New("connection refused")
+
+	got := WrapIfForbidden(err, "create", "secrets", "ns", "name")
+
+	assert.Same(t, err, got)
+}
+
+func TestWrapIfForbidden_NonStatusErrorIsUnchanged(t *testing.T) {
+	// Some other package's error type that happens to say "forbidden" in its
+	// message shouldn't be mistaken for a real API server denial.
+	err := errors.New("forbidden")
+
+	got := WrapIfForbidden(err, "create", "secrets", "ns", "name")
+
+	assert.Same(t, err, got)
+}
+
+func TestWrapIfForbidden_ForbiddenErrorIsWrapped(t *testing.T) {
+	statusErr := apierrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "datadog-webhook-certificate", errors.New("denied"))
+
+	got := WrapIfForbidden(statusErr, "create", "secrets", "datadog", "datadog-webhook-certificate")
+
+	var rbacErr *RBACError
+	require.ErrorAs(t, got, &rbacErr)
+	assert.Equal(t, "create", rbacErr.Verb)
+	assert.Equal(t, "secrets", rbacErr.Resource)
+	assert.Equal(t, "datadog", rbacErr.Namespace)
+	assert.Equal(t, "datadog-webhook-certificate", rbacErr.Name)
+	assert.Empty(t, rbacErr.Username, "the underlying error here has no recognizable identity to extract")
+
+	// Method promotion from the embedded *apierrors.StatusError means the
+	// wrapped error is still recognized as Forbidden without unwrapping.
+	assert.True(t, apierrors.IsForbidden(got))
+}
+
+func TestWrapIfForbidden_ExtractsUsernameFromAPIServerMessage(t *testing.T) {
+	// This is the shape of a real RBAC denial from the Kubernetes API server:
+	// the identity that was denied is embedded in the message text, since
+	// metav1.Status has no structured field for it.
+	underlying := errors.New(`User "system:serviceaccount:datadog:datadog-cluster-agent" cannot create resource "secrets" in API group "" in the namespace "datadog"`)
+	statusErr := apierrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "datadog-webhook-certificate", underlying)
+
+	got := WrapIfForbidden(statusErr, "create", "secrets", "datadog", "datadog-webhook-certificate")
+
+	var rbacErr *RBACError
+	require.ErrorAs(t, got, &rbacErr)
+	assert.Equal(t, "system:serviceaccount:datadog:datadog-cluster-agent", rbacErr.Username)
+}
+
+func TestRBACError_Error(t *testing.T) {
+	statusErr := apierrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "datadog-webhook-certificate", errors.New("denied"))
+
+	err := WrapIfForbidden(statusErr, "create", "secrets", "datadog", "datadog-webhook-certificate")
+
+	assert.Contains(t, err.Error(), `"create"`)
+	assert.Contains(t, err.Error(), "secrets")
+	assert.Contains(t, err.Error(), "datadog-webhook-certificate")
+	assert.Contains(t, err.Error(), "datadog")
+}

--- a/pkg/clusteragent/admission/common/webhook_status.go
+++ b/pkg/clusteragent/admission/common/webhook_status.go
@@ -1,0 +1,187 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// GetValidatingWebhookStatus fetches the ValidatingWebhookConfiguration status.
+var GetValidatingWebhookStatus = func(context.Context, string, kubernetes.Interface) (map[string]interface{}, error) {
+	return nil, errors.New("admission controller not started")
+}
+
+// GetMutatingWebhookStatus fetches the MutatingWebhookConfiguration status.
+var GetMutatingWebhookStatus = func(context.Context, string, kubernetes.Interface) (map[string]interface{}, error) {
+	return nil, errors.New("admission controller not started")
+}
+
+// GetValidatingWebhookStatusV1 fetches a ValidatingWebhookConfiguration via the v1 API.
+func GetValidatingWebhookStatusV1(ctx context.Context, name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
+	validatingWebhookStatus := make(map[string]interface{})
+	validatingWebhook, err := apiCl.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return validatingWebhookStatus, err
+	}
+
+	validatingWebhookStatus["Name"] = validatingWebhook.GetName()
+	validatingWebhookStatus["CreatedAt"] = validatingWebhook.GetCreationTimestamp()
+	validatingWebhooksConfig := make(map[string]map[string]interface{})
+	validatingWebhookStatus["Webhooks"] = validatingWebhooksConfig
+	for _, w := range validatingWebhook.Webhooks {
+		validatingWebhooksConfig[w.Name] = make(map[string]interface{})
+		svc := w.ClientConfig.Service
+		if svc != nil {
+			port := "Port: None (default 443)"
+			path := "Path: None"
+			if svc.Port != nil {
+				port = fmt.Sprintf("Port: %d", *svc.Port)
+			}
+			if svc.Path != nil {
+				path = "Path: " + *svc.Path
+			}
+			validatingWebhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - %s - %s", svc.Namespace, svc.Name, port, path)
+		}
+		if w.ObjectSelector != nil {
+			validatingWebhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
+		}
+		for i, r := range w.Rules {
+			validatingWebhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
+		}
+		validatingWebhooksConfig[w.Name]["CA bundle digest"] = Digest(w.ClientConfig.CABundle)
+	}
+
+	return validatingWebhookStatus, nil
+}
+
+// GetValidatingWebhookStatusV1beta1 fetches a ValidatingWebhookConfiguration via the v1beta1 API.
+func GetValidatingWebhookStatusV1beta1(ctx context.Context, name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
+	validatingWebhookStatus := make(map[string]interface{})
+	validatingWebhook, err := apiCl.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return validatingWebhookStatus, err
+	}
+
+	validatingWebhookStatus["Name"] = validatingWebhook.GetName()
+	validatingWebhookStatus["CreatedAt"] = validatingWebhook.GetCreationTimestamp()
+	validatingWebhooksConfig := make(map[string]map[string]interface{})
+	validatingWebhookStatus["Webhooks"] = validatingWebhooksConfig
+	for _, w := range validatingWebhook.Webhooks {
+		validatingWebhooksConfig[w.Name] = make(map[string]interface{})
+		svc := w.ClientConfig.Service
+		if svc != nil {
+			port := "Port: None (default 443)"
+			path := "Path: None"
+			if svc.Port != nil {
+				port = fmt.Sprintf("Port: %d", *svc.Port)
+			}
+			if svc.Path != nil {
+				path = "Path: " + *svc.Path
+			}
+			validatingWebhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - %s - %s", svc.Namespace, svc.Name, port, path)
+		}
+		if w.ObjectSelector != nil {
+			validatingWebhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
+		}
+		for i, r := range w.Rules {
+			validatingWebhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
+		}
+		validatingWebhooksConfig[w.Name]["CA bundle digest"] = Digest(w.ClientConfig.CABundle)
+	}
+
+	return validatingWebhookStatus, nil
+}
+
+// GetMutatingWebhookStatusV1 fetches a MutatingWebhookConfiguration via the v1 API.
+func GetMutatingWebhookStatusV1(ctx context.Context, name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
+	mutatingWebhookStatus := make(map[string]interface{})
+	mutatingWebhook, err := apiCl.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return mutatingWebhookStatus, err
+	}
+
+	mutatingWebhookStatus["Name"] = mutatingWebhook.GetName()
+	mutatingWebhookStatus["CreatedAt"] = mutatingWebhook.GetCreationTimestamp()
+	mutatingWebhooksConfig := make(map[string]map[string]interface{})
+	mutatingWebhookStatus["Webhooks"] = mutatingWebhooksConfig
+	for _, w := range mutatingWebhook.Webhooks {
+		mutatingWebhooksConfig[w.Name] = make(map[string]interface{})
+		svc := w.ClientConfig.Service
+		if svc != nil {
+			port := "Port: None (default 443)"
+			path := "Path: None"
+			if svc.Port != nil {
+				port = fmt.Sprintf("Port: %d", *svc.Port)
+			}
+			if svc.Path != nil {
+				path = "Path: " + *svc.Path
+			}
+			mutatingWebhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - %s - %s", svc.Namespace, svc.Name, port, path)
+		}
+		if w.ObjectSelector != nil {
+			mutatingWebhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
+		}
+		for i, r := range w.Rules {
+			mutatingWebhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
+		}
+		mutatingWebhooksConfig[w.Name]["CA bundle digest"] = Digest(w.ClientConfig.CABundle)
+	}
+	return mutatingWebhookStatus, nil
+}
+
+// GetMutatingWebhookStatusV1beta1 fetches a MutatingWebhookConfiguration via the v1beta1 API.
+func GetMutatingWebhookStatusV1beta1(ctx context.Context, name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
+	mutatingWebhookStatus := make(map[string]interface{})
+	mutatingWebhook, err := apiCl.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return mutatingWebhookStatus, err
+	}
+
+	mutatingWebhookStatus["Name"] = mutatingWebhook.GetName()
+	mutatingWebhookStatus["CreatedAt"] = mutatingWebhook.GetCreationTimestamp()
+	mutatingWebhooksConfig := make(map[string]map[string]interface{})
+	mutatingWebhookStatus["Webhooks"] = mutatingWebhooksConfig
+	for _, w := range mutatingWebhook.Webhooks {
+		mutatingWebhooksConfig[w.Name] = make(map[string]interface{})
+		svc := w.ClientConfig.Service
+		if svc != nil {
+			port := "Port: None (default 443)"
+			path := "Path: None"
+			if svc.Path != nil {
+				path = "Path: " + *svc.Path
+			}
+			if svc.Port != nil {
+				port = fmt.Sprintf("Port: %d", *svc.Port)
+			}
+			mutatingWebhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - %s - %s", svc.Namespace, svc.Name, port, path)
+		}
+		if w.ObjectSelector != nil {
+			mutatingWebhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
+		}
+		for i, r := range w.Rules {
+			mutatingWebhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
+		}
+		mutatingWebhooksConfig[w.Name]["CA bundle digest"] = Digest(w.ClientConfig.CABundle)
+	}
+	return mutatingWebhookStatus, nil
+}
+
+// Digest returns a short hash of b, used to display a certificate/CA bundle
+// fingerprint without printing the raw bytes.
+func Digest(b []byte) string {
+	h := fnv.New64()
+	_, _ = h.Write(b)
+	return strconv.FormatUint(h.Sum64(), 16)
+}

--- a/pkg/clusteragent/admission/common/webhook_status_test.go
+++ b/pkg/clusteragent/admission/common/webhook_status_test.go
@@ -1,0 +1,197 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package common
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestDigest_DeterministicAndDistinct(t *testing.T) {
+	assert.Equal(t, Digest([]byte("hello")), Digest([]byte("hello")))
+	assert.NotEqual(t, Digest([]byte("hello")), Digest([]byte("world")))
+	assert.NotEmpty(t, Digest(nil), "digest of empty input should still be a valid (non-empty) hash")
+}
+
+func TestGetValidatingWebhookStatusV1_NotFound(t *testing.T) {
+	client := fakeclientset.NewSimpleClientset()
+
+	_, err := GetValidatingWebhookStatusV1(context.Background(), "datadog-webhook", client)
+	require.Error(t, err)
+	assert.True(t, k8serrors.IsNotFound(err))
+}
+
+func TestGetValidatingWebhookStatusV1_Found(t *testing.T) {
+	port := int32(443)
+	path := "/mutate"
+	webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-webhook"},
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{
+			{
+				Name: "datadog.webhook.validation",
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
+						Namespace: "system",
+						Name:      "datadog-agent-cluster-agent-admission-controller",
+						Port:      &port,
+						Path:      &path,
+					},
+					CABundle: []byte("fake-ca-bundle"),
+				},
+				Rules: []admissionregistrationv1.RuleWithOperations{
+					{
+						Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"pods"},
+						},
+					},
+				},
+			},
+		},
+	}
+	client := fakeclientset.NewSimpleClientset(webhook)
+
+	status, err := GetValidatingWebhookStatusV1(context.Background(), "datadog-webhook", client)
+	require.NoError(t, err)
+	assert.Equal(t, "datadog-webhook", status["Name"])
+
+	webhooks, ok := status["Webhooks"].(map[string]map[string]interface{})
+	require.True(t, ok)
+	entry := webhooks["datadog.webhook.validation"]
+	require.NotNil(t, entry)
+	assert.Contains(t, entry["Service"], "system/datadog-agent-cluster-agent-admission-controller")
+	assert.Contains(t, entry["Service"], "Port: 443")
+	assert.Contains(t, entry["Service"], "Path: /mutate")
+	assert.Equal(t, Digest([]byte("fake-ca-bundle")), entry["CA bundle digest"])
+	assert.Contains(t, entry, "Rule 1")
+}
+
+func TestGetValidatingWebhookStatusV1_ServiceDefaults(t *testing.T) {
+	webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-webhook"},
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{
+			{
+				Name: "datadog.webhook.validation",
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
+						Namespace: "system",
+						Name:      "svc",
+					},
+				},
+			},
+		},
+	}
+	client := fakeclientset.NewSimpleClientset(webhook)
+
+	status, err := GetValidatingWebhookStatusV1(context.Background(), "datadog-webhook", client)
+	require.NoError(t, err)
+	webhooks := status["Webhooks"].(map[string]map[string]interface{})
+	entry := webhooks["datadog.webhook.validation"]
+	assert.Contains(t, entry["Service"], "Port: None (default 443)")
+	assert.Contains(t, entry["Service"], "Path: None")
+}
+
+func TestGetMutatingWebhookStatusV1_NotFound(t *testing.T) {
+	client := fakeclientset.NewSimpleClientset()
+
+	_, err := GetMutatingWebhookStatusV1(context.Background(), "datadog-webhook", client)
+	require.Error(t, err)
+	assert.True(t, k8serrors.IsNotFound(err))
+}
+
+func TestGetMutatingWebhookStatusV1_Found(t *testing.T) {
+	webhook := &admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-webhook"},
+		Webhooks: []admissionregistrationv1.MutatingWebhook{
+			{
+				Name: "datadog.webhook.agent.config",
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					CABundle: []byte("fake-ca-bundle"),
+				},
+			},
+		},
+	}
+	client := fakeclientset.NewSimpleClientset(webhook)
+
+	status, err := GetMutatingWebhookStatusV1(context.Background(), "datadog-webhook", client)
+	require.NoError(t, err)
+	assert.Equal(t, "datadog-webhook", status["Name"])
+	webhooks := status["Webhooks"].(map[string]map[string]interface{})
+	assert.Contains(t, webhooks, "datadog.webhook.agent.config")
+}
+
+func TestGetValidatingWebhookStatusV1beta1_NotFound(t *testing.T) {
+	client := fakeclientset.NewSimpleClientset()
+
+	_, err := GetValidatingWebhookStatusV1beta1(context.Background(), "datadog-webhook", client)
+	require.Error(t, err)
+	assert.True(t, k8serrors.IsNotFound(err))
+}
+
+func TestGetMutatingWebhookStatusV1beta1_NotFound(t *testing.T) {
+	client := fakeclientset.NewSimpleClientset()
+
+	_, err := GetMutatingWebhookStatusV1beta1(context.Background(), "datadog-webhook", client)
+	require.Error(t, err)
+	assert.True(t, k8serrors.IsNotFound(err))
+}
+
+func TestGetMutatingWebhookStatusV1beta1_Found(t *testing.T) {
+	webhook := &admissionregistrationv1beta1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-webhook"},
+		Webhooks: []admissionregistrationv1beta1.MutatingWebhook{
+			{
+				Name: "datadog.webhook.agent.config",
+				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+					CABundle: []byte("fake-ca-bundle"),
+				},
+			},
+		},
+	}
+	client := fakeclientset.NewSimpleClientset(webhook)
+
+	status, err := GetMutatingWebhookStatusV1beta1(context.Background(), "datadog-webhook", client)
+	require.NoError(t, err)
+	assert.Equal(t, "datadog-webhook", status["Name"])
+}
+
+func TestGetValidatingWebhookStatusV1_PropagatesNonNotFoundError(t *testing.T) {
+	client := fakeclientset.NewSimpleClientset()
+	client.PrependReactor("get", "validatingwebhookconfigurations", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "validatingwebhookconfigurations"}, "datadog-webhook", errors.New("forbidden"))
+	})
+
+	_, err := GetValidatingWebhookStatusV1(context.Background(), "datadog-webhook", client)
+	require.Error(t, err)
+	assert.False(t, k8serrors.IsNotFound(err))
+}
+
+func TestGetMutatingWebhookStatusV1_PropagatesNonNotFoundError(t *testing.T) {
+	client := fakeclientset.NewSimpleClientset()
+	client.PrependReactor("get", "mutatingwebhookconfigurations", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "mutatingwebhookconfigurations"}, "datadog-webhook", errors.New("forbidden"))
+	})
+
+	_, err := GetMutatingWebhookStatusV1(context.Background(), "datadog-webhook", client)
+	require.Error(t, err)
+	assert.False(t, k8serrors.IsNotFound(err))
+}

--- a/pkg/clusteragent/admission/controllers/secret/controller.go
+++ b/pkg/clusteragent/admission/controllers/secret/controller.go
@@ -14,8 +14,10 @@ import (
 	"fmt"
 	"hash/fnv"
 	"sort"
+	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -43,6 +45,17 @@ type Controller struct {
 	queue                workqueue.TypedRateLimitingInterface[string]
 	isLeaderFunc         func() bool
 	leadershipStateNotif <-chan struct{}
+
+	reconcileErrMu   sync.RWMutex
+	lastReconcileErr error
+}
+
+// LastReconcileError returns the error from the most recent reconciliation
+// attempt, or nil if the last reconciliation succeeded or none has run yet.
+func (c *Controller) LastReconcileError() error {
+	c.reconcileErrMu.RLock()
+	defer c.reconcileErrMu.RUnlock()
+	return c.lastReconcileErr
 }
 
 // NewController returns a new Secret Controller.
@@ -173,7 +186,13 @@ func (c *Controller) processNextWorkItem() bool {
 	}
 	defer c.queue.Done(key)
 
-	if err := c.reconcile(); err != nil {
+	err := c.reconcile()
+
+	c.reconcileErrMu.Lock()
+	c.lastReconcileErr = err
+	c.reconcileErrMu.Unlock()
+
+	if err != nil {
 		c.requeue(key)
 		log.Errorf("Couldn't reconcile Secret %s/%s: %v", c.config.GetNs(), c.config.GetName(), err)
 		metrics.ReconcileErrors.Inc(metrics.SecretControllerName)
@@ -238,7 +257,7 @@ func (c *Controller) createSecret() error {
 	}
 
 	_, err = c.clientSet.CoreV1().Secrets(c.config.GetNs()).Create(context.TODO(), secret, metav1.CreateOptions{})
-	return err
+	return common.WrapIfForbidden(err, "create", "secrets", c.config.GetNs(), c.config.GetName())
 }
 
 // updateSecret stores a new certificate in the Secret object
@@ -251,7 +270,7 @@ func (c *Controller) updateSecret(secret *corev1.Secret) error {
 	secret = secret.DeepCopy()
 	secret.Data = data
 	_, err = c.clientSet.CoreV1().Secrets(c.config.GetNs()).Update(context.TODO(), secret, metav1.UpdateOptions{})
-	return err
+	return common.WrapIfForbidden(err, "update", "secrets", c.config.GetNs(), c.config.GetName())
 }
 
 // notAfter defines the validity bounds when creating a new certificate

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -9,6 +9,7 @@ package webhook
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	admiv1 "k8s.io/api/admissionregistration/v1"
@@ -55,6 +56,9 @@ import (
 type Controller interface {
 	Run(stopCh <-chan struct{})
 	EnabledWebhooks() []Webhook
+	// LastReconcileError returns the error from the most recent reconciliation
+	// attempt, or nil if the last reconciliation succeeded or none has run yet.
+	LastReconcileError() error
 }
 
 // NewController returns the adequate implementation of the Controller interface.
@@ -216,6 +220,17 @@ type controllerBase struct {
 	isLeaderFunc             func() bool
 	leadershipStateNotif     <-chan struct{}
 	webhooks                 []Webhook
+
+	reconcileErrMu   sync.RWMutex
+	lastReconcileErr error
+}
+
+// LastReconcileError returns the error from the most recent reconciliation
+// attempt, or nil if the last reconciliation succeeded or none has run yet.
+func (c *controllerBase) LastReconcileError() error {
+	c.reconcileErrMu.RLock()
+	defer c.reconcileErrMu.RUnlock()
+	return c.lastReconcileErr
 }
 
 // EnabledWebhooks returns the list of enabled webhooks.
@@ -357,7 +372,13 @@ func (c *controllerBase) processNextWorkItem(reconcile func() error) bool {
 	}
 	defer c.queue.Done(key)
 
-	if err := reconcile(); err != nil {
+	err := reconcile()
+
+	c.reconcileErrMu.Lock()
+	c.lastReconcileErr = err
+	c.reconcileErrMu.Unlock()
+
+	if err != nil {
 		c.requeue(key)
 		log.Errorf("Couldn't reconcile webhook %s: %v", c.config.getWebhookName(), err)
 		metrics.ReconcileErrors.Inc(metrics.WebhooksControllerName)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -271,7 +271,7 @@ func (c *ControllerV1) createValidatingWebhook(secret *corev1.Secret) error {
 		return nil
 	}
 
-	return err
+	return common.WrapIfForbidden(err, "create", "validatingwebhookconfigurations", "", webhook.GetName())
 }
 
 // updateValidatingWebhook stores a new configuration in the ValidatingWebhookConfiguration object.
@@ -279,7 +279,7 @@ func (c *ControllerV1) updateValidatingWebhook(secret *corev1.Secret, webhook *a
 	webhook = webhook.DeepCopy()
 	webhook.Webhooks = c.newValidatingWebhooks(secret)
 	_, err := c.clientSet.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(context.TODO(), webhook, metav1.UpdateOptions{})
-	return err
+	return common.WrapIfForbidden(err, "update", "validatingwebhookconfigurations", "", webhook.GetName())
 }
 
 // newValidatingWebhooks generates Webhook objects from config templates with updated CABundle from Secret.
@@ -314,7 +314,7 @@ func (c *ControllerV1) createMutatingWebhook(secret *corev1.Secret) error {
 		return nil
 	}
 
-	return err
+	return common.WrapIfForbidden(err, "create", "mutatingwebhookconfigurations", "", webhook.GetName())
 }
 
 // updateMutatingWebhook stores a new configuration in the MutatingWebhookConfiguration object.
@@ -322,7 +322,7 @@ func (c *ControllerV1) updateMutatingWebhook(secret *corev1.Secret, webhook *adm
 	webhook = webhook.DeepCopy()
 	webhook.Webhooks = c.newMutatingWebhooks(secret)
 	_, err := c.clientSet.AdmissionregistrationV1().MutatingWebhookConfigurations().Update(context.TODO(), webhook, metav1.UpdateOptions{})
-	return err
+	return common.WrapIfForbidden(err, "update", "mutatingwebhookconfigurations", "", webhook.GetName())
 }
 
 // newMutatingWebhooks generates Webhook objects from config templates with updated CABundle from Secret.

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -272,7 +272,7 @@ func (c *ControllerV1beta1) createValidatingWebhook(secret *corev1.Secret) error
 		return nil
 	}
 
-	return err
+	return common.WrapIfForbidden(err, "create", "validatingwebhookconfigurations", "", webhook.GetName())
 }
 
 // updateValidatingWebhook stores a new configuration in the ValidatingWebhookConfiguration object.
@@ -280,7 +280,7 @@ func (c *ControllerV1beta1) updateValidatingWebhook(secret *corev1.Secret, webho
 	webhook = webhook.DeepCopy()
 	webhook.Webhooks = c.newValidatingWebhooks(secret)
 	_, err := c.clientSet.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Update(context.TODO(), webhook, metav1.UpdateOptions{})
-	return err
+	return common.WrapIfForbidden(err, "update", "validatingwebhookconfigurations", "", webhook.GetName())
 }
 
 // newValidatingWebhooks generates Webhook objects from config templates with updated CABundle from Secret.
@@ -315,7 +315,7 @@ func (c *ControllerV1beta1) createMutatingWebhook(secret *corev1.Secret) error {
 		return nil
 	}
 
-	return err
+	return common.WrapIfForbidden(err, "create", "mutatingwebhookconfigurations", "", webhook.GetName())
 }
 
 // updateMutatingWebhook stores a new config in the MutatingWebhookConfiguration object.
@@ -324,7 +324,7 @@ func (c *ControllerV1beta1) updateMutatingWebhook(secret *corev1.Secret, webhook
 	webhook.Webhooks = c.newMutatingWebhooks(secret)
 	_, err := c.clientSet.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Update(context.TODO(), webhook, metav1.UpdateOptions{})
 
-	return err
+	return common.WrapIfForbidden(err, "update", "mutatingwebhookconfigurations", "", webhook.GetName())
 }
 
 // newWebhooks generates Webhook objects from config templates with updated CABundle from Secret.

--- a/pkg/clusteragent/admission/probe/BUILD.bazel
+++ b/pkg/clusteragent/admission/probe/BUILD.bazel
@@ -41,6 +41,7 @@ dd_agent_go_test(
         "//pkg/util/log",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_k8s_api//admissionregistration/v1:admissionregistration",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/errors",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",

--- a/pkg/clusteragent/admission/probe/kind_manual_test.go
+++ b/pkg/clusteragent/admission/probe/kind_manual_test.go
@@ -1,0 +1,282 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package probe
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	healthplatformmock "github.com/DataDog/datadog-agent/comp/healthplatform/store/mock"
+	admcommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// This is a manual, throwaway verification against a real kind cluster (not
+// part of CI). Skipped unless RUN_KIND_MANUAL_TEST=1 is set, since it needs a
+// real API server reachable via the current kubeconfig context, and RBAC
+// objects it creates/deletes as it goes to drive each scenario.
+func TestManual_AgainstRealKindCluster(t *testing.T) {
+	if os.Getenv("RUN_KIND_MANUAL_TEST") != "1" {
+		t.Skip("set RUN_KIND_MANUAL_TEST=1 to run against the current kubeconfig context's cluster")
+	}
+
+	restCfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{}).ClientConfig()
+	require.NoError(t, err)
+
+	adminClient, err := kubernetes.NewForConfig(restCfg)
+	require.NoError(t, err)
+
+	saUsername := "system:serviceaccount:test-probe-ns:datadog-cluster-agent"
+	restrictedClient := impersonatedClient(t, restCfg, saUsername)
+
+	ctx := context.Background()
+
+	// webhookExists calls admcommon's package-level dispatch vars, which
+	// default to a stub returning "admission controller not started" until
+	// something wires them to the real v1 implementations (normally done at
+	// cluster agent startup in start.go). Point them at the real
+	// implementations here so the probe actually queries the API server.
+	prevValidating := admcommon.GetValidatingWebhookStatus
+	prevMutating := admcommon.GetMutatingWebhookStatus
+	admcommon.GetValidatingWebhookStatus = admcommon.GetValidatingWebhookStatusV1
+	admcommon.GetMutatingWebhookStatus = admcommon.GetMutatingWebhookStatusV1
+	t.Cleanup(func() {
+		admcommon.GetValidatingWebhookStatus = prevValidating
+		admcommon.GetMutatingWebhookStatus = prevMutating
+	})
+
+	newProbe := func(client kubernetes.Interface) (*Probe, *healthplatformmock.Mock) {
+		hp := healthplatformmock.New(t)
+		return &Probe{
+			k8sClient:      client,
+			namespace:      "test-probe-ns",
+			webhookName:    "datadog-webhook",
+			isLeaderFunc:   func() bool { return true },
+			logLimiter:     log.NewLogLimit(10, time.Minute),
+			healthPlatform: hp,
+			diagnosticHint: "check network",
+		}, hp
+	}
+
+	revokeAllRBAC(ctx, t, adminClient)
+
+	t.Run("1_CauseProbeConfigForbidden_no_rbac_at_all", func(t *testing.T) {
+		p, hp := newProbe(restrictedClient)
+		p.mutationEnabled = true
+		p.runProbe(ctx)
+
+		issue := hp.GetIssue(healthIssueID)
+		require.NotNil(t, issue, "expected a health issue to be reported")
+		t.Logf("Description: %s", issue.Description)
+		for _, s := range issue.Remediation.Steps {
+			t.Logf("Step %d: %s", s.Order, s.Text)
+		}
+		assert.Contains(t, issue.Description, "does not have permission to create configmaps")
+		assert.Contains(t, issue.Description, saUsername, "real API server message should have been parsed for the exact identity")
+		require.NotEmpty(t, issue.Remediation.Steps)
+		assert.Contains(t, issue.Remediation.Steps[0].Text, saUsername)
+		assert.Contains(t, issue.Remediation.Steps[0].Text, `"create"`)
+		assert.Contains(t, issue.Remediation.Steps[0].Text, "configmaps")
+	})
+
+	grantConfigMapCreate(ctx, t, adminClient)
+	grantWebhookConfigGet(ctx, t, adminClient)
+
+	t.Run("2_CauseWebhookMissing_confirmed_absent", func(t *testing.T) {
+		p, hp := newProbe(restrictedClient)
+		p.mutationEnabled = true
+		p.runProbe(ctx)
+
+		issue := hp.GetIssue(healthIssueID)
+		require.NotNil(t, issue)
+		t.Logf("Description: %s", issue.Description)
+		for _, s := range issue.Remediation.Steps {
+			t.Logf("Step %d: %s", s.Order, s.Text)
+		}
+		assert.Contains(t, issue.Description, `"datadog-webhook" does not exist`)
+		assert.Contains(t, issue.Description, "deleted after being created")
+		for _, s := range issue.Remediation.Steps {
+			assert.NotContains(t, s.Text, "kubectl get")
+		}
+	})
+
+	revokeWebhookConfigGet(ctx, t, adminClient)
+
+	t.Run("3_CauseIndeterminate_rbac_denies_lookup", func(t *testing.T) {
+		p, hp := newProbe(restrictedClient)
+		p.mutationEnabled = true
+		p.runProbe(ctx)
+
+		issue := hp.GetIssue(healthIssueID)
+		require.NotNil(t, issue)
+		t.Logf("Description: %s", issue.Description)
+		for _, s := range issue.Remediation.Steps {
+			t.Logf("Step %d: %s", s.Order, s.Text)
+		}
+		require.NotEmpty(t, issue.Remediation.Steps)
+		assert.Contains(t, issue.Remediation.Steps[0].Text, saUsername)
+		assert.Contains(t, issue.Remediation.Steps[0].Text, `"get"`)
+		assert.Contains(t, issue.Remediation.Steps[0].Text, "mutatingwebhookconfigurations")
+	})
+
+	grantWebhookConfigGet(ctx, t, adminClient)
+	createWebhookConfig(ctx, t, adminClient)
+
+	t.Run("4_default_network_cause_webhook_confirmed_exists", func(t *testing.T) {
+		p, hp := newProbe(restrictedClient)
+		p.mutationEnabled = true
+		p.runProbe(ctx)
+
+		issue := hp.GetIssue(healthIssueID)
+		require.NotNil(t, issue)
+		t.Logf("Description: %s", issue.Description)
+		for _, s := range issue.Remediation.Steps {
+			t.Logf("Step %d: %s", s.Order, s.Text)
+		}
+		assert.NotContains(t, issue.Description, "does not exist")
+	})
+
+	t.Run("5_secret_controller_forbidden_real_error_shape", func(t *testing.T) {
+		_, rawErr := restrictedClient.CoreV1().Secrets("test-probe-ns").Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "datadog-webhook-certificate"},
+		}, metav1.CreateOptions{})
+		require.Error(t, rawErr, "secrets create was never granted to the SA")
+		t.Logf("raw API server error: %v", rawErr)
+
+		// The real secret controller wraps its create/update errors with
+		// WrapIfForbidden before storing them as LastReconcileError (see
+		// controllers/secret/controller.go) so rbacFixHint can classify them;
+		// mirror that here rather than handing the probe a raw client-go error.
+		wrappedErr := admcommon.WrapIfForbidden(rawErr, "create", "secrets", "test-probe-ns", "datadog-webhook-certificate")
+
+		p, hp := newProbe(restrictedClient)
+		p.mutationEnabled = true
+		p.secretController = &fakeReconcileStatusProvider{err: wrappedErr}
+		p.runProbe(ctx)
+
+		issue := hp.GetIssue(healthIssueID)
+		require.NotNil(t, issue)
+		t.Logf("Description: %s", issue.Description)
+		for _, s := range issue.Remediation.Steps {
+			t.Logf("Step %d: %s", s.Order, s.Text)
+		}
+		require.NotEmpty(t, issue.Remediation.Steps)
+		assert.Contains(t, issue.Remediation.Steps[0].Text, saUsername)
+		assert.Contains(t, issue.Remediation.Steps[0].Text, `"create"`)
+		assert.Contains(t, issue.Remediation.Steps[0].Text, "secrets")
+	})
+}
+
+func impersonatedClient(t *testing.T, base *rest.Config, username string) kubernetes.Interface {
+	cfg := rest.CopyConfig(base)
+	cfg.Impersonate = rest.ImpersonationConfig{
+		UserName: username,
+		Groups:   []string{"system:serviceaccounts", "system:serviceaccounts:test-probe-ns", "system:authenticated"},
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	require.NoError(t, err)
+	return client
+}
+
+func revokeAllRBAC(ctx context.Context, t *testing.T, client kubernetes.Interface) {
+	_ = client.RbacV1().RoleBindings("test-probe-ns").Delete(ctx, "datadog-cluster-agent-probe", metav1.DeleteOptions{})
+	_ = client.RbacV1().Roles("test-probe-ns").Delete(ctx, "datadog-cluster-agent-probe", metav1.DeleteOptions{})
+	_ = client.RbacV1().ClusterRoleBindings().Delete(ctx, "datadog-cluster-agent-probe-webhooks", metav1.DeleteOptions{})
+	_ = client.RbacV1().ClusterRoles().Delete(ctx, "datadog-cluster-agent-probe-webhooks", metav1.DeleteOptions{})
+	_ = client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, "datadog-webhook", metav1.DeleteOptions{})
+	waitForRBACPropagation(t)
+}
+
+func grantConfigMapCreate(ctx context.Context, t *testing.T, client kubernetes.Interface) {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-cluster-agent-probe", Namespace: "test-probe-ns"},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{""}, Resources: []string{"configmaps"}, Verbs: []string{"create"}},
+		},
+	}
+	_, err := client.RbacV1().Roles("test-probe-ns").Create(ctx, role, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-cluster-agent-probe", Namespace: "test-probe-ns"},
+		Subjects: []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: "datadog-cluster-agent", Namespace: "test-probe-ns"},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "datadog-cluster-agent-probe"},
+	}
+	_, err = client.RbacV1().RoleBindings("test-probe-ns").Create(ctx, binding, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	waitForRBACPropagation(t)
+}
+
+func createWebhookConfig(ctx context.Context, t *testing.T, client kubernetes.Interface) {
+	sideEffects := admissionregistrationv1.SideEffectClassNone
+	url := "https://127.0.0.1:8000/dummy"
+	_, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(ctx, &admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-webhook"},
+		Webhooks: []admissionregistrationv1.MutatingWebhook{
+			{
+				Name: "webhook.example.com",
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					URL: &url,
+				},
+				SideEffects:             &sideEffects,
+				AdmissionReviewVersions: []string{"v1"},
+			},
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func grantWebhookConfigGet(ctx context.Context, t *testing.T, client kubernetes.Interface) {
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-cluster-agent-probe-webhooks"},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{"admissionregistration.k8s.io"}, Resources: []string{"mutatingwebhookconfigurations", "validatingwebhookconfigurations"}, Verbs: []string{"get"}},
+		},
+	}
+	_, err := client.RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	binding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-cluster-agent-probe-webhooks"},
+		Subjects: []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: "datadog-cluster-agent", Namespace: "test-probe-ns"},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "datadog-cluster-agent-probe-webhooks"},
+	}
+	_, err = client.RbacV1().ClusterRoleBindings().Create(ctx, binding, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	waitForRBACPropagation(t)
+}
+
+func revokeWebhookConfigGet(ctx context.Context, t *testing.T, client kubernetes.Interface) {
+	require.NoError(t, client.RbacV1().ClusterRoleBindings().Delete(ctx, "datadog-cluster-agent-probe-webhooks", metav1.DeleteOptions{}))
+	require.NoError(t, client.RbacV1().ClusterRoles().Delete(ctx, "datadog-cluster-agent-probe-webhooks", metav1.DeleteOptions{}))
+	waitForRBACPropagation(t)
+}
+
+func waitForRBACPropagation(t *testing.T) {
+	t.Helper()
+	time.Sleep(2 * time.Second)
+}

--- a/pkg/clusteragent/admission/probe/probe.go
+++ b/pkg/clusteragent/admission/probe/probe.go
@@ -248,10 +248,15 @@ func (p *Probe) handleError(ctx context.Context, err error) {
 			return
 		}
 
-		if p.logLimiter.ShouldLog() {
-			if existsErr != nil {
+		if existsErr != nil {
+			if p.logLimiter.ShouldLog() {
 				log.Warnf("Admission controller probe: could not determine whether the webhook configuration exists: %v", existsErr)
 			}
+			p.reportHealthIssue(fmt.Sprintf("Could not determine whether the admission webhook configuration exists: %v. The probe cannot rule out either a missing webhook or a network connectivity issue.", existsErr))
+			return
+		}
+
+		if p.logLimiter.ShouldLog() {
 			log.Errorf(
 				"Admission controller probe failed: the webhook did not handle the probe configmap. "+
 					"This indicates a network connectivity issue between the Kubernetes API server "+

--- a/pkg/clusteragent/admission/probe/probe.go
+++ b/pkg/clusteragent/admission/probe/probe.go
@@ -43,6 +43,10 @@ type Probe struct {
 	logLimiter     *log.Limit
 	diagnosticHint string
 
+	webhookName       string
+	mutationEnabled   bool
+	validationEnabled bool
+
 	healthPlatform healthplatformdef.Component
 
 	stats Stats
@@ -92,13 +96,16 @@ func New(k8sClient kubernetes.Interface, isLeaderFunc func() bool, namespace str
 	}
 
 	return &Probe{
-		k8sClient:      k8sClient,
-		isLeaderFunc:   isLeaderFunc,
-		namespace:      namespace,
-		interval:       interval,
-		gracePeriod:    time.Duration(datadogConfig.GetInt("admission_controller.probe.grace_period")) * time.Second,
-		logLimiter:     log.NewLogLimit(1, 10*time.Minute),
-		healthPlatform: healthPlatform,
+		k8sClient:         k8sClient,
+		isLeaderFunc:      isLeaderFunc,
+		namespace:         namespace,
+		interval:          interval,
+		gracePeriod:       time.Duration(datadogConfig.GetInt("admission_controller.probe.grace_period")) * time.Second,
+		logLimiter:        log.NewLogLimit(1, 10*time.Minute),
+		healthPlatform:    healthPlatform,
+		webhookName:       datadogConfig.GetString("admission_controller.webhook_name"),
+		mutationEnabled:   datadogConfig.GetBool("admission_controller.mutation.enabled"),
+		validationEnabled: datadogConfig.GetBool("admission_controller.validation.enabled"),
 	}
 }
 
@@ -215,10 +222,10 @@ func (p *Probe) runProbe(ctx context.Context) {
 		return
 	}
 
-	p.handleError(err)
+	p.handleError(ctx, err)
 }
 
-func (p *Probe) handleError(err error) {
+func (p *Probe) handleError(ctx context.Context, err error) {
 	if k8serrors.IsForbidden(err) {
 		msg := fmt.Sprintf("The cluster agent service account does not have permission to create configmaps in namespace %q. Grant configmap creation RBAC to enable connectivity probing.", p.namespace)
 		p.stats.mu.Lock()
@@ -232,7 +239,19 @@ func (p *Probe) handleError(err error) {
 	}
 
 	if errors.Is(err, errProbeNotReceived) {
+		exists, existsErr := p.webhookExists(ctx)
+		if existsErr == nil && !exists {
+			if p.logLimiter.ShouldLog() {
+				log.Errorf("Admission controller probe failed: webhook configuration %q does not exist — it was never created, commonly because the certificate secret is missing or unreadable.", p.webhookName)
+			}
+			p.reportHealthIssue("The admission webhook configuration does not exist in the cluster; it was never created, commonly because the certificate secret is missing or unreadable.")
+			return
+		}
+
 		if p.logLimiter.ShouldLog() {
+			if existsErr != nil {
+				log.Warnf("Admission controller probe: could not determine whether the webhook configuration exists: %v", existsErr)
+			}
 			log.Errorf(
 				"Admission controller probe failed: the webhook did not handle the probe configmap. "+
 					"This indicates a network connectivity issue between the Kubernetes API server "+
@@ -240,20 +259,51 @@ func (p *Probe) handleError(err error) {
 				p.diagnosticHint,
 			)
 		}
-		p.reportHealthIssue()
+		p.reportHealthIssue("")
 		return
 	}
 
 	if p.logLimiter.ShouldLog() {
 		log.Errorf("Admission controller probe failed: %v", err)
 	}
-	p.reportHealthIssue()
+	p.reportHealthIssue("")
 }
 
-func (p *Probe) reportHealthIssue() {
-	issue, buildErr := (&admissionprobe.AdmissionProbeIssue{}).BuildIssue(map[string]string{
+// webhookExists reports whether the enabled webhook configuration objects
+// exist in the cluster. False+nil means confirmed missing; non-nil error
+// means existence could not be determined.
+func (p *Probe) webhookExists(ctx context.Context) (bool, error) {
+	if p.mutationEnabled {
+		_, err := admcommon.GetMutatingWebhookStatus(ctx, p.webhookName, p.k8sClient)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("checking mutating webhook configuration: %w", err)
+		}
+	}
+
+	if p.validationEnabled {
+		_, err := admcommon.GetValidatingWebhookStatus(ctx, p.webhookName, p.k8sClient)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("checking validating webhook configuration: %w", err)
+		}
+	}
+
+	return true, nil
+}
+
+func (p *Probe) reportHealthIssue(issueDescription string) {
+	context := map[string]string{
 		"remediation": p.diagnosticHint,
-	})
+	}
+	if issueDescription != "" {
+		context["issue"] = issueDescription
+	}
+	issue, buildErr := (&admissionprobe.AdmissionProbeIssue{}).BuildIssue(context)
 	if buildErr != nil {
 		issue = &healthplatformpayload.Issue{
 			Id:        healthIssueID,

--- a/pkg/clusteragent/admission/probe/probe.go
+++ b/pkg/clusteragent/admission/probe/probe.go
@@ -32,6 +32,12 @@ import (
 
 var errProbeNotReceived = errors.New("dry-run probe configmap was not annotated by the webhook")
 
+// reconcileStatusProvider reports the outcome of the most recent reconciliation
+// attempt of a controller. Implemented by the secret and webhook controllers.
+type reconcileStatusProvider interface {
+	LastReconcileError() error
+}
+
 // Probe periodically verifies that the admission webhook is reachable by
 // creating dry-run ConfigMaps and checking if they are handled by the webhook.
 type Probe struct {
@@ -46,6 +52,9 @@ type Probe struct {
 	webhookName       string
 	mutationEnabled   bool
 	validationEnabled bool
+
+	secretController  reconcileStatusProvider
+	webhookController reconcileStatusProvider
 
 	healthPlatform healthplatformdef.Component
 
@@ -88,7 +97,7 @@ const (
 // New creates a new admission controller connectivity probe.
 // The namespace parameter specifies where dry-run ConfigMaps are created; this
 // should be the namespace the cluster agent is deployed in.
-func New(k8sClient kubernetes.Interface, isLeaderFunc func() bool, namespace string, datadogConfig config.Component, healthPlatform healthplatformdef.Component) *Probe {
+func New(k8sClient kubernetes.Interface, isLeaderFunc func() bool, namespace string, datadogConfig config.Component, healthPlatform healthplatformdef.Component, secretController, webhookController reconcileStatusProvider) *Probe {
 	interval := time.Duration(datadogConfig.GetInt("admission_controller.probe.interval")) * time.Second
 	if interval <= 0 {
 		log.Warnf("admission_controller.probe.interval is invalid (%s), falling back to %s", interval, defaultInterval)
@@ -106,6 +115,8 @@ func New(k8sClient kubernetes.Interface, isLeaderFunc func() bool, namespace str
 		webhookName:       datadogConfig.GetString("admission_controller.webhook_name"),
 		mutationEnabled:   datadogConfig.GetBool("admission_controller.mutation.enabled"),
 		validationEnabled: datadogConfig.GetBool("admission_controller.validation.enabled"),
+		secretController:  secretController,
+		webhookController: webhookController,
 	}
 }
 
@@ -227,24 +238,65 @@ func (p *Probe) runProbe(ctx context.Context) {
 
 func (p *Probe) handleError(ctx context.Context, err error) {
 	if k8serrors.IsForbidden(err) {
-		msg := fmt.Sprintf("The cluster agent service account does not have permission to create configmaps in namespace %q. Grant configmap creation RBAC to enable connectivity probing.", p.namespace)
+		wrappedErr := admcommon.WrapIfForbidden(err, "create", "configmaps", p.namespace, "")
+		msg := fmt.Sprintf("The cluster agent service account does not have permission to create configmaps in namespace %q: %v", p.namespace, wrappedErr)
 		p.stats.mu.Lock()
 		p.stats.ConfigError = msg
 		p.stats.mu.Unlock()
 		if p.logLimiter.ShouldLog() {
 			log.Errorf("Admission controller probe misconfigured: %s", msg)
 		}
-		p.clearHealthIssue()
+		fixHint := ""
+		if fix, ok := rbacFixHint(wrappedErr); ok {
+			fixHint = fix
+		}
+		p.reportHealthIssue(fmt.Sprintf("The cluster agent cannot verify admission webhook connectivity: %s. This does not mean the webhook itself is unreachable.", msg), admissionprobe.CauseProbeConfigForbidden, fixHint)
 		return
 	}
 
 	if errors.Is(err, errProbeNotReceived) {
+		if p.secretController != nil {
+			if scErr := p.secretController.LastReconcileError(); scErr != nil {
+				if p.logLimiter.ShouldLog() {
+					log.Errorf("Admission controller probe failed: the secret controller's last reconciliation attempt failed: %v", scErr)
+				}
+				cause := admissionprobe.CauseSecretControllerFailed
+				fixHint := ""
+				if fix, ok := rbacFixHint(scErr); ok {
+					cause = admissionprobe.CauseSecretControllerForbidden
+					fixHint = fix
+				} else if fix, ok := k8sErrorFixHint(scErr); ok {
+					fixHint = fix
+				}
+				p.reportHealthIssue(fmt.Sprintf("The cluster agent failed to create or refresh the TLS certificate Secret used by the admission webhook: %v", scErr), cause, fixHint)
+				return
+			}
+		}
+
+		if p.webhookController != nil {
+			if wcErr := p.webhookController.LastReconcileError(); wcErr != nil {
+				if p.logLimiter.ShouldLog() {
+					log.Errorf("Admission controller probe failed: the webhook controller's last reconciliation attempt failed: %v", wcErr)
+				}
+				cause := admissionprobe.CauseWebhookControllerFailed
+				fixHint := ""
+				if fix, ok := rbacFixHint(wcErr); ok {
+					cause = admissionprobe.CauseWebhookControllerForbidden
+					fixHint = fix
+				} else if fix, ok := k8sErrorFixHint(wcErr); ok {
+					fixHint = fix
+				}
+				p.reportHealthIssue(fmt.Sprintf("The cluster agent failed to register the admission webhook configuration with the Kubernetes API server: %v", wcErr), cause, fixHint)
+				return
+			}
+		}
+
 		exists, existsErr := p.webhookExists(ctx)
 		if existsErr == nil && !exists {
 			if p.logLimiter.ShouldLog() {
-				log.Errorf("Admission controller probe failed: webhook configuration %q does not exist — it was never created, commonly because the certificate secret is missing or unreadable.", p.webhookName)
+				log.Errorf("Admission controller probe failed: webhook configuration %q does not exist. The secret and webhook controllers report no reconciliation error, so it was most likely deleted after being created.", p.webhookName)
 			}
-			p.reportHealthIssue("The admission webhook configuration does not exist in the cluster; it was never created, commonly because the certificate secret is missing or unreadable.")
+			p.reportHealthIssue(fmt.Sprintf("The admission webhook configuration %q does not exist in the cluster. Both the secret controller and the webhook controller last reconciled successfully, so the object was most likely deleted after being created rather than never created.", p.webhookName), admissionprobe.CauseWebhookMissing, "")
 			return
 		}
 
@@ -252,7 +304,14 @@ func (p *Probe) handleError(ctx context.Context, err error) {
 			if p.logLimiter.ShouldLog() {
 				log.Warnf("Admission controller probe: could not determine whether the webhook configuration exists: %v", existsErr)
 			}
-			p.reportHealthIssue(fmt.Sprintf("Could not determine whether the admission webhook configuration exists: %v. The probe cannot rule out either a missing webhook or a network connectivity issue.", existsErr))
+			cause := admissionprobe.CauseIndeterminate
+			fixHint := ""
+			if fix, ok := rbacFixHint(existsErr); ok {
+				fixHint = fix
+			} else if fix, ok := k8sErrorFixHint(existsErr); ok {
+				fixHint = fix
+			}
+			p.reportHealthIssue(fmt.Sprintf("Could not determine whether the admission webhook configuration %q exists: %v.", p.webhookName, existsErr), cause, fixHint)
 			return
 		}
 
@@ -264,14 +323,58 @@ func (p *Probe) handleError(ctx context.Context, err error) {
 				p.diagnosticHint,
 			)
 		}
-		p.reportHealthIssue("")
+		p.reportHealthIssue("", "", "")
 		return
 	}
 
 	if p.logLimiter.ShouldLog() {
 		log.Errorf("Admission controller probe failed: %v", err)
 	}
-	p.reportHealthIssue("")
+	p.reportHealthIssue("", "", "")
+}
+
+// rbacFixHint reports the exact RBAC permission that was denied, if err
+// carries that information (see admcommon.RBACError). It returns ok=false
+// when err isn't an RBAC denial, so callers don't have to guess a cause.
+func rbacFixHint(err error) (fix string, ok bool) {
+	var rbacErr *admcommon.RBACError
+	if !errors.As(err, &rbacErr) {
+		return "", false
+	}
+	account := "the cluster agent's Kubernetes service account"
+	if rbacErr.Username != "" {
+		account = fmt.Sprintf("service account %q", rbacErr.Username)
+	}
+	if rbacErr.Namespace != "" {
+		return fmt.Sprintf("Grant %s %q permission on %s %q in namespace %q", account, rbacErr.Verb, rbacErr.Resource, rbacErr.Name, rbacErr.Namespace), true
+	}
+	return fmt.Sprintf("Grant %s %q permission on the cluster-scoped %s %q", account, rbacErr.Verb, rbacErr.Resource, rbacErr.Name), true
+}
+
+// k8sErrorFixHint classifies common Kubernetes API error conditions that
+// aren't RBAC denials, so the remediation can point at the specific
+// condition the API server reported instead of telling the user to go find
+// the error that's already in the issue description.
+func k8sErrorFixHint(err error) (fix string, ok bool) {
+	switch {
+	case k8serrors.IsTimeout(err) || k8serrors.IsServerTimeout(err):
+		return "The Kubernetes API server timed out handling the request; check network connectivity and API server load between the cluster agent and the control plane", true
+	case k8serrors.IsTooManyRequests(err):
+		return "The Kubernetes API server is rate-limiting the cluster agent's requests (429 Too Many Requests); check API server load", true
+	case k8serrors.IsServiceUnavailable(err):
+		return "The Kubernetes API server was unavailable (503); check API server health and cluster agent connectivity to the control plane", true
+	case k8serrors.IsConflict(err):
+		return "The request conflicted with a concurrent update to the same object; the controller retries automatically and this typically resolves on its own", true
+	case k8serrors.IsAlreadyExists(err):
+		return "The object already exists with content the controller doesn't manage; check for another process creating an object with the same name", true
+	case k8serrors.IsInvalid(err):
+		return "The Kubernetes API server rejected the object as invalid; see the validation error above for the specific field", true
+	case k8serrors.IsNotFound(err):
+		return "A dependent Kubernetes object was not found; verify the cluster agent's configured namespace and object names", true
+	case k8serrors.IsInternalError(err):
+		return "The Kubernetes API server returned an internal error (500); check the API server's own logs for the root cause", true
+	}
+	return "", false
 }
 
 // webhookExists reports whether the enabled webhook configuration objects
@@ -284,6 +387,7 @@ func (p *Probe) webhookExists(ctx context.Context) (bool, error) {
 			if k8serrors.IsNotFound(err) {
 				return false, nil
 			}
+			err = admcommon.WrapIfForbidden(err, "get", "mutatingwebhookconfigurations", "", p.webhookName)
 			return false, fmt.Errorf("checking mutating webhook configuration: %w", err)
 		}
 	}
@@ -294,6 +398,7 @@ func (p *Probe) webhookExists(ctx context.Context) (bool, error) {
 			if k8serrors.IsNotFound(err) {
 				return false, nil
 			}
+			err = admcommon.WrapIfForbidden(err, "get", "validatingwebhookconfigurations", "", p.webhookName)
 			return false, fmt.Errorf("checking validating webhook configuration: %w", err)
 		}
 	}
@@ -301,12 +406,18 @@ func (p *Probe) webhookExists(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (p *Probe) reportHealthIssue(issueDescription string) {
+func (p *Probe) reportHealthIssue(issueDescription, cause, fixHint string) {
 	context := map[string]string{
 		"remediation": p.diagnosticHint,
 	}
 	if issueDescription != "" {
 		context["issue"] = issueDescription
+	}
+	if cause != "" {
+		context["cause"] = cause
+	}
+	if fixHint != "" {
+		context["fix_hint"] = fixHint
 	}
 	issue, buildErr := (&admissionprobe.AdmissionProbeIssue{}).BuildIssue(context)
 	if buildErr != nil {

--- a/pkg/clusteragent/admission/probe/probe_test.go
+++ b/pkg/clusteragent/admission/probe/probe_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -311,4 +312,192 @@ func TestRunProbe_NoHealthReportWithoutPlatform(t *testing.T) {
 
 	snap := p.GetStatsSnapshot()
 	assert.Equal(t, int64(1), snap.FailCount)
+}
+
+// withRealWebhookStatusLookup points the package-level admcommon dispatch vars
+// at the real v1 implementations for the duration of the test, then restores
+// them, since they are shared global state.
+func withRealWebhookStatusLookup(t *testing.T) {
+	prevValidating := admcommon.GetValidatingWebhookStatus
+	prevMutating := admcommon.GetMutatingWebhookStatus
+	admcommon.GetValidatingWebhookStatus = admcommon.GetValidatingWebhookStatusV1
+	admcommon.GetMutatingWebhookStatus = admcommon.GetMutatingWebhookStatusV1
+	t.Cleanup(func() {
+		admcommon.GetValidatingWebhookStatus = prevValidating
+		admcommon.GetMutatingWebhookStatus = prevMutating
+	})
+}
+
+func TestWebhookExists_NeitherEnabled(t *testing.T) {
+	client := fakeclientset.NewSimpleClientset()
+	p := newTestProbe(client)
+	p.webhookName = "datadog-webhook"
+
+	exists, err := p.webhookExists(context.Background())
+	assert.NoError(t, err)
+	assert.True(t, exists, "with no webhook type enabled, existence can't be disproven")
+}
+
+func TestWebhookExists_MutatingConfigured(t *testing.T) {
+	withRealWebhookStatusLookup(t)
+
+	t.Run("exists", func(t *testing.T) {
+		client := fakeclientset.NewSimpleClientset(&admissionregistrationv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: "datadog-webhook"},
+		})
+		p := newTestProbe(client)
+		p.webhookName = "datadog-webhook"
+		p.mutationEnabled = true
+
+		exists, err := p.webhookExists(context.Background())
+		assert.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		client := fakeclientset.NewSimpleClientset()
+		p := newTestProbe(client)
+		p.webhookName = "datadog-webhook"
+		p.mutationEnabled = true
+
+		exists, err := p.webhookExists(context.Background())
+		assert.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("api error", func(t *testing.T) {
+		client := fakeclientset.NewSimpleClientset()
+		client.PrependReactor("get", "mutatingwebhookconfigurations", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "mutatingwebhookconfigurations"}, "datadog-webhook", errors.New("forbidden"))
+		})
+		p := newTestProbe(client)
+		p.webhookName = "datadog-webhook"
+		p.mutationEnabled = true
+
+		exists, err := p.webhookExists(context.Background())
+		require.Error(t, err)
+		assert.False(t, exists)
+	})
+}
+
+func TestWebhookExists_ValidatingConfigured(t *testing.T) {
+	withRealWebhookStatusLookup(t)
+
+	t.Run("exists", func(t *testing.T) {
+		client := fakeclientset.NewSimpleClientset(&admissionregistrationv1.ValidatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: "datadog-webhook"},
+		})
+		p := newTestProbe(client)
+		p.webhookName = "datadog-webhook"
+		p.validationEnabled = true
+
+		exists, err := p.webhookExists(context.Background())
+		assert.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		client := fakeclientset.NewSimpleClientset()
+		p := newTestProbe(client)
+		p.webhookName = "datadog-webhook"
+		p.validationEnabled = true
+
+		exists, err := p.webhookExists(context.Background())
+		assert.NoError(t, err)
+		assert.False(t, exists)
+	})
+}
+
+func TestWebhookExists_BothConfigured_MutatingMissingShortCircuits(t *testing.T) {
+	withRealWebhookStatusLookup(t)
+
+	// Only the ValidatingWebhookConfiguration exists; the mutating one is
+	// missing and should be reported first without needing to check validating.
+	client := fakeclientset.NewSimpleClientset(&admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-webhook"},
+	})
+	p := newTestProbe(client)
+	p.webhookName = "datadog-webhook"
+	p.mutationEnabled = true
+	p.validationEnabled = true
+
+	exists, err := p.webhookExists(context.Background())
+	assert.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestWebhookExists_BothConfigured_ValidatingMissing(t *testing.T) {
+	withRealWebhookStatusLookup(t)
+
+	// The mutating config exists but the validating one is missing; both must
+	// be checked, so this should still report false.
+	client := fakeclientset.NewSimpleClientset(&admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-webhook"},
+	})
+	p := newTestProbe(client)
+	p.webhookName = "datadog-webhook"
+	p.mutationEnabled = true
+	p.validationEnabled = true
+
+	exists, err := p.webhookExists(context.Background())
+	assert.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestRunProbe_ReportsWebhookMissingIssue(t *testing.T) {
+	withRealWebhookStatusLookup(t)
+
+	// No MutatingWebhookConfiguration exists, so the probe should diagnose
+	// this as "webhook was never created" rather than a network issue.
+	client := fakeclientset.NewSimpleClientset()
+	p, hp := newTestProbeWithHP(t, client)
+	p.webhookName = "datadog-webhook"
+	p.mutationEnabled = true
+
+	p.runProbe(context.Background())
+
+	issue := hp.GetIssue(healthIssueID)
+	require.NotNil(t, issue)
+	assert.Contains(t, issue.Description, "does not exist")
+}
+
+func TestRunProbe_ReportsNetworkIssueWhenWebhookConfirmedExists(t *testing.T) {
+	withRealWebhookStatusLookup(t)
+
+	// The MutatingWebhookConfiguration exists but the dry-run configmap was
+	// never annotated, so this should be diagnosed as a network/reachability
+	// issue rather than "webhook was never created".
+	client := fakeclientset.NewSimpleClientset(&admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-webhook"},
+	})
+	p, hp := newTestProbeWithHP(t, client)
+	p.webhookName = "datadog-webhook"
+	p.mutationEnabled = true
+
+	p.runProbe(context.Background())
+
+	issue := hp.GetIssue(healthIssueID)
+	require.NotNil(t, issue)
+	assert.NotContains(t, issue.Description, "does not exist")
+}
+
+func TestRunProbe_ReportsNetworkIssueWhenExistenceCheckErrors(t *testing.T) {
+	withRealWebhookStatusLookup(t)
+
+	// If webhookExists itself can't determine an answer (e.g. RBAC denies the
+	// lookup), the probe should still report the generic network-issue
+	// diagnosis rather than silently swallowing the failure.
+	client := fakeclientset.NewSimpleClientset()
+	client.PrependReactor("get", "mutatingwebhookconfigurations", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "mutatingwebhookconfigurations"}, "datadog-webhook", errors.New("forbidden"))
+	})
+	p, hp := newTestProbeWithHP(t, client)
+	p.webhookName = "datadog-webhook"
+	p.mutationEnabled = true
+
+	p.runProbe(context.Background())
+
+	issue := hp.GetIssue(healthIssueID)
+	require.NotNil(t, issue)
+	assert.NotContains(t, issue.Description, "does not exist")
 }

--- a/pkg/clusteragent/admission/probe/probe_test.go
+++ b/pkg/clusteragent/admission/probe/probe_test.go
@@ -481,12 +481,13 @@ func TestRunProbe_ReportsNetworkIssueWhenWebhookConfirmedExists(t *testing.T) {
 	assert.NotContains(t, issue.Description, "does not exist")
 }
 
-func TestRunProbe_ReportsNetworkIssueWhenExistenceCheckErrors(t *testing.T) {
+func TestRunProbe_ReportsUnknownIssueWhenExistenceCheckErrors(t *testing.T) {
 	withRealWebhookStatusLookup(t)
 
 	// If webhookExists itself can't determine an answer (e.g. RBAC denies the
-	// lookup), the probe should still report the generic network-issue
-	// diagnosis rather than silently swallowing the failure.
+	// lookup), the probe can't rule out either a missing webhook or a network
+	// issue, so it should report a distinct "could not determine" diagnosis
+	// rather than claiming either one.
 	client := fakeclientset.NewSimpleClientset()
 	client.PrependReactor("get", "mutatingwebhookconfigurations", func(_ k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "mutatingwebhookconfigurations"}, "datadog-webhook", errors.New("forbidden"))
@@ -500,4 +501,5 @@ func TestRunProbe_ReportsNetworkIssueWhenExistenceCheckErrors(t *testing.T) {
 	issue := hp.GetIssue(healthIssueID)
 	require.NotNil(t, issue)
 	assert.NotContains(t, issue.Description, "does not exist")
+	assert.Contains(t, issue.Description, "Could not determine whether")
 }

--- a/pkg/clusteragent/admission/probe/probe_test.go
+++ b/pkg/clusteragent/admission/probe/probe_test.go
@@ -182,6 +182,28 @@ func TestRunProbe_StatsOnForbidden(t *testing.T) {
 	assert.Contains(t, snap.ConfigError, "does not have permission")
 }
 
+func TestRunProbe_ReportsHealthIssueOnConfigMapForbidden(t *testing.T) {
+	// Even though the probe can't tell whether the webhook itself is
+	// reachable, the RBAC denial on its own dry-run ConfigMap is a known,
+	// actionable cause and should be reported as a health issue rather than
+	// silently cleared.
+	client := fakeclientset.NewSimpleClientset()
+	client.PrependReactor("create", "configmaps", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		underlying := errors.New(`User "system:serviceaccount:test-probe-ns:datadog-cluster-agent" cannot create resource "configmaps" in API group "" in the namespace "test-probe-ns"`)
+		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "", underlying)
+	})
+
+	p, hp := newTestProbeWithHP(t, client)
+	p.runProbe(context.Background())
+
+	issue := hp.GetIssue(healthIssueID)
+	require.NotNil(t, issue)
+	assert.Contains(t, issue.Description, "does not have permission to create configmaps")
+	assert.Contains(t, issue.Description, "does not mean the webhook itself is unreachable")
+	require.NotEmpty(t, issue.Remediation.Steps)
+	assert.Equal(t, `Grant service account "system:serviceaccount:test-probe-ns:datadog-cluster-agent" "create" permission on configmaps "" in namespace "test-probe-ns"`, issue.Remediation.Steps[0].Text)
+}
+
 func TestRunProbe_ConfigErrorClearedOnSuccess(t *testing.T) {
 	client := fakeclientset.NewSimpleClientset()
 	client.PrependReactor("create", "configmaps", func(_ k8stesting.Action) (bool, runtime.Object, error) {
@@ -263,18 +285,6 @@ func TestRunProbe_ReportsHealthIssueOnConnectivityFailure(t *testing.T) {
 
 	issue := hp.GetIssue(healthIssueID)
 	require.NotNil(t, issue, "expected a health issue to be reported on connectivity failure")
-}
-
-func TestRunProbe_NoHealthIssueOnForbidden(t *testing.T) {
-	client := fakeclientset.NewSimpleClientset()
-	client.PrependReactor("create", "configmaps", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "", errors.New("forbidden"))
-	})
-
-	p, hp := newTestProbeWithHP(t, client)
-	p.runProbe(context.Background())
-
-	assert.Nil(t, hp.GetIssue(healthIssueID), "forbidden errors should not report health issues")
 }
 
 func TestRunProbe_ClearsHealthIssueOnSuccess(t *testing.T) {
@@ -458,7 +468,8 @@ func TestRunProbe_ReportsWebhookMissingIssue(t *testing.T) {
 
 	issue := hp.GetIssue(healthIssueID)
 	require.NotNil(t, issue)
-	assert.Contains(t, issue.Description, "does not exist")
+	assert.Contains(t, issue.Description, `"datadog-webhook" does not exist`)
+	assert.Contains(t, issue.Description, "deleted after being created")
 }
 
 func TestRunProbe_ReportsNetworkIssueWhenWebhookConfirmedExists(t *testing.T) {
@@ -484,13 +495,15 @@ func TestRunProbe_ReportsNetworkIssueWhenWebhookConfirmedExists(t *testing.T) {
 func TestRunProbe_ReportsUnknownIssueWhenExistenceCheckErrors(t *testing.T) {
 	withRealWebhookStatusLookup(t)
 
-	// If webhookExists itself can't determine an answer (e.g. RBAC denies the
-	// lookup), the probe can't rule out either a missing webhook or a network
-	// issue, so it should report a distinct "could not determine" diagnosis
-	// rather than claiming either one.
+	// If webhookExists itself can't determine an answer because the lookup
+	// itself is RBAC-denied, the probe can't rule out either a missing
+	// webhook or a network issue — but since the denial is right there in the
+	// error, the remediation should state the exact permission to grant
+	// instead of a generic "could not determine" checklist.
 	client := fakeclientset.NewSimpleClientset()
 	client.PrependReactor("get", "mutatingwebhookconfigurations", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "mutatingwebhookconfigurations"}, "datadog-webhook", errors.New("forbidden"))
+		underlying := errors.New(`User "system:serviceaccount:test-probe-ns:datadog-cluster-agent" cannot get resource "mutatingwebhookconfigurations" in API group "admissionregistration.k8s.io" at the cluster scope`)
+		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "mutatingwebhookconfigurations"}, "datadog-webhook", underlying)
 	})
 	p, hp := newTestProbeWithHP(t, client)
 	p.webhookName = "datadog-webhook"
@@ -502,4 +515,139 @@ func TestRunProbe_ReportsUnknownIssueWhenExistenceCheckErrors(t *testing.T) {
 	require.NotNil(t, issue)
 	assert.NotContains(t, issue.Description, "does not exist")
 	assert.Contains(t, issue.Description, "Could not determine whether")
+	require.NotEmpty(t, issue.Remediation.Steps)
+	assert.Equal(t, `Grant service account "system:serviceaccount:test-probe-ns:datadog-cluster-agent" "get" permission on the cluster-scoped mutatingwebhookconfigurations "datadog-webhook"`, issue.Remediation.Steps[0].Text)
+}
+
+// fakeReconcileStatusProvider is a minimal stand-in for the secret and
+// webhook controllers, letting tests simulate a reconciliation failure
+// without standing up a real controller.
+type fakeReconcileStatusProvider struct {
+	err error
+}
+
+func (f *fakeReconcileStatusProvider) LastReconcileError() error {
+	return f.err
+}
+
+func TestRunProbe_ReportsSecretControllerForbiddenFailure(t *testing.T) {
+	withRealWebhookStatusLookup(t)
+
+	// The webhook configuration exists (so the webhookExists fallback alone
+	// would diagnose a network issue), but the secret controller reports its
+	// own RBAC reconciliation error, which should take priority and produce
+	// a remediation step pointing directly at the RBAC fix — not a guess.
+	client := fakeclientset.NewSimpleClientset(&admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-webhook"},
+	})
+	p, hp := newTestProbeWithHP(t, client)
+	p.webhookName = "datadog-webhook"
+	p.mutationEnabled = true
+	underlying := errors.New(`User "system:serviceaccount:test-probe-ns:datadog-cluster-agent" cannot create resource "secrets" in API group "" in the namespace "test-probe-ns"`)
+	forbiddenErr := k8serrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "datadog-webhook-certificate", underlying)
+	wrappedErr := admcommon.WrapIfForbidden(forbiddenErr, "create", "secrets", testNamespace, "datadog-webhook-certificate")
+	p.secretController = &fakeReconcileStatusProvider{err: wrappedErr}
+
+	p.runProbe(context.Background())
+
+	issue := hp.GetIssue(healthIssueID)
+	require.NotNil(t, issue)
+	assert.Contains(t, issue.Description, "TLS certificate Secret")
+	assert.Contains(t, issue.Description, "forbidden")
+	require.NotEmpty(t, issue.Remediation.Steps)
+	assert.Equal(t, `Grant service account "system:serviceaccount:test-probe-ns:datadog-cluster-agent" "create" permission on secrets "datadog-webhook-certificate" in namespace "test-probe-ns"`, issue.Remediation.Steps[0].Text)
+}
+
+func TestRunProbe_ReportsSecretControllerNonRBACFailure(t *testing.T) {
+	withRealWebhookStatusLookup(t)
+
+	// When the secret controller's error is not an RBAC denial, the
+	// remediation must not guess that RBAC is the cause.
+	client := fakeclientset.NewSimpleClientset(&admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-webhook"},
+	})
+	p, hp := newTestProbeWithHP(t, client)
+	p.webhookName = "datadog-webhook"
+	p.mutationEnabled = true
+	p.secretController = &fakeReconcileStatusProvider{err: errors.New("connection refused")}
+
+	p.runProbe(context.Background())
+
+	issue := hp.GetIssue(healthIssueID)
+	require.NotNil(t, issue)
+	assert.Contains(t, issue.Description, "TLS certificate Secret")
+	for _, step := range issue.Remediation.Steps {
+		assert.NotContains(t, step.Text, "RBAC", "should not guess RBAC when the error isn't a Forbidden error")
+	}
+}
+
+func TestRunProbe_ReportsWebhookControllerForbiddenFailure(t *testing.T) {
+	withRealWebhookStatusLookup(t)
+
+	// The webhook configuration exists and the secret controller is healthy,
+	// but the webhook controller itself reports an RBAC reconciliation
+	// error, which should take priority over the generic network diagnosis.
+	client := fakeclientset.NewSimpleClientset(&admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-webhook"},
+	})
+	p, hp := newTestProbeWithHP(t, client)
+	p.webhookName = "datadog-webhook"
+	p.mutationEnabled = true
+	p.secretController = &fakeReconcileStatusProvider{err: nil}
+	underlying := errors.New(`User "system:serviceaccount:test-probe-ns:datadog-cluster-agent" cannot create resource "mutatingwebhookconfigurations" in API group "admissionregistration.k8s.io" at the cluster scope`)
+	forbiddenErr := k8serrors.NewForbidden(schema.GroupResource{Resource: "mutatingwebhookconfigurations"}, "datadog-webhook", underlying)
+	wrappedErr := admcommon.WrapIfForbidden(forbiddenErr, "create", "mutatingwebhookconfigurations", "", "datadog-webhook")
+	p.webhookController = &fakeReconcileStatusProvider{err: wrappedErr}
+
+	p.runProbe(context.Background())
+
+	issue := hp.GetIssue(healthIssueID)
+	require.NotNil(t, issue)
+	assert.Contains(t, issue.Description, "register the admission webhook configuration")
+	assert.Contains(t, issue.Description, "forbidden")
+	require.NotEmpty(t, issue.Remediation.Steps)
+	assert.Equal(t, `Grant service account "system:serviceaccount:test-probe-ns:datadog-cluster-agent" "create" permission on the cluster-scoped mutatingwebhookconfigurations "datadog-webhook"`, issue.Remediation.Steps[0].Text)
+}
+
+func TestRunProbe_SecretControllerFailureTakesPriorityOverWebhookMissing(t *testing.T) {
+	withRealWebhookStatusLookup(t)
+
+	// The webhook configuration doesn't exist yet, which alone would be
+	// diagnosed as "webhook missing" — but since that's commonly caused by
+	// the certificate secret never getting created, a live secret controller
+	// error is a more specific and more useful diagnosis to surface first.
+	client := fakeclientset.NewSimpleClientset()
+	p, hp := newTestProbeWithHP(t, client)
+	p.webhookName = "datadog-webhook"
+	p.mutationEnabled = true
+	forbiddenErr := k8serrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "datadog-webhook-certificate", errors.New("forbidden"))
+	wrappedErr := admcommon.WrapIfForbidden(forbiddenErr, "create", "secrets", testNamespace, "datadog-webhook-certificate")
+	p.secretController = &fakeReconcileStatusProvider{err: wrappedErr}
+
+	p.runProbe(context.Background())
+
+	issue := hp.GetIssue(healthIssueID)
+	require.NotNil(t, issue)
+	assert.Contains(t, issue.Description, "TLS certificate Secret")
+	assert.NotContains(t, issue.Description, "does not exist")
+}
+
+func TestRunProbe_NilControllersFallBackToWebhookExistsCheck(t *testing.T) {
+	withRealWebhookStatusLookup(t)
+
+	// With no controllers wired in (the zero-value case for probes built via
+	// struct literal, as in newTestProbe), the probe must still fall back to
+	// the pre-existing webhookExists-based diagnosis rather than panicking.
+	client := fakeclientset.NewSimpleClientset()
+	p, hp := newTestProbeWithHP(t, client)
+	p.webhookName = "datadog-webhook"
+	p.mutationEnabled = true
+
+	assert.NotPanics(t, func() {
+		p.runProbe(context.Background())
+	})
+
+	issue := hp.GetIssue(healthIssueID)
+	require.NotNil(t, issue)
+	assert.Contains(t, issue.Description, "does not exist")
 }

--- a/pkg/clusteragent/admission/start.go
+++ b/pkg/clusteragent/admission/start.go
@@ -17,6 +17,7 @@ import (
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
+	admcommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/secret"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection"
@@ -132,13 +133,13 @@ func StartControllers(ctx ControllerContext, datadogConfig config.Component, wme
 	if v1Enabled {
 		informers[apiserver.ValidatingWebhooksInformer] = ctx.ValidatingInformers.Admissionregistration().V1().ValidatingWebhookConfigurations().Informer()
 		informers[apiserver.MutatingWebhooksInformer] = ctx.MutatingInformers.Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
-		getValidatingWebhookStatus = getValidatingWebhookStatusV1
-		getMutatingWebhookStatus = getMutatingWebhookStatusV1
+		admcommon.GetValidatingWebhookStatus = admcommon.GetValidatingWebhookStatusV1
+		admcommon.GetMutatingWebhookStatus = admcommon.GetMutatingWebhookStatusV1
 	} else {
 		informers[apiserver.ValidatingWebhooksInformer] = ctx.ValidatingInformers.Admissionregistration().V1beta1().ValidatingWebhookConfigurations().Informer()
 		informers[apiserver.MutatingWebhooksInformer] = ctx.MutatingInformers.Admissionregistration().V1beta1().MutatingWebhookConfigurations().Informer()
-		getValidatingWebhookStatus = getValidatingWebhookStatusV1beta1
-		getMutatingWebhookStatus = getMutatingWebhookStatusV1beta1
+		admcommon.GetValidatingWebhookStatus = admcommon.GetValidatingWebhookStatusV1beta1
+		admcommon.GetMutatingWebhookStatus = admcommon.GetMutatingWebhookStatusV1beta1
 	}
 
 	webhooks = append(webhooks, webhookController.EnabledWebhooks()...)

--- a/pkg/clusteragent/admission/start.go
+++ b/pkg/clusteragent/admission/start.go
@@ -145,7 +145,7 @@ func StartControllers(ctx ControllerContext, datadogConfig config.Component, wme
 	webhooks = append(webhooks, webhookController.EnabledWebhooks()...)
 
 	if datadogConfig.GetBool("admission_controller.probe.enabled") {
-		admissionProbe := admprobe.New(ctx.Client, isLeaderFunc, namespace.GetResourcesNamespace(), datadogConfig, healthPlatform)
+		admissionProbe := admprobe.New(ctx.Client, isLeaderFunc, namespace.GetResourcesNamespace(), datadogConfig, healthPlatform, secretController, webhookController)
 		setProbe(admissionProbe)
 		probeCtx, probeCancel := context.WithCancel(context.Background())
 		go func() {

--- a/pkg/clusteragent/admission/status.go
+++ b/pkg/clusteragent/admission/status.go
@@ -10,14 +10,11 @@ package admission
 import (
 	"context"
 	"embed"
-	"errors"
-	"fmt"
-	"hash/fnv"
 	"io"
-	"strconv"
 	"sync/atomic"
 
 	"github.com/DataDog/datadog-agent/comp/core/status"
+	admcommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	admprobe "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/probe"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -35,14 +32,9 @@ func setProbe(p *admprobe.Probe) {
 	currentProbe.Store(p)
 }
 
-// getProbeStatus builds the complete probe status map for the agent status
-// output.
-//
-// The returned map always contains "Enabled" (bool). Depending on the state,
-// it also contains exactly one of:
-//   - "Error"    (string) — runtime config error (e.g. missing RBAC)
-//   - "Detail"   (string) — informational message (follower, not yet started)
-//   - "HasStats" (bool)   — execution stats are present
+// getProbeStatus builds the probe status map for the agent status output.
+// Always contains "Enabled"; also contains one of "Error", "Detail", or "HasStats"
+// depending on state.
 func getProbeStatus() map[string]interface{} {
 	result := map[string]interface{}{}
 
@@ -90,184 +82,34 @@ func GetStatus(apiCl kubernetes.Interface) map[string]interface{} {
 	status["WebhookName"] = webhookName
 	status["SecretName"] = ns + "/" + secretName
 
-	validatingWebhookStatus, err := getValidatingWebhookStatus(webhookName, apiCl)
-	if err != nil {
-		status["ValidatingWebhookError"] = err.Error()
+	validatingWebhookStatus, validatingErr := admcommon.GetValidatingWebhookStatus(context.TODO(), webhookName, apiCl)
+	if validatingErr != nil {
+		status["ValidatingWebhookError"] = validatingErr.Error()
 	} else {
 		status["ValidatingWebhooks"] = validatingWebhookStatus
 	}
 
-	mutatingWebhookStatus, err := getMutatingWebhookStatus(webhookName, apiCl)
-	if err != nil {
-		status["MutatingWebhookError"] = err.Error()
+	mutatingWebhookStatus, mutatingErr := admcommon.GetMutatingWebhookStatus(context.TODO(), webhookName, apiCl)
+	if mutatingErr != nil {
+		status["MutatingWebhookError"] = mutatingErr.Error()
 	} else {
 		status["MutatingWebhooks"] = mutatingWebhookStatus
 	}
 
-	secretStatus, err := getSecretStatus(ns, secretName, apiCl)
-	if err != nil {
-		status["SecretError"] = err.Error()
+	secretStatus, secretErr := getSecretStatus(ns, secretName, apiCl)
+	if secretErr != nil {
+		status["SecretError"] = secretErr.Error()
 	} else {
 		status["Secret"] = secretStatus
 	}
 
+	// Running summarizes whether the enabled webhook types are registered with the API server.
+	validationDown := validatingErr != nil && pkgconfigsetup.Datadog().GetBool("admission_controller.validation.enabled")
+	mutationDown := mutatingErr != nil && pkgconfigsetup.Datadog().GetBool("admission_controller.mutation.enabled")
+	status["Running"] = !validationDown && !mutationDown && secretErr == nil
 	status["Probe"] = getProbeStatus()
 
 	return status
-}
-
-var getValidatingWebhookStatus = func(string, kubernetes.Interface) (map[string]interface{}, error) {
-	return nil, errors.New("admission controller not started")
-}
-
-var getMutatingWebhookStatus = func(string, kubernetes.Interface) (map[string]interface{}, error) {
-	return nil, errors.New("admission controller not started")
-}
-
-func getValidatingWebhookStatusV1(name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
-	validatingWebhookStatus := make(map[string]interface{})
-	validatingWebhook, err := apiCl.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		return validatingWebhookStatus, err
-	}
-
-	validatingWebhookStatus["Name"] = validatingWebhook.GetName()
-	validatingWebhookStatus["CreatedAt"] = validatingWebhook.GetCreationTimestamp()
-	validatingWebhooksConfig := make(map[string]map[string]interface{})
-	validatingWebhookStatus["Webhooks"] = validatingWebhooksConfig
-	for _, w := range validatingWebhook.Webhooks {
-		validatingWebhooksConfig[w.Name] = make(map[string]interface{})
-		svc := w.ClientConfig.Service
-		if svc != nil {
-			port := "Port: None (default 443)"
-			path := "Path: None"
-			if svc.Port != nil {
-				port = fmt.Sprintf("Port: %d", *svc.Port)
-			}
-			if svc.Path != nil {
-				path = "Path: " + *svc.Path
-			}
-			validatingWebhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - %s - %s", svc.Namespace, svc.Name, port, path)
-		}
-		if w.ObjectSelector != nil {
-			validatingWebhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
-		}
-		for i, r := range w.Rules {
-			validatingWebhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
-		}
-		validatingWebhooksConfig[w.Name]["CA bundle digest"] = getDigest(w.ClientConfig.CABundle)
-	}
-
-	return validatingWebhookStatus, nil
-}
-
-func getValidatingWebhookStatusV1beta1(name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
-	validatingWebhookStatus := make(map[string]interface{})
-	validatingWebhook, err := apiCl.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		return validatingWebhookStatus, err
-	}
-
-	validatingWebhookStatus["Name"] = validatingWebhook.GetName()
-	validatingWebhookStatus["CreatedAt"] = validatingWebhook.GetCreationTimestamp()
-	validatingWebhooksConfig := make(map[string]map[string]interface{})
-	validatingWebhookStatus["Webhooks"] = validatingWebhooksConfig
-	for _, w := range validatingWebhook.Webhooks {
-		validatingWebhooksConfig[w.Name] = make(map[string]interface{})
-		svc := w.ClientConfig.Service
-		if svc != nil {
-			port := "Port: None (default 443)"
-			path := "Path: None"
-			if svc.Port != nil {
-				port = fmt.Sprintf("Port: %d", *svc.Port)
-			}
-			if svc.Path != nil {
-				path = "Path: " + *svc.Path
-			}
-			validatingWebhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - %s - %s", svc.Namespace, svc.Name, port, path)
-		}
-		if w.ObjectSelector != nil {
-			validatingWebhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
-		}
-		for i, r := range w.Rules {
-			validatingWebhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
-		}
-		validatingWebhooksConfig[w.Name]["CA bundle digest"] = getDigest(w.ClientConfig.CABundle)
-	}
-
-	return validatingWebhookStatus, nil
-}
-
-func getMutatingWebhookStatusV1(name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
-	mutatingWebhookStatus := make(map[string]interface{})
-	mutatingWebhook, err := apiCl.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		return mutatingWebhookStatus, err
-	}
-
-	mutatingWebhookStatus["Name"] = mutatingWebhook.GetName()
-	mutatingWebhookStatus["CreatedAt"] = mutatingWebhook.GetCreationTimestamp()
-	mutatingWebhooksConfig := make(map[string]map[string]interface{})
-	mutatingWebhookStatus["Webhooks"] = mutatingWebhooksConfig
-	for _, w := range mutatingWebhook.Webhooks {
-		mutatingWebhooksConfig[w.Name] = make(map[string]interface{})
-		svc := w.ClientConfig.Service
-		if svc != nil {
-			port := "Port: None (default 443)"
-			path := "Path: None"
-			if svc.Port != nil {
-				port = fmt.Sprintf("Port: %d", *svc.Port)
-			}
-			if svc.Path != nil {
-				path = "Path: " + *svc.Path
-			}
-			mutatingWebhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - %s - %s", svc.Namespace, svc.Name, port, path)
-		}
-		if w.ObjectSelector != nil {
-			mutatingWebhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
-		}
-		for i, r := range w.Rules {
-			mutatingWebhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
-		}
-		mutatingWebhooksConfig[w.Name]["CA bundle digest"] = getDigest(w.ClientConfig.CABundle)
-	}
-	return mutatingWebhookStatus, nil
-}
-
-func getMutatingWebhookStatusV1beta1(name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
-	mutatingWebhookStatus := make(map[string]interface{})
-	mutatingWebhook, err := apiCl.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		return mutatingWebhookStatus, err
-	}
-
-	mutatingWebhookStatus["Name"] = mutatingWebhook.GetName()
-	mutatingWebhookStatus["CreatedAt"] = mutatingWebhook.GetCreationTimestamp()
-	mutatingWebhooksConfig := make(map[string]map[string]interface{})
-	mutatingWebhookStatus["Webhooks"] = mutatingWebhooksConfig
-	for _, w := range mutatingWebhook.Webhooks {
-		mutatingWebhooksConfig[w.Name] = make(map[string]interface{})
-		svc := w.ClientConfig.Service
-		if svc != nil {
-			port := "Port: None (default 443)"
-			path := "Path: None"
-			if svc.Port != nil {
-				port = fmt.Sprintf("Port: %d", *svc.Port)
-			}
-			if svc.Path != nil {
-				path = "Path: " + *svc.Path
-			}
-			mutatingWebhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - %s - %s", svc.Namespace, svc.Name, port, path)
-		}
-		if w.ObjectSelector != nil {
-			mutatingWebhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
-		}
-		for i, r := range w.Rules {
-			mutatingWebhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
-		}
-		mutatingWebhooksConfig[w.Name]["CA bundle digest"] = getDigest(w.ClientConfig.CABundle)
-	}
-	return mutatingWebhookStatus, nil
 }
 
 func getSecretStatus(ns, name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
@@ -279,7 +121,7 @@ func getSecretStatus(ns, name string, apiCl kubernetes.Interface) (map[string]in
 	secretStatus["Name"] = secret.GetName()
 	secretStatus["Namespace"] = secret.GetNamespace()
 	secretStatus["CreatedAt"] = secret.GetCreationTimestamp()
-	secretStatus["CABundleDigest"] = getDigest(secret.Data["cert.pem"])
+	secretStatus["CABundleDigest"] = admcommon.Digest(secret.Data["cert.pem"])
 	cert, err := certificate.GetCertFromSecret(secret.Data)
 	if err != nil {
 		log.Errorf("Cannot get certificate from secret: %v", err)
@@ -287,12 +129,6 @@ func getSecretStatus(ns, name string, apiCl kubernetes.Interface) (map[string]in
 	t := certificate.GetDurationBeforeExpiration(cert)
 	secretStatus["CertValidDuration"] = t.String()
 	return secretStatus, nil
-}
-
-func getDigest(b []byte) string {
-	h := fnv.New64()
-	_, _ = h.Write(b)
-	return strconv.FormatUint(h.Sum64(), 16)
 }
 
 // Provider provides the functionality to populate the status output

--- a/pkg/clusteragent/admission/status_templates/admissionwebhook.tmpl
+++ b/pkg/clusteragent/admission/status_templates/admissionwebhook.tmpl
@@ -6,6 +6,7 @@
   {{ else }}
     Webhooks info
     -------------
+    Webhook running: {{ if .admissionWebhook.Running }}true{{ else }}false{{ end }}
     {{ if .admissionWebhook.ValidatingWebhookError }}
       ValidatingWebhookConfigurations name: {{ .admissionWebhook.WebhookName }}
       Error: {{ .admissionWebhook.ValidatingWebhookError }}

--- a/releasenotes-dca/notes/admission-webhook-probe-diagnosis-b72c7c5cb1b454f0.yaml
+++ b/releasenotes-dca/notes/admission-webhook-probe-diagnosis-b72c7c5cb1b454f0.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    The admission controller connectivity probe now distinguishes between the admission
+    webhook configuration not existing in the cluster (commonly caused by a missing or
+    unreadable certificate secret) and a network connectivity issue between the Kubernetes
+    API server and the Cluster Agent. Each case now surfaces its own targeted diagnostic
+    message and remediation steps in the Cluster Agent logs and health reporting.


### PR DESCRIPTION
### What does this PR do?

The DCA connectivity probe treated a missing admission webhook configuration (usually caused by an unavailable certificate secret) the same as a generic network connectivity failure between the API server and cluster agent — same log message, same health issue, same remediation steps. Now the probe checks whether the webhook configuration actually exists before reporting, and surfaces a distinct log line, health issue description, and remediation guidance for each case (webhook confirmed missing vs. existence check itself failed vs. generic network issue). Also adds a "Webhook running" line to `datadog-cluster-agent status` output, and pulls the webhook-status lookup code into a new `pkg/clusteragent/admission/common` package (previously private functions in `status.go`) so the probe can reuse it.

### Motivation

Fixes [CONTP-2026](https://datadoghq.atlassian.net/browse/CONTP-2026): today, when the webhook was never created (commonly due to a missing/unreadable cert secret), the health report and logs pointed users at network troubleshooting steps that don't apply, obscuring the real cause.

### Describe how you validated your changes

Added unit tests for the new `common` package and updated probe/health-issue tests. Manually verified all three failure states live on a local kind cluster: webhook confirmed missing, webhook existence check itself failing (RBAC forbidden), and a generic network/dry-run connectivity failure — confirmed correct log lines and health issue descriptions for each.

Ran `codex review` against main, which caught a missing Bazel BUILD update and a log rate-limiter bug where two `ShouldLog()` calls in the same code path could suppress the primary failure log; fixed both.

[CONTP-2026]: https://datadoghq.atlassian.net/browse/CONTP-2026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ