### PR TITLE
Run aix test CI job on changes

### DIFF
--- a/.gitlab/aix/test/aix_unit_tests.yml
+++ b/.gitlab/aix/test/aix_unit_tests.yml
@@ -7,6 +7,13 @@ tests_aix-ppc64:
   rules:
     - !reference [.except_mergequeue]
     - !reference [.on_scheduled_main]
+    - changes:
+        paths:
+          - .gitlab/aix/aix_remote.yml
+          - .gitlab/aix/test/aix_unit_tests.yml
+        compare_to: $COMPARE_TO_BRANCH
+      # TODO: uncomment once the job is stable enough
+      # allow_failure: false
     - when: manual
       variables:
         EXTRA_TEST_FLAGS: "--only-modified-packages"


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Update the AIX unit test job to run automatically when changing it.

### Motivation
Makes it simpler to validate changes to the job itself, and avoids breaking it by accident.

### Describe how you validated your changes
CI

### Additional Notes
