### PR TITLE
[procmgr] start exit watcher inside ManagedProcess::spawn

### DIFF
--- a/pkg/procmgr/rust/src/grpc/mod.rs
+++ b/pkg/procmgr/rust/src/grpc/mod.rs
@@ -72,7 +72,7 @@ mod tests {
             drop(dir);
         });
 
-        let (exit_tx, mut exit_rx) = mpsc::channel::<crate::manager::ExitEvent>(256);
+        let (exit_tx, mut exit_rx) = mpsc::channel::<crate::process::ExitEvent>(256);
         let mgr_loop = mgr.clone();
         let exit_tx_loop = exit_tx.clone();
         tokio::spawn(async move {

--- a/pkg/procmgr/rust/src/grpc/service.rs
+++ b/pkg/procmgr/rust/src/grpc/service.rs
@@ -357,6 +357,7 @@ fn process_detail_fields(proc: &ManagedProcess) -> proto::ProcessDetail {
 mod tests {
     use super::*;
     use crate::config::ProcessConfig;
+    use crate::process::test_exit_channel;
     use crate::test_helpers;
 
     #[test]
@@ -472,7 +473,7 @@ mod tests {
         };
         let mut proc =
             ManagedProcess::new_config("sleeper".to_string(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
+        proc.spawn(test_exit_channel().0).unwrap();
 
         let proto = process_to_proto(&proc);
         assert_eq!(proto.name, "sleeper");
@@ -496,10 +497,13 @@ mod tests {
         };
         let mut proc =
             ManagedProcess::new_config("fail-proc".to_string(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
+        let mut exit_rx = {
+            let (tx, rx) = test_exit_channel();
+            proc.spawn(tx).unwrap();
+            rx
+        };
 
-        let mut handle = proc.take_handle().unwrap();
-        let status = handle.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         proc.set_last_status(status);
 
         let proto = process_to_proto(&proc);

--- a/pkg/procmgr/rust/src/manager.rs
+++ b/pkg/procmgr/rust/src/manager.rs
@@ -10,7 +10,7 @@ use crate::config::{self, ConfigLoader, ProcessDefinition};
 use crate::grpc;
 use crate::ordering;
 use crate::platform;
-use crate::process::{ManagedProcess, ProcessOrigin};
+use crate::process::{ExitEvent, ManagedProcess, ProcessOrigin};
 use crate::shutdown;
 use crate::uuid_gen::UuidGenerator;
 use anyhow::Result;
@@ -18,12 +18,6 @@ use log::{debug, info, warn};
 use std::sync::Arc;
 use tokio::sync::{RwLock, mpsc, oneshot};
 use tonic::Status;
-
-pub(crate) struct ExitEvent {
-    pub name: String,
-    pub pid: u32,
-    pub status: std::process::ExitStatus,
-}
 
 #[derive(Clone)]
 pub struct ProcessManager {
@@ -56,11 +50,10 @@ impl ProcessManager {
         let mut procs = self.processes.write().await;
         for &idx in order.iter() {
             let proc = &mut procs[idx];
-            if proc.should_start() {
-                match proc.spawn() {
-                    Ok(()) => spawn_watcher(proc, exit_tx.clone()),
-                    Err(e) => warn!("{e:#}"),
-                }
+            if proc.should_start()
+                && let Err(e) = proc.spawn(exit_tx.clone())
+            {
+                warn!("{e:#}");
             }
         }
     }
@@ -178,9 +171,8 @@ impl ProcessManager {
             info!("[{name}] already running, skipping queued restart");
             return;
         }
-        match proc.spawn() {
-            Ok(()) => spawn_watcher(proc, exit_tx.clone()),
-            Err(e) => warn!("[{}] restart failed: {e:#}", proc.name()),
+        if let Err(e) = proc.spawn(exit_tx.clone()) {
+            warn!("[{}] restart failed: {e:#}", proc.name());
         }
     }
 
@@ -217,11 +209,10 @@ impl ProcessManager {
             info!("[{name}] created via RPC (uuid={uuid})");
             procs.push(proc);
             let proc = procs.last_mut().unwrap();
-            if proc.should_start() {
-                match proc.spawn() {
-                    Ok(()) => spawn_watcher(proc, exit_tx.clone()),
-                    Err(e) => warn!("[{name}] auto-start failed: {e:#}"),
-                }
+            if proc.should_start()
+                && let Err(e) = proc.spawn(exit_tx.clone())
+            {
+                warn!("[{name}] auto-start failed: {e:#}");
             }
         }
         let warnings = self.update_startup_order().await;
@@ -243,12 +234,11 @@ impl ProcessManager {
                 proc.name()
             )));
         }
-        proc.spawn()
+        proc.spawn(exit_tx.clone())
             .map_err(|e| Status::internal(format!("failed to start '{}': {e:#}", proc.name())))?;
         let uuid = proc.uuid().to_owned();
         let pid = proc.pid();
         let state = proc.state();
-        spawn_watcher(proc, exit_tx.clone());
         Ok(StartResult { uuid, pid, state })
     }
 
@@ -330,12 +320,10 @@ impl ProcessManager {
                         self.uuid_gen.generate(),
                         np.config,
                     );
-                    if proc.should_start() {
-                        if let Err(e) = proc.spawn() {
-                            warn!("[{}] failed to start: {e:#}", np.name);
-                        } else {
-                            spawn_watcher(&mut proc, exit_tx.clone());
-                        }
+                    if proc.should_start()
+                        && let Err(e) = proc.spawn(exit_tx.clone())
+                    {
+                        warn!("[{}] failed to start: {e:#}", np.name);
                     }
                     added.push(np.name);
                     procs.push(proc);
@@ -351,10 +339,8 @@ impl ProcessManager {
                 if let Some(proc) = procs.iter_mut().find(|p| p.name() == *name) {
                     proc.wait_for_stop().await;
                     info!("[{name}] restarting with updated config");
-                    if let Err(e) = proc.spawn() {
+                    if let Err(e) = proc.spawn(exit_tx.clone()) {
                         warn!("[{name}] failed to restart: {e:#}");
-                    } else {
-                        spawn_watcher(proc, exit_tx.clone());
                     }
                 }
             }
@@ -422,36 +408,6 @@ fn resolve_index(procs: &[ManagedProcess], name_or_uuid: &str) -> Result<usize, 
         .ok_or_else(|| Status::not_found(format!("process '{name_or_uuid}' not found")))
 }
 
-/// Spawn a background task that awaits the child's exit and sends the result.
-fn spawn_watcher(proc: &mut ManagedProcess, tx: mpsc::Sender<ExitEvent>) {
-    if let Some(mut handle) = proc.take_handle() {
-        let name = proc.name().to_owned();
-        let pid = proc.pid().unwrap_or(0);
-        let watcher_handle = tokio::spawn(async move {
-            let status = match handle.wait().await {
-                Ok(status) => status,
-                Err(e) => {
-                    warn!("[{name}] wait error: {e}, killing process");
-                    let _ = handle.kill().await;
-                    match handle.wait().await {
-                        Ok(s) => s,
-                        Err(e2) => {
-                            warn!("[{name}] failed to reap after kill: {e2}");
-                            return;
-                        }
-                    }
-                }
-            };
-            let _ = tx.try_send(ExitEvent {
-                name: name.clone(),
-                pid,
-                status,
-            });
-        });
-        proc.set_watcher_handle(watcher_handle);
-    }
-}
-
 /// Build `ProcessDefinition`s from the live processes Vec and resolve their
 /// dependency order. Because the definitions are built in the same index order
 /// as the Vec, the returned indices can be used directly for indexing into it.
@@ -487,6 +443,7 @@ fn recompute_startup_order(procs: &[ManagedProcess]) -> StartupOrderResult {
 mod tests {
     use super::*;
     use crate::config::{MutableConfigLoader, ProcessConfig, StaticConfigLoader};
+    use crate::process::ExitEvent;
     use crate::test_helpers;
     use crate::uuid_gen::{SequentialUuidGenerator, V4UuidGenerator};
 

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -294,11 +294,7 @@ impl ManagedProcess {
                     }
                 }
             };
-            let _ = tx.try_send(ExitEvent {
-                name,
-                pid,
-                status,
-            });
+            let _ = tx.try_send(ExitEvent { name, pid, status });
         });
         self.set_watcher_handle(watcher_handle);
     }

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -12,8 +12,20 @@ use crate::state::ProcessState;
 use anyhow::{Context, Result, bail};
 use log::{info, warn};
 use std::collections::VecDeque;
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio::time::{self, Duration, Instant};
+
+pub(crate) struct ExitEvent {
+    pub name: String,
+    pub pid: u32,
+    pub status: std::process::ExitStatus,
+}
+
+#[cfg(test)]
+pub(crate) fn test_exit_channel() -> (mpsc::Sender<ExitEvent>, mpsc::Receiver<ExitEvent>) {
+    mpsc::channel(8)
+}
 
 // ---------------------------------------------------------------------------
 // RestartTracker
@@ -244,7 +256,7 @@ impl ManagedProcess {
         true
     }
 
-    pub fn spawn(&mut self) -> Result<()> {
+    pub(crate) fn spawn(&mut self, exit_tx: mpsc::Sender<ExitEvent>) -> Result<()> {
         if !self.state.can_transition_to(ProcessState::Starting) {
             bail!("[{}] cannot spawn: invalid state {}", self.name, self.state);
         }
@@ -255,8 +267,40 @@ impl ManagedProcess {
             #[cfg(windows)]
             self.clear_windows_spawn_resources();
             self.transition_to(ProcessState::Failed);
+            return result;
         }
+        self.start_exit_watcher(exit_tx);
         result
+    }
+
+    fn start_exit_watcher(&mut self, tx: mpsc::Sender<ExitEvent>) {
+        let Some(mut handle) = self.take_handle() else {
+            return;
+        };
+        let name = self.name().to_owned();
+        let pid = self.pid().unwrap_or(0);
+        let watcher_handle = tokio::spawn(async move {
+            let status = match handle.wait().await {
+                Ok(status) => status,
+                Err(e) => {
+                    warn!("[{name}] wait error: {e}, killing process");
+                    let _ = handle.kill().await;
+                    match handle.wait().await {
+                        Ok(s) => s,
+                        Err(e2) => {
+                            warn!("[{name}] failed to reap after kill: {e2}");
+                            return;
+                        }
+                    }
+                }
+            };
+            let _ = tx.try_send(ExitEvent {
+                name,
+                pid,
+                status,
+            });
+        });
+        self.set_watcher_handle(watcher_handle);
     }
 
     fn try_spawn(&mut self) -> Result<()> {
@@ -283,7 +327,7 @@ impl ManagedProcess {
         self.state.is_alive()
     }
 
-    pub fn take_handle(&mut self) -> Option<ProcessHandle> {
+    pub(crate) fn take_handle(&mut self) -> Option<ProcessHandle> {
         self.handle.take()
     }
 
@@ -291,7 +335,7 @@ impl ManagedProcess {
         self.handle.is_some()
     }
 
-    pub(crate) fn set_watcher_handle(&mut self, handle: JoinHandle<()>) {
+    fn set_watcher_handle(&mut self, handle: JoinHandle<()>) {
         self.watcher_handle = Some(handle);
     }
 
@@ -506,6 +550,12 @@ pub mod tests {
     #[cfg(unix)]
     use nix::sys::signal::Signal;
 
+    fn spawn_ok(proc: &mut ManagedProcess) -> mpsc::Receiver<ExitEvent> {
+        let (tx, rx) = test_exit_channel();
+        proc.spawn(tx).unwrap();
+        rx
+    }
+
     // -- ${VAR} expansion tests --
 
     #[test]
@@ -590,11 +640,11 @@ pub mod tests {
         );
         assert_eq!(proc.state(), ProcessState::Created);
 
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
         assert_eq!(proc.state(), ProcessState::Running);
         assert!(proc.is_running());
 
-        let status = proc.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert!(status.success());
         proc.set_last_status(status);
         assert_eq!(proc.state(), ProcessState::Exited);
@@ -609,10 +659,10 @@ pub mod tests {
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
         assert_eq!(proc.state(), ProcessState::Running);
 
-        let status = proc.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert!(!status.success());
         proc.set_last_status(status);
         assert_eq!(proc.state(), ProcessState::Failed);
@@ -626,23 +676,25 @@ pub mod tests {
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
+        let _exit_rx = spawn_ok(&mut proc);
         assert_eq!(proc.state(), ProcessState::Running);
 
+        // Watcher owns the wait handle after a successful spawn.
         let child = proc.take_handle();
-        assert!(child.is_some());
+        assert!(
+            child.is_none(),
+            "exit watcher takes the child handle on spawn"
+        );
         assert_eq!(
             proc.state(),
             ProcessState::Running,
-            "state should remain Running after take_handle"
+            "state should remain Running after spawn takes the handle for the watcher"
         );
         assert!(proc.is_running());
 
         if let Some(pid) = proc.pid() {
             test_helpers::cleanup_process(pid);
         }
-        let mut child = child.unwrap();
-        let _ = child.wait().await;
     }
 
     #[cfg(unix)]
@@ -654,14 +706,13 @@ pub mod tests {
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
-        let mut child = proc.take_handle().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
 
         proc.send_signal(Signal::SIGTERM);
-        let status = child.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert!(
             !status.success(),
-            "signal by stored PID should reach child after take_handle"
+            "signal by stored PID should reach child after spawn (watcher owns the handle)"
         );
     }
 
@@ -718,11 +769,11 @@ pub mod tests {
         );
 
         assert!(!proc.is_running());
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
         assert!(proc.is_running());
 
         proc.request_stop();
-        let status = proc.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         proc.set_last_status(status);
         assert_eq!(proc.state(), ProcessState::Stopped);
     }
@@ -731,7 +782,7 @@ pub mod tests {
     async fn test_spawn_nonexistent_binary() {
         let cfg = test_helpers::make_config("/nonexistent/binary", vec![]);
         let mut proc = ManagedProcess::new_config("bad".into(), test_helpers::test_uuid(), cfg);
-        assert!(proc.spawn().is_err());
+        assert!(proc.spawn(test_exit_channel().0).is_err());
         assert!(!proc.is_running());
         assert_eq!(proc.state(), ProcessState::Failed);
     }
@@ -744,17 +795,16 @@ pub mod tests {
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
         proc.request_stop();
-        let mut child = proc.take_handle().unwrap();
-        let status = child.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         proc.set_last_status(status);
         assert_eq!(proc.state(), ProcessState::Stopped);
 
         let mut bad_cfg = proc.config().clone();
         bad_cfg.command = "/nonexistent/binary".to_string();
         proc.set_config(bad_cfg);
-        assert!(proc.spawn().is_err());
+        assert!(proc.spawn(test_exit_channel().0).is_err());
         assert_eq!(
             proc.state(),
             ProcessState::Failed,
@@ -770,8 +820,8 @@ pub mod tests {
 
         let mut proc =
             ManagedProcess::new_config("env-test".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
-        let status = proc.wait().await.unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert_eq!(status.code(), Some(42));
     }
 
@@ -783,8 +833,8 @@ pub mod tests {
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
-        let status = proc.wait().await.unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert_eq!(status.code(), Some(7));
     }
 
@@ -799,10 +849,10 @@ pub mod tests {
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
 
         proc.send_signal(Signal::SIGTERM);
-        let status = proc.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert!(!status.success());
     }
 
@@ -832,8 +882,8 @@ pub mod tests {
         let cfg = test_helpers::make_config(sh, vec![flag.into(), script.into()]);
         let mut proc =
             ManagedProcess::new_config("clean-env".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
-        let status = proc.wait().await.unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert_eq!(
             status.code(),
             Some(0),
@@ -857,8 +907,8 @@ pub mod tests {
         cfg.environment_file = Some(env_file.to_str().unwrap().to_string());
 
         let mut proc = ManagedProcess::new_config("envfile".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
-        let status = proc.wait().await.unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert_eq!(
             status.code(),
             Some(0),
@@ -884,8 +934,8 @@ pub mod tests {
 
         let mut proc =
             ManagedProcess::new_config("override".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
-        let status = proc.wait().await.unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert_eq!(
             status.code(),
             Some(0),
@@ -901,7 +951,7 @@ pub mod tests {
         let mut proc =
             ManagedProcess::new_config("bad-envfile".into(), test_helpers::test_uuid(), cfg);
         assert!(
-            proc.spawn().is_err(),
+            proc.spawn(test_exit_channel().0).is_err(),
             "spawn should fail if environment_file is missing without - prefix"
         );
         assert!(!proc.is_running());
@@ -914,8 +964,8 @@ pub mod tests {
         cfg.environment_file = Some("-/nonexistent/env".to_string());
         let mut proc =
             ManagedProcess::new_config("optional-envfile".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
-        let status = proc.wait().await.unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert!(
             status.success(),
             "spawn should succeed when optional environment_file (- prefix) is missing"
@@ -1103,12 +1153,11 @@ runtime_success_sec: 5
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
         assert_eq!(proc.state(), ProcessState::Running);
 
         proc.request_stop();
-        let mut child = proc.take_handle().unwrap();
-        let status = child.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         proc.set_last_status(status);
 
         assert_eq!(proc.state(), ProcessState::Stopped);
@@ -1120,18 +1169,15 @@ runtime_success_sec: 5
         let mut cfg = test_helpers::make_config(cmd, args);
         cfg.restart = RestartPolicy::OnFailure;
         let mut proc = ManagedProcess::new_config("svc".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
 
         proc.request_stop();
-        let _ = proc.take_handle();
-        // Mirrors handle_stop: wait_for_stop may call mark_stopped before the exit
-        // watcher runs set_last_status, leaving stop_requested set without this clear.
-        proc.mark_stopped();
+        proc.wait_for_stop().await;
+        let _ = exit_rx.try_recv();
 
-        proc.spawn().unwrap();
-        let mut child = proc.take_handle().unwrap();
-        child.kill().await.expect("kill child");
-        let status = child.wait().await.unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
+        test_helpers::cleanup_process(proc.pid().expect("running pid"));
+        let status = exit_rx.recv().await.expect("exit event").status;
         proc.set_last_status(status);
 
         assert_eq!(proc.state(), ProcessState::Failed);
@@ -1147,11 +1193,10 @@ runtime_success_sec: 5
         let mut cfg = test_helpers::make_config(cmd, args);
         cfg.restart = RestartPolicy::Always;
         let mut proc = ManagedProcess::new_config("svc".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
 
         proc.request_stop();
-        let mut child = proc.take_handle().unwrap();
-        let status = child.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         proc.set_last_status(status);
 
         assert_eq!(proc.state(), ProcessState::Stopped);
@@ -1169,10 +1214,9 @@ runtime_success_sec: 5
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
 
-        let mut child = proc.take_handle().unwrap();
-        let status = child.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         proc.set_last_status(status);
 
         assert_eq!(

--- a/pkg/procmgr/rust/src/shutdown.rs
+++ b/pkg/procmgr/rust/src/shutdown.rs
@@ -4,6 +4,8 @@
 // Copyright 2026-present Datadog, Inc.
 
 use crate::process::ManagedProcess;
+#[cfg(test)]
+use crate::process::test_exit_channel;
 
 /// Shut down processes in the given index order (typically reverse startup order).
 /// Sends SIGTERM to all first, then waits for each in order.
@@ -41,8 +43,8 @@ mod tests {
 
         let mut p1 = ManagedProcess::new_config("p1".into(), test_helpers::test_uuid(), cfg1);
         let mut p2 = ManagedProcess::new_config("p2".into(), test_helpers::test_uuid(), cfg2);
-        p1.spawn().unwrap();
-        p2.spawn().unwrap();
+        p1.spawn(test_exit_channel().0).unwrap();
+        p2.spawn(test_exit_channel().0).unwrap();
 
         let mut procs = vec![p1, p2];
         shutdown_all(&mut procs).await;
@@ -66,7 +68,7 @@ mod tests {
         cfg.stop_timeout = Some(1);
         let mut proc =
             ManagedProcess::new_config("stubborn".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
+        proc.spawn(test_exit_channel().0).unwrap();
 
         let mut procs = vec![proc];
         shutdown_all(&mut procs).await;
@@ -78,8 +80,11 @@ mod tests {
     async fn test_shutdown_all_after_take_child() {
         let mut proc =
             ManagedProcess::new_config("t".into(), test_helpers::test_uuid(), sleep_config());
-        proc.spawn().unwrap();
-        let _child = proc.take_handle();
+        proc.spawn(test_exit_channel().0).unwrap();
+        assert!(
+            proc.take_handle().is_none(),
+            "exit watcher owns the wait handle after spawn"
+        );
 
         assert!(proc.is_running(), "state should still be Running");
         let mut procs = vec![proc];
@@ -99,9 +104,9 @@ mod tests {
             ManagedProcess::new_config("p2".into(), test_helpers::test_uuid(), sleep_config());
         let mut p3 =
             ManagedProcess::new_config("p3".into(), test_helpers::test_uuid(), sleep_config());
-        p1.spawn().unwrap();
-        p2.spawn().unwrap();
-        p3.spawn().unwrap();
+        p1.spawn(test_exit_channel().0).unwrap();
+        p2.spawn(test_exit_channel().0).unwrap();
+        p3.spawn(test_exit_channel().0).unwrap();
 
         let mut procs = vec![p1, p2, p3];
         // Reverse order: p3, p2, p1


### PR DESCRIPTION
### What does this PR do?

Successful `ManagedProcess::spawn` now starts the exit watcher itself. The manager no longer calls `spawn` then `spawn_watcher` as two steps. `ExitEvent` moves to `process.rs`, and `spawn_watcher` is removed.

### Motivation

Forgetting the watcher left a running child with no `ExitEvent` on the manager channel. Folding it into spawn makes that impossible.

### Describe how you validated your changes

- `cargo test -p dd-procmgrd --lib` (157 passed on macOS)
- `cargo clippy -p dd-procmgrd --lib --tests -- -D warnings`
- Bazel `//pkg/procmgr/rust:dd-procmgrd_test` is linux/windows only (skipped locally)

### Additional Notes

Mechanical refactor only. No change to Windows LogonUser spawn, privileged spawn, stop timeouts, or handle inheritance. Stacks on the Windows agent-profile spawn PR.