### PR TITLE
Set OTLP span-name overrides on the core agent container

### DIFF
--- a/test/new-e2e/tests/otel/otlp-ingest/operation_and_resource_name_logic_v2_test.go
+++ b/test/new-e2e/tests/otel/otlp-ingest/operation_and_resource_name_logic_v2_test.go
@@ -108,7 +108,7 @@ datadog:
     containerCollectUsingFiles: false
 agents:
   containers:
-    traceAgent:
+    agent:
       env:
         - name: DD_OTLP_CONFIG_TRACES_SPAN_NAME_AS_RESOURCE_NAME
           value: 'true'
@@ -150,7 +150,7 @@ datadog:
     containerCollectUsingFiles: false
 agents:
   containers:
-    traceAgent:
+    agent:
       env:
         - name: DD_OTLP_CONFIG_TRACES_SPAN_NAME_REMAPPINGS
           value: '{"calendar-rest-go.client":"mapping.output","go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.server":"calendar.server"}'


### PR DESCRIPTION
### What does this PR do?

Moves `DD_OTLP_CONFIG_TRACES_SPAN_NAME_AS_RESOURCE_NAME` and `DD_OTLP_CONFIG_TRACES_SPAN_NAME_REMAPPINGS` from the `traceAgent` container to the `agent` container in two OTLP ingest tests.

### Motivation

#55817 enabled config streaming by default. The consumer drops the local env layer, so trace-agent-scoped `DD_*` vars no longer take effect — both tests saw v1 operation names instead of the overrides, and auto-revert #55851 was generated. The core agent holds these keys and streams them down, so setting them there works.

### Describe how you validated your changes

Linter passes; the behavior itself is verified by `new-e2e-otel` in CI.
