### PR TITLE
configfilesdiscovery: collect Spark driver env vars

### DIFF
--- a/comp/core/configfilesdiscovery/fx/fx.go
+++ b/comp/core/configfilesdiscovery/fx/fx.go
@@ -68,6 +68,7 @@ func newOptionalComponent(reqs Requires) Provides {
 			collectors.KafkaIntegrationName:    collectors.NewKafka(),
 			collectors.PostgresIntegrationName: collectors.NewPostgres(),
 			collectors.RedisIntegrationName:    collectors.NewRedis(),
+			collectors.SparkIntegrationName:    collectors.NewSpark(),
 		},
 	})
 	return Provides{Comp: option.New(provides.Comp)}

--- a/comp/core/configfilesdiscovery/impl/collectors/BUILD.bazel
+++ b/comp/core/configfilesdiscovery/impl/collectors/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "kafka.go",
         "postgres.go",
         "redis.go",
+        "spark.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl/collectors",
     visibility = ["//visibility:public"],
@@ -26,6 +27,7 @@ dd_agent_go_test(
         "kafka_test.go",
         "postgres_test.go",
         "redis_test.go",
+        "spark_test.go",
     ],
     embed = [":collectors"],
     deps = [

--- a/comp/core/configfilesdiscovery/impl/collectors/spark.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/spark.go
@@ -1,0 +1,144 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package collectors
+
+import (
+	"context"
+	"fmt"
+
+	configfilesdiscoveryimpl "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl"
+)
+
+const (
+	// SparkIntegrationName is the Autodiscovery check name for Spark.
+	SparkIntegrationName = "spark"
+
+	// sparkStandaloneDriverClass is launched by a Spark Standalone Worker for
+	// applications submitted in cluster deploy mode. It is the stable process
+	// identity that distinguishes a Driver from the submitting client and the
+	// Worker itself.
+	sparkStandaloneDriverClass = "org.apache.spark.deploy.worker.DriverWrapper"
+)
+
+type sparkConfigCollector struct{}
+
+// sparkEnvAllowlist contains the documented, non-secret environment variables
+// supported by Apache Spark Standalone and the Bitnami Spark image. JVM options,
+// commands, arbitrary extensions, and secret-bearing variables are deliberately
+// excluded: their values are not safe to forward by name alone.
+var sparkEnvAllowlist = map[string]struct{}{
+	"SPARK_BASE_DIR":                         {},
+	"SPARK_CONF_DIR":                         {},
+	"SPARK_CONF_FILE":                        {},
+	"SPARK_DAEMON_GROUP":                     {},
+	"SPARK_DAEMON_MEMORY":                    {},
+	"SPARK_DAEMON_USER":                      {},
+	"SPARK_DEFAULT_CONF_DIR":                 {},
+	"SPARK_DRIVER_CORES":                     {},
+	"SPARK_DRIVER_MEMORY":                    {},
+	"SPARK_EXECUTOR_CORES":                   {},
+	"SPARK_EXECUTOR_MEMORY":                  {},
+	"SPARK_INITSCRIPTS_DIR":                  {},
+	"SPARK_IDENT_STRING":                     {},
+	"SPARK_JARS_DIR":                         {},
+	"SPARK_LOCAL_DIRS":                       {},
+	"SPARK_LOCAL_IP":                         {},
+	"SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED": {},
+	"SPARK_LOG_DIR":                          {},
+	"SPARK_LOG_MAX_FILES":                    {},
+	"SPARK_MASTER_HOST":                      {},
+	"SPARK_MASTER_PORT":                      {},
+	"SPARK_MASTER_URL":                       {},
+	"SPARK_MASTER_WEBUI_PORT":                {},
+	"SPARK_METRICS_ENABLED":                  {},
+	"SPARK_MODE":                             {},
+	"SPARK_NICENESS":                         {},
+	"SPARK_NO_DAEMONIZE":                     {},
+	"SPARK_PID_DIR":                          {},
+	"SPARK_PUBLIC_DNS":                       {},
+	"SPARK_RPC_AUTHENTICATION_ENABLED":       {},
+	"SPARK_RPC_ENCRYPTION_ENABLED":           {},
+	"SPARK_SSL_ENABLED":                      {},
+	"SPARK_SSL_KEYSTORE_FILE":                {},
+	"SPARK_SSL_KEYSTORE_TYPE":                {},
+	"SPARK_SSL_NEED_CLIENT_AUTH":             {},
+	"SPARK_SSL_PROTOCOL":                     {},
+	"SPARK_SSL_TRUSTSTORE_FILE":              {},
+	"SPARK_SSL_TRUSTSTORE_TYPE":              {},
+	"SPARK_TMP_DIR":                          {},
+	"SPARK_USER":                             {},
+	"SPARK_WEBUI_SSL_PORT":                   {},
+	"SPARK_WORK_DIR":                         {},
+	"SPARK_WORKER_CORES":                     {},
+	"SPARK_WORKER_DIR":                       {},
+	"SPARK_WORKER_MEMORY":                    {},
+	"SPARK_WORKER_PORT":                      {},
+	"SPARK_WORKER_WEBUI_PORT":                {},
+}
+
+// NewSpark returns a collector for Spark Standalone Drivers running in cluster
+// deploy mode. Other Spark deployment modes do not have a portable,
+// unambiguous Driver process identity available through ConfigReader.
+func NewSpark() configfilesdiscoveryimpl.ConfigCollector {
+	return sparkConfigCollector{}
+}
+
+// CanCollectFromProcess returns whether a process event identifies a Spark
+// Standalone Driver and can trigger the one-shot recollection fallback.
+func (sparkConfigCollector) CanCollectFromProcess(commandline configfilesdiscoveryimpl.TargetCommandline) bool {
+	return isSparkDriverCommand(commandline.Args)
+}
+
+func (sparkConfigCollector) Collect(ctx context.Context, reader configfilesdiscoveryimpl.ConfigReader) (configfilesdiscoveryimpl.CollectedConfig, error) {
+	isDriver, err := isSparkDriver(ctx, reader)
+	if err != nil {
+		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("identify spark driver: %w", err)
+	}
+	if !isDriver {
+		return configfilesdiscoveryimpl.CollectedConfig{}, nil
+	}
+
+	envVars, err := readEnvVars(ctx, reader, includeSparkEnvVar)
+	if err != nil {
+		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read spark env vars: %w", err)
+	}
+	if len(envVars) == 0 {
+		return configfilesdiscoveryimpl.CollectedConfig{}, nil
+	}
+
+	return configfilesdiscoveryimpl.CollectedConfig{
+		EnvVars: envVars,
+	}, nil
+}
+
+func includeSparkEnvVar(name string) bool {
+	_, allowed := sparkEnvAllowlist[name]
+	return allowed && !configfilesdiscoveryimpl.IsSecretEnvVarName(name)
+}
+
+func isSparkDriver(ctx context.Context, reader configfilesdiscoveryimpl.ConfigReader) (bool, error) {
+	runtimeCommandline, runtimeErr := reader.ReadRuntimeCommandline(ctx)
+	if runtimeErr == nil && isSparkDriverCommand(runtimeCommandline.Args) {
+		return true, nil
+	}
+
+	for _, commandline := range reader.ReadLiveProcessCommandlines(ctx) {
+		if isSparkDriverCommand(commandline.Args) {
+			return true, nil
+		}
+	}
+
+	return false, runtimeErr
+}
+
+func isSparkDriverCommand(args []string) bool {
+	for _, arg := range unwrapShellCommandline(args) {
+		if arg == sparkStandaloneDriverClass {
+			return true
+		}
+	}
+	return false
+}

--- a/comp/core/configfilesdiscovery/impl/collectors/spark_test.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/spark_test.go
@@ -1,0 +1,233 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package collectors
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	configfilesdiscoveryimpl "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIncludeSparkEnvVar(t *testing.T) {
+	tests := []struct {
+		name    string
+		envName string
+		want    bool
+	}{
+		{name: "native local IP", envName: "SPARK_LOCAL_IP", want: true},
+		{name: "native public DNS", envName: "SPARK_PUBLIC_DNS", want: true},
+		{name: "official image driver memory", envName: "SPARK_DRIVER_MEMORY", want: true},
+		{name: "bitnami RPC encryption", envName: "SPARK_RPC_ENCRYPTION_ENABLED", want: true},
+		{name: "bitnami keystore path", envName: "SPARK_SSL_KEYSTORE_FILE", want: true},
+		{name: "known Bitnami config directory", envName: "SPARK_CONF_DIR", want: true},
+		{name: "known Bitnami mode", envName: "SPARK_MODE", want: true},
+		{name: "known standalone process identity", envName: "SPARK_IDENT_STRING", want: true},
+		{name: "known standalone process priority", envName: "SPARK_NICENESS", want: true},
+		{name: "known standalone worker resource", envName: "SPARK_WORKER_MEMORY", want: true},
+		{name: "unrelated", envName: "UNREQUESTED"},
+		{name: "lowercase", envName: "spark_local_ip"},
+		{name: "unknown setting", envName: "SPARK_FUTURE_SAFE_SETTING"},
+		{name: "RPC authentication secret", envName: "SPARK_RPC_AUTHENTICATION_SECRET"},
+		{name: "SSL keystore password", envName: "SPARK_SSL_KEYSTORE_PASSWORD"},
+		{name: "daemon JVM opts", envName: "SPARK_DAEMON_JAVA_OPTS"},
+		{name: "driver Java options", envName: "SPARK_DRIVER_EXTRA_JAVA_OPTIONS"},
+		{name: "numbered Java option", envName: "SPARK_JAVA_OPT_1"},
+		{name: "classpath", envName: "SPARK_EXTRA_CLASSPATH"},
+		{name: "custom command", envName: "SPARK_CUSTOM_COMMAND"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, includeSparkEnvVar(tt.envName))
+		})
+	}
+}
+
+func TestSparkCollectorCollectsDriverEnvVars(t *testing.T) {
+	reader := &sparkCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"java", sparkStandaloneDriverClass, "worker-url", "user-jar", "application-class"},
+		},
+		env: map[string]string{
+			"SPARK_DRIVER_MEMORY":             "2g",
+			"SPARK_LOCAL_IP":                  "192.0.2.4",
+			"SPARK_RPC_AUTHENTICATION_SECRET": "must-not-be-forwarded",
+			"SPARK_DAEMON_JAVA_OPTS":          "-Dsecret=must-not-be-forwarded",
+			"SPARK_DRIVER_EXTRA_JAVA_OPTIONS": "-Dsecret=must-not-be-forwarded",
+			"UNREQUESTED":                     "value",
+		},
+	}
+
+	collected, err := NewSpark().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	requireSparkEnvVarPredicate(t, reader)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "SPARK_DRIVER_MEMORY", Value: "2g"},
+		{Name: "SPARK_LOCAL_IP", Value: "192.0.2.4"},
+	}, collected.EnvVars)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Equal(t, 0, reader.processCommandlineCalls)
+}
+
+func TestSparkCollectorFindsLiveDriverAfterRuntimeInspectionError(t *testing.T) {
+	runtimeErr := errors.New("inspect unavailable")
+	reader := &sparkCollectorTestReader{
+		runtimeCommandlineErr: runtimeErr,
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{
+			{Args: []string{"/opt/spark/bin/spark-class", sparkStandaloneDriverClass, "worker-url", "user-jar", "application-class"}},
+		},
+		env: map[string]string{"SPARK_LOCAL_DIRS": "/tmp/spark"},
+	}
+
+	collected, err := NewSpark().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	requireSparkEnvVarPredicate(t, reader)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{{Name: "SPARK_LOCAL_DIRS", Value: "/tmp/spark"}}, collected.EnvVars)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+}
+
+func TestSparkCollectorSkipsNonDriverWithoutReadingEnvVars(t *testing.T) {
+	reader := &sparkCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"java", "org.apache.spark.deploy.worker.Worker"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{
+			{Args: []string{"java", "org.apache.spark.deploy.master.Master"}},
+		},
+		env: map[string]string{"SPARK_LOCAL_IP": "192.0.2.4"},
+	}
+
+	collected, err := NewSpark().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+	assert.Empty(t, reader.readEnvVarPredicates)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+}
+
+func TestSparkCollectorReturnsRuntimeInspectionErrorWithoutLiveDriver(t *testing.T) {
+	runtimeErr := errors.New("inspect unavailable")
+	reader := &sparkCollectorTestReader{
+		runtimeCommandlineErr: runtimeErr,
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{
+			{Args: []string{"java", "org.apache.spark.deploy.worker.Worker"}},
+		},
+	}
+
+	collected, err := NewSpark().Collect(context.Background(), reader)
+
+	require.ErrorIs(t, err, runtimeErr)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+	assert.Empty(t, reader.readEnvVarPredicates)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+}
+
+func TestSparkCollectorReturnsEnvVarErrorForDriver(t *testing.T) {
+	envErr := errors.New("environment unavailable")
+	reader := &sparkCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"java", sparkStandaloneDriverClass},
+		},
+		readEnvVarsErr: envErr,
+	}
+
+	collected, err := NewSpark().Collect(context.Background(), reader)
+
+	require.ErrorIs(t, err, envErr)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+	requireSparkEnvVarPredicate(t, reader)
+}
+
+func TestSparkCollectorCanCollectFromProcess(t *testing.T) {
+	collector := NewSpark()
+
+	assert.True(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{
+		Args: []string{"java", sparkStandaloneDriverClass},
+	}))
+	assert.True(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{
+		Args: []string{"/bin/sh", "-c", "/opt/spark/bin/spark-class " + sparkStandaloneDriverClass + " worker-url user-jar application-class"},
+	}))
+	assert.False(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{
+		Args: []string{"java", "org.apache.spark.deploy.worker.Worker"},
+	}))
+	assert.False(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{
+		Args: []string{"java", "com.example.DriverWrapper"},
+	}))
+}
+
+func TestSparkCollectorSkipsDriverWithoutSelectedEnvVars(t *testing.T) {
+	reader := &sparkCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"java", sparkStandaloneDriverClass},
+		},
+		env: map[string]string{"UNREQUESTED": "value"},
+	}
+
+	collected, err := NewSpark().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	requireSparkEnvVarPredicate(t, reader)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+}
+
+type sparkCollectorTestReader struct {
+	runtimeCommandline      configfilesdiscoveryimpl.TargetCommandline
+	runtimeCommandlineErr   error
+	liveProcessCommandlines []configfilesdiscoveryimpl.TargetCommandline
+	processCommandlineCalls int
+	env                     map[string]string
+	readEnvVarsErr          error
+	readEnvVarPredicates    []configfilesdiscoveryimpl.ConfigEnvVarPredicate
+}
+
+func (r *sparkCollectorTestReader) Runtime() configfilesdiscoveryimpl.RuntimeType {
+	return configfilesdiscoveryimpl.RuntimeDocker
+}
+
+func (r *sparkCollectorTestReader) Close() {}
+
+func (r *sparkCollectorTestReader) ReadFile(context.Context, string) (configfilesdiscoveryimpl.ConfigFile, error) {
+	return configfilesdiscoveryimpl.ConfigFile{}, errors.New("not implemented")
+}
+
+func (r *sparkCollectorTestReader) ReadEnvVars(_ context.Context, predicate configfilesdiscoveryimpl.ConfigEnvVarPredicate) (map[string]string, error) {
+	r.readEnvVarPredicates = append(r.readEnvVarPredicates, predicate)
+	if r.readEnvVarsErr != nil {
+		return nil, r.readEnvVarsErr
+	}
+
+	env := make(map[string]string)
+	for name, value := range r.env {
+		if predicate != nil && predicate(name) {
+			env[name] = value
+		}
+	}
+	return env, nil
+}
+
+func (r *sparkCollectorTestReader) ReadRuntimeCommandline(context.Context) (configfilesdiscoveryimpl.TargetCommandline, error) {
+	if r.runtimeCommandlineErr != nil {
+		return configfilesdiscoveryimpl.TargetCommandline{}, r.runtimeCommandlineErr
+	}
+	return r.runtimeCommandline, nil
+}
+
+func (r *sparkCollectorTestReader) ReadLiveProcessCommandlines(context.Context) []configfilesdiscoveryimpl.TargetCommandline {
+	r.processCommandlineCalls++
+	return r.liveProcessCommandlines
+}
+
+func requireSparkEnvVarPredicate(t *testing.T, reader *sparkCollectorTestReader) {
+	t.Helper()
+	require.Len(t, reader.readEnvVarPredicates, 1)
+	require.NotNil(t, reader.readEnvVarPredicates[0])
+}

--- a/test/new-e2e/tests/discovery/configfilesdiscovery_docker_test.go
+++ b/test/new-e2e/tests/discovery/configfilesdiscovery_docker_test.go
@@ -74,6 +74,16 @@ const (
 	postgresUser            = "configfilesdiscovery"
 )
 
+const (
+	sparkMasterContainerName  = "spark-driver-configfilesdiscovery-master"
+	sparkWorkerContainerName  = "spark-driver-configfilesdiscovery-worker"
+	sparkSubmitContainerName  = "spark-driver-configfilesdiscovery-submit"
+	sparkIntegrationName      = "spark"
+	sparkDriverMemory         = "2g"
+	sparkLocalDirs            = "/tmp/configfilesdiscovery-spark"
+	sparkRPCEncryptionEnabled = "no"
+)
+
 //go:embed testdata/compose/docker-compose.configfilesdiscovery-redis.yaml
 var redisComposeTemplate string
 
@@ -82,6 +92,9 @@ var kafkaCompose string
 
 //go:embed testdata/compose/docker-compose.configfilesdiscovery-postgres.yaml
 var postgresCompose string
+
+//go:embed testdata/compose/docker-compose.configfilesdiscovery-spark.yaml
+var sparkCompose string
 
 const redisExplicitConfig = `port 6379
 appendonly no
@@ -150,10 +163,11 @@ type configFilesDiscoveryFixtureFile struct {
 }
 
 type configFilesDiscoveryContainerFixture struct {
-	integrationName     string
-	configDir           string
-	containerNames      []string
-	startContainerNames []string
+	integrationName       string
+	configDir             string
+	containerNames        []string
+	startContainerNames   []string
+	restartContainerNames []string
 }
 
 type configFilePayloadExpectation struct {
@@ -176,6 +190,7 @@ func TestConfigFilesDiscoveryDockerSuite(t *testing.T) {
 		dockeragentparams.WithExtraComposeManifest("configfilesdiscovery-redis", pulumi.String(redisCompose)),
 		dockeragentparams.WithExtraComposeManifest("configfilesdiscovery-kafka", pulumi.String(kafkaCompose)),
 		dockeragentparams.WithExtraComposeManifest("configfilesdiscovery-postgres", pulumi.String(postgresCompose)),
+		dockeragentparams.WithExtraComposeManifest("configfilesdiscovery-spark", pulumi.String(sparkCompose)),
 		dockeragentparams.WithEnvironmentVariables(pulumi.StringMap{
 			"CONFIG_FILES_DISCOVERY_REDIS_CONFIG_DIR":    pulumi.String(redisConfigDir),
 			"CONFIG_FILES_DISCOVERY_KAFKA_CONFIG_DIR":    pulumi.String(kafkaConfigDir),
@@ -250,7 +265,10 @@ func (s *configFilesDiscoveryDockerSuite) prepareConfigFilesDiscoveryContainers(
 	t.Helper()
 
 	host := s.Env().RemoteHost
-	startFilePath := path.Join(fixture.configDir, startMarkerFileName)
+	startFilePath := ""
+	if fixture.configDir != "" {
+		startFilePath = path.Join(fixture.configDir, startMarkerFileName)
+	}
 	containerNames := strings.Join(fixture.containerNames, " ")
 	startContainerNames := containerNames
 	if len(fixture.startContainerNames) > 0 {
@@ -268,8 +286,10 @@ func (s *configFilesDiscoveryDockerSuite) prepareConfigFilesDiscoveryContainers(
 				}
 			}
 		}
-		if _, cleanupErr := host.Execute("sudo rm -f " + startFilePath); cleanupErr != nil {
-			t.Logf("failed to remove %s start file: %v", fixture.integrationName, cleanupErr)
+		if startFilePath != "" {
+			if _, cleanupErr := host.Execute("sudo rm -f " + startFilePath); cleanupErr != nil {
+				t.Logf("failed to remove %s start file: %v", fixture.integrationName, cleanupErr)
+			}
 		}
 		if _, cleanupErr := host.Execute("sudo docker restart " + containerNames); cleanupErr != nil {
 			t.Logf("failed to restart %s containers: %v", fixture.integrationName, cleanupErr)
@@ -278,14 +298,20 @@ func (s *configFilesDiscoveryDockerSuite) prepareConfigFilesDiscoveryContainers(
 
 	_, err := host.Execute("sudo docker stop " + containerNames)
 	require.NoError(t, err)
-	_, err = host.Execute("sudo rm -f " + startFilePath)
-	require.NoError(t, err)
+	if startFilePath != "" {
+		_, err = host.Execute("sudo rm -f " + startFilePath)
+		require.NoError(t, err)
+	}
 	require.Eventually(t, func() bool {
 		return !isIntegrationScheduled(s.Env().Agent.Client.ConfigCheck(), fixture.integrationName)
 	}, time.Minute, time.Second, "%s AD config remained scheduled after its containers stopped", fixture.integrationName)
 	require.NoError(t, s.Env().FakeIntake.Client().FlushServerAndResetAggregators())
 	_, err = host.Execute("sudo docker start " + startContainerNames)
 	require.NoError(t, err)
+	if len(fixture.restartContainerNames) > 0 {
+		_, err = host.Execute("sudo docker restart " + strings.Join(fixture.restartContainerNames, " "))
+		require.NoError(t, err)
+	}
 
 	return startFilePath
 }
@@ -433,6 +459,52 @@ func (s *configFilesDiscoveryDockerSuite) TestPostgresConfigFileAndEnvVarsDiscov
 			assert.NotContains(c, envVars, "POSTGRESQL_LDAP_URL")
 		}
 	}, 3*time.Minute, 10*time.Second, "timed out waiting for postgres config file discovery payload")
+}
+
+func (s *configFilesDiscoveryDockerSuite) TestSparkDriverEnvVarsDiscovered() {
+	t := s.T()
+	host := s.Env().RemoteHost
+	s.prepareConfigFilesDiscoveryContainers(t, configFilesDiscoveryContainerFixture{
+		integrationName:       sparkIntegrationName,
+		containerNames:        []string{sparkMasterContainerName, sparkWorkerContainerName},
+		startContainerNames:   []string{sparkMasterContainerName, sparkWorkerContainerName},
+		restartContainerNames: []string{sparkSubmitContainerName},
+	})
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		processes, processErr := host.Execute("sudo docker top " + sparkWorkerContainerName + " -eo pid,args")
+		if !assert.NoError(c, processErr) {
+			return
+		}
+		assert.Contains(c, processes, "org.apache.spark.deploy.worker.DriverWrapper")
+		assert.True(c, isIntegrationScheduled(s.Env().Agent.Client.ConfigCheck(), sparkIntegrationName))
+	}, 2*time.Minute, 2*time.Second, "Spark Driver was not running after the cluster started")
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		payloads, err := s.Env().FakeIntake.Client().GetAgentDiscoveryPayloads()
+		if !assert.NoError(c, err) {
+			return
+		}
+		sparkPayloads := findEnvPayloads(payloads, sparkIntegrationName)
+		if !assert.NotEmpty(c, sparkPayloads, "no Spark Driver env payloads found in %+v", payloads) {
+			return
+		}
+
+		for _, payload := range sparkPayloads {
+			assertAgentDiscoveryPayload(c, payload, sparkIntegrationName)
+			assert.Empty(c, payload.ConfigFiles)
+
+			envVars := make(map[string]string, len(payload.EnvVars))
+			for _, envVar := range payload.EnvVars {
+				envVars[envVar.Name] = envVar.Value
+			}
+			assert.Equal(c, sparkDriverMemory, envVars["SPARK_DRIVER_MEMORY"])
+			assert.Equal(c, sparkLocalDirs, envVars["SPARK_LOCAL_DIRS"])
+			assert.Equal(c, sparkRPCEncryptionEnabled, envVars["SPARK_RPC_ENCRYPTION_ENABLED"])
+			assert.NotContains(c, envVars, "SPARK_RPC_AUTHENTICATION_SECRET")
+			assert.NotContains(c, envVars, "SPARK_DAEMON_JAVA_OPTS")
+		}
+	}, 3*time.Minute, 10*time.Second, "timed out waiting for Spark Driver env discovery payload")
 }
 
 func (s *configFilesDiscoveryDockerSuite) TestKafkaDefaultConfigFileDiscovered() {

--- a/test/new-e2e/tests/discovery/testdata/compose/docker-compose.configfilesdiscovery-spark.yaml
+++ b/test/new-e2e/tests/discovery/testdata/compose/docker-compose.configfilesdiscovery-spark.yaml
@@ -1,0 +1,52 @@
+services:
+  spark-driver-configfilesdiscovery-master:
+    image: ${DD_REGISTRY:-docker.io}/apache/spark:4.0.0@sha256:a89782d90529a623fc4471cdddb0f9c32d6eed10a81b256a80207b23c3b1df00
+    container_name: spark-driver-configfilesdiscovery-master
+    command:
+      - /opt/spark/bin/spark-class
+      - org.apache.spark.deploy.master.Master
+      - --host
+      - spark-driver-configfilesdiscovery-master
+      - --port
+      - "7077"
+      - --webui-port
+      - "8080"
+
+  spark-driver-configfilesdiscovery-worker:
+    image: ${DD_REGISTRY:-docker.io}/apache/spark:4.0.0@sha256:a89782d90529a623fc4471cdddb0f9c32d6eed10a81b256a80207b23c3b1df00
+    container_name: spark-driver-configfilesdiscovery-worker
+    environment:
+      SPARK_DAEMON_JAVA_OPTS: -Dsecret=must-not-be-forwarded
+      SPARK_DRIVER_MEMORY: 2g
+      SPARK_LOCAL_DIRS: /tmp/configfilesdiscovery-spark
+      SPARK_LOCAL_IP: spark-driver-configfilesdiscovery-worker
+      SPARK_RPC_AUTHENTICATION_SECRET: must-not-be-forwarded
+      SPARK_RPC_ENCRYPTION_ENABLED: "no"
+    command:
+      - /opt/spark/bin/spark-class
+      - org.apache.spark.deploy.worker.Worker
+      - spark://spark-driver-configfilesdiscovery-master:7077
+    volumes:
+      - spark-driver-configfilesdiscovery-artifacts:/opt/configfilesdiscovery
+    labels:
+      com.datadoghq.ad.checks: >-
+        {"spark":{"instances":[{"spark_url":"http://%%host%%:4040","spark_cluster_mode":"spark_driver_mode"}]}}
+
+  spark-driver-configfilesdiscovery-submit:
+    image: ${DD_REGISTRY:-docker.io}/apache/spark:4.0.0@sha256:a89782d90529a623fc4471cdddb0f9c32d6eed10a81b256a80207b23c3b1df00
+    container_name: spark-driver-configfilesdiscovery-submit
+    user: "0"
+    command:
+      - /bin/bash
+      - -ec
+      - |-
+        until curl -fs http://spark-driver-configfilesdiscovery-master:8080/json/ | grep -q '"aliveworkers" : 1'; do sleep 1; done
+        printf '%s\n' 'public final class ConfigFilesDiscoveryDriver { public static void main(String[] args) throws Exception { Thread.sleep(300000); } }' > /opt/configfilesdiscovery/ConfigFilesDiscoveryDriver.java
+        /opt/java/openjdk/bin/javac -d /opt/configfilesdiscovery /opt/configfilesdiscovery/ConfigFilesDiscoveryDriver.java
+        /opt/java/openjdk/bin/jar cf /opt/configfilesdiscovery/configfilesdiscovery-driver.jar -C /opt/configfilesdiscovery ConfigFilesDiscoveryDriver.class
+        exec /opt/spark/bin/spark-submit --master spark://spark-driver-configfilesdiscovery-master:7077 --deploy-mode cluster --class ConfigFilesDiscoveryDriver /opt/configfilesdiscovery/configfilesdiscovery-driver.jar
+    volumes:
+      - spark-driver-configfilesdiscovery-artifacts:/opt/configfilesdiscovery
+
+volumes:
+  spark-driver-configfilesdiscovery-artifacts:


### PR DESCRIPTION
### What does this PR do?

Adds environment-variable discovery for Spark Standalone Drivers running in cluster deploy mode. The collector detects `org.apache.spark.deploy.worker.DriverWrapper`, collects a reviewed allowlist of non-sensitive `SPARK_*` metadata, and applies the shared secret-name filter.

### Motivation
[DSCVR-708](https://datadoghq.atlassian.net/browse/DSCVR-708)

### Describe how you validated your changes

- Add unit test and E2E test.
- Manually verified Agent Discovery delivery to Fake Intake using a Docker workload with a DriverWrapper-shaped command: allowed Spark environment variables were forwarded, while secrets and JVM options were excluded.

### Additional Notes

[DSCVR-708]: https://datadoghq.atlassian.net/browse/DSCVR-708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ