### PR TITLE
Quarantine Xenial DDOT install test

### DIFF
--- a/test/new-e2e/tests/agent-platform/tests/BUILD.bazel
+++ b/test/new-e2e/tests/agent-platform/tests/BUILD.bazel
@@ -15,6 +15,7 @@ dd_agent_go_test(
     ],
     data = ["//cmd/agent:macos/uninstall_mac_os.sh"],
     deps = [
+        "//pkg/util/testutil/flake",
         "//test/e2e-framework/components/os",
         "//test/e2e-framework/scenarios/aws/ec2",
         "//test/e2e-framework/testing/components",

--- a/test/new-e2e/tests/agent-platform/tests/ddot_install_test.go
+++ b/test/new-e2e/tests/agent-platform/tests/ddot_install_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
 	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
@@ -64,6 +65,10 @@ func TestDDOTInstallScript(t *testing.T) {
 
 		t.Run("test ddot install on "+osDesc.String(), func(tt *testing.T) {
 			tt.Parallel()
+			if osDesc.Flavor == e2eos.Ubuntu && strings.Contains(osDesc.Version, "16-04") {
+				// Quarantine Xenial because its EOL apt mirrors are unreliable (incident 60253).
+				flake.Mark(tt)
+			}
 			tt.Logf("Testing %s", osDesc.Version)
 			slice := strings.Split(osDesc.Version, "-")
 			var version float64


### PR DESCRIPTION
<!-- dd-meta {"pullId":"aa75ebe7-72c6-4871-93bf-0430c9c61e54","source":"chat","resourceId":"78b9b092-bf65-4357-bba0-255509bdd387","workflowId":"24f167af-64e9-45e4-ad98-a43c407c09cb","codeChangeId":"24f167af-64e9-45e4-ad98-a43c407c09cb","sourceType":"assistant"} -->
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

- Marks only the Ubuntu 16.04 DDOT install subtest as flaky so other operating-system coverage remains blocking.
- Documents the Xenial mirror quarantine and incident 60253 at the call site.

### Motivation

Ubuntu 16.04 is end-of-life, and its apt mirrors are repeatedly failing with unsigned or missing Release metadata, hash mismatches, and connection errors. Its apt 1.2 client cannot use the mirror failover hardening available to newer Ubuntu versions, causing this subtest to block `main` continuously.

### Describe how you validated your changes

- Formatted `test/new-e2e/tests/agent-platform/tests/ddot_install_test.go` with `gofmt`.
- Ran `git diff --check` successfully.
- Attempted a compile-only targeted test with `dda inv test`; the sandbox could not complete it because Go 1.26.7 is unavailable locally and the Bazel 9.2.0 download returned HTTP 502 before compilation.

### Additional Notes

Tracks incident IR-60253.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/78b9b092-bf65-4357-bba0-255509bdd387)

Comment @datadog to request changes