### PR TITLE
Set CWS enablement on the core agent container for the package-in-use SBOM suite

### DIFF
--- a/test/new-e2e/tests/sbom/packageinuse_test.go
+++ b/test/new-e2e/tests/sbom/packageinuse_test.go
@@ -135,6 +135,11 @@ agents:
       env:
         - name: DD_SBOM_ENRICHMENT_USAGE_ENABLED
           value: "true"
+        # Config streaming makes the core agent the source of truth, so the
+        # security-agent's own DD_RUNTIME_SECURITY_CONFIG_ENABLED is discarded; without
+        # it here the streamed default (false) makes the security-agent exit.
+        - name: DD_RUNTIME_SECURITY_CONFIG_ENABLED
+          value: "true"
     systemProbe:
       env:
         # The UsageConsumer that registers the SBOMCollector gRPC stream the core


### PR DESCRIPTION
Config streaming (#55817) makes the core agent the source of truth, so the security-agent's own `DD_RUNTIME_SECURITY_CONFIG_ENABLED` is discarded and it exits into CrashLoopBackOff. Setting it on the core agent container streams it down, fixing `TestSBOMPackageInUseKubeadmSuite` (incident 60263).

The Operator and Helm chart have the same gap and are tracked separately.