### PR TITLE
[DO NOT MERGE] otel-agent: drop the DD_CC/DD_CXX glibc override

### DIFF
--- a/.gitlab/build/package_build/otel_musl_poc.yml
+++ b/.gitlab/build/package_build/otel_musl_poc.yml
@@ -5,7 +5,7 @@ otel-agent-musl-poc:
   tags: ["arch:amd64", "specific:true"]
   needs: []
   script:
-    - apk add --no-cache python3 py3-pip go musl-dev gcc git bash curl
+    - apk add --no-cache python3 py3-pip go musl-dev gcc git bash curl aws-cli
     - pip install --break-system-packages dda
     - dda inv -- -e otel-agent.build
     - file ./bin/otel-agent/otel-agent

--- a/.gitlab/build/package_build/otel_musl_poc.yml
+++ b/.gitlab/build/package_build/otel_musl_poc.yml
@@ -1,0 +1,13 @@
+---
+otel-agent-musl-poc:
+  stage: package_build
+  image: registry.ddbuild.io/images/mirror/library/alpine:3.23.3
+  tags: ["arch:amd64", "specific:true"]
+  needs: []
+  script:
+    - apk add --no-cache python3 py3-pip go musl-dev gcc git bash curl
+    - pip install --break-system-packages dda
+    - dda inv -- -e otel-agent.build
+    - file ./bin/otel-agent/otel-agent
+    - file ./bin/otel-agent/otel-agent | grep -q "musl" || (echo "binary is not musl-linked, this validation job is broken" && exit 1)
+    - echo "otel-agent builds cleanly against real musl (Alpine), no glibc override needed"

--- a/.gitlab/build/package_build/otel_musl_poc.yml
+++ b/.gitlab/build/package_build/otel_musl_poc.yml
@@ -9,7 +9,7 @@ otel-agent-musl-poc:
     KUBERNETES_MEMORY_REQUEST: "32Gi"
     KUBERNETES_MEMORY_LIMIT: "32Gi"
   script:
-    - apk add --no-cache python3 py3-pip go musl-dev gcc git bash curl aws-cli
+    - apk add --no-cache python3 py3-pip go musl-dev gcc git bash curl aws-cli file
     - pip install --break-system-packages dda
     - export GOTOOLCHAIN=auto
     - dda inv -- -e otel-agent.build

--- a/.gitlab/build/package_build/otel_musl_poc.yml
+++ b/.gitlab/build/package_build/otel_musl_poc.yml
@@ -3,10 +3,11 @@ otel-agent-musl-poc:
   stage: package_build
   image: registry.ddbuild.io/images/mirror/library/alpine:3.23.3
   tags: ["arch:amd64", "specific:true"]
-  needs: []
+  needs: ["setup_agent_version"]
   script:
     - apk add --no-cache python3 py3-pip go musl-dev gcc git bash curl aws-cli
     - pip install --break-system-packages dda
+    - export GOTOOLCHAIN=auto
     - dda inv -- -e otel-agent.build
     - file ./bin/otel-agent/otel-agent
     - file ./bin/otel-agent/otel-agent | grep -q "musl" || (echo "binary is not musl-linked, this validation job is broken" && exit 1)

--- a/.gitlab/build/package_build/otel_musl_poc.yml
+++ b/.gitlab/build/package_build/otel_musl_poc.yml
@@ -4,6 +4,10 @@ otel-agent-musl-poc:
   image: registry.ddbuild.io/images/mirror/library/alpine:3.23.3
   tags: ["arch:amd64", "specific:true"]
   needs: ["setup_agent_version"]
+  variables:
+    KUBERNETES_CPU_REQUEST: 16
+    KUBERNETES_MEMORY_REQUEST: "32Gi"
+    KUBERNETES_MEMORY_LIMIT: "32Gi"
   script:
     - apk add --no-cache python3 py3-pip go musl-dev gcc git bash curl aws-cli
     - pip install --break-system-packages dda

--- a/omnibus/config/software/datadog-otel-agent.rb
+++ b/omnibus/config/software/datadog-otel-agent.rb
@@ -50,17 +50,6 @@ build do
 
     env = with_standard_compiler_flags(env)
 
-    # Set CC/CXX explicitly so CGo uses the glibc cross-compiler (DD_CC).
-    # The CI build image uses musl libc by default, which lacks tm_gmtoff in
-    # struct tm. The glibc cross-compiler has tm_gmtoff in its sysroot headers,
-    # which is required by internal/coreinternal/timeutils/strptime_cgo_testlib.go.
-    unless ENV["DD_CC"].nil? || ENV["DD_CC"].empty?
-        env["CC"] = ENV["DD_CC"]
-    end
-    unless ENV["DD_CXX"].nil? || ENV["DD_CXX"].empty?
-        env["CXX"] = ENV["DD_CXX"]
-    end
-
     if fips_mode?
       add_msgo_to_env(env)
     end


### PR DESCRIPTION
### What does this PR do?

Removes the `DD_CC`/`DD_CXX` override in `omnibus/config/software/datadog-otel-agent.rb` to validate that it can actually build with musl

### Motivation

Investigating the feasibility of building OTEL with musl so that it can be shipped on an alpine image

### Describe how you validated your changes

* Local build with the override removed
* The CI should validate the change and provide a publicly sharable link
* 
### Additional Notes
