### PR TITLE
fix(logs): stop duplicated configured tags on journald and Windows Event

### DIFF
--- a/pkg/logs/message/origin_test.go
+++ b/pkg/logs/message/origin_test.go
@@ -63,19 +63,6 @@ func TestConfiguredTagsAppearOnceWhenNotPassedToSetTags(t *testing.T) {
 
 	tags := origin.Tags()
 	assert.Equal(t, []string{"sourcecategory:b", "team:infra"}, tags)
-	for _, configuredTag := range cfg.Tags {
-		assert.Equal(t, 1, countTagOccurrences(tags, configuredTag))
-	}
-}
-
-func countTagOccurrences(tags []string, target string) int {
-	count := 0
-	for _, tag := range tags {
-		if tag == target {
-			count++
-		}
-	}
-	return count
 }
 
 func TestSetTagsWithConfigTags(t *testing.T) {

--- a/pkg/logs/message/origin_test.go
+++ b/pkg/logs/message/origin_test.go
@@ -50,6 +50,34 @@ func TestSetTagsWithNoConfigTags(t *testing.T) {
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"foo:bar,baz\"]", string(origin.TagsPayload(nil)))
 }
 
+func TestConfiguredTagsAppearOnceWhenNotPassedToSetTags(t *testing.T) {
+	// Configured tags belong in LogSource.Config.Tags; the origin merges them on read.
+	// Tailers must not also pass Config.Tags into SetTags (journald/windowsevent #38334).
+	cfg := &config.LogsConfig{
+		SourceCategory: "b",
+		Tags:           []string{"team:infra"},
+	}
+	source := sources.NewLogSource("", cfg)
+	origin := NewOrigin(source)
+	origin.SetTags([]string{})
+
+	tags := origin.Tags()
+	assert.Equal(t, []string{"sourcecategory:b", "team:infra"}, tags)
+	for _, configuredTag := range cfg.Tags {
+		assert.Equal(t, 1, countTagOccurrences(tags, configuredTag))
+	}
+}
+
+func countTagOccurrences(tags []string, target string) int {
+	count := 0
+	for _, tag := range tags {
+		if tag == target {
+			count++
+		}
+	}
+	return count
+}
+
 func TestSetTagsWithConfigTags(t *testing.T) {
 	cfg := &config.LogsConfig{
 		Source:         "a",

--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -82,7 +82,7 @@ func NewTailer(source *sources.LogSource, outputChan chan *message.Message, jour
 		stop:                   make(chan struct{}, 1),
 		done:                   make(chan struct{}, 1),
 		processRawMessage:      processRawMessage,
-		tagProvider:            tag.NewLocalProvider(source.Config.Tags),
+		tagProvider:            tag.NewLocalProvider([]string{}),
 		tagger:                 tagger,
 		registry:               registry,
 		defaultApplicationName: source.Config.DefaultApplicationName,

--- a/pkg/logs/tailers/journald/tailer_test.go
+++ b/pkg/logs/tailers/journald/tailer_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	auditorMock "github.com/DataDog/datadog-agent/comp/logs/auditor/mock"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tag"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -687,6 +688,31 @@ func TestTailerCompareUnstructuredAndStructured(t *testing.T) {
 	assert.NoError(err2)
 
 	assert.Equal(v1, v2)
+}
+
+func TestGetOriginConfiguredTagsAppearOnce(t *testing.T) {
+	source := sources.NewLogSource("", &config.LogsConfig{
+		Tags: []string{"team:infra", "env:prod"},
+	})
+	tailer := &Tailer{
+		source:      source,
+		tagProvider: tag.NewLocalProvider([]string{}),
+	}
+	entry := &sdjournal.JournalEntry{Fields: map[string]string{"MESSAGE": "hello"}}
+
+	tags := tailer.getOrigin(entry).Tags()
+	assert.Equal(t, 1, countTagOccurrences(tags, "team:infra"))
+	assert.Equal(t, 1, countTagOccurrences(tags, "env:prod"))
+}
+
+func countTagOccurrences(tags []string, target string) int {
+	count := 0
+	for _, tag := range tags {
+		if tag == target {
+			count++
+		}
+	}
+	return count
 }
 
 func TestExpectedTagDuration(t *testing.T) {

--- a/pkg/logs/tailers/journald/tailer_test.go
+++ b/pkg/logs/tailers/journald/tailer_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	auditorMock "github.com/DataDog/datadog-agent/comp/logs/auditor/mock"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
-	"github.com/DataDog/datadog-agent/pkg/logs/internal/tag"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -694,25 +693,14 @@ func TestGetOriginConfiguredTagsAppearOnce(t *testing.T) {
 	source := sources.NewLogSource("", &config.LogsConfig{
 		Tags: []string{"team:infra", "env:prod"},
 	})
-	tailer := &Tailer{
-		source:      source,
-		tagProvider: tag.NewLocalProvider([]string{}),
-	}
+	mockJournal := &MockJournal{m: &sync.Mutex{}}
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	fakeRegistry := auditorMock.NewMockAuditor()
+	tailer := NewTailer(source, make(chan *message.Message, 1), mockJournal, true, fakeTagger, fakeRegistry)
 	entry := &sdjournal.JournalEntry{Fields: map[string]string{"MESSAGE": "hello"}}
 
 	tags := tailer.getOrigin(entry).Tags()
-	assert.Equal(t, 1, countTagOccurrences(tags, "team:infra"))
-	assert.Equal(t, 1, countTagOccurrences(tags, "env:prod"))
-}
-
-func countTagOccurrences(tags []string, target string) int {
-	count := 0
-	for _, tag := range tags {
-		if tag == target {
-			count++
-		}
-	}
-	return count
+	assert.Equal(t, []string{"team:infra", "env:prod"}, tags)
 }
 
 func TestExpectedTagDuration(t *testing.T) {

--- a/pkg/logs/tailers/windowsevent/tailer.go
+++ b/pkg/logs/tailers/windowsevent/tailer.go
@@ -162,11 +162,8 @@ func (t *Tailer) forwardMessages() {
 			// This preserves all bookmark information and is more efficient
 			msg := decodedMessage
 
-			// Update tags to include source config tags
 			if msg.Origin != nil {
-				// Combine tags from multiple sources: parsing extra tags and source config tags
-				tags := append(msg.ParsingExtra.Tags, t.source.Config.Tags...)
-				msg.Origin.SetTags(tags)
+				msg.Origin.SetTags(msg.ParsingExtra.Tags)
 			}
 
 			t.outputChan <- msg

--- a/pkg/logs/tailers/windowsevent/tailer_test.go
+++ b/pkg/logs/tailers/windowsevent/tailer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	evtapi "github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+	winevtapi "github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api/windows"
 	publishermetadatacache "github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/publishermetadatacache"
 	eventlog_test "github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/test"
 )
@@ -443,6 +444,35 @@ collectLoop:
 	}
 
 	s.Require().Equal(newEvents, receivedEvents, "Should receive all %d new events", newEvents)
+}
+
+func TestForwardMessagesConfiguredTagsAppearOnce(t *testing.T) {
+	source := sources.NewLogSource("", &logconfig.LogsConfig{
+		Tags: []string{"team:infra", "env:prod"},
+	})
+	out := make(chan *message.Message, 1)
+	evtAPI := winevtapi.New()
+	tailer := NewTailer(evtAPI, source, &Config{}, out, auditormock.NewMockAuditor(), publishermetadatacache.New(evtAPI))
+	tailer.done = make(chan struct{})
+
+	go tailer.forwardMessages()
+	tailer.decoder.Start()
+
+	origin := message.NewOrigin(source)
+	msg := message.NewMessageWithParsingExtra(
+		[]byte("windows event text"),
+		origin,
+		message.StatusInfo,
+		0,
+		message.ParsingExtra{Tags: []string{"truncated:true"}},
+	)
+	tailer.decoder.InputChan() <- msg
+
+	received := <-out
+	require.Equal(t, []string{"truncated:true", "team:infra", "env:prod"}, received.Origin.Tags())
+
+	tailer.decoder.Stop()
+	<-tailer.done
 }
 
 func BenchmarkReadEvents(b *testing.B) {


### PR DESCRIPTION
### What does this PR do?

Fixes a #38334 regression where journald and Windows Event logs emitted configured tags twice.

- **journald** — restore an empty tag provider seed (`NewLocalProvider([]string{})`) so `getOrigin` no longer pushes `Config.Tags` into `SetTags`.
- **Windows Event** — attach only parsing tags (`SetTags(msg.ParsingExtra.Tags)`), matching the socket tailer pattern; drops configured-tag duplication and the slice-aliasing `append` onto the message backing array.
- **Tests** — add regression coverage for both tailers plus a cross-platform origin contract test.

File, container, and socket tailers are unchanged; configured tags still merge once in `Origin` on read.

### Motivation

Configured tags belong in one place: `Origin.Tags()` / `TagsPayload()` merge `LogSource.Config.Tags` on read. File, container, and socket tailers already follow this — they call `SetTags` with parsing/provider tags only.

#38334 accidentally changed journald and Windows Event to also inject `Config.Tags` at the tailer, so each configured tag appeared twice (e.g. `env:prod, team:infra, env:prod, team:infra`). Windows Event also appended onto the message's backing slice, which a concurrent reader could observe.

This is a standalone correctness fix (no flag). It can land on `main` independently of the subscriber stack and clears the baseline before tag-snapshot work in PR2.

### Describe how you validated your changes

- [x] `go test ./pkg/logs/message/...` — `TestConfiguredTagsAppearOnceWhenNotPassedToSetTags` (cross-platform origin contract)
- [x] `go test ./pkg/logs/message/...` — existing origin tag tests still pass
- [x] CI — `TestGetOriginConfiguredTagsAppearOnce` (journald, `//go:build systemd`)
- [x] CI — `TestForwardMessagesConfiguredTagsAppearOnce` (Windows Event, `//go:build windows`)
- [x] CI — file/container/socket output byte-identical (no tailer changes on those sources)

### Additional Notes

- Does **not** change `origin.go`; the origin merge was already correct.
- Does **not** implement tag-snapshot centralization (PR2) or provider-tag timing (PR3).
- journald and Windows Event tests are platform-gated and do not compile on macOS — the origin test is the local dev guard; tailer tests run in Linux/Windows CI.