### PR TITLE
Partial Revert "default CNM direct send to true"

### DIFF
--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -620,7 +620,9 @@ properties:
       direct_send:
         node_type: setting
         type: boolean
-        default: false
+        platform_default:
+          linux: true
+          other: false
       dns_recorded_query_types:
         node_type: setting
         type: array

--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -620,10 +620,7 @@ properties:
       direct_send:
         node_type: setting
         type: boolean
-        platform_default:
-          linux: true
-          windows: true
-          other: false
+        default: false
       dns_recorded_query_types:
         node_type: setting
         type: array

--- a/releasenotes/notes/sysprobe-direct-send-default-ceb993833bec3b26.yaml
+++ b/releasenotes/notes/sysprobe-direct-send-default-ceb993833bec3b26.yaml
@@ -1,7 +1,0 @@
----
-enhancements:
-  - |
-    Send CNM/USM data directly to Datadog from system-probe on Linux and Windows.
-    This eliminates the need to run process-agent in certain configurations.
-    Customers with tight memory limits on system-probe may need to increase
-    the limit by 50-100MiB, but an equal amount can be removed from the process-agent memory limit.


### PR DESCRIPTION
Reverts DataDog/datadog-agent#55844

On this PR windows USM tests started failing. They are clearly broken since then.
https://app.datadoghq.com/ci/ci-cd/explorer?query=ci_level%3Ajob%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40git.branch%3Amain%20%40ci.job.name%3A%22new-e2e-windows-usm%3A%20%5B--run%20TestWindowsUSMSuite%5D%22&agg_m=%40ci.job.name&agg_m_source=base&agg_t=cardinality&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&ci_cd_explorer_tab=pipelines&cipipeline_explorer_sort=time%2Cdesc&colorByAttr=meta%5B%27ci.stage.name%27%5D&cols=%40git.branch%2C%40ci.status%2Ctimestamp%2C%40ci.pipeline.name%2C%40ci.stage.name%2C%40ci.job.name%2C%40duration%2C%40ci.pipeline.id%2C%40git.repository.name&currentTab=trace&fromUser=false&graphType=flamegraph&index=cipipeline&mode=sliding&refresh_mode=sliding&sort=time&spanViewType=metadata&step=86400000&tab=overview&viz=stream&start=1783306613958&end=1788490613958&paused=false

