### PR TITLE
Deflake `TestClusterID_BlocksUpToRetryBudget` and fix a cache race

### DIFF
--- a/comp/healthplatform/issueregistry/utils/selfident/selfident.go
+++ b/comp/healthplatform/issueregistry/utils/selfident/selfident.go
@@ -26,7 +26,7 @@ const (
 
 	// defaultResolveRetries/defaultResolveRetryDelay bound how long DeploymentID
 	// waits for workloadmeta to observe the agent's own pod before giving up,
-	// and how long ClusterID retries the Cluster Agent in the background. Kept
+	// and how long resolveClusterID retries the Cluster Agent in the background. Kept
 	// short (~1s) since DeploymentID can block a synchronous ReportIssue caller.
 	defaultResolveRetries    = 5
 	defaultResolveRetryDelay = 200 * time.Millisecond
@@ -109,26 +109,20 @@ func (s *SelfIdent) IssueDiscriminator() string {
 }
 
 // ClusterID returns the best-effort Kubernetes cluster id for payload
-// enrichment only — never part of the issue id. Resolution runs in the
-// background since clustername.GetClusterID() usually makes a synchronous
-// Cluster Agent HTTP call, but a caller made before resolution finishes
-// blocks up to resolveRetries*resolveRetryDelay for it — a startup-only
-// health check (e.g. invalidconfig) calls this exactly once and never
-// re-reports, so returning immediately would permanently miss the id.
-// Callers made after resolution settles return immediately from cache.
+// enrichment only — never part of the issue id. A caller made before
+// resolution finishes waits for it; resolveClusterID itself gives up
+// after resolveRetries*resolveRetryDelay — a startup-only health check
+// (e.g. invalidconfig) calls this exactly once and never re-reports, so
+// returning immediately would permanently miss the id. Callers made
+// after resolution settles return immediately from cache.
 func (s *SelfIdent) ClusterID() string {
 	s.clusterIDResolveOnce.Do(func() {
-		go s.resolveClusterID()
+		s.resolveClusterID()
 	})
-	for attempt := 0; ; attempt++ {
-		if id := s.clusterID.Load(); id != nil {
-			return *id
-		}
-		if attempt >= s.resolveRetries {
-			return ""
-		}
-		time.Sleep(s.resolveRetryDelay)
+	if id := s.clusterID.Load(); id != nil {
+		return *id
 	}
+	return ""
 }
 
 // resolveClusterID retries clustername.GetClusterID() a bounded number of

--- a/comp/healthplatform/issueregistry/utils/selfident/selfident_test.go
+++ b/comp/healthplatform/issueregistry/utils/selfident/selfident_test.go
@@ -9,6 +9,7 @@ package selfident
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -211,27 +212,30 @@ func TestNew_NoopOutsideKubernetes(t *testing.T) {
 // settles — long enough to give a one-shot startup check a real chance at
 // getting the id, but not indefinitely.
 func TestClusterID_BlocksUpToRetryBudget(t *testing.T) {
+	synctest.Test(t, syncTestClusterIDBlocksUpToRetryBudget)
+}
+
+func syncTestClusterIDBlocksUpToRetryBudget(t *testing.T) {
 	env.SetFeatures(t, env.Kubernetes)
 
 	s := New(nil)
-	s.resolveRetries = 3
-	s.resolveRetryDelay = 10 * time.Millisecond
 
 	start := time.Now()
 	first := s.ClusterID()
 	elapsed := time.Since(start)
 	assert.Empty(t, first, "no Cluster Agent is configured in this test, so resolution settles on empty")
-	assert.Less(t, elapsed, time.Second, "ClusterID must not block indefinitely")
+	wantElapsed := time.Duration(s.resolveRetries) * s.resolveRetryDelay
+	assert.Equal(t, wantElapsed, elapsed, "ClusterID must unblock as soon as resolveClusterID's own retry loop settles")
 
 	// Cached from the settled resolution; must return immediately without
-	// re-running the resolution loop. A single before/after comparison is
-	// too sensitive to one-off scheduler/GC jitter under -race, so this
-	// amortizes across many calls: if caching were broken and each call
-	// re-ran the full retry loop, this would take ~50x the first call's
-	// elapsed time; if cached, it's ~50 atomic loads.
+	// re-running the resolution loop. The bubble's fake clock makes a
+	// single before/after comparison exact rather than jitter-prone, but
+	// this still amortizes across many calls: if caching were broken and
+	// each call re-ran the full retry loop, this would take ~50x the first
+	// call's elapsed time; if cached, it's ~50 atomic loads.
 	start = time.Now()
 	for i := 0; i < 50; i++ {
 		assert.Empty(t, s.ClusterID())
 	}
-	assert.Less(t, time.Since(start), elapsed, "later calls must return immediately from cache, not re-run resolution")
+	assert.Zero(t, time.Since(start), "later calls must return immediately from cache, not re-run resolution")
 }


### PR DESCRIPTION
### What does this PR do?
Wrap `TestClusterID_BlocksUpToRetryBudget` in a `testing/synctest` bubble so its timing runs on a deterministic fake clock instead of the real, wallclock-sensitive one.

Run `resolveClusterID` synchronously inside `ClusterID`'s `sync.Once`, replacing the goroutine-plus-polling-loop it used before.

Tighten the test's timing assertions from `assert.Less` bounds to exact `assert.Equal`/`assert.Zero` values.

### Motivation
An unrelated PR (#55808) got ejected from the merge queue due to `bazel:coverage:macos-amd64` failing twice in a row ([2011118732](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/2011118732) and [2011169018](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/2011169018)), requiring a manual reschedule, with:
```
FAIL   //comp/healthplatform/issueregistry/utils/selfident:selfident_test_dca :: TestClusterID_BlocksUpToRetryBudget
      type: assertion
      selfident_test.go:236: "31.255354ms" is not less than "30.724187ms", later calls must return immediately from cache, not re-run resolution
```
and
```
FAIL   //comp/healthplatform/issueregistry/utils/selfident:selfident_test_dca :: TestClusterID_BlocksUpToRetryBudget
      type: assertion
      selfident_test.go:236: "41.358615ms" is not less than "30.962192ms", later calls must return immediately from cache, not re-run resolution
```
[Flaky Test Management](https://app.datadoghq.com/ci/test/flaky?query=fingerprint_fqn%3Abceb74420d888c81) tracks it as active since 2026-07-30.

The test's own 30+ms budget (`resolveRetries * resolveRetryDelay`) is too tight for the `assert.Empty` reflection and `-race`/coverage instrumentation overhead that 50 cached calls pay under a loaded runner.

The same test binary also has a deeper bug once timing stops masking it: `ClusterID`'s caller-side poll loop and the background goroutine race the same deadline on two independent timers instead of the caller waiting for the goroutine's actual result.

Removing the goroutine, rather than resynchronizing it, closes both gaps at once: `sync.Once.Do` **already blocks** every caller until the function it wraps returns, so calling `resolveClusterID` directly inside it gives every caller that same guarantee for free, with nothing left to race.

### Describe how you validated your changes
Reproduced by saturating every CPU core under `-race`:
| | before | after |
|---|---|---|
| failures | 1 / 30 runs | 0 / 100 runs |
| per-run time | ~0.04-0.09s | ~0.00-0.02s |

Ran `dda inv test --targets=./comp/healthplatform/...`: 156/156 passing.