### PR TITLE
fix docker_build_fips_agent7_jmx

### DIFF
--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -20,14 +20,18 @@
     - CACHE_TARGET=${CACHE_TARGET:-}
     # Don't use caching on nightlies, to allow for regular cache invalidation,
     # and update the cache on both main and nightly builds
+    # compression=gzip,force-compression=true keeps cache blobs gzip-encoded so a
+    # later build can never reuse a zstd-compressed cache layer under the
+    # gzip-only Docker media types forced on the final image export below
+    # (see the crane flatten "magic number mismatch" comment further down).
     - |
       if [[ "$BUCKET_BRANCH" == "nightly" ]]; then
         DOCKER_NO_CACHE="--no-cache"
         CACHE_SOURCE=""
-        CACHE_TO="--cache-to type=registry,ref=${DOCKER_CACHE_REGISTRY_TARGET},mode=max"
+        CACHE_TO="--cache-to type=registry,ref=${DOCKER_CACHE_REGISTRY_TARGET},mode=max,compression=gzip,force-compression=true"
       fi
       if [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" ]]; then
-        CACHE_TO="--cache-to type=registry,ref=${DOCKER_CACHE_REGISTRY_TARGET},mode=max"
+        CACHE_TO="--cache-to type=registry,ref=${DOCKER_CACHE_REGISTRY_TARGET},mode=max,compression=gzip,force-compression=true"
       fi
     # Don't use the cache on deploy pipelines to make sure we get the latest of everything
     - |
@@ -82,8 +86,12 @@
       fi
     # Build image, use target none label to avoid replication
     # Force Docker media types to prevent buildx from switching to OCI manifests (#incident-59848)
+    # Force gzip + re-encode on export so a layer reused from the registry build
+    # cache (which buildkit may store as zstd) can never be re-exported with a
+    # mismatched compressed-content/media-type, which crane flatten's registry
+    # verification rejects as "invalid input: magic number mismatch".
     - |-
-      docker buildx build --output=type=image,push=true,oci-mediatypes=false --pull --platform linux/$ARCH \
+      docker buildx build --output=type=image,push=true,oci-mediatypes=false,compression=gzip,force-compression=true --pull --platform linux/$ARCH \
         ${CACHE_SOURCE} \
         ${DOCKER_NO_CACHE} \
         --build-arg AGENT_BASE_IMAGE_TAG=${AGENT_BASE_IMAGE_TAG} \


### PR DESCRIPTION
**This fixes broken CI on main.  If you approve it,  please also merge immediately.**

Apologies for the verbose PR description.  Claude wrote it.
I looked at the code and it makes sense with the comments added.

**what this does**
Fixes the docker_build_fips_agent7_jmx CI job, which has been failing on
main since #55906 with `crane flatten` erroring "verifying layer: invalid
input: magic number mismatch" during layer upload.

The apt-mirror content change in #55906 invalidated the registry build
cache for the `baseimage` layer repo-wide, forcing every job to
repopulate its cache. BuildKit's registry cache exporter can store cache
blobs as zstd; when a later build reuses such a blob as-is under the
`oci-mediatypes=false` flag (which forces Docker-schema, gzip-only media
types on the final push), the layer ends up with content that doesn't
match its declared media type. `crane flatten`'s registry verification
then rejects the mismatched blob. This surfaced specifically on the
FIPS+JMX amd64 flavor's flatten step.

Adds `compression=gzip,force-compression=true` to both the cache export
(`--cache-to`) and the final image export (`docker buildx build
--output=...`) so every layer -- including ones reused from cache -- is
always re-encoded as gzip, matching the Docker media types already
forced for #incident-59848. This does not touch or revert the apt-mirror
change from #55906.

**testing**
Change is CI-config only; verified via `docker_linux.yml` diff review
and by correlating Datadog CI Visibility job/log data to isolate the
`crane flatten` failure to the cache/media-type-mismatch mechanism
described above.

**next steps**
Watch the docker_build_fips_agent7_jmx (and arm64/non-FIPS variants) job
on this branch's pipeline to confirm the fix resolves the failure.