### PR TITLE
Add keepalive options to ssh commands in AIX job

### DIFF
--- a/.gitlab/aix/test/aix_unit_tests.yml
+++ b/.gitlab/aix/test/aix_unit_tests.yml
@@ -15,7 +15,7 @@ tests_aix-ppc64:
   script:
     - 'echo "=== AIX: running unit tests ==="'
     - >
-      ssh -tt -p $AIX_PORT $AIX_USER@$AIX_HOST
+      ssh -tt -o ServerAliveInterval=20 -o ServerAliveCountMax=6 -p $AIX_PORT $AIX_USER@$AIX_HOST
       "bash -c '
         set -eu
         cd $AIX_AGENT_SRC


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Add keepalive options on the AIX unit test job to mitigate connectivity issues.

### Motivation
Quick mitigation for connectivity issues in the job. 
I've seen a job hang until the 2h timeout, this should at least make it fail early if the connection drops.

### Describe how you validated your changes

### Additional Notes
This is a quick fix specifically for the unit test job, a follow-up will refactor to make it simpler to run commands and always apply those options.
