### PR TITLE
tasks: explicitly assign cluster_agent tasks to container-platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -864,6 +864,8 @@
 /tasks/unit_tests/macos_tests.py                                @DataDog/windows-products
 /tasks/unit_tests/winbuild_tests.py                             @DataDog/windows-products
 /tasks/cluster_agent_cloudfoundry.py                            @DataDog/agent-integrations
+/tasks/cluster_agent.py                                         @DataDog/container-platform
+/tasks/cluster_agent_helpers.py                                 @DataDog/container-platform
 /tasks/devcontainer.py                                          @DataDog/agent-devx @DataDog/container-platform
 /tasks/skaffold.py                                              @DataDog/agent-devx @DataDog/container-platform
 /tasks/new_e2e_tests.py                                         @DataDog/agent-devx


### PR DESCRIPTION


<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Assign cluster-agent invoke tasks to container-platform

### Motivation

They are currently owned by agent-devx by default, which is inconsistent with the rest of the cluster-agent files

### Describe how you validated your changes

### Additional Notes
