### PR TITLE
[AXT] tasks: fix GPU metadata generation

### DIFF
--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -348,6 +348,7 @@ metrics:
   device.total:
     metadata:
       metric_type: gauge
+      unit: device
       description: Number of GPU devices found in the host
       used_in_dd_ui: true
       aggregation: absolute_usage
@@ -598,6 +599,7 @@ metrics:
   errors.xid.total:
     metadata:
       metric_type: gauge
+      unit: error
       used_in_dd_ui: true
       description: >-
         XID errors are NVIDIA driver error codes that indicate GPU hardware or

--- a/pkg/collector/corechecks/gpu/spec/metadata/BUILD.bazel
+++ b/pkg/collector/corechecks/gpu/spec/metadata/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "metadata_lib",
@@ -12,4 +13,10 @@ go_binary(
     name = "metadata",
     embed = [":metadata_lib"],
     visibility = ["//visibility:public"],
+)
+
+dd_agent_go_test(
+    name = "metadata_test",
+    srcs = ["main_test.go"],
+    embed = [":metadata_lib"],
 )

--- a/pkg/collector/corechecks/gpu/spec/metadata/main.go
+++ b/pkg/collector/corechecks/gpu/spec/metadata/main.go
@@ -54,8 +54,9 @@ type metadataEntry struct {
 }
 
 type config struct {
-	metadataPath    string
-	defaultInterval int
+	metadataPath      string
+	defaultInterval   int
+	includeHistograms bool
 }
 
 func main() {
@@ -74,6 +75,7 @@ func parseFlags() config {
 	cfg := config{}
 	flag.StringVar(&cfg.metadataPath, "metadata-path", "", "Path to integrations-core gpu/metadata.csv")
 	flag.IntVar(&cfg.defaultInterval, "default-interval", 16, "Interval value to write to metadata.csv for all GPU metrics")
+	flag.BoolVar(&cfg.includeHistograms, "include-histograms", false, "Include histogram metrics in metadata.csv")
 	flag.Parse()
 	return cfg
 }
@@ -172,6 +174,10 @@ func updateMetadataEntries(entries map[string]metadataEntry, cfg config) (map[st
 		}
 
 		prefixedMetricName := gpuspec.PrefixedMetricName(specs, metricName)
+		if metricSpec.Metadata.MetricType == "histogram" && !cfg.includeHistograms {
+			delete(entries, prefixedMetricName)
+			continue
+		}
 		entry, found := entries[prefixedMetricName]
 		if !found {
 			entry = metadataEntry{
@@ -190,7 +196,10 @@ func updateMetadataEntries(entries map[string]metadataEntry, cfg config) (map[st
 			return nil, fmt.Errorf("split unit: %w", err)
 		}
 
-		entry.MetricType = metricSpec.Metadata.MetricType
+		entry.MetricType, err = metadataMetricType(metricSpec.Metadata.MetricType)
+		if err != nil {
+			return nil, fmt.Errorf("map metric type for %q: %w", metricName, err)
+		}
 		entry.Interval = strconv.Itoa(cfg.defaultInterval)
 		entry.Description = metricSpec.Metadata.Description
 
@@ -198,6 +207,21 @@ func updateMetadataEntries(entries map[string]metadataEntry, cfg config) (map[st
 	}
 
 	return entries, nil
+}
+
+func metadataMetricType(metricType string) (string, error) {
+	switch metricType {
+	case "gauge":
+		return "gauge", nil
+	case "rate":
+		return "gauge", nil
+	case "count", "monotonic_count":
+		return "count", nil
+	case "counter", "histogram", "historate":
+		return "rate", nil
+	default:
+		return "", fmt.Errorf("unsupported metric type %q", metricType)
+	}
 }
 
 func splitUnit(unit string) (string, string, error) {

--- a/pkg/collector/corechecks/gpu/spec/metadata/main_test.go
+++ b/pkg/collector/corechecks/gpu/spec/metadata/main_test.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package main
+
+import "testing"
+
+func TestMetadataMetricType(t *testing.T) {
+	tests := map[string]struct {
+		input string
+		want  string
+	}{
+		"gauge":           {input: "gauge", want: "gauge"},
+		"rate":            {input: "rate", want: "gauge"},
+		"count":           {input: "count", want: "count"},
+		"monotonic count": {input: "monotonic_count", want: "count"},
+		"counter":         {input: "counter", want: "rate"},
+		"histogram":       {input: "histogram", want: "rate"},
+		"historate":       {input: "historate", want: "rate"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := metadataMetricType(test.input)
+			if err != nil {
+				t.Fatalf("metadataMetricType(%q) returned an error: %v", test.input, err)
+			}
+			if got != test.want {
+				t.Errorf("metadataMetricType(%q) = %q, want %q", test.input, got, test.want)
+			}
+		})
+	}
+}
+
+func TestMetadataMetricTypeRejectsUnknownType(t *testing.T) {
+	_, err := metadataMetricType("distribution")
+	if err == nil {
+		t.Fatal("metadataMetricType() returned nil error, want error")
+	}
+}

--- a/pkg/collector/corechecks/gpu/spec/metrics-list/main.go
+++ b/pkg/collector/corechecks/gpu/spec/metrics-list/main.go
@@ -192,7 +192,12 @@ func earliestSupportedArchitecture(specs *gpuspec.Specs, metricSpec gpuspec.Metr
 	slices.SortFunc(architectures, compareArchitectureName)
 
 	for _, arch := range architectures {
-		if metricSpec.SupportsArchitecture(arch) {
+		if !metricSpec.SupportsArchitecture(arch) {
+			continue
+		}
+		archSpec := specs.Architectures.Architectures[arch]
+		capabilities := archSpec.EffectiveCapabilities(gpuspec.DeviceModePhysical)
+		if metricSpec.SupportsCapabilities(capabilities) {
 			return arch
 		}
 	}

--- a/tasks/gpu.py
+++ b/tasks/gpu.py
@@ -182,12 +182,14 @@ def update_metrics_allowlist(ctx, allowlist_path: str = DEFAULT_ALLOWLIST_PATH):
     help={
         "metadata_path": f"Path to gpu/metadata.csv (default: {DEFAULT_METADATA_PATH})",
         "default_interval": "Default interval value for metrics missing metadata.interval",
+        "include_histograms": "Include histogram metrics in metadata.csv",
     },
 )
 def update_metadata(
     ctx,
     metadata_path: str = DEFAULT_METADATA_PATH,
     default_interval: int = 16,
+    include_histograms: bool = False,
 ):
     """
     Update integrations-core GPU metadata.csv entries from the shared GPU spec.
@@ -198,6 +200,8 @@ def update_metadata(
         f"--metadata-path {shlex.quote(metadata_path)} "
         f"--default-interval {int(default_interval)}"
     )
+    if include_histograms:
+        command += " --include-histograms"
     print(f"== Updating GPU metadata at {metadata_path} ==")
     ctx.run(command)
 


### PR DESCRIPTION
### What does this PR do?
Maps GPU metric submission types to valid integrations-core metadata types, skips histograms by default, and preserves the device-total and XID-total units. `dda inv gpu.update-metadata --include-histograms` now forwards the opt-in to include histograms.

Also makes the GPU metric-list generator select the earliest physical architecture that satisfies each metric’s NVLink/C2C capability requirements.

### Motivation
Prevents `gpu.update-metadata` from generating metadata that integrations-core rejects, and prevents GPU metric lists from reporting unsupported minimum architectures for capability-gated metrics.

### Describe how you validated your changes
`dda inv test --targets=./pkg/collector/corechecks/gpu/spec/...` passed. `dda inv gpu.update-metadata --help` confirms the histogram opt-in is exposed.

### Additional Notes
The regenerated integrations-core metadata is in [PR #25114](https://github.com/DataDog/integrations-core/pull/25114).