### PR TITLE
[ABLD-8] Package security-agent and APM hands-off example configs via Bazel

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -279,7 +279,6 @@ build do
     else
       copy 'bin/security-agent/security-agent', "#{install_dir}/embedded/bin"
     end
-    move 'pkg/config/example/security-agent.yaml.example', "#{conf_dir}/security-agent.yaml.example"
   end
 
   # CWS Instrumentation
@@ -315,11 +314,6 @@ build do
     command "swiftc -O -swift-version \"5\" -target \"#{target}\" -Xlinker '-rpath' -Xlinker '@executable_path/../Frameworks' Sources/*.swift -o gui", cwd: systray_build_dir
     copy "#{systray_build_dir}/gui", "#{app_temp_dir}/MacOS/"
     copy "#{systray_build_dir}/agent.png", "#{app_temp_dir}/MacOS/"
-  end
-
-  # APM Hands Off config file
-  if linux_target?
-    copy 'pkg/config/example/application_monitoring.yaml.example', "#{conf_dir}/application_monitoring.yaml.example"
   end
 
   # Allows the agent to be installed in a custom location

--- a/packages/agent/product/BUILD.bazel
+++ b/packages/agent/product/BUILD.bazel
@@ -29,6 +29,8 @@ pkg_filegroup(
         # "//packages/agent/dependencies:all_files",
         ":dirs",
         ":example_config",
+        ":security_agent_example_config",
+        ":application_monitoring_example_config",
         "//cmd/agent/dist:all_files",
         "//cmd/agent/dist:all_python_files",
         "//rtloader:all_files",
@@ -88,8 +90,10 @@ pkg_filegroup(
 pkg_filegroup(
     name = "all_install_dir_files",
     srcs = [
+        ":application_monitoring_example_config",
         ":dirs",
         ":example_config",
+        ":security_agent_example_config",
         "//cmd/agent/dist:all_files",
         "//cmd/agent/dist:all_python_files",
     ],
@@ -131,6 +135,24 @@ pkg_files(
     renames = {
         "//pkg/config:agent_config": "datadog.yaml.example",
     },
+)
+
+pkg_files(
+    name = "security_agent_example_config",
+    srcs = select({
+        "//packages/agent:heroku_flavor": [],
+        "//conditions:default": ["//pkg/config:example/security-agent.yaml.example"],
+    }),
+    prefix = select(ETC_DIR_SELECTOR),
+)
+
+pkg_files(
+    name = "application_monitoring_example_config",
+    srcs = select({
+        "@platforms//os:linux": ["//pkg/config:example/application_monitoring.yaml.example"],
+        "//conditions:default": [],
+    }),
+    prefix = select(ETC_DIR_SELECTOR),
 )
 
 pkg_files(


### PR DESCRIPTION
Adds \`pkg_files\` targets for \`security-agent.yaml.example\` (skipped on heroku) and \`application_monitoring.yaml.example\` (linux only) in \`packages/agent/product\`, and removes the now-redundant \`move\`/\`copy\` calls for these files from \`omnibus/config/software/datadog-agent.rb\`.

Part of ABLD-8 (shrinking \`datadog-agent.rb\` by moving config file packaging into Bazel \`pkg_files\` targets).

Stacked on #55915 (exports the static example config files from \`pkg/config\`) — not mergeable independently.