### PR TITLE
test(new-e2e): declare Discovery Compose embed inputs

### DIFF
--- a/test/new-e2e/tests/discovery/BUILD.bazel
+++ b/test/new-e2e/tests/discovery/BUILD.bazel
@@ -12,6 +12,10 @@ dd_agent_go_test(
     ],
     data = [
         "config/helm-values.tmpl",
+        "testdata/compose/docker-compose.configfilesdiscovery-kafka.yaml",
+        "testdata/compose/docker-compose.configfilesdiscovery-postgres.yaml",
+        "testdata/compose/docker-compose.configfilesdiscovery-redis.yaml",
+        "testdata/compose/docker-compose.configfilesdiscovery-spark.yaml",
         "testdata/config/agent_config.yaml",
         "testdata/config/agent_process_autodiscovery.yaml",
         "testdata/config/agent_process_config.yaml",
@@ -32,6 +36,10 @@ dd_agent_go_test(
     }),
     embedsrcs = [
         "config/helm-values.tmpl",
+        "testdata/compose/docker-compose.configfilesdiscovery-kafka.yaml",
+        "testdata/compose/docker-compose.configfilesdiscovery-postgres.yaml",
+        "testdata/compose/docker-compose.configfilesdiscovery-redis.yaml",
+        "testdata/compose/docker-compose.configfilesdiscovery-spark.yaml",
         "testdata/config/agent_config.yaml",
         "testdata/config/agent_process_autodiscovery.yaml",
         "testdata/config/agent_process_config.yaml",


### PR DESCRIPTION
### What does this PR do?

Declares the four Config Files Discovery Docker Compose fixtures in the shared Discovery E2E Bazel target's `data` and `embedsrcs` attributes.

### Motivation

The fixtures are consumed through `//go:embed`. Declaring them makes the Bazel target's inputs explicit and hermetic for Kafka, PostgreSQL, Redis, and Spark.

### Validation

- `git diff --check`
- Focused `bazel build //test/new-e2e/tests/discovery:discovery_test` started locally; result will be added when complete.