### PR TITLE
feat(orchestrator): collect Gateway and Inference API resources by default

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -49,7 +49,9 @@ const (
 	KubeRayAPIGroup         = "ray.io"
 
 	// Gateway API
-	GatewayAPIGroup = "gateway.networking.k8s.io"
+	GatewayAPIGroup               = "gateway.networking.k8s.io"
+	InferenceAPIGroup             = "inference.networking.k8s.io"
+	InferenceExperimentalAPIGroup = "inference.networking.x-k8s.io"
 
 	// Service mesh
 	IstioNetworkingAPIGroup = "networking.istio.io"
@@ -479,7 +481,7 @@ func (cb *CollectorBundle) importBuiltinCollectors() {
 
 	// add builtin collectors and check if they are already activated
 	for _, collector := range builtinCollectors {
-		if _, ok := cb.activatedCollectors[collector.Metadata().FullName()]; ok {
+		if cb.isBuiltinCollectorAlreadyActivated(collector) {
 			log.Debugf("collector %s has already been added", collector.Metadata().FullName())
 			continue
 		}
@@ -488,6 +490,28 @@ func (cb *CollectorBundle) importBuiltinCollectors() {
 		log.Debugf("import builtin collector: %s", collector.Metadata().FullName())
 		cb.collectors = append(cb.collectors, collector)
 	}
+}
+
+// isBuiltinCollectorAlreadyActivated returns true when the exact collector is active, or when
+// a custom resource collector for the same group and resource is active at another version.
+// Kubernetes serves the same objects through every served version of a CRD, so activating both
+// versions would emit duplicate manifests.
+func (cb *CollectorBundle) isBuiltinCollectorAlreadyActivated(collector collectors.K8sCollector) bool {
+	metadata := collector.Metadata()
+	if _, ok := cb.activatedCollectors[metadata.FullName()]; ok {
+		return true
+	}
+	if metadata.NodeType != orchestrator.K8sCR {
+		return false
+	}
+
+	for _, activeCollector := range cb.collectors {
+		activeMetadata := activeCollector.Metadata()
+		if activeMetadata.NodeType == orchestrator.K8sCR && activeMetadata.Group == metadata.Group && activeMetadata.Name == metadata.Name {
+			return true
+		}
+	}
+	return false
 }
 
 // builtinCRDConfig represents the configuration for a built-in custom resource definition.
@@ -573,11 +597,21 @@ func newBuiltinCRDConfigs() []builtinCRDConfig {
 		newBuiltinCRDConfig(KubeRayAPIGroup, "rayservices", isOOTBCRDEnabled, "v1", "v1alpha1"),
 
 		// Gateway API resources
+		newBuiltinCRDConfig(GatewayAPIGroup, "gatewayclasses", isGatewayAPIEnabled, "v1", "v1beta1"),
 		newBuiltinCRDConfig(GatewayAPIGroup, "gateways", isGatewayAPIEnabled, "v1", "v1beta1"),
 		newBuiltinCRDConfig(GatewayAPIGroup, "httproutes", isGatewayAPIEnabled, "v1", "v1beta1"),
 		newBuiltinCRDConfig(GatewayAPIGroup, "grpcroutes", isGatewayAPIEnabled, "v1", "v1alpha2"),
-		newBuiltinCRDConfig(GatewayAPIGroup, "tlsroutes", isGatewayAPIEnabled, "v1alpha2"),
-		newBuiltinCRDConfig(GatewayAPIGroup, "listenersets", isGatewayAPIEnabled, "v1alpha1"),
+		newBuiltinCRDConfig(GatewayAPIGroup, "backendtlspolicies", isGatewayAPIEnabled, "v1", "v1alpha3", "v1alpha2"),
+		newBuiltinCRDConfig(GatewayAPIGroup, "listenersets", isGatewayAPIEnabled, "v1", "v1alpha1"),
+		newBuiltinCRDConfig(GatewayAPIGroup, "referencegrants", isGatewayAPIEnabled, "v1", "v1beta1"),
+		newBuiltinCRDConfig(GatewayAPIGroup, "tcproutes", isGatewayAPIEnabled, "v1", "v1alpha2"),
+		newBuiltinCRDConfig(GatewayAPIGroup, "tlsroutes", isGatewayAPIEnabled, "v1", "v1alpha3", "v1alpha2"),
+		newBuiltinCRDConfig(GatewayAPIGroup, "udproutes", isGatewayAPIEnabled, "v1", "v1alpha2"),
+
+		// Gateway API Inference Extension resources
+		newBuiltinCRDConfig(InferenceAPIGroup, "inferencepools", isGatewayAPIEnabled, "v1"),
+		newBuiltinCRDConfig(InferenceExperimentalAPIGroup, "inferencepools", isGatewayAPIEnabled, "v1alpha2", "v1alpha1"),
+		newBuiltinCRDConfig(InferenceExperimentalAPIGroup, "inferencepoolimports", isGatewayAPIEnabled, "v1alpha1"),
 
 		// Service mesh — Istio (resource-specific to avoid over-collection)
 		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "virtualservices", isServiceMeshEnabled, "v1", "v1beta1", "v1alpha3"),
@@ -632,7 +666,7 @@ func (cb *CollectorBundle) collectorsForBuiltinCRD(builtinCustomResource builtin
 		return nil
 	}
 
-	version, ok := cb.collectorDiscovery.OptimalVersion(builtinCustomResource.group, builtinCustomResource.preferredVersion, builtinCustomResource.fallbackVersions)
+	version, ok := cb.collectorDiscovery.OptimalVersion(builtinCustomResource.group, builtinCustomResource.kind, builtinCustomResource.preferredVersion, builtinCustomResource.fallbackVersions)
 	if !ok {
 		log.Infof("Skipping built-in CR collector: no supported version found for %s/%s (preferred: %s, fallback: %s)",
 			builtinCustomResource.group, builtinCustomResource.kind, builtinCustomResource.preferredVersion, builtinCustomResource.fallbackVersions)

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
@@ -450,11 +450,21 @@ func TestNewBuiltinCRDConfigs(t *testing.T) {
 		"ray.io/v1/rayservices",
 
 		// Gateway API
+		"gateway.networking.k8s.io/v1/gatewayclasses",
 		"gateway.networking.k8s.io/v1/gateways",
 		"gateway.networking.k8s.io/v1/httproutes",
 		"gateway.networking.k8s.io/v1/grpcroutes",
-		"gateway.networking.k8s.io/v1alpha2/tlsroutes",
-		"gateway.networking.k8s.io/v1alpha1/listenersets",
+		"gateway.networking.k8s.io/v1/backendtlspolicies",
+		"gateway.networking.k8s.io/v1/listenersets",
+		"gateway.networking.k8s.io/v1/referencegrants",
+		"gateway.networking.k8s.io/v1/tcproutes",
+		"gateway.networking.k8s.io/v1/tlsroutes",
+		"gateway.networking.k8s.io/v1/udproutes",
+
+		// Gateway API Inference Extension
+		"inference.networking.k8s.io/v1/inferencepools",
+		"inference.networking.x-k8s.io/v1alpha2/inferencepools",
+		"inference.networking.x-k8s.io/v1alpha1/inferencepoolimports",
 
 		// Service mesh — Istio
 		"networking.istio.io/v1/virtualservices",
@@ -505,7 +515,7 @@ func TestNewBuiltinCRDConfigsPerFamilyFlags(t *testing.T) {
 		gatewayAPI          bool
 		serviceMesh         bool
 		ingressControllers  bool
-		expectedGatewayAPI  int // 5 entries
+		expectedGatewayAPI  int // 13 entries
 		expectedServiceMesh int // 11 entries (5 Istio + 6 group-level)
 		expectedIngress     int // 6 entries (2 NGINX + 1 Traefik + 3 group-level)
 	}{
@@ -515,7 +525,7 @@ func TestNewBuiltinCRDConfigsPerFamilyFlags(t *testing.T) {
 			gatewayAPI:          true,
 			serviceMesh:         true,
 			ingressControllers:  true,
-			expectedGatewayAPI:  5,
+			expectedGatewayAPI:  13,
 			expectedServiceMesh: 11,
 			expectedIngress:     6,
 		},
@@ -535,7 +545,7 @@ func TestNewBuiltinCRDConfigsPerFamilyFlags(t *testing.T) {
 			gatewayAPI:          true,
 			serviceMesh:         false,
 			ingressControllers:  true,
-			expectedGatewayAPI:  5,
+			expectedGatewayAPI:  13,
 			expectedServiceMesh: 0,
 			expectedIngress:     6,
 		},
@@ -545,7 +555,7 @@ func TestNewBuiltinCRDConfigsPerFamilyFlags(t *testing.T) {
 			gatewayAPI:          true,
 			serviceMesh:         true,
 			ingressControllers:  false,
-			expectedGatewayAPI:  5,
+			expectedGatewayAPI:  13,
 			expectedServiceMesh: 11,
 			expectedIngress:     0,
 		},
@@ -569,7 +579,11 @@ func TestNewBuiltinCRDConfigsPerFamilyFlags(t *testing.T) {
 
 			configs := newBuiltinCRDConfigs()
 
-			gatewayAPIGroups := map[string]bool{GatewayAPIGroup: true}
+			gatewayAPIGroups := map[string]bool{
+				GatewayAPIGroup:               true,
+				InferenceAPIGroup:             true,
+				InferenceExperimentalAPIGroup: true,
+			}
 			serviceMeshGroups := map[string]bool{
 				IstioNetworkingAPIGroup: true, EnvoyGatewayAPIGroup: true,
 				TraefikLegacyAPIGroup: true, LinkerdPolicyAPIGroup: true,
@@ -600,6 +614,29 @@ func TestNewBuiltinCRDConfigsPerFamilyFlags(t *testing.T) {
 			require.Equal(t, testCase.expectedIngress, ingressCount, "ingress controllers count mismatch")
 		})
 	}
+}
+
+func TestIsBuiltinCollectorAlreadyActivated(t *testing.T) {
+	explicitGateway, err := k8s.NewCRCollector("gateways", "gateway.networking.k8s.io/v1beta1")
+	require.NoError(t, err)
+	builtinGateway, err := k8s.NewCRCollector("gateways", "gateway.networking.k8s.io/v1")
+	require.NoError(t, err)
+	differentResource, err := k8s.NewCRCollector("httproutes", "gateway.networking.k8s.io/v1")
+	require.NoError(t, err)
+	differentGroup, err := k8s.NewCRCollector("gateways", "example.com/v1")
+	require.NoError(t, err)
+
+	cb := CollectorBundle{
+		collectors: []collectors.K8sCollector{explicitGateway},
+		activatedCollectors: map[string]struct{}{
+			explicitGateway.Metadata().FullName(): {},
+		},
+	}
+
+	require.True(t, cb.isBuiltinCollectorAlreadyActivated(explicitGateway))
+	require.True(t, cb.isBuiltinCollectorAlreadyActivated(builtinGateway))
+	require.False(t, cb.isBuiltinCollectorAlreadyActivated(differentResource))
+	require.False(t, cb.isBuiltinCollectorAlreadyActivated(differentGroup))
 }
 
 func TestFilterCRCollectorsByPermission(t *testing.T) {

--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
@@ -215,21 +215,26 @@ func matchesGroupVersion(cv, group, version string) bool {
 	}
 }
 
-// OptimalVersion returns the best available version for a given group.
-func (d *DiscoveryCollector) OptimalVersion(groupName, preferredVersion string, fallbackVersions []string) (string, bool) {
+// OptimalVersion returns the best available version for a given resource in a group.
+// An empty resource name matches any resource in the group.
+func (d *DiscoveryCollector) OptimalVersion(groupName, resourceName, preferredVersion string, fallbackVersions []string) (string, bool) {
 	supportedVersions := d.getSupportedVersions(groupName)
 	if len(supportedVersions) == 0 {
 		return "", false
 	}
 
+	isAvailable := func(version string) bool {
+		return supportedVersions[version] && (resourceName == "" || len(d.List(groupName, version, resourceName)) > 0)
+	}
+
 	// Try preferred version first
-	if preferredVersion != "" && supportedVersions[preferredVersion] {
+	if preferredVersion != "" && isAvailable(preferredVersion) {
 		return preferredVersion, true
 	}
 
 	// Try fallback versions in order
 	for _, version := range fallbackVersions {
-		if version != "" && supportedVersions[version] {
+		if version != "" && isAvailable(version) {
 			return version, true
 		}
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd_test.go
@@ -223,11 +223,40 @@ func TestDiscoveryCollector_OptimalVersion(t *testing.T) {
 		name             string
 		setup            func() *DiscoveryCollector
 		groupName        string
+		resourceName     string
 		preferredVersion string
 		fallbackVersions []string
 		expectedVersion  string
 		expectedFound    bool
 	}{
+		{
+			name: "skips a version only exposed by another resource in the group",
+			setup: func() *DiscoveryCollector {
+				return &DiscoveryCollector{
+					cache: DiscoveryCache{
+						Groups: []*v1.APIGroup{
+							{
+								Name: "ray.io",
+								Versions: []v1.GroupVersionForDiscovery{
+									{Version: "v1"},
+									{Version: "v1alpha1"},
+								},
+							},
+						},
+						CollectorForVersion: map[CollectorVersion]struct{}{
+							{GroupVersion: "ray.io/v1", Kind: "rayjobs"}:           {},
+							{GroupVersion: "ray.io/v1alpha1", Kind: "rayclusters"}: {},
+						},
+					},
+				}
+			},
+			groupName:        "ray.io",
+			resourceName:     "rayclusters",
+			preferredVersion: "v1",
+			fallbackVersions: []string{"v1alpha1"},
+			expectedVersion:  "v1alpha1",
+			expectedFound:    true,
+		},
 		{
 			name: "returns preferred version when available",
 			setup: func() *DiscoveryCollector {
@@ -416,7 +445,7 @@ func TestDiscoveryCollector_OptimalVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dc := tt.setup()
-			version, found := dc.OptimalVersion(tt.groupName, tt.preferredVersion, tt.fallbackVersions)
+			version, found := dc.OptimalVersion(tt.groupName, tt.resourceName, tt.preferredVersion, tt.fallbackVersions)
 
 			assert.Equal(t, tt.expectedFound, found, "OptimalVersion() found mismatch")
 			assert.Equal(t, tt.expectedVersion, version, "OptimalVersion() version mismatch")

--- a/pkg/config/schema/yaml/orchestrator_explorer.yaml
+++ b/pkg/config/schema/yaml/orchestrator_explorer.yaml
@@ -41,7 +41,7 @@ properties:
           gateway_api:
             node_type: setting
             type: boolean
-            default: false
+            default: true
           ingress_controllers:
             node_type: setting
             type: boolean

--- a/releasenotes-dca/notes/collect-gateway-inference-api-resources-by-default-3b7de62eb95c03c8.yaml
+++ b/releasenotes-dca/notes/collect-gateway-inference-api-resources-by-default-3b7de62eb95c03c8.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Collect Gateway API and Gateway API Inference Extension custom resources
+    in Orchestrator Explorer by default. Set
+    ``orchestrator_explorer.custom_resources.ootb.gateway_api`` to ``false``
+    to opt out.

--- a/test/e2e-framework/AGENTS.md
+++ b/test/e2e-framework/AGENTS.md
@@ -195,6 +195,10 @@ When that's not enough, common advanced patterns:
 
 - **`e2e.WithDevMode()`** — keep infrastructure alive after test for faster iteration.
 - **`e2e.WithStackName(name)`** — custom Pulumi stack naming for parameterized tests.
+- **`kindvm.WithPreAgentWorkloadApp(...)`** — install CRDs or other setup workloads
+  before the Helm Agent or Operator. The Agent installation depends on the returned
+  workload component. This Kind-on-VM option cannot be combined with a standalone
+  OpenTelemetry Agent.
 
 ### Example tests by pattern
 

--- a/test/e2e-framework/scenarios/aws/kindvm/run.go
+++ b/test/e2e-framework/scenarios/aws/kindvm/run.go
@@ -7,6 +7,7 @@ package kindvm
 
 import (
 	_ "embed"
+	"errors"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
@@ -71,6 +72,9 @@ func Run(ctx *pulumi.Context) error {
 // RunWithEnv deploys a KIND-on-EC2 environment using a provided env and params.
 // It accepts KubernetesOutputs interface, enabling reuse between provisioners and direct Pulumi runs.
 func RunWithEnv(ctx *pulumi.Context, awsEnv resAws.Environment, env outputs.KubernetesOutputs, params *RunParams) error {
+	if len(params.preAgentWorkloadAppFuncs) > 0 && params.standaloneDdotFunc != nil {
+		return errors.New("pre-agent workloads are not supported with a standalone OTel Agent")
+	}
 
 	var err error
 	var fakeIntake *fakeintakeComp.Fakeintake
@@ -175,6 +179,30 @@ func RunWithEnv(ctx *pulumi.Context, awsEnv resAws.Environment, env outputs.Kube
 			return err
 		}
 		dependsOnArgoRollout = utils.PulumiDependsOn(argoHelm)
+	}
+
+	preAgentWorkloads := make([]pulumi.Resource, 0, len(params.preAgentWorkloadAppFuncs))
+	for _, appFunc := range params.preAgentWorkloadAppFuncs {
+		workload, err := appFunc(&awsEnv, kubeProvider)
+		if err != nil {
+			return err
+		}
+		preAgentWorkloads = append(preAgentWorkloads, workload)
+	}
+	if len(preAgentWorkloads) > 0 {
+		dependsOnPreAgentWorkloads := utils.PulumiDependsOn(preAgentWorkloads...)
+		if len(params.agentOptions) > 0 {
+			params.agentOptions = append(params.agentOptions,
+				kubernetesagentparams.WithPulumiResourceOptions(dependsOnPreAgentWorkloads))
+		}
+		if params.deployOperator {
+			params.operatorOptions = append(params.operatorOptions,
+				operatorparams.WithPulumiResourceOptions(dependsOnPreAgentWorkloads))
+			if params.operatorDDAOptions != nil {
+				params.operatorDDAOptions = append(params.operatorDDAOptions,
+					agentwithoperatorparams.WithPulumiResourceOptions(dependsOnPreAgentWorkloads))
+			}
+		}
 	}
 
 	var dependsOnDDAgent pulumi.ResourceOption

--- a/test/e2e-framework/scenarios/aws/kindvm/run_args.go
+++ b/test/e2e-framework/scenarios/aws/kindvm/run_args.go
@@ -25,13 +25,14 @@ const csiDriverCommitSHA = "d91af776a15382b030035129e3b93dc8620d787e"
 
 // RunParams collects parameters for the Kind-on-VM scenario
 type RunParams struct {
-	Name                string
-	vmOptions           []ec2.VMOption
-	agentOptions        []kubernetesagentparams.Option
-	fakeintakeOptions   []fakeintake.Option
-	ciliumOptions       []cilium.Option
-	workloadAppFuncs    []kubecomp.WorkloadAppFunc
-	depWorkloadAppFuncs []kubecomp.AgentDependentWorkloadAppFunc
+	Name                     string
+	vmOptions                []ec2.VMOption
+	agentOptions             []kubernetesagentparams.Option
+	fakeintakeOptions        []fakeintake.Option
+	ciliumOptions            []cilium.Option
+	preAgentWorkloadAppFuncs []kubecomp.WorkloadAppFunc
+	workloadAppFuncs         []kubecomp.WorkloadAppFunc
+	depWorkloadAppFuncs      []kubecomp.AgentDependentWorkloadAppFunc
 
 	deployOperator     bool
 	operatorDDAOptions []agentwithoperatorparams.Option
@@ -59,17 +60,18 @@ type RunOption = func(*RunParams) error
 
 func GetRunParams(opts ...RunOption) *RunParams {
 	p := &RunParams{
-		Name:                defaultKindName,
-		vmOptions:           []ec2.VMOption{},
-		agentOptions:        nil, // nil by default - Agent is only deployed when options are explicitly provided
-		fakeintakeOptions:   []fakeintake.Option{},
-		workloadAppFuncs:    []kubecomp.WorkloadAppFunc{},
-		depWorkloadAppFuncs: []kubecomp.AgentDependentWorkloadAppFunc{},
-		operatorOptions:     []operatorparams.Option{},
-		operatorDDAOptions:  nil, // nil by default - DDA is only deployed when options are explicitly provided
-		deployDogstatsd:     false,
-		deployOperator:      false,
-		workerNodes:         []kubecomp.KindWorkerNode{},
+		Name:                     defaultKindName,
+		vmOptions:                []ec2.VMOption{},
+		agentOptions:             nil, // nil by default - Agent is only deployed when options are explicitly provided
+		fakeintakeOptions:        []fakeintake.Option{},
+		preAgentWorkloadAppFuncs: []kubecomp.WorkloadAppFunc{},
+		workloadAppFuncs:         []kubecomp.WorkloadAppFunc{},
+		depWorkloadAppFuncs:      []kubecomp.AgentDependentWorkloadAppFunc{},
+		operatorOptions:          []operatorparams.Option{},
+		operatorDDAOptions:       nil, // nil by default - DDA is only deployed when options are explicitly provided
+		deployDogstatsd:          false,
+		deployOperator:           false,
+		workerNodes:              []kubecomp.KindWorkerNode{},
 	}
 	if err := optional.ApplyOptions(p, opts); err != nil {
 		panic(fmt.Errorf("unable to apply RunOption, err: %w", err))
@@ -176,6 +178,14 @@ func WithDeployDogstatsd() RunOption {
 // WithDeployTestWorkload enables test workloads
 func WithDeployTestWorkload() RunOption {
 	return func(p *RunParams) error { p.deployTestWorkload = true; return nil }
+}
+
+// WithPreAgentWorkloadApp adds a workload app that must be ready before the Agent is installed.
+func WithPreAgentWorkloadApp(appFunc kubecomp.WorkloadAppFunc) RunOption {
+	return func(p *RunParams) error {
+		p.preAgentWorkloadAppFuncs = append(p.preAgentWorkloadAppFuncs, appFunc)
+		return nil
+	}
 }
 
 // WithWorkloadApp adds a workload app to the environment

--- a/test/new-e2e/tests/orchestrator/BUILD.bazel
+++ b/test/new-e2e/tests/orchestrator/BUILD.bazel
@@ -12,6 +12,7 @@ dd_agent_go_test(
     name = "orchestrator_test",
     srcs = [
         "ecs_test.go",
+        "gateway_inference_test.go",
         "k8s_api_key_test.go",
         "k8s_test.go",
         "util_test.go",
@@ -19,17 +20,21 @@ dd_agent_go_test(
     data = [
         "agent_api_key_values.yaml",
         "agent_values.yaml",
+        "fixtures/gateway_inference.yaml",
     ],
     embed = [":orchestrator"],
     embedsrcs = [
         "agent_api_key_values.yaml",
         "agent_values.yaml",
+        "fixtures/gateway_inference.yaml",
     ],
     deps = [
+        "//test/e2e-framework/common/config",
         "//test/e2e-framework/components/datadog/apps/cpustress",
         "//test/e2e-framework/components/datadog/fakeintake",
         "//test/e2e-framework/components/datadog/kubernetesagentparams",
         "//test/e2e-framework/components/ecs",
+        "//test/e2e-framework/components/kubernetes",
         "//test/e2e-framework/resources/aws",
         "//test/e2e-framework/scenarios/aws/ecs",
         "//test/e2e-framework/scenarios/aws/kindvm",
@@ -40,6 +45,8 @@ dd_agent_go_test(
         "//test/fakeintake/aggregator",
         "//test/fakeintake/client",
         "@com_github_datadog_agent_payload_v5//process",
+        "@com_github_pulumi_pulumi_kubernetes_sdk_v4//go/kubernetes",
+        "@com_github_pulumi_pulumi_kubernetes_sdk_v4//go/kubernetes/yaml",
         "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/test/new-e2e/tests/orchestrator/agent_values.yaml
+++ b/test/new-e2e/tests/orchestrator/agent_values.yaml
@@ -4,6 +4,9 @@ datadog:
   orchestratorExplorer:
     customResources:
       - datadoghq.com/v1alpha1/datadogmetrics
+      # Grant RBAC without adding Gateway API collectors to the custom orchestrator config below.
+      - gateway.networking.k8s.io/v1/httproutes
+      - inference.networking.k8s.io/v1/inferencepools
 agents:
   useHostNetwork: true
 

--- a/test/new-e2e/tests/orchestrator/fixtures/gateway_inference.yaml
+++ b/test/new-e2e/tests/orchestrator/fixtures/gateway_inference.yaml
@@ -1,0 +1,55 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: httproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    kind: HTTPRoute
+    listKind: HTTPRouteList
+    plural: httproutes
+    singular: httproute
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gateway-api-e2e
+  namespace: default
+spec: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: inferencepools.inference.networking.k8s.io
+spec:
+  group: inference.networking.k8s.io
+  names:
+    kind: InferencePool
+    listKind: InferencePoolList
+    plural: inferencepools
+    singular: inferencepool
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: inference-pool-e2e
+  namespace: default
+spec: {}

--- a/test/new-e2e/tests/orchestrator/gateway_inference_test.go
+++ b/test/new-e2e/tests/orchestrator/gateway_inference_test.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package orchestrator
+
+import (
+	_ "embed"
+
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/yaml"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	agentmodel "github.com/DataDog/agent-payload/v5/process"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
+	kubecomp "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+)
+
+//go:embed fixtures/gateway_inference.yaml
+var gatewayInferenceManifest string
+
+func deployGatewayInferenceTestResources(e config.Env, kubeProvider *kubernetes.Provider) (*kubecomp.Workload, error) {
+	workload := &kubecomp.Workload{}
+	if err := e.Ctx().RegisterComponentResource("dd:apps", "gateway-inference-test-resources", workload); err != nil {
+		return nil, err
+	}
+
+	_, err := yaml.NewConfigGroup(e.Ctx(), "gateway-inference-test-resources", &yaml.ConfigGroupArgs{
+		YAML: []string{gatewayInferenceManifest},
+	}, pulumi.Provider(kubeProvider), pulumi.Parent(workload))
+	if err != nil {
+		return nil, err
+	}
+
+	return workload, nil
+}
+
+func (suite *k8sSuite) TestGatewayAPICRManifest() {
+	expectAtLeastOneManifest{
+		test: func(payload *aggregator.OrchestratorManifestPayload, manif manifest) bool {
+			return payload.Type == agentmodel.TypeCollectorManifestCR &&
+				manif.APIVersion == "gateway.networking.k8s.io/v1" &&
+				manif.Kind == "HTTPRoute" &&
+				manif.Metadata.Name == "gateway-api-e2e"
+		},
+		message: "find a Gateway API HTTPRoute manifest collected through the built-in configuration",
+		timeout: defaultTimeout,
+	}.Assert(suite)
+}
+
+func (suite *k8sSuite) TestGatewayInferenceCRManifest() {
+	expectAtLeastOneManifest{
+		test: func(payload *aggregator.OrchestratorManifestPayload, manif manifest) bool {
+			return payload.Type == agentmodel.TypeCollectorManifestCR &&
+				manif.APIVersion == "inference.networking.k8s.io/v1" &&
+				manif.Kind == "InferencePool" &&
+				manif.Metadata.Name == "inference-pool-e2e"
+		},
+		message: "find an Inference Extension InferencePool manifest collected through the built-in configuration",
+		timeout: defaultTimeout,
+	}.Assert(suite)
+}

--- a/test/new-e2e/tests/orchestrator/k8s_test.go
+++ b/test/new-e2e/tests/orchestrator/k8s_test.go
@@ -43,6 +43,7 @@ func TestKindSuite(t *testing.T) {
 		e2e.WithProvisioner(awskindvm.Provisioner(
 			awskindvm.WithRunOptions(
 				scenariokindvm.WithDeployTestWorkload(),
+				scenariokindvm.WithPreAgentWorkloadApp(deployGatewayInferenceTestResources),
 				scenariokindvm.WithAgentOptions(
 					kubernetesagentparams.WithDualShipping(),
 					kubernetesagentparams.WithHelmValues(agentCustomValuesFmt),


### PR DESCRIPTION
### What does this PR do?

Collects standard Gateway API and Gateway API Inference Extension custom resources in Orchestrator Explorer by default, with fallbacks for versions served by older releases. It preserves the existing `gateway_api` opt-out and avoids duplicate collection when the same resource is configured explicitly at another version.

It also makes version discovery resource-aware and adds an orchestrator E2E covering HTTPRoute and InferencePool manifests.

### Motivation

Make Gateway and inference-routing topology available without manual collector configuration.

Backend allowlisting and default RBAC are supplied by the companion dd-go, Operator, Helm, and internal Operator chart PRs. Those dependencies must roll out before the Agent release.

Companion PRs:

- ddoghq/dd-go#14657
- DataDog/datadog-operator#3438
- DataDog/helm-charts#2898
- DataDog/k8s-datadog-agent-ops#9648

### Describe how you validated your changes

- `dda inv test --targets=./pkg/collector/corechecks/cluster/orchestrator/...`
- `dda inv linter.go --targets=./pkg/collector/corechecks/cluster/orchestrator,./pkg/collector/corechecks/cluster/orchestrator/discovery`
- `dda inv linter.go --module=test/new-e2e --targets=./tests/orchestrator`
- `bazel run //bazel/buildifier`
- `bazel build //test/new-e2e/tests/orchestrator:orchestrator_test`
- YAML and release-note validation

The cloud E2E was not provisioned locally; the existing orchestrator CI job will run it.

### Additional Notes

Set `orchestrator_explorer.custom_resources.ootb.gateway_api` to `false` to opt out.
