### PR TITLE
Use 2 for parallelism of aix ci test job

### DIFF
--- a/.gitlab/aix/test/aix_unit_tests.yml
+++ b/.gitlab/aix/test/aix_unit_tests.yml
@@ -27,5 +27,5 @@ tests_aix-ppc64:
         set -eu
         cd $AIX_AGENT_SRC
         . ./packaging/aix/lib/env.sh
-        python3.12 -m invoke -e test $EXTRA_TEST_FLAGS --build-exclude=python --build-cpus=1
+        python3.12 -m invoke -e test $EXTRA_TEST_FLAGS --build-exclude=python --build-cpus 2
       '"


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Use `--build-cpus 2` for aix ci test job.

### Motivation
Previously we used 1 so a single package was built/tested at once, using 2 should be fine and help speed up the test significantly.
We don't want to use too much either to avoid OOMs.

### Describe how you validated your changes

### Additional Notes
