### PR TITLE
test(ssi): give RC e2e pod restarts more time

### DIFF
--- a/test/new-e2e/tests/ssi/utils.go
+++ b/test/new-e2e/tests/ssi/utils.go
@@ -66,7 +66,7 @@ func RestartPod(t *testing.T, client kubeClient.Interface, namespace string, app
 			}
 		}
 		return false
-	}, 2*time.Minute, 5*time.Second, "pod %s was not recreated in namespace %s", appName, namespace)
+	}, 4*time.Minute, 5*time.Second, "pod %s was not recreated in namespace %s", appName, namespace)
 }
 
 // WaitForAdmissionWebhookReady blocks until the Datadog mutating webhook configuration exists. The
@@ -128,7 +128,7 @@ func RestartUntil(t *testing.T, client kubeClient.Interface, namespace, appName 
 		RestartPod(t, client, namespace, appName)
 		pod = FindPodInNamespace(t, client, namespace, appName)
 		return ready(pod)
-	}, 4*time.Minute, 5*time.Second, "pod %s in namespace %s did not reach the expected admission state", appName, namespace)
+	}, 6*time.Minute, 5*time.Second, "pod %s in namespace %s did not reach the expected admission state", appName, namespace)
 	return pod
 }
 


### PR DESCRIPTION
## Summary
- `TestSSISuite/TestRemoteConfig/HostOnlyPolicyDoesNotMatchK8s` is flaky on `main`: the recreated `rc-ann-only` pod sometimes stays Pending past the current wait, so `RestartPod` fails with "was not recreated" and `RestartUntil` dies at ~4m.

<img width="1397" height="422" alt="image" src="https://github.com/user-attachments/assets/fc2f3a04-97c8-4224-8612-a53a48c03b09" />


## Test plan
- [ ] Confirm `new-e2e-ssi-kind` / `TestRemoteConfig/HostOnlyPolicyDoesNotMatchK8s` is green on this PR
