### PR TITLE
fic(ci): run `new-e2e-cleanup-on-failure` on merge-queue pipelines too

### DIFF
--- a/.gitlab/.post/cleanup.yml
+++ b/.gitlab/.post/cleanup.yml
@@ -23,6 +23,5 @@ new-e2e-cleanup-on-failure:
     E2E_PIPELINE_ID: $CI_PIPELINE_ID
     REMOTE_STACK_CLEANING: "true"
   rules:
-    - !reference [.except_mergequeue]
     - when: always
   allow_failure: true


### PR DESCRIPTION
### What does this PR do?
Remove the `.except_mergequeue` rule from `new-e2e-cleanup-on-failure` so it also runs on merge-queue pipelines.

### Motivation
`new-e2e-cleanup-on-failure` is the only job that destroys the shared `ci-init-<pipeline_id>-*` Pulumi stacks used by e2e job families that rely on the init/pre-initialized pattern (`new-e2e-otel`, containers, npm, ssi).

Merge-queue pipelines were unconditionally excluded from this job, so a canceled or superseded merge-queue pipeline, routine during a fan-out, left its EKS cluster and ENIs allocated with no cleanup path.

#[incident-59945](https://dd.enterprise.slack.com/archives/C0BT0Q588TH) traced a Friday merge-queue fan-out that exhausted 3 shared AWS subnets this way.

### Additional Notes
`.except_mergequeue` was **likely carried over** from the sibling `notify` job moved into the same `.post` stage in #44763, where excluding merge-queue fits Slack notifications but not resource cleanup.