### PR TITLE
Bump `rules_go` again to drop the stdlib config fork

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -106,9 +106,9 @@ archive_override(
     patches = [
         "//bazel/patches:rules_go-windows-symlink-workaround.patch",  # bazel-contrib/rules_go#3977
     ],
-    sha256 = "9f066d4ad363d049b7b6c3c7f64d73e5ba36caf065fab51848a540a49ab1bb49",
-    strip_prefix = "rules_go-f6afe7478c645595839adc211644e6e5474d9fd3",
-    urls = ["https://github.com/bazel-contrib/rules_go/archive/f6afe7478c645595839adc211644e6e5474d9fd3.tar.gz"],  # master as of September 3, 2026
+    sha256 = "7fc1406e690e6e434b91de9fc88832203dddc2f5d2615e616b9c9b960c95db55",
+    strip_prefix = "rules_go-7da903b60f6e97643166e56ecd15c46f9aa61a66",
+    urls = ["https://github.com/bazel-contrib/rules_go/archive/7da903b60f6e97643166e56ecd15c46f9aa61a66.tar.gz"],  # master as of September 10, 2026
 )
 
 # Temporary until rules_pkg > 1.2.0 is in BCR


### PR DESCRIPTION
### What does this PR do?
Bump the `rules_go` `archive_override` pin in `MODULE.bazel` to its latest upstream master commit, bazel-contrib/rules_go@975884f705a9721a3c39bad4033852b0b795a3ce, for bazel-contrib/rules_go#4705.

### Motivation
`rules_go`'s `go_stdlib_transition` was unnecessarily forking the Go standard library into its own configuration by resetting `//go/private:request_nogo` to `false`, since nogo never runs against the stdlib anyway.

bazel-contrib/rules_go#4705 resets it to its true default instead, so the stdlib of a default build now shares the target's configuration rather than getting a private one.

This is the same class of unnecessary config-forking fix as bazel-contrib/rules_go#4706 and bazel-contrib/rules_go#4704, already picked up in a prior bump, which we are chasing as a **mitigation for the coverage fingerprint-mismatch issue** described there.

The PR itself also flags two further follow-up fixes in the same direction that have not landed upstream yet.

### Describe how you validated your changes
Built `//pkg/util/common:common` and `//pkg/network/go/bininspect:bininspect_test`, the repo's only target setting `static = "on"`, both succeeded.