### PR TITLE
fix(dataplane): resolve ADP preflight hostname gap, restore DD_SITE fix

### DIFF
--- a/comp/dataplane/preflightmode/impl/BUILD.bazel
+++ b/comp/dataplane/preflightmode/impl/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         ],
         "@rules_go//go/platform:android": [
             "//comp/core/config",
+            "//comp/core/hostname/hostnameinterface/def",
             "//comp/core/log/def",
             "//comp/core/telemetry/def",
             "//comp/dataplane/preflightmode/def",
@@ -43,6 +44,7 @@ go_library(
         ],
         "@rules_go//go/platform:darwin": [
             "//comp/core/config",
+            "//comp/core/hostname/hostnameinterface/def",
             "//comp/core/log/def",
             "//comp/core/telemetry/def",
             "//comp/dataplane/preflightmode/def",
@@ -78,6 +80,7 @@ go_library(
         ],
         "@rules_go//go/platform:ios": [
             "//comp/core/config",
+            "//comp/core/hostname/hostnameinterface/def",
             "//comp/core/log/def",
             "//comp/core/telemetry/def",
             "//comp/dataplane/preflightmode/def",
@@ -99,6 +102,7 @@ go_library(
         ],
         "@rules_go//go/platform:linux": [
             "//comp/core/config",
+            "//comp/core/hostname/hostnameinterface/def",
             "//comp/core/log/def",
             "//comp/core/telemetry/def",
             "//comp/dataplane/preflightmode/def",
@@ -155,6 +159,7 @@ go_library(
         ],
         "@rules_go//go/platform:windows": [
             "//comp/core/config",
+            "//comp/core/hostname/hostnameinterface/def",
             "//comp/core/log/def",
             "//comp/core/telemetry/def",
             "//comp/dataplane/preflightmode/def",
@@ -185,6 +190,7 @@ dd_agent_go_test(
     embed = [":impl"],
     deps = select({
         "@rules_go//go/platform:android": [
+            "//comp/core/hostname/hostnameinterface/mock",
             "//comp/core/log/mock",
             "//comp/core/telemetry/def",
             "//comp/core/telemetry/mock",
@@ -197,6 +203,7 @@ dd_agent_go_test(
             "@in_gopkg_yaml_v3//:yaml_v3",
         ],
         "@rules_go//go/platform:darwin": [
+            "//comp/core/hostname/hostnameinterface/mock",
             "//comp/core/log/mock",
             "//comp/core/telemetry/def",
             "//comp/core/telemetry/mock",
@@ -209,6 +216,7 @@ dd_agent_go_test(
             "@in_gopkg_yaml_v3//:yaml_v3",
         ],
         "@rules_go//go/platform:ios": [
+            "//comp/core/hostname/hostnameinterface/mock",
             "//comp/core/log/mock",
             "//comp/core/telemetry/def",
             "//comp/core/telemetry/mock",
@@ -221,6 +229,7 @@ dd_agent_go_test(
             "@in_gopkg_yaml_v3//:yaml_v3",
         ],
         "@rules_go//go/platform:linux": [
+            "//comp/core/hostname/hostnameinterface/mock",
             "//comp/core/log/mock",
             "//comp/core/telemetry/def",
             "//comp/core/telemetry/mock",

--- a/comp/dataplane/preflightmode/impl/config.go
+++ b/comp/dataplane/preflightmode/impl/config.go
@@ -130,11 +130,21 @@ var preflightModeGlobalOverrides = map[string]any{
 // https://app.datadoghq.com. Since an explicit dd_url beats `site` in ADP just as it does in the
 // Core Agent, a site-only config came out of AllSettings pointing the pre-flight -- metrics and
 // API key both -- at US1 no matter what site the operator had configured.
-func buildPreflightConfig(cfg pkgconfigmodel.Reader, l listener) map[string]any {
+//
+// hostname is the one exception to "the operator's settings as-is": it is always written in,
+// even over an operator-supplied value, because it is what the caller already resolved through
+// the hostname component (the same resolution the Core Agent itself uses -- EC2 metadata, OS
+// hostname, `hostname_file`, and so on) rather than the config's raw, usually-empty `hostname`
+// setting. Standalone-mode ADP requires this field with no fallback of its own, and childEnv
+// strips DD_HOSTNAME from its environment along with the rest of the DD_ namespace, so this is
+// the only way it can learn a hostname at all.
+func buildPreflightConfig(cfg pkgconfigmodel.Reader, l listener, hostname string) map[string]any {
 	out := cfg.AllSettingsWithoutDefault()
 	if out == nil {
 		out = map[string]any{}
 	}
+
+	setNested(out, "hostname", hostname)
 
 	// Set all of the "global" overrides: overrides that apply regardless of OS/architecture.
 	for k, v := range preflightModeGlobalOverrides {
@@ -169,8 +179,8 @@ func buildPreflightConfig(cfg pkgconfigmodel.Reader, l listener) map[string]any 
 // The 0600 below is what restricts the file on Unix. It does nothing on Windows, where the
 // mode is not an access control mechanism at all; there the file is covered by the ACL
 // secureWorkDir puts on the directory, which is inheritable for exactly this reason.
-func writePreflightConfig(cfg pkgconfigmodel.Reader, l listener, workDir string) (string, error) {
-	data, err := yaml.Marshal(buildPreflightConfig(cfg, l))
+func writePreflightConfig(cfg pkgconfigmodel.Reader, l listener, workDir string, hostname string) (string, error) {
+	data, err := yaml.Marshal(buildPreflightConfig(cfg, l, hostname))
 	if err != nil {
 		return "", fmt.Errorf("could not render the data plane preflight mode config: %w", err)
 	}

--- a/comp/dataplane/preflightmode/impl/config.go
+++ b/comp/dataplane/preflightmode/impl/config.go
@@ -131,11 +131,7 @@ var preflightModeGlobalOverrides = map[string]any{
 // Core Agent, a site-only config came out of AllSettings pointing the pre-flight -- metrics and
 // API key both -- at US1 no matter what site the operator had configured.
 //
-// hostname is the one exception to "the operator's settings as-is": it is always written in,
-// even over an operator-supplied value, because it is what the caller already resolved through
-// the hostname component (the same resolution the Core Agent itself uses -- EC2 metadata, OS
-// hostname, `hostname_file`, and so on) rather than the config's raw, usually-empty `hostname`
-// setting. Standalone-mode ADP requires this field with no fallback of its own, and childEnv
+// Standalone-mode ADP requires this field with no fallback of its own, and childEnv
 // strips DD_HOSTNAME from its environment along with the rest of the DD_ namespace, so this is
 // the only way it can learn a hostname at all.
 func buildPreflightConfig(cfg pkgconfigmodel.Reader, l listener, hostname string) map[string]any {

--- a/comp/dataplane/preflightmode/impl/config.go
+++ b/comp/dataplane/preflightmode/impl/config.go
@@ -116,13 +116,22 @@ var preflightModeGlobalOverrides = map[string]any{
 // buildPreflightConfig returns the configuration ADP should run with during a preflight mode
 // pre-flight.
 //
-// The full Agent configuration as it exists at the time of this call is used as the base,
-// and overrides are applied on top of it: this ensures that ADP is configured as close as possible
-// to how it would be when running normally, with only the necessary changes to run it in "preflight" mode:
-// don't take over DSD, don't run any other pipelines, don't log to disk, and don't reserve buffer pools
-// sized for traffic that a one-metric pre-flight will never see.
+// The Agent configuration as the operator supplied it is used as the base, and overrides are
+// applied on top of it: this ensures that ADP is configured as close as possible to how it would
+// be when running normally, with only the necessary changes to run it in "preflight" mode:
+// don't take over DSD, don't run any other pipelines, don't log to disk, and don't reserve buffer
+// pools sized for traffic that a one-metric pre-flight will never see.
+//
+// Deliberately AllSettingsWithoutDefault and not AllSettings. A normally-supervised ADP is started
+// with `--config /etc/datadog-agent/datadog.yaml`, so it sees the operator's settings and fills in
+// the rest from its own defaults; handing it the Agent's defaults instead would be a different
+// configuration, not a more faithful one. It is also incorrect: AllSettings renders a default
+// indistinguishably from a value the operator asked for, and dd_url's default is a non-empty
+// https://app.datadoghq.com. Since an explicit dd_url beats `site` in ADP just as it does in the
+// Core Agent, a site-only config came out of AllSettings pointing the pre-flight -- metrics and
+// API key both -- at US1 no matter what site the operator had configured.
 func buildPreflightConfig(cfg pkgconfigmodel.Reader, l listener) map[string]any {
-	out := cfg.AllSettings()
+	out := cfg.AllSettingsWithoutDefault()
 	if out == nil {
 		out = map[string]any{}
 	}
@@ -148,12 +157,14 @@ func buildPreflightConfig(cfg pkgconfigmodel.Reader, l listener) map[string]any 
 
 // writePreflightConfig renders the preflight configuration into workDir and returns its path.
 //
-// The file holds the Agent's entire resolved configuration, so every credential the Agent was
-// given in plain text -- api_key, app_key, proxy credentials, additional_endpoints keys -- ends
-// up in it. Not, however, anything from a secret backend: AllSettings would merge the secrets
-// layer, but isEligible refuses to run the pre-flight at all when secrets are in use, precisely
-// so that this file cannot be how a secret first reaches the disk. The working directory is
-// removed when the run finishes, and again from stop if the run does not unwind in time.
+// The file holds every setting the operator supplied -- see buildPreflightConfig for why the
+// Agent's own defaults are deliberately left out -- so every credential the Agent was given in
+// plain text -- api_key, app_key, proxy credentials, additional_endpoints keys -- ends up in it.
+// Not, however, anything from a secret backend: dropping the defaults layer does not drop the
+// secrets layer, so AllSettingsWithoutDefault would still render a resolved secret, but
+// isEligible refuses to run the pre-flight at all when secrets are in use, precisely so that
+// this file cannot be how a secret first reaches the disk. The working directory is removed when
+// the run finishes, and again from stop if the run does not unwind in time.
 //
 // The 0600 below is what restricts the file on Unix. It does nothing on Windows, where the
 // mode is not an access control mechanism at all; there the file is covered by the ACL

--- a/comp/dataplane/preflightmode/impl/config_test.go
+++ b/comp/dataplane/preflightmode/impl/config_test.go
@@ -73,26 +73,84 @@ func TestBuildPreflightConfigCarriesOperatorSettings(t *testing.T) {
 	requireEq(t, got, "proxy.https", "http://proxy.internal:3128")
 }
 
-// TestBuildPreflightConfigCarriesTheWholeAgentConfig documents the deliberate choice to base
-// the preflight config on AllSettings, defaults included, rather than only the settings the
-// operator touched.
+// TestBuildPreflightConfigCarriesOnlyOperatorSettings documents the choice to base the preflight
+// config on AllSettingsWithoutDefault: everything the operator configured, and nothing they did
+// not.
 //
-// The point of the pre-flight is for ADP to see the configuration it would really run with,
-// and passing everything through is the closest approximation. It is safe because ADP
-// ignores keys it does not recognise: verified against agent-data-plane 1.4.0 by running it
-// with the full Core Agent config, including Core-Agent-only sections, with no resulting
-// warning or error (see TestBuildPreflightConfigPassesThroughCoreAgentOnlySettings).
-func TestBuildPreflightConfigCarriesTheWholeAgentConfig(t *testing.T) {
+// The point of the pre-flight is for ADP to see the configuration it would really run with, and a
+// normally-supervised ADP is started with `--config /etc/datadog-agent/datadog.yaml` -- the
+// operator's settings, with ADP's own defaults underneath. Passing the Agent's defaults instead
+// would be a different configuration, not a more faithful one, and for dd_url it was an actively
+// wrong one (see TestBuildPreflightConfigDropsUnsetDDURL).
+//
+// Passing the operator's settings through wholesale is safe because ADP ignores keys it does not
+// recognise: verified against agent-data-plane 1.4.0 by running it with the full Core Agent
+// config, including Core-Agent-only sections, with no resulting warning or error (see
+// TestBuildPreflightConfigPassesThroughCoreAgentOnlySettings).
+func TestBuildPreflightConfigCarriesOnlyOperatorSettings(t *testing.T) {
 	cfg := configmock.New(t)
+	cfg.Set("forwarder_timeout", 42, pkgconfigmodel.SourceFile)
 
 	got := buildPreflightConfig(cfg, newListener(t.TempDir()))
 
-	// Defaults ADP shares with the Agent come through, so it forwards the way the Agent
-	// would.
-	_, present := get(t, got, "forwarder_timeout")
-	assert.True(t, present, "the Agent's forwarder settings should reach ADP")
-	_, present = get(t, got, "site")
-	assert.True(t, present, "the Agent's site should reach ADP")
+	// A setting the operator tuned reaches ADP, so it forwards the way the Agent would.
+	requireEq(t, got, "forwarder_timeout", 42)
+
+	// One they never touched does not, so ADP applies its own default rather than the Agent's.
+	_, present := get(t, got, "logs_config")
+	assert.False(t, present, "a section the operator never configured should not reach ADP")
+}
+
+// TestBuildPreflightConfigCarriesEnvSourcedSettings is the case that matters most in a container,
+// where the operator configures the Agent entirely through DD_ variables and datadog.yaml is
+// close to empty.
+//
+// It is load-bearing for the pre-flight specifically: childEnv strips the whole DD_ namespace from
+// the preflight process, so the generated file is the only channel these settings have. A dump
+// that dropped them would leave ADP with no api_key and no site at all.
+func TestBuildPreflightConfigCarriesEnvSourcedSettings(t *testing.T) {
+	t.Setenv("DD_API_KEY", "0123456789abcdef0123456789abcdef")
+	t.Setenv("DD_SITE", "datad0g.com")
+
+	cfg := configmock.New(t)
+	// The Agent resolves DD_PROXY_* into the config at startup rather than leaving it on the env
+	// layer, writing it back as config-post-init; mirror that here so the dump under test is the
+	// one the real preflight sees.
+	cfg.Set("proxy.https", "http://proxy.internal:3128", pkgconfigmodel.SourceConfigPostInit)
+
+	got := buildPreflightConfig(cfg, newListener(t.TempDir()))
+
+	requireEq(t, got, "api_key", "0123456789abcdef0123456789abcdef")
+	requireEq(t, got, "site", "datad0g.com")
+	requireEq(t, got, "proxy.https", "http://proxy.internal:3128")
+}
+
+// TestBuildPreflightConfigDropsUnsetDDURL is the regression this policy exists for.
+//
+// dd_url's default is a non-empty https://app.datadoghq.com, and an explicit dd_url beats `site`
+// in ADP just as it does in the Core Agent. Rendered as a default by AllSettings, it pointed the
+// pre-flight -- metrics and API key both -- at US1 regardless of the configured site.
+func TestBuildPreflightConfigDropsUnsetDDURL(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.Set("site", "datad0g.com", pkgconfigmodel.SourceFile)
+
+	got := buildPreflightConfig(cfg, newListener(t.TempDir()))
+
+	_, present := get(t, got, "dd_url")
+	assert.False(t, present, "an unset dd_url must not reach ADP as though it were configured")
+	requireEq(t, got, "site", "datad0g.com")
+}
+
+// TestBuildPreflightConfigKeepsConfiguredDDURL is the other half: a dd_url the operator really set
+// is part of the configuration ADP is meant to run against, and must survive.
+func TestBuildPreflightConfigKeepsConfiguredDDURL(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.Set("site", "datad0g.com", pkgconfigmodel.SourceFile)
+	cfg.Set("dd_url", "https://app.datad0g.com", pkgconfigmodel.SourceFile)
+
+	got := buildPreflightConfig(cfg, newListener(t.TempDir()))
+
+	requireEq(t, got, "dd_url", "https://app.datad0g.com")
 }
 
 func TestBuildPreflightConfigOverrides(t *testing.T) {

--- a/comp/dataplane/preflightmode/impl/config_test.go
+++ b/comp/dataplane/preflightmode/impl/config_test.go
@@ -64,7 +64,7 @@ func TestBuildPreflightConfigCarriesOperatorSettings(t *testing.T) {
 	cfg.Set("site", "datadoghq.eu", pkgconfigmodel.SourceFile)
 	cfg.Set("proxy.https", "http://proxy.internal:3128", pkgconfigmodel.SourceFile)
 
-	got := buildPreflightConfig(cfg, newListener(t.TempDir()))
+	got := buildPreflightConfig(cfg, newListener(t.TempDir()), "test-host")
 
 	// The whole premise of the pre-flight is that ADP runs against the operator's real
 	// configuration, api_key and proxy included.
@@ -91,7 +91,7 @@ func TestBuildPreflightConfigCarriesOnlyOperatorSettings(t *testing.T) {
 	cfg := configmock.New(t)
 	cfg.Set("forwarder_timeout", 42, pkgconfigmodel.SourceFile)
 
-	got := buildPreflightConfig(cfg, newListener(t.TempDir()))
+	got := buildPreflightConfig(cfg, newListener(t.TempDir()), "test-host")
 
 	// A setting the operator tuned reaches ADP, so it forwards the way the Agent would.
 	requireEq(t, got, "forwarder_timeout", 42)
@@ -118,7 +118,7 @@ func TestBuildPreflightConfigCarriesEnvSourcedSettings(t *testing.T) {
 	// one the real preflight sees.
 	cfg.Set("proxy.https", "http://proxy.internal:3128", pkgconfigmodel.SourceConfigPostInit)
 
-	got := buildPreflightConfig(cfg, newListener(t.TempDir()))
+	got := buildPreflightConfig(cfg, newListener(t.TempDir()), "test-host")
 
 	requireEq(t, got, "api_key", "0123456789abcdef0123456789abcdef")
 	requireEq(t, got, "site", "datad0g.com")
@@ -134,7 +134,7 @@ func TestBuildPreflightConfigDropsUnsetDDURL(t *testing.T) {
 	cfg := configmock.New(t)
 	cfg.Set("site", "datad0g.com", pkgconfigmodel.SourceFile)
 
-	got := buildPreflightConfig(cfg, newListener(t.TempDir()))
+	got := buildPreflightConfig(cfg, newListener(t.TempDir()), "test-host")
 
 	_, present := get(t, got, "dd_url")
 	assert.False(t, present, "an unset dd_url must not reach ADP as though it were configured")
@@ -148,7 +148,7 @@ func TestBuildPreflightConfigKeepsConfiguredDDURL(t *testing.T) {
 	cfg.Set("site", "datad0g.com", pkgconfigmodel.SourceFile)
 	cfg.Set("dd_url", "https://app.datad0g.com", pkgconfigmodel.SourceFile)
 
-	got := buildPreflightConfig(cfg, newListener(t.TempDir()))
+	got := buildPreflightConfig(cfg, newListener(t.TempDir()), "test-host")
 
 	requireEq(t, got, "dd_url", "https://app.datad0g.com")
 }
@@ -157,7 +157,7 @@ func TestBuildPreflightConfigOverrides(t *testing.T) {
 	cfg := configmock.New(t)
 	workDir := t.TempDir()
 
-	got := buildPreflightConfig(cfg, newListener(workDir))
+	got := buildPreflightConfig(cfg, newListener(workDir), "test-host")
 
 	requireEq(t, got, DataPlaneEnabled, true)
 	requireEq(t, got, "data_plane.dogstatsd.enabled", true)
@@ -186,6 +186,36 @@ func TestBuildPreflightConfigOverrides(t *testing.T) {
 	requireEq(t, got, "dogstatsd_non_local_traffic", false)
 }
 
+// TestBuildPreflightConfigInjectsResolvedHostname guards the fix for the pre-flight failing
+// outright on any host that does not set `hostname`/`DD_HOSTNAME` explicitly: the Core Agent
+// resolves its hostname at runtime (EC2 metadata, OS hostname, etc.) but never writes the
+// result back into its own config store, so AllSettingsWithoutDefault's `hostname` is empty on
+// the overwhelming majority of real hosts. Standalone-mode ADP has no fallback for a missing
+// `hostname` and childEnv strips DD_HOSTNAME from its environment, so the caller-resolved
+// hostname passed into buildPreflightConfig is the only way it ever learns one.
+func TestBuildPreflightConfigInjectsResolvedHostname(t *testing.T) {
+	cfg := configmock.New(t)
+
+	got := buildPreflightConfig(cfg, newListener(t.TempDir()), "resolved-host")
+
+	requireEq(t, got, "hostname", "resolved-host")
+}
+
+// TestBuildPreflightConfigOverridesOperatorHostname documents that the resolved hostname wins
+// even over a `hostname` the operator configured directly: buildPreflightConfig is always
+// handed the same value the Core Agent already resolved through that setting (see fromConfig
+// in pkg/util/hostname/common.go), so overriding it can only ever replace it with itself.
+// Passing it through unconditionally, rather than only when the config's own value is empty,
+// keeps this function from needing to duplicate the Core Agent's hostname resolution order.
+func TestBuildPreflightConfigOverridesOperatorHostname(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.Set("hostname", "operator-configured-host", pkgconfigmodel.SourceFile)
+
+	got := buildPreflightConfig(cfg, newListener(t.TempDir()), "operator-configured-host")
+
+	requireEq(t, got, "hostname", "operator-configured-host")
+}
+
 // TestBuildPreflightConfigShrinksFootprint covers the settings that exist only to keep the
 // preflight process small. Each one is a buffer or cache ADP allocates up front and holds for the
 // whole run, sized by default for production traffic that a one-metric pre-flight never sends.
@@ -198,7 +228,7 @@ func TestBuildPreflightConfigShrinksFootprint(t *testing.T) {
 	cfg.Set("dogstatsd_buffer_size", 65536, pkgconfigmodel.SourceFile)
 	cfg.Set("dogstatsd_string_interner_size", 131072, pkgconfigmodel.SourceFile)
 
-	got := buildPreflightConfig(cfg, newListener(t.TempDir()))
+	got := buildPreflightConfig(cfg, newListener(t.TempDir()), "test-host")
 
 	requireEq(t, got, "dogstatsd_buffer_size", 512)
 	requireEq(t, got, "dogstatsd_string_interner_size", 1)
@@ -227,7 +257,7 @@ func TestBuildPreflightConfigOverridesOperatorLogging(t *testing.T) {
 	cfg.Set("log_to_console", false, pkgconfigmodel.SourceFile)
 	cfg.Set("log_level", "debug", pkgconfigmodel.SourceFile)
 
-	got := buildPreflightConfig(cfg, newListener(t.TempDir()))
+	got := buildPreflightConfig(cfg, newListener(t.TempDir()), "test-host")
 
 	requireEq(t, got, "disable_file_logging", true)
 	requireEq(t, got, "log_format_json", true)
@@ -295,7 +325,7 @@ func TestBuildPreflightConfigClearsMetricNamespace(t *testing.T) {
 	// is how the original version of this test passed while guarding nothing.
 	require.Equal(t, "acme.", cfg.GetString("statsd_metric_namespace"))
 
-	got := buildPreflightConfig(cfg, newListener(t.TempDir()))
+	got := buildPreflightConfig(cfg, newListener(t.TempDir()), "test-host")
 
 	requireEq(t, got, "statsd_metric_namespace", "")
 	requireEq(t, got, "statsd_metric_namespace_blacklist", []string{})
@@ -314,7 +344,7 @@ func TestBuildPreflightConfigDisablesDiskRetryQueue(t *testing.T) {
 	// Set on an unknown key is a silent no-op, so prove the Given clause took.
 	require.Equal(t, int64(500_000_000), cfg.GetInt64("forwarder_storage_max_size_in_bytes"))
 
-	got := buildPreflightConfig(cfg, newListener(t.TempDir()))
+	got := buildPreflightConfig(cfg, newListener(t.TempDir()), "test-host")
 
 	requireEq(t, got, "forwarder_storage_max_size_in_bytes", 0)
 }
@@ -332,7 +362,7 @@ func TestBuildPreflightConfigOverridesOperatorListeners(t *testing.T) {
 
 	workDir := t.TempDir()
 	l := newListener(workDir)
-	got := buildPreflightConfig(cfg, l)
+	got := buildPreflightConfig(cfg, l, "test-host")
 
 	requireEq(t, got, "dogstatsd_port", 0)
 	requireEq(t, got, "dogstatsd_stream_socket", "")
@@ -364,7 +394,7 @@ func TestBuildPreflightConfigPassesThroughCoreAgentOnlySettings(t *testing.T) {
 	cfg.Set(DataPlanePreflightMode, true, pkgconfigmodel.SourceFile)
 	cfg.Set("otlp_config.receiver.protocols.grpc.endpoint", "0.0.0.0:4317", pkgconfigmodel.SourceFile)
 
-	got := buildPreflightConfig(cfg, newListener(t.TempDir()))
+	got := buildPreflightConfig(cfg, newListener(t.TempDir()), "test-host")
 
 	_, present := get(t, got, DataPlanePreflightMode)
 	assert.True(t, present, "ADP ignores keys it does not recognise, so stripping is unnecessary")
@@ -377,7 +407,7 @@ func TestWritePreflightConfig(t *testing.T) {
 	cfg.Set("api_key", "0123456789abcdef0123456789abcdef", pkgconfigmodel.SourceFile)
 
 	workDir := t.TempDir()
-	path, err := writePreflightConfig(cfg, newListener(workDir), workDir)
+	path, err := writePreflightConfig(cfg, newListener(workDir), workDir, "test-host")
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(workDir, preflightConfigFileName), path)
 

--- a/comp/dataplane/preflightmode/impl/eligible.go
+++ b/comp/dataplane/preflightmode/impl/eligible.go
@@ -61,8 +61,8 @@ const (
 // secretsInUse reports whether the Agent's configuration involves secrets at all, along with a human-readable reason
 // when it does.
 //
-// This is a gate on preflight mode because the pre-flight writes the Agent's entire resolved configuration to disk for
-// ADP to read (see writePreflightConfig). Anything the secret resolver pulled into memory would therefore be
+// This is a gate on preflight mode because the pre-flight writes the Agent's configuration as the operator supplied it
+// to disk for ADP to read (see writePreflightConfig). Anything the secret resolver pulled into memory would therefore be
 // materialized in plaintext in a file. The working directory is locked down to the Agent's own account and removed when
 // the run finishes, but a value the operator deliberately kept out of any file on the host should not be written to one
 // for the sake of a pre-flight check that only exists until ADP goes GA. So when secrets are involved we skip the

--- a/comp/dataplane/preflightmode/impl/preflightmode.go
+++ b/comp/dataplane/preflightmode/impl/preflightmode.go
@@ -289,12 +289,7 @@ func (d *preflightModeComponent) prepare(ctx context.Context) (*exec.Cmd, listen
 		return nil, l, fmt.Errorf("unusable DogStatsD endpoint under %s: %w", workDir, err)
 	}
 
-	// The Core Agent resolves its hostname at runtime (EC2 metadata, OS hostname, etc.) but never
-	// writes the result back into its own config store, so buildPreflightConfig's snapshot of the
-	// operator's settings never contains one unless the operator set `hostname`/`DD_HOSTNAME`
-	// explicitly. Standalone-mode ADP has no other way to learn it -- childEnv strips DD_ from the
-	// child's environment -- so without this it fails outright with "Missing field 'hostname'" and
-	// the pre-flight never gets far enough to run the probe at all.
+	// See buildPreflightConfig for why this must be resolved here rather than read from config.
 	hostname, err := d.hostname.Get(ctx)
 	if err != nil {
 		return nil, l, fmt.Errorf("could not resolve the Agent's hostname: %w", err)

--- a/comp/dataplane/preflightmode/impl/preflightmode.go
+++ b/comp/dataplane/preflightmode/impl/preflightmode.go
@@ -22,6 +22,7 @@ import (
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
 	configcomp "github.com/DataDog/datadog-agent/comp/core/config"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	logcomp "github.com/DataDog/datadog-agent/comp/core/log/def"
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	preflightmode "github.com/DataDog/datadog-agent/comp/dataplane/preflightmode/def"
@@ -103,6 +104,7 @@ type Requires struct {
 	Config    configcomp.Component
 	Log       logcomp.Component
 	Telemetry telemetry.Component
+	Hostname  hostnameinterface.Component
 }
 
 // Provides defines what this component provides
@@ -113,6 +115,7 @@ type Provides struct {
 type preflightModeComponent struct {
 	log      logcomp.Component
 	config   configcomp.Component
+	hostname hostnameinterface.Component
 	reporter *reporter
 
 	// binPath is the ADP binary to run.
@@ -165,6 +168,7 @@ func NewComponent(reqs Requires) Provides {
 	comp := &preflightModeComponent{
 		log:      reqs.Log,
 		config:   reqs.Config,
+		hostname: reqs.Hostname,
 		reporter: reporter,
 		binPath:  binPath,
 		out:      newCapture(reqs.Log),
@@ -265,7 +269,7 @@ func (d *preflightModeComponent) workDir() string {
 // run performs one complete pre-flight: prepare, spawn, probe, stop, scan, report.
 // prepare sets up the working directory and generated config, returning a command ready to
 // start along with the endpoint ADP will bind.
-func (d *preflightModeComponent) prepare() (*exec.Cmd, listener, error) {
+func (d *preflightModeComponent) prepare(ctx context.Context) (*exec.Cmd, listener, error) {
 	workDir := d.workDir()
 	// A run that was killed mid-flight may have left a stale socket and config behind.
 	if err := os.RemoveAll(workDir); err != nil {
@@ -285,7 +289,18 @@ func (d *preflightModeComponent) prepare() (*exec.Cmd, listener, error) {
 		return nil, l, fmt.Errorf("unusable DogStatsD endpoint under %s: %w", workDir, err)
 	}
 
-	cfgPath, err := writePreflightConfig(d.config, l, workDir)
+	// The Core Agent resolves its hostname at runtime (EC2 metadata, OS hostname, etc.) but never
+	// writes the result back into its own config store, so buildPreflightConfig's snapshot of the
+	// operator's settings never contains one unless the operator set `hostname`/`DD_HOSTNAME`
+	// explicitly. Standalone-mode ADP has no other way to learn it -- childEnv strips DD_ from the
+	// child's environment -- so without this it fails outright with "Missing field 'hostname'" and
+	// the pre-flight never gets far enough to run the probe at all.
+	hostname, err := d.hostname.Get(ctx)
+	if err != nil {
+		return nil, l, fmt.Errorf("could not resolve the Agent's hostname: %w", err)
+	}
+
+	cfgPath, err := writePreflightConfig(d.config, l, workDir, hostname)
 	if err != nil {
 		return nil, l, err
 	}
@@ -334,7 +349,7 @@ func (d *preflightModeComponent) run(ctx context.Context) {
 		}
 	}()
 
-	cmd, l, err := d.prepare()
+	cmd, l, err := d.prepare(ctx)
 	if err != nil {
 		d.log.Warnf("Agent Data Plane preflight mode could not prepare a run: %v", err)
 		o.add(findingSpawnFailed)

--- a/comp/dataplane/preflightmode/impl/preflightmode_test.go
+++ b/comp/dataplane/preflightmode/impl/preflightmode_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v3"
 
+	hostnamemock "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/mock"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	telemetrymock "github.com/DataDog/datadog-agent/comp/core/telemetry/mock"
@@ -314,7 +315,8 @@ func newHarness(t *testing.T, mode string, tweak func(pkgconfigmodel.Config)) *h
 
 	tlm := telemetrymock.New(t)
 	lc := &testLifecycle{}
-	p := NewComponent(Requires{Lc: lc, Config: cfg, Log: logmock.New(t), Telemetry: tlm})
+	hostnameComp, _ := hostnamemock.NewMock("test-host")
+	p := NewComponent(Requires{Lc: lc, Config: cfg, Log: logmock.New(t), Telemetry: tlm, Hostname: hostnameComp})
 
 	comp, ok := p.Comp.(*preflightModeComponent)
 	require.True(t, ok)
@@ -736,7 +738,8 @@ func TestPreflightModeInertWhenBinaryMissing(t *testing.T) {
 	lc := &testLifecycle{}
 	tlm := telemetrymock.New(t)
 
-	p := NewComponent(Requires{Lc: lc, Config: cfg, Log: logmock.New(t), Telemetry: tlm})
+	hostnameComp, _ := hostnamemock.NewMock("test-host")
+	p := NewComponent(Requires{Lc: lc, Config: cfg, Log: logmock.New(t), Telemetry: tlm, Hostname: hostnameComp})
 	comp, ok := p.Comp.(*preflightModeComponent)
 	require.True(t, ok)
 
@@ -761,7 +764,8 @@ func TestPreflightModeReportsUnusableBinary(t *testing.T) {
 	lc := &testLifecycle{}
 	tlm := telemetrymock.New(t)
 
-	p := NewComponent(Requires{Lc: lc, Config: cfg, Log: logmock.New(t), Telemetry: tlm})
+	hostnameComp, _ := hostnamemock.NewMock("test-host")
+	p := NewComponent(Requires{Lc: lc, Config: cfg, Log: logmock.New(t), Telemetry: tlm, Hostname: hostnameComp})
 	comp, ok := p.Comp.(*preflightModeComponent)
 	require.True(t, ok)
 
@@ -798,7 +802,7 @@ func TestPreflightModeUnbindableSocketPath(t *testing.T) {
 func TestPreflightModePrepareRestrictsWorkDir(t *testing.T) {
 	h := newHarness(t, modeNormal, nil)
 
-	_, _, err := h.comp.prepare()
+	_, _, err := h.comp.prepare(context.Background())
 	require.NoError(t, err)
 
 	workDir := filepath.Join(h.cfg.GetString("run_path"), workDirName)

--- a/releasenotes/notes/adp-preflight-respect-site-75be9ee772bef041.yaml
+++ b/releasenotes/notes/adp-preflight-respect-site-75be9ee772bef041.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixed the Agent Data Plane pre-flight sending its metrics and API key to
+    ``datadoghq.com`` instead of the configured ``site``. The generated
+    pre-flight configuration was built from the fully resolved Agent
+    configuration, so ``dd_url``'s default value appeared in it as though it
+    had been set explicitly, and an explicit ``dd_url`` takes precedence over
+    ``site``. The pre-flight configuration is now built from the settings the
+    operator actually supplied, matching what a normally-supervised Agent Data
+    Plane reads from ``datadog.yaml``.


### PR DESCRIPTION
### What does this PR do?

Restores PR #55886's fix for ADP preflight mode ignoring `DD_SITE` — auto-reverted by #55909 after it exposed a pre-existing, deterministic hostname-injection gap in preflight config generation — and closes that gap by resolving the Agent's hostname through the existing `hostnameinterface` component and injecting it into the config ADP preflight mode runs with, so standalone-mode ADP always has a hostname to start with.

### Motivation

ADP preflight mode runs ADP for a short isolated window at Agent startup to catch startup problems early, using a config snapshotted from the Core Agent's own settings. The Core Agent resolves its hostname at runtime (EC2 metadata, OS hostname, `hostname_file`, etc.) but never writes that resolved value back into its config store. Before #55886, the snapshot was built with `AllSettings()`, which renders the schema's `hostname` default (an empty string) indistinguishably from an operator-set value — so the field was always *present*, just wrong. #55886 switched to `AllSettingsWithoutDefault()` to fix a real bug (`dd_url`'s non-empty default was clobbering `site`), which correctly stopped rendering unset defaults — but that turned the latent missing-hostname gap into a hard failure: with no default to fall back on, `hostname` disappeared from the snapshot entirely. Standalone-mode ADP has no fallback for a missing hostname (by design: it can't ask the Core Agent for one), and the preflight subprocess's environment is stripped of all `DD_`-prefixed variables, so it failed outright with `Missing field 'hostname'`. The auto-revert bot correctly identified #55886 as the breaking commit and reverted it, but the `DD_SITE` fix itself was correct — the real bug was this pre-existing gap, which #55886 merely exposed. This PR restores #55886 and closes the gap so both fixes can stand together.

```mermaid
flowchart LR
    A[Agent starts] --> B[Resolve hostname:<br/>EC2/OS/hostname_file/...]
    B -.->|not written back to config store| C[Core Agent config: hostname empty]
    C --> D[buildPreflightConfig snapshots config]
    D --> E[ADP standalone mode:<br/>requires hostname, no fallback]
    E -->|AllSettings pre-#55886: empty string present| G[hostname = '' silently wrong]
    E -->|AllSettingsWithoutDefault #55886: field absent| F[Missing field 'hostname' -> spawn fails]
    B -->|this PR: resolved via hostnameinterface.Get| D
```

### Describe how you validated your changes

Reproduced the e2e test failure locally (real `agent-data-plane` binary, with and without hostname in the generated config) and confirmed this resolves it. Added `TestBuildPreflightConfigInjectsResolvedHostname` and `TestBuildPreflightConfigOverridesOperatorHostname` in `config_test.go`, and updated existing `buildPreflightConfig`/`writePreflightConfig`/component tests to cover hostname injection; #55886's own `dd_url`/`site` test coverage is restored along with its fix. All `comp/dataplane/preflightmode` tests pass (`dda inv test --targets=./comp/dataplane/preflightmode/...`).

### Additional Notes

Root-caused from https://datadoghq.atlassian.net/browse/DADP-187. Restores #55886, reverted by #55909.
