### PR TITLE
fix(e2e): return correct success message from destroy_remote_stack_api

### DIFF
--- a/tasks/tools/e2e_stacks.py
+++ b/tasks/tools/e2e_stacks.py
@@ -44,4 +44,4 @@ def destroy_remote_stack_api(stack: str, ctx: Context | None = None):
         exit_code = 1
         stderr = str(e)
 
-    return exit_code, f"Failed to destroy stack {stack} using the API", stderr, stack
+    return exit_code, "Stack cleanup request submitted to stackcleaner" if exit_code == 0 else "", stderr, stack


### PR DESCRIPTION
## Summary
- Fixes a regression from #55894 (revert of #55831): `destroy_remote_stack_api` was returning `"Failed to destroy stack ... using the API"` on the success path, which `cleanup_remote_stacks` prints right before also announcing the same stack was destroyed successfully, producing contradictory CI logs.
- Restores the correct success message, [as flagged in review](https://github.com/DataDog/datadog-agent/pull/55894#discussion_r3935684871).

## Test plan
- [x] `dda inv linter.python` passes