### PR TITLE
(fix) secret-generic-connector: share build flags computation & honor DD_CC/DD_CXX

### DIFF
--- a/.gitlab/build/binary_build/secret_generic_connector.yml
+++ b/.gitlab/build/binary_build/secret_generic_connector.yml
@@ -18,6 +18,8 @@
   needs: ["go_deps"]
   variables:
     ARCH: amd64
+    DD_CC: "x86_64-linux-gnu-gcc"
+    DD_CXX: "x86_64-linux-gnu-g++"
   before_script:
     - !reference [.retrieve_linux_go_deps]
 
@@ -29,6 +31,8 @@
   needs: ["go_deps"]
   variables:
     ARCH: arm64
+    DD_CC: "aarch64-linux-gnu-gcc"
+    DD_CXX: "aarch64-linux-gnu-g++"
   before_script:
     - !reference [.retrieve_linux_go_deps]
 

--- a/tasks/secret_generic_connector.py
+++ b/tasks/secret_generic_connector.py
@@ -12,7 +12,7 @@ from tasks.build_tags import get_default_build_tags
 from tasks.flavor import AgentFlavor
 from tasks.libs.common.constants import CONTAINER_PLATFORM_MAPPING, REPO_PATH
 from tasks.libs.common.go import go_build
-from tasks.libs.common.utils import bin_name
+from tasks.libs.common.utils import bin_name, get_build_flags
 from tasks.libs.releasing.version import get_version
 from tasks.windows_resources import build_messagetable, build_rc, versioninfo_vars
 
@@ -49,25 +49,27 @@ def build(
             out="cmd/secret-generic-connector/rsrc.syso",
         )
 
+    ldflags, gcflags, env = get_build_flags(ctx)
+
     # ldflags: -s -w to reduce binary size, -s not compatible with FIPS
     # https://github.com/DataDog/datadog-secret-backend/blob/v1/.github/workflows/release.yaml
-    ldflags = f"-X main.appVersion={version}"
+    ldflags += f" -X main.appVersion={version}"
     if strip_binary:
         if fips_mode:
             ldflags += " -w"
         else:
             ldflags += " -s -w"
 
-    # gcflags: -l disables inlining to reduce binary size
+    # gcflags: -l disables inlining to reduce binary size.
+    # get_build_flags() only sets gcflags for DELVE/NO_GO_OPT, and both already disable inlining,
+    # so only fall back to our own flag when it left gcflags empty.
     # https://github.com/DataDog/datadog-secret-backend/blob/v1/.github/workflows/release.yaml
-    gcflags = "all=-l"
+    if not gcflags:
+        gcflags = "all=-l"
 
     # FIPS mode requires CGO for BoringCrypto bindings
     # Non-FIPS builds use CGO_ENABLED=0 for static binary
-    env = {
-        "GO111MODULE": "on",
-        "CGO_ENABLED": "1" if fips_mode else "0",
-    }
+    env["CGO_ENABLED"] = "1" if fips_mode else "0"
 
     build_tags = get_default_build_tags(
         build="secret-generic-connector", flavor=AgentFlavor.fips if fips_mode else AgentFlavor.base


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Use the shared helper for go builds & provide `DD_CC` / `DD_CXX` to the build jobs

### Motivation

The FIPS secret-generic-connector currently use the default build image toolchain, which makes the resulting binaries require glibc 2.34 (ubuntu 22.04 and later)
This change ensures we do support the same OSes as the other agent binaries

### Describe how you validated your changes

Local build & checking for glibc symbols

### Additional Notes
