### PR TITLE
assign datadog-agent packaging related BUILD.bazel to agent-build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1066,3 +1066,10 @@
 # Temporary during Bazel migration
 # This needs to go after all other rules that may include BUILD.bazel files, it otherwise gets overridden
 /**/*.bzl       @DataDog/agent-build
+
+# Packaging rules (which files go into which package) for the main agent binary, owned by agent-build.
+# Must stay last for the same reason as the /**/*.bzl rule above.
+/cmd/agent/dist/BUILD.bazel        @DataDog/agent-build
+/cmd/agent/dist/checks/BUILD.bazel @DataDog/agent-build
+/cmd/agent/dist/conf.d/BUILD.bazel @DataDog/agent-build
+/cmd/agent/dist/utils/BUILD.bazel  @DataDog/agent-build

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1069,7 +1069,4 @@
 
 # Packaging rules (which files go into which package) for the main agent binary, owned by agent-build.
 # Must stay last for the same reason as the /**/*.bzl rule above.
-/cmd/agent/dist/BUILD.bazel        @DataDog/agent-build
-/cmd/agent/dist/checks/BUILD.bazel @DataDog/agent-build
-/cmd/agent/dist/conf.d/BUILD.bazel @DataDog/agent-build
-/cmd/agent/dist/utils/BUILD.bazel  @DataDog/agent-build
+/cmd/agent/dist/**/BUILD.bazel     @DataDog/agent-build


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Assign ownership of packaging related BUILD.bazel files to agent-build

### Motivation

They are currently owned by Fleet Remediation, but it seems more logical for agent-build to own them

### Describe how you validated your changes

### Additional Notes
