### PR TITLE
Add per-agent log_level settings for config streaming

### DIFF
--- a/pkg/config/schema/yaml/apm_config.yaml
+++ b/pkg/config/schema/yaml/apm_config.yaml
@@ -718,6 +718,16 @@ properties:
       all entries must be surrounded by double quotes and separated by commas.
     example: '["(GET|POST) /healthcheck"]'
     env_parser: csv_comma_separated
+  log_level:
+    node_type: setting
+    type: string
+    default: ''
+    env_vars:
+    - DD_APM_LOG_LEVEL
+    visibility: public
+    description: |-
+      Overrides the global `log_level` for the trace Agent only.
+      Leave empty to use the global `log_level`.
   log_file:
     node_type: setting
     type: string

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -8832,6 +8832,8 @@ properties:
   security_agent:
     node_type: section
     type: object
+    visibility: public
+    description: Settings specific to the security Agent process.
     properties:
       cmd_port:
         node_type: setting
@@ -8939,6 +8941,16 @@ properties:
             node_type: setting
             type: string
             default: ''
+      log_level:
+        node_type: setting
+        type: string
+        default: ''
+        env_vars:
+        - DD_SECURITY_AGENT_LOG_LEVEL
+        visibility: public
+        description: |-
+          Overrides the global `log_level` for the security Agent only.
+          Leave empty to use the global `log_level`.
       log_file:
         node_type: setting
         type: string

--- a/pkg/config/schema/yaml/process_config.yaml
+++ b/pkg/config/schema/yaml/process_config.yaml
@@ -64,6 +64,17 @@ properties:
     - DD_PROCESS_AGENT_CMD_PORT
     visibility: public
     description: Port for configuring runtime settings for the process Agent.
+  log_level:
+    node_type: setting
+    type: string
+    default: ''
+    env_vars:
+    - DD_PROCESS_CONFIG_LOG_LEVEL
+    - DD_PROCESS_AGENT_LOG_LEVEL
+    visibility: public
+    description: |-
+      Overrides the global `log_level` for the process Agent only.
+      Leave empty to use the global `log_level`.
   log_file:
     node_type: setting
     type: string

--- a/releasenotes/notes/configstream-per-agent-log-level-2dce6ca6580b6bc3.yaml
+++ b/releasenotes/notes/configstream-per-agent-log-level-2dce6ca6580b6bc3.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Added three new configuration settings that override the global ``log_level``
+    for a single Agent process: ``security_agent.log_level``
+    (``DD_SECURITY_AGENT_LOG_LEVEL``), ``process_config.log_level``
+    (``DD_PROCESS_CONFIG_LOG_LEVEL``, ``DD_PROCESS_AGENT_LOG_LEVEL``) and
+    ``apm_config.log_level`` (``DD_APM_LOG_LEVEL``). They complement the existing
+    ``system_probe_config.log_level`` and default to an empty string, meaning no
+    override. These per-Agent keys allow a distinct log level to be kept for each
+    Agent process when configuration streaming makes the core Agent the source of
+    truth for configuration.


### PR DESCRIPTION
### What does this PR do?

Adds three namespaced settings to the core Agent schema — `security_agent.log_level`, `process_config.log_level`, `apm_config.log_level` — each with its `DD_*` env vars and an empty-string default, alongside their existing `log_file` siblings. Also makes the `security_agent` section public.

### Motivation

Under config streaming the core Agent is the source of truth, so a setting that applies to only one remote agent needs a home on the core Agent. `log_level` is the case that cannot be hoisted: it is divergent by design, rendered per container. Empty string means "no override", which is what makes the remap in the next branch retractable.

### Describe how you validated your changes

`schema.lint` and `schema.codegen` succeed and emit the expected `BindEnvAndSetDefault` calls; `dda inv tidy`, `linter.go` and `dda inv test` clean. Live: all three keys resolve on a running core Agent from their env vars.

### Additional Notes

`system_probe_config.log_level` already exists and is unchanged.

The release note describes behaviour that only exists once the next branch lands, so **A1 and A2 must ship together**. Bottom of the config-streaming stack; base is `main`.
