### PR TITLE
feat(discovery): collect services immediately at startup

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -276,10 +276,10 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 
 		if useCachedServiceCollection {
 			log.Debug("Starting cached service collection (process data collection enabled)")
-			go c.collectServicesCached(ctx, c.clock.Ticker(serviceCollectionInterval), processesReady)
+			go c.collectServicesCached(ctx, c.clock.Timer(serviceCollectionInterval), serviceCollectionInterval, processesReady)
 		} else {
 			log.Debug("Starting non-cached service collection (process data collection disabled)")
-			go c.collectServicesNoCache(ctx, c.clock.Ticker(serviceCollectionInterval))
+			go c.collectServicesNoCache(ctx, c.clock.Timer(serviceCollectionInterval), serviceCollectionInterval)
 		}
 	}
 
@@ -922,10 +922,11 @@ func (c *collector) collectProcesses(ctx context.Context, collectionTicker *cloc
 }
 
 // collectServices runs one collection as soon as its startup prerequisites are
-// ready, then collects at the configured interval. If the first regular tick
-// arrives before startup readiness, periodic collection takes over.
-func (c *collector) collectServices(ctx context.Context, collectionTicker *clock.Ticker, processesReady <-chan struct{}, collectOnce func(context.Context)) {
-	defer collectionTicker.Stop()
+// ready, then waits the configured interval after each collection before
+// collecting again. If the initial timer expires before startup readiness,
+// periodic collection takes over.
+func (c *collector) collectServices(ctx context.Context, collectionTimer *clock.Timer, collectionInterval time.Duration, processesReady <-chan struct{}, collectOnce func(context.Context)) {
+	defer collectionTimer.Stop()
 
 	startupCtx, cancelStartup := context.WithCancel(ctx)
 	defer cancelStartup()
@@ -938,18 +939,30 @@ func (c *collector) collectServices(ctx context.Context, collectionTicker *clock
 			cancelStartup()
 			if err == nil {
 				collectOnce(ctx)
+				resetTimer(collectionTimer, collectionInterval)
 			} else if !errors.Is(err, context.Canceled) {
 				log.Debugf("startup service collection readiness check stopped: %v", err)
 			}
-		case <-collectionTicker.C:
+		case <-collectionTimer.C:
 			cancelStartup()
 			startupReady = nil
 			collectOnce(ctx)
+			resetTimer(collectionTimer, collectionInterval)
 		case <-ctx.Done():
 			log.Infof("The %s service collector has stopped", collectorID)
 			return
 		}
 	}
+}
+
+func resetTimer(timer *clock.Timer, interval time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(interval)
 }
 
 func (c *collector) waitForServiceStartup(ctx context.Context, processesReady <-chan struct{}) <-chan error {
@@ -968,8 +981,8 @@ func (c *collector) waitForServiceStartup(ctx context.Context, processesReady <-
 	return ready
 }
 
-func (c *collector) collectServicesNoCache(ctx context.Context, collectionTicker *clock.Ticker) {
-	c.collectServices(ctx, collectionTicker, nil, c.collectServicesNoCacheOnce)
+func (c *collector) collectServicesNoCache(ctx context.Context, collectionTimer *clock.Timer, collectionInterval time.Duration) {
+	c.collectServices(ctx, collectionTimer, collectionInterval, nil, c.collectServicesNoCacheOnce)
 }
 
 // collectServicesNoCacheOnce performs one non-cached service collection.
@@ -1005,8 +1018,8 @@ func (c *collector) collectServicesNoCacheOnce(ctx context.Context) {
 }
 
 // collectServices captures service discovery data for alive processes
-func (c *collector) collectServicesCached(ctx context.Context, collectionTicker *clock.Ticker, processesReady <-chan struct{}) {
-	c.collectServices(ctx, collectionTicker, processesReady, c.collectServicesCachedOnce)
+func (c *collector) collectServicesCached(ctx context.Context, collectionTimer *clock.Timer, collectionInterval time.Duration, processesReady <-chan struct{}) {
+	c.collectServices(ctx, collectionTimer, collectionInterval, processesReady, c.collectServicesCachedOnce)
 }
 
 // collectServicesCachedOnce performs one cached service collection.

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -907,6 +907,7 @@ func (c *collector) collectProcesses(ctx context.Context, collectionTicker *cloc
 				processesReady = nil
 			}
 			if !c.sendProcessEvent(ctx, event) {
+				log.Infof("The %s collector has stopped", collectorID)
 				return
 			}
 		}

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -922,6 +922,7 @@ func (c *collector) collectProcesses(ctx context.Context, collectionTicker *cloc
 	}
 }
 
+// serviceCollectionTimer lets tests observe when Reset completes before advancing the mock clock.
 type serviceCollectionTimer interface {
 	C() <-chan time.Time
 	Reset(time.Duration) bool

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -922,11 +922,25 @@ func (c *collector) collectProcesses(ctx context.Context, collectionTicker *cloc
 	}
 }
 
+type serviceCollectionTimer interface {
+	C() <-chan time.Time
+	Reset(time.Duration) bool
+	Stop() bool
+}
+
+type clockServiceCollectionTimer struct {
+	*clock.Timer
+}
+
+func (t clockServiceCollectionTimer) C() <-chan time.Time {
+	return t.Timer.C
+}
+
 // collectServices runs one collection as soon as its startup prerequisites are
 // ready, then waits the configured interval after each collection before
 // collecting again. If the initial timer expires before startup readiness,
 // periodic collection takes over.
-func (c *collector) collectServices(ctx context.Context, collectionTimer *clock.Timer, collectionInterval time.Duration, processesReady <-chan struct{}, waitForSystemProbe func(context.Context) error, collectOnce func(context.Context)) {
+func (c *collector) collectServices(ctx context.Context, collectionTimer serviceCollectionTimer, collectionInterval time.Duration, processesReady <-chan struct{}, waitForSystemProbe func(context.Context) error, collectOnce func(context.Context)) {
 	defer collectionTimer.Stop()
 
 	startupCtx, cancelStartup := context.WithCancel(ctx)
@@ -945,7 +959,7 @@ func (c *collector) collectServices(ctx context.Context, collectionTimer *clock.
 			} else if !errors.Is(err, context.Canceled) {
 				log.Debugf("startup service collection readiness check stopped: %v", err)
 			}
-		case <-collectionTimer.C:
+		case <-collectionTimer.C():
 			cancelStartup()
 			startupReady = nil
 			collectOnce(ctx)
@@ -974,7 +988,7 @@ func waitForServiceStartup(ctx context.Context, processesReady <-chan struct{}, 
 }
 
 func (c *collector) collectServicesNoCache(ctx context.Context, collectionTimer *clock.Timer, collectionInterval time.Duration) {
-	c.collectServices(ctx, collectionTimer, collectionInterval, nil, c.sysProbeClient.WaitForStartup, c.collectServicesNoCacheOnce)
+	c.collectServices(ctx, clockServiceCollectionTimer{collectionTimer}, collectionInterval, nil, c.sysProbeClient.WaitForStartup, c.collectServicesNoCacheOnce)
 }
 
 // collectServicesNoCacheOnce performs one non-cached service collection.
@@ -1011,7 +1025,7 @@ func (c *collector) collectServicesNoCacheOnce(ctx context.Context) {
 
 // collectServices captures service discovery data for alive processes
 func (c *collector) collectServicesCached(ctx context.Context, collectionTimer *clock.Timer, collectionInterval time.Duration, processesReady <-chan struct{}) {
-	c.collectServices(ctx, collectionTimer, collectionInterval, processesReady, c.sysProbeClient.WaitForStartup, c.collectServicesCachedOnce)
+	c.collectServices(ctx, clockServiceCollectionTimer{collectionTimer}, collectionInterval, processesReady, c.sysProbeClient.WaitForStartup, c.collectServicesCachedOnce)
 }
 
 // collectServicesCachedOnce performs one cached service collection.

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -925,12 +925,12 @@ func (c *collector) collectProcesses(ctx context.Context, collectionTicker *cloc
 // ready, then waits the configured interval after each collection before
 // collecting again. If the initial timer expires before startup readiness,
 // periodic collection takes over.
-func (c *collector) collectServices(ctx context.Context, collectionTimer *clock.Timer, collectionInterval time.Duration, processesReady <-chan struct{}, collectOnce func(context.Context)) {
+func (c *collector) collectServices(ctx context.Context, collectionTimer *clock.Timer, collectionInterval time.Duration, processesReady <-chan struct{}, waitForSystemProbe func(context.Context) error, collectOnce func(context.Context)) {
 	defer collectionTimer.Stop()
 
 	startupCtx, cancelStartup := context.WithCancel(ctx)
 	defer cancelStartup()
-	startupReady := c.waitForServiceStartup(startupCtx, processesReady)
+	startupReady := waitForServiceStartup(startupCtx, processesReady, waitForSystemProbe)
 
 	for {
 		select {
@@ -956,7 +956,7 @@ func (c *collector) collectServices(ctx context.Context, collectionTimer *clock.
 	}
 }
 
-func (c *collector) waitForServiceStartup(ctx context.Context, processesReady <-chan struct{}) <-chan error {
+func waitForServiceStartup(ctx context.Context, processesReady <-chan struct{}, waitForSystemProbe func(context.Context) error) <-chan error {
 	ready := make(chan error, 1)
 	go func() {
 		if processesReady != nil {
@@ -967,13 +967,13 @@ func (c *collector) waitForServiceStartup(ctx context.Context, processesReady <-
 			case <-processesReady:
 			}
 		}
-		ready <- c.sysProbeClient.WaitForStartup(ctx)
+		ready <- waitForSystemProbe(ctx)
 	}()
 	return ready
 }
 
 func (c *collector) collectServicesNoCache(ctx context.Context, collectionTimer *clock.Timer, collectionInterval time.Duration) {
-	c.collectServices(ctx, collectionTimer, collectionInterval, nil, c.collectServicesNoCacheOnce)
+	c.collectServices(ctx, collectionTimer, collectionInterval, nil, c.sysProbeClient.WaitForStartup, c.collectServicesNoCacheOnce)
 }
 
 // collectServicesNoCacheOnce performs one non-cached service collection.
@@ -1010,7 +1010,7 @@ func (c *collector) collectServicesNoCacheOnce(ctx context.Context) {
 
 // collectServices captures service discovery data for alive processes
 func (c *collector) collectServicesCached(ctx context.Context, collectionTimer *clock.Timer, collectionInterval time.Duration, processesReady <-chan struct{}) {
-	c.collectServices(ctx, collectionTimer, collectionInterval, processesReady, c.collectServicesCachedOnce)
+	c.collectServices(ctx, collectionTimer, collectionInterval, processesReady, c.sysProbeClient.WaitForStartup, c.collectServicesCachedOnce)
 }
 
 // collectServicesCachedOnce performs one cached service collection.

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -69,6 +69,8 @@ const (
 	serviceCollectionBatchSizeConfigKey              = "discovery.service_collection_batch_size"
 	serviceCollectionMaxConsecutiveTimeoutsConfigKey = "discovery.service_collection_max_consecutive_timeouts"
 	serviceCollectionMinProcessAgeConfigKey          = "discovery.service_collection_min_process_age"
+
+	serviceCollectionStartupRetryInterval = 2 * time.Second
 )
 
 type collector struct {
@@ -270,10 +272,10 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 
 		if c.isProcessDataCollectionEnabled() {
 			log.Debug("Starting cached service collection (process data collection enabled)")
-			go c.collectServicesCached(ctx, c.clock.Ticker(serviceCollectionInterval))
+			go c.collectServicesCached(ctx, c.clock.Ticker(serviceCollectionInterval), serviceCollectionInterval)
 		} else {
 			log.Debug("Starting non-cached service collection (process data collection disabled)")
-			go c.collectServicesNoCache(ctx, c.clock.Ticker(serviceCollectionInterval))
+			go c.collectServicesNoCache(ctx, c.clock.Ticker(serviceCollectionInterval), serviceCollectionInterval)
 		}
 	}
 
@@ -689,14 +691,14 @@ func (c *collector) getProcessEntitiesFromServices(newPids []int32, heartbeatPid
 }
 
 // updateServices retrieves service discovery data for alive processes and returns workloadmeta entities
-func (c *collector) updateServices(ctx context.Context, alivePids core.PidSet, procs map[int32]*procutil.Process) ([]*workloadmeta.Process, core.PidSet) {
+func (c *collector) updateServices(ctx context.Context, alivePids core.PidSet, procs map[int32]*procutil.Process) ([]*workloadmeta.Process, core.PidSet, error) {
 	if c.serviceDiscoveryDisabledByTimeouts() {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	newPids, heartbeatPids := c.filterPidsToRequest(alivePids, procs)
 	if len(newPids) == 0 && len(heartbeatPids) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	resp, successfulNewPids, successfulHeartbeatPids, err := c.getDiscoveryServicesBatched(ctx, newPids, heartbeatPids)
@@ -708,7 +710,7 @@ func (c *collector) updateServices(ctx context.Context, alivePids core.PidSet, p
 	}
 
 	if len(successfulNewPids) == 0 && len(successfulHeartbeatPids) == 0 {
-		return nil, nil
+		return nil, nil, err
 	}
 
 	pidsToService := make(map[int32]*model.Service, len(successfulNewPids)+len(successfulHeartbeatPids))
@@ -733,13 +735,13 @@ func (c *collector) updateServices(ctx context.Context, alivePids core.PidSet, p
 		gpuPids.Add(int32(pid))
 	}
 
-	return c.getProcessEntitiesFromServices(successfulNewPids, successfulHeartbeatPids, pidsToService, injectedPids, gpuPids), injectedPids
+	return c.getProcessEntitiesFromServices(successfulNewPids, successfulHeartbeatPids, pidsToService, injectedPids, gpuPids), injectedPids, err
 }
 
-func (c *collector) updateServicesNoCache(ctx context.Context, alivePids core.PidSet, procs map[int32]*procutil.Process) []*workloadmeta.Process {
-	entities, _ := c.updateServices(ctx, alivePids, procs)
+func (c *collector) updateServicesNoCache(ctx context.Context, alivePids core.PidSet, procs map[int32]*procutil.Process) ([]*workloadmeta.Process, error) {
+	entities, _, err := c.updateServices(ctx, alivePids, procs)
 	if len(entities) == 0 {
-		return nil
+		return nil, err
 	}
 
 	pidToCid := c.containerProvider.GetPidToCid(cacheValidityNoRT)
@@ -768,7 +770,7 @@ func (c *collector) updateServicesNoCache(ctx context.Context, alivePids core.Pi
 		}
 	}
 
-	return entities
+	return entities, err
 }
 
 // getProcessDataForServices returns alive pids and processes
@@ -909,39 +911,55 @@ func (c *collector) collectProcesses(ctx context.Context, collectionTicker *cloc
 	}
 }
 
-func (c *collector) collectServicesNoCache(ctx context.Context, collectionTicker *clock.Ticker) {
-	ctx, cancel := context.WithCancel(ctx)
+// collectServices runs an initial collection immediately, then collects at the
+// configured interval. If the initial request reaches system-probe before it is
+// ready, collectOnce asks for short retries until either one succeeds or the
+// first regular collection is due.
+func (c *collector) collectServices(ctx context.Context, collectionTicker *clock.Ticker, collectionInterval time.Duration, collectOnce func(context.Context, bool) bool) {
 	defer collectionTicker.Stop()
-	defer cancel()
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
+	startupDeadline := c.clock.Now().Add(collectionInterval)
+	retryAtStartup := collectOnce(ctx, true)
+
+	var startupRetryTicker *clock.Ticker
+	var startupRetryC <-chan time.Time
+	if retryAtStartup && c.clock.Now().Add(serviceCollectionStartupRetryInterval).Before(startupDeadline) {
+		startupRetryTicker = c.clock.Ticker(serviceCollectionStartupRetryInterval)
+		startupRetryC = startupRetryTicker.C
+		log.Debugf("service discovery is not ready; retrying every %s until the first regular collection", serviceCollectionStartupRetryInterval)
+	}
+	stopStartupRetries := func() {
+		if startupRetryTicker != nil {
+			startupRetryTicker.Stop()
+			startupRetryTicker = nil
+			startupRetryC = nil
+		}
+	}
+	defer stopStartupRetries()
+
 	for {
 		select {
-		case <-collectionTicker.C:
-			alivePids, procs, err := c.getProcessDataForServices()
-			if err != nil {
-				log.Errorf("Error getting processes for service discovery: %v", err)
+		case <-startupRetryC:
+			if !collectOnce(ctx, true) {
+				log.Debugf("startup service collection retries finished after %s", collectionInterval-c.clock.Until(startupDeadline))
+				stopStartupRetries()
 				continue
 			}
-			if len(alivePids) == 0 {
-				continue // no processes to check
+
+			// Do not schedule an accelerated retry at or after the first regular
+			// collection. This keeps the startup behavior bounded by the configured
+			// interval instead of relying on a fixed attempt count.
+			if !c.clock.Now().Add(serviceCollectionStartupRetryInterval).Before(startupDeadline) {
+				stopStartupRetries()
 			}
-
-			wlmServiceEntities := c.updateServicesNoCache(ctx, alivePids, procs)
-			deletedProcesses := c.findDeletedProcesses(procs)
-
-			if len(wlmServiceEntities) > 0 || len(deletedProcesses) > 0 {
-				c.processEventsCh <- &Event{
-					Type:    EventTypeServiceDiscovery,
-					Created: wlmServiceEntities,
-					Deleted: deletedProcesses,
-				}
-			}
-
-			c.mux.Lock()
-			c.lastCollectedProcesses = procs
-			c.mux.Unlock()
-
-			c.cleanDiscoveryMaps(alivePids)
-			c.updateDiscoveredServicesMetric()
+		case <-collectionTicker.C:
+			stopStartupRetries()
+			collectOnce(ctx, false)
 		case <-ctx.Done():
 			log.Infof("The %s service collector has stopped", collectorID)
 			return
@@ -949,64 +967,114 @@ func (c *collector) collectServicesNoCache(ctx context.Context, collectionTicker
 	}
 }
 
-// collectServices captures service discovery data for alive processes
-func (c *collector) collectServicesCached(ctx context.Context, collectionTicker *clock.Ticker) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer collectionTicker.Stop()
-	defer cancel()
-	for {
-		select {
-		case <-collectionTicker.C:
-			alivePids, procs, err := c.getCachedProcessData()
-			if err != nil {
-				log.Errorf("Error getting processes for service discovery: %v", err)
-				continue
-			}
+func (c *collector) collectServicesNoCache(ctx context.Context, collectionTicker *clock.Ticker, collectionInterval time.Duration) {
+	c.collectServices(ctx, collectionTicker, collectionInterval, c.collectServicesNoCacheOnce)
+}
 
-			var wlmDeletedProcs []*workloadmeta.Process
-			for pid := range c.pidHeartbeats {
-				if alivePids.Has(pid) {
-					continue
-				}
+// collectServicesNoCacheOnce performs one non-cached service collection and
+// reports whether the startup scheduler should retry because system-probe is
+// not ready yet.
+func (c *collector) collectServicesNoCacheOnce(ctx context.Context, _ bool) bool {
+	alivePids, procs, err := c.getProcessDataForServices()
+	if err != nil {
+		log.Errorf("Error getting processes for service discovery: %v", err)
+		return false
+	}
+	if len(alivePids) == 0 {
+		return false // no processes to check
+	}
 
-				wlmDeletedProcs = append(wlmDeletedProcs, &workloadmeta.Process{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindProcess,
-						ID:   strconv.Itoa(int(pid)),
-					},
-				})
-			}
+	wlmServiceEntities, err := c.updateServicesNoCache(ctx, alivePids, procs)
+	deletedProcesses := c.findDeletedProcesses(procs)
 
-			// Check for deleted processes whose injection status we reported (but had no service)
-			for pid := range c.knownInjectionStatusPids {
-				if alivePids.Has(pid) {
-					continue
-				}
-
-				wlmDeletedProcs = append(wlmDeletedProcs, &workloadmeta.Process{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindProcess,
-						ID:   strconv.Itoa(int(pid)),
-					},
-				})
-			}
-
-			wlmServiceEntities, _ := c.updateServices(ctx, alivePids, procs)
-
-			if len(wlmServiceEntities) > 0 || len(wlmDeletedProcs) > 0 {
-				c.processEventsCh <- &Event{
-					Type:    EventTypeServiceDiscovery,
-					Created: wlmServiceEntities,
-					Deleted: wlmDeletedProcs,
-				}
-			}
-
-			c.cleanDiscoveryMaps(alivePids)
-			c.updateDiscoveredServicesMetric()
-		case <-ctx.Done():
-			log.Infof("The %s service collector has stopped", collectorID)
-			return
+	if len(wlmServiceEntities) > 0 || len(deletedProcesses) > 0 {
+		if !c.sendProcessEvent(ctx, &Event{
+			Type:    EventTypeServiceDiscovery,
+			Created: wlmServiceEntities,
+			Deleted: deletedProcesses,
+		}) {
+			return false
 		}
+	}
+
+	c.mux.Lock()
+	c.lastCollectedProcesses = procs
+	c.mux.Unlock()
+
+	c.cleanDiscoveryMaps(alivePids)
+	c.updateDiscoveredServicesMetric()
+	return errors.Is(err, errServiceDiscoveryRequestStartup)
+}
+
+// collectServices captures service discovery data for alive processes
+func (c *collector) collectServicesCached(ctx context.Context, collectionTicker *clock.Ticker, collectionInterval time.Duration) {
+	c.collectServices(ctx, collectionTicker, collectionInterval, c.collectServicesCachedOnce)
+}
+
+// collectServicesCachedOnce performs one cached service collection and reports
+// whether the startup scheduler should retry. An empty cache is retryable
+// because the process collector populates it concurrently during startup.
+func (c *collector) collectServicesCachedOnce(ctx context.Context, startup bool) bool {
+	alivePids, procs, err := c.getCachedProcessData()
+	if err != nil {
+		log.Errorf("Error getting processes for service discovery: %v", err)
+		return false
+	}
+	if startup && len(alivePids) == 0 {
+		return true
+	}
+
+	var wlmDeletedProcs []*workloadmeta.Process
+	for pid := range c.pidHeartbeats {
+		if alivePids.Has(pid) {
+			continue
+		}
+
+		wlmDeletedProcs = append(wlmDeletedProcs, &workloadmeta.Process{
+			EntityID: workloadmeta.EntityID{
+				Kind: workloadmeta.KindProcess,
+				ID:   strconv.Itoa(int(pid)),
+			},
+		})
+	}
+
+	// Check for deleted processes whose injection status we reported (but had no service)
+	for pid := range c.knownInjectionStatusPids {
+		if alivePids.Has(pid) {
+			continue
+		}
+
+		wlmDeletedProcs = append(wlmDeletedProcs, &workloadmeta.Process{
+			EntityID: workloadmeta.EntityID{
+				Kind: workloadmeta.KindProcess,
+				ID:   strconv.Itoa(int(pid)),
+			},
+		})
+	}
+
+	wlmServiceEntities, _, err := c.updateServices(ctx, alivePids, procs)
+
+	if len(wlmServiceEntities) > 0 || len(wlmDeletedProcs) > 0 {
+		if !c.sendProcessEvent(ctx, &Event{
+			Type:    EventTypeServiceDiscovery,
+			Created: wlmServiceEntities,
+			Deleted: wlmDeletedProcs,
+		}) {
+			return false
+		}
+	}
+
+	c.cleanDiscoveryMaps(alivePids)
+	c.updateDiscoveredServicesMetric()
+	return errors.Is(err, errServiceDiscoveryRequestStartup)
+}
+
+func (c *collector) sendProcessEvent(ctx context.Context, event *Event) bool {
+	select {
+	case c.processEventsCh <- event:
+		return true
+	case <-ctx.Done():
+		return false
 	}
 }
 

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -937,11 +937,11 @@ func (t clockServiceCollectionTimer) C() <-chan time.Time {
 	return t.Timer.C
 }
 
-// collectServices runs one collection as soon as its startup prerequisites are
+// collectServicesWithTimer runs one collection as soon as its startup prerequisites are
 // ready, then waits the configured interval after each collection before
 // collecting again. If the initial timer expires before startup readiness,
 // periodic collection takes over.
-func (c *collector) collectServices(ctx context.Context, collectionTimer serviceCollectionTimer, collectionInterval time.Duration, processesReady <-chan struct{}, waitForSystemProbe func(context.Context) error, collectOnce func(context.Context)) {
+func (c *collector) collectServicesWithTimer(ctx context.Context, collectionTimer serviceCollectionTimer, collectionInterval time.Duration, processesReady <-chan struct{}, waitForSystemProbe func(context.Context) error, collectOnce func(context.Context)) {
 	defer collectionTimer.Stop()
 
 	startupCtx, cancelStartup := context.WithCancel(ctx)
@@ -972,6 +972,10 @@ func (c *collector) collectServices(ctx context.Context, collectionTimer service
 	}
 }
 
+func (c *collector) collectServices(ctx context.Context, collectionTimer *clock.Timer, collectionInterval time.Duration, processesReady <-chan struct{}, collectOnce func(context.Context)) {
+	c.collectServicesWithTimer(ctx, clockServiceCollectionTimer{collectionTimer}, collectionInterval, processesReady, c.sysProbeClient.WaitForStartup, collectOnce)
+}
+
 func waitForServiceStartup(ctx context.Context, processesReady <-chan struct{}, waitForSystemProbe func(context.Context) error) <-chan error {
 	ready := make(chan error, 1)
 	go func() {
@@ -989,7 +993,7 @@ func waitForServiceStartup(ctx context.Context, processesReady <-chan struct{}, 
 }
 
 func (c *collector) collectServicesNoCache(ctx context.Context, collectionTimer *clock.Timer, collectionInterval time.Duration) {
-	c.collectServices(ctx, clockServiceCollectionTimer{collectionTimer}, collectionInterval, nil, c.sysProbeClient.WaitForStartup, c.collectServicesNoCacheOnce)
+	c.collectServices(ctx, collectionTimer, collectionInterval, nil, c.collectServicesNoCacheOnce)
 }
 
 // collectServicesNoCacheOnce performs one non-cached service collection.
@@ -1026,7 +1030,7 @@ func (c *collector) collectServicesNoCacheOnce(ctx context.Context) {
 
 // collectServices captures service discovery data for alive processes
 func (c *collector) collectServicesCached(ctx context.Context, collectionTimer *clock.Timer, collectionInterval time.Duration, processesReady <-chan struct{}) {
-	c.collectServices(ctx, clockServiceCollectionTimer{collectionTimer}, collectionInterval, processesReady, c.sysProbeClient.WaitForStartup, c.collectServicesCachedOnce)
+	c.collectServices(ctx, collectionTimer, collectionInterval, processesReady, c.collectServicesCachedOnce)
 }
 
 // collectServicesCachedOnce performs one cached service collection.

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -69,8 +69,6 @@ const (
 	serviceCollectionBatchSizeConfigKey              = "discovery.service_collection_batch_size"
 	serviceCollectionMaxConsecutiveTimeoutsConfigKey = "discovery.service_collection_max_consecutive_timeouts"
 	serviceCollectionMinProcessAgeConfigKey          = "discovery.service_collection_min_process_age"
-
-	serviceCollectionStartupRetryInterval = 2 * time.Second
 )
 
 type collector struct {
@@ -263,19 +261,25 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 	}
 	c.store = store
 
+	useCachedServiceCollection := c.isProcessDataCollectionEnabled()
+	var processesReady chan struct{}
+	if c.isServiceDiscoveryEnabled() && useCachedServiceCollection {
+		processesReady = make(chan struct{})
+	}
+
 	if c.isProcessDataCollectionEnabled() {
-		go c.collectProcesses(ctx, c.clock.Ticker(c.processCollectionIntervalConfig()))
+		go c.collectProcesses(ctx, c.clock.Ticker(c.processCollectionIntervalConfig()), processesReady)
 	}
 
 	if c.isServiceDiscoveryEnabled() {
 		serviceCollectionInterval := c.getServiceCollectionInterval()
 
-		if c.isProcessDataCollectionEnabled() {
+		if useCachedServiceCollection {
 			log.Debug("Starting cached service collection (process data collection enabled)")
-			go c.collectServicesCached(ctx, c.clock.Ticker(serviceCollectionInterval), serviceCollectionInterval)
+			go c.collectServicesCached(ctx, c.clock.Ticker(serviceCollectionInterval), processesReady)
 		} else {
 			log.Debug("Starting non-cached service collection (process data collection disabled)")
-			go c.collectServicesNoCache(ctx, c.clock.Ticker(serviceCollectionInterval), serviceCollectionInterval)
+			go c.collectServicesNoCache(ctx, c.clock.Ticker(serviceCollectionInterval))
 		}
 	}
 
@@ -691,14 +695,14 @@ func (c *collector) getProcessEntitiesFromServices(newPids []int32, heartbeatPid
 }
 
 // updateServices retrieves service discovery data for alive processes and returns workloadmeta entities
-func (c *collector) updateServices(ctx context.Context, alivePids core.PidSet, procs map[int32]*procutil.Process) ([]*workloadmeta.Process, core.PidSet, error) {
+func (c *collector) updateServices(ctx context.Context, alivePids core.PidSet, procs map[int32]*procutil.Process) ([]*workloadmeta.Process, core.PidSet) {
 	if c.serviceDiscoveryDisabledByTimeouts() {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	newPids, heartbeatPids := c.filterPidsToRequest(alivePids, procs)
 	if len(newPids) == 0 && len(heartbeatPids) == 0 {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	resp, successfulNewPids, successfulHeartbeatPids, err := c.getDiscoveryServicesBatched(ctx, newPids, heartbeatPids)
@@ -710,7 +714,7 @@ func (c *collector) updateServices(ctx context.Context, alivePids core.PidSet, p
 	}
 
 	if len(successfulNewPids) == 0 && len(successfulHeartbeatPids) == 0 {
-		return nil, nil, err
+		return nil, nil
 	}
 
 	pidsToService := make(map[int32]*model.Service, len(successfulNewPids)+len(successfulHeartbeatPids))
@@ -735,13 +739,13 @@ func (c *collector) updateServices(ctx context.Context, alivePids core.PidSet, p
 		gpuPids.Add(int32(pid))
 	}
 
-	return c.getProcessEntitiesFromServices(successfulNewPids, successfulHeartbeatPids, pidsToService, injectedPids, gpuPids), injectedPids, err
+	return c.getProcessEntitiesFromServices(successfulNewPids, successfulHeartbeatPids, pidsToService, injectedPids, gpuPids), injectedPids
 }
 
-func (c *collector) updateServicesNoCache(ctx context.Context, alivePids core.PidSet, procs map[int32]*procutil.Process) ([]*workloadmeta.Process, error) {
-	entities, _, err := c.updateServices(ctx, alivePids, procs)
+func (c *collector) updateServicesNoCache(ctx context.Context, alivePids core.PidSet, procs map[int32]*procutil.Process) []*workloadmeta.Process {
+	entities, _ := c.updateServices(ctx, alivePids, procs)
 	if len(entities) == 0 {
-		return nil, err
+		return nil
 	}
 
 	pidToCid := c.containerProvider.GetPidToCid(cacheValidityNoRT)
@@ -770,7 +774,7 @@ func (c *collector) updateServicesNoCache(ctx context.Context, alivePids core.Pi
 		}
 	}
 
-	return entities, err
+	return entities
 }
 
 // getProcessDataForServices returns alive pids and processes
@@ -892,13 +896,19 @@ func (c *collector) collectProcessesOnce() *Event {
 }
 
 // collectProcesses captures all the required process data for the process check
-func (c *collector) collectProcesses(ctx context.Context, collectionTicker *clock.Ticker) {
+func (c *collector) collectProcesses(ctx context.Context, collectionTicker *clock.Ticker, processesReady chan<- struct{}) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer collectionTicker.Stop()
 	defer cancel()
 	for {
 		if event := c.collectProcessesOnce(); event != nil {
-			c.processEventsCh <- event
+			if processesReady != nil {
+				close(processesReady)
+				processesReady = nil
+			}
+			if !c.sendProcessEvent(ctx, event) {
+				return
+			}
 		}
 
 		select {
@@ -911,55 +921,30 @@ func (c *collector) collectProcesses(ctx context.Context, collectionTicker *cloc
 	}
 }
 
-// collectServices runs an initial collection immediately, then collects at the
-// configured interval. If the initial request reaches system-probe before it is
-// ready, collectOnce asks for short retries until either one succeeds or the
-// first regular collection is due.
-func (c *collector) collectServices(ctx context.Context, collectionTicker *clock.Ticker, collectionInterval time.Duration, collectOnce func(context.Context, bool) bool) {
+// collectServices runs one collection as soon as its startup prerequisites are
+// ready, then collects at the configured interval. If the first regular tick
+// arrives before startup readiness, periodic collection takes over.
+func (c *collector) collectServices(ctx context.Context, collectionTicker *clock.Ticker, processesReady <-chan struct{}, collectOnce func(context.Context)) {
 	defer collectionTicker.Stop()
-	select {
-	case <-ctx.Done():
-		return
-	default:
-	}
 
-	startupDeadline := c.clock.Now().Add(collectionInterval)
-	retryAtStartup := collectOnce(ctx, true)
-
-	var startupRetryTicker *clock.Ticker
-	var startupRetryC <-chan time.Time
-	if retryAtStartup && c.clock.Now().Add(serviceCollectionStartupRetryInterval).Before(startupDeadline) {
-		startupRetryTicker = c.clock.Ticker(serviceCollectionStartupRetryInterval)
-		startupRetryC = startupRetryTicker.C
-		log.Debugf("service discovery is not ready; retrying every %s until the first regular collection", serviceCollectionStartupRetryInterval)
-	}
-	stopStartupRetries := func() {
-		if startupRetryTicker != nil {
-			startupRetryTicker.Stop()
-			startupRetryTicker = nil
-			startupRetryC = nil
-		}
-	}
-	defer stopStartupRetries()
+	startupCtx, cancelStartup := context.WithCancel(ctx)
+	defer cancelStartup()
+	startupReady := c.waitForServiceStartup(startupCtx, processesReady)
 
 	for {
 		select {
-		case <-startupRetryC:
-			if !collectOnce(ctx, true) {
-				log.Debugf("startup service collection retries finished after %s", collectionInterval-c.clock.Until(startupDeadline))
-				stopStartupRetries()
-				continue
-			}
-
-			// Do not schedule an accelerated retry at or after the first regular
-			// collection. This keeps the startup behavior bounded by the configured
-			// interval instead of relying on a fixed attempt count.
-			if !c.clock.Now().Add(serviceCollectionStartupRetryInterval).Before(startupDeadline) {
-				stopStartupRetries()
+		case err := <-startupReady:
+			startupReady = nil
+			cancelStartup()
+			if err == nil {
+				collectOnce(ctx)
+			} else if !errors.Is(err, context.Canceled) {
+				log.Debugf("startup service collection readiness check stopped: %v", err)
 			}
 		case <-collectionTicker.C:
-			stopStartupRetries()
-			collectOnce(ctx, false)
+			cancelStartup()
+			startupReady = nil
+			collectOnce(ctx)
 		case <-ctx.Done():
 			log.Infof("The %s service collector has stopped", collectorID)
 			return
@@ -967,24 +952,38 @@ func (c *collector) collectServices(ctx context.Context, collectionTicker *clock
 	}
 }
 
-func (c *collector) collectServicesNoCache(ctx context.Context, collectionTicker *clock.Ticker, collectionInterval time.Duration) {
-	c.collectServices(ctx, collectionTicker, collectionInterval, c.collectServicesNoCacheOnce)
+func (c *collector) waitForServiceStartup(ctx context.Context, processesReady <-chan struct{}) <-chan error {
+	ready := make(chan error, 1)
+	go func() {
+		if processesReady != nil {
+			select {
+			case <-ctx.Done():
+				ready <- ctx.Err()
+				return
+			case <-processesReady:
+			}
+		}
+		ready <- c.sysProbeClient.WaitForStartup(ctx)
+	}()
+	return ready
 }
 
-// collectServicesNoCacheOnce performs one non-cached service collection and
-// reports whether the startup scheduler should retry because system-probe is
-// not ready yet.
-func (c *collector) collectServicesNoCacheOnce(ctx context.Context, _ bool) bool {
+func (c *collector) collectServicesNoCache(ctx context.Context, collectionTicker *clock.Ticker) {
+	c.collectServices(ctx, collectionTicker, nil, c.collectServicesNoCacheOnce)
+}
+
+// collectServicesNoCacheOnce performs one non-cached service collection.
+func (c *collector) collectServicesNoCacheOnce(ctx context.Context) {
 	alivePids, procs, err := c.getProcessDataForServices()
 	if err != nil {
 		log.Errorf("Error getting processes for service discovery: %v", err)
-		return false
+		return
 	}
 	if len(alivePids) == 0 {
-		return false // no processes to check
+		return // no processes to check
 	}
 
-	wlmServiceEntities, err := c.updateServicesNoCache(ctx, alivePids, procs)
+	wlmServiceEntities := c.updateServicesNoCache(ctx, alivePids, procs)
 	deletedProcesses := c.findDeletedProcesses(procs)
 
 	if len(wlmServiceEntities) > 0 || len(deletedProcesses) > 0 {
@@ -993,7 +992,7 @@ func (c *collector) collectServicesNoCacheOnce(ctx context.Context, _ bool) bool
 			Created: wlmServiceEntities,
 			Deleted: deletedProcesses,
 		}) {
-			return false
+			return
 		}
 	}
 
@@ -1003,25 +1002,19 @@ func (c *collector) collectServicesNoCacheOnce(ctx context.Context, _ bool) bool
 
 	c.cleanDiscoveryMaps(alivePids)
 	c.updateDiscoveredServicesMetric()
-	return errors.Is(err, errServiceDiscoveryRequestStartup)
 }
 
 // collectServices captures service discovery data for alive processes
-func (c *collector) collectServicesCached(ctx context.Context, collectionTicker *clock.Ticker, collectionInterval time.Duration) {
-	c.collectServices(ctx, collectionTicker, collectionInterval, c.collectServicesCachedOnce)
+func (c *collector) collectServicesCached(ctx context.Context, collectionTicker *clock.Ticker, processesReady <-chan struct{}) {
+	c.collectServices(ctx, collectionTicker, processesReady, c.collectServicesCachedOnce)
 }
 
-// collectServicesCachedOnce performs one cached service collection and reports
-// whether the startup scheduler should retry. An empty cache is retryable
-// because the process collector populates it concurrently during startup.
-func (c *collector) collectServicesCachedOnce(ctx context.Context, startup bool) bool {
+// collectServicesCachedOnce performs one cached service collection.
+func (c *collector) collectServicesCachedOnce(ctx context.Context) {
 	alivePids, procs, err := c.getCachedProcessData()
 	if err != nil {
 		log.Errorf("Error getting processes for service discovery: %v", err)
-		return false
-	}
-	if startup && len(alivePids) == 0 {
-		return true
+		return
 	}
 
 	var wlmDeletedProcs []*workloadmeta.Process
@@ -1052,7 +1045,7 @@ func (c *collector) collectServicesCachedOnce(ctx context.Context, startup bool)
 		})
 	}
 
-	wlmServiceEntities, _, err := c.updateServices(ctx, alivePids, procs)
+	wlmServiceEntities, _ := c.updateServices(ctx, alivePids, procs)
 
 	if len(wlmServiceEntities) > 0 || len(wlmDeletedProcs) > 0 {
 		if !c.sendProcessEvent(ctx, &Event{
@@ -1060,13 +1053,12 @@ func (c *collector) collectServicesCachedOnce(ctx context.Context, startup bool)
 			Created: wlmServiceEntities,
 			Deleted: wlmDeletedProcs,
 		}) {
-			return false
+			return
 		}
 	}
 
 	c.cleanDiscoveryMaps(alivePids)
 	c.updateDiscoveredServicesMetric()
-	return errors.Is(err, errServiceDiscoveryRequestStartup)
 }
 
 func (c *collector) sendProcessEvent(ctx context.Context, event *Event) bool {

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -939,7 +939,8 @@ func (c *collector) collectServices(ctx context.Context, collectionTimer *clock.
 			cancelStartup()
 			if err == nil {
 				collectOnce(ctx)
-				resetTimer(collectionTimer, collectionInterval)
+				// The real clock wraps time.Timer, whose Reset discards stale values since Go 1.23.
+				collectionTimer.Reset(collectionInterval)
 			} else if !errors.Is(err, context.Canceled) {
 				log.Debugf("startup service collection readiness check stopped: %v", err)
 			}
@@ -947,22 +948,12 @@ func (c *collector) collectServices(ctx context.Context, collectionTimer *clock.
 			cancelStartup()
 			startupReady = nil
 			collectOnce(ctx)
-			resetTimer(collectionTimer, collectionInterval)
+			collectionTimer.Reset(collectionInterval)
 		case <-ctx.Done():
 			log.Infof("The %s service collector has stopped", collectorID)
 			return
 		}
 	}
-}
-
-func resetTimer(timer *clock.Timer, interval time.Duration) {
-	if !timer.Stop() {
-		select {
-		case <-timer.C:
-		default:
-		}
-	}
-	timer.Reset(interval)
 }
 
 func (c *collector) waitForServiceStartup(ctx context.Context, processesReady <-chan struct{}) <-chan error {

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -53,6 +53,64 @@ func (c collectorTest) cleanup() {
 	telemetryimpl.GetCompatComponent().Reset()
 }
 
+func TestCollectProcessesSignalsReadinessAfterSuccessfulEmptyScan(t *testing.T) {
+	c := setUpCollectorTest(t, config.NewMock(t), nil, nil)
+	c.collector.processEventsCh = make(chan *Event, 1)
+	c.probe.EXPECT().ProcessesByPID(mock.Anything, false).Return(map[int32]*procutil.Process{}, nil).Once()
+	c.mockContainerProvider.EXPECT().GetPidToCid(cacheValidityNoRT).Return(nil).Times(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	processesReady := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.collector.collectProcesses(ctx, c.mockClock.Ticker(time.Minute), processesReady)
+	}()
+
+	select {
+	case <-processesReady:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for process readiness")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for process collection to stop")
+	}
+}
+
+func TestCollectProcessesDoesNotSignalReadinessAfterFailedScan(t *testing.T) {
+	c := setUpCollectorTest(t, config.NewMock(t), nil, nil)
+	firstAttempt := make(chan struct{})
+	c.probe.EXPECT().ProcessesByPID(mock.Anything, false).
+		Run(func(time.Time, bool) { close(firstAttempt) }).
+		Return(nil, assert.AnError).
+		Once()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	processesReady := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.collector.collectProcesses(ctx, c.mockClock.Ticker(time.Minute), processesReady)
+	}()
+	<-firstAttempt
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for process collection to stop")
+	}
+	select {
+	case <-processesReady:
+		t.Fatal("failed process scan unexpectedly signaled readiness")
+	default:
+	}
+}
+
 // TestBasicCreatedProcessesCollection tests the collector capturing new processes without language + container data
 func TestBasicCreatedProcessesCollection(t *testing.T) {
 	creationTime1 := time.Now().Unix()

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -21,7 +21,6 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -634,27 +633,6 @@ func waitForServiceCollectionCall(t *testing.T, calls <-chan time.Time) time.Tim
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for service collection")
 		return time.Time{}
-	}
-}
-
-func TestResetTimerDiscardsExpiredValue(t *testing.T) {
-	mockClock := clock.NewMock()
-	timer := mockClock.Timer(time.Minute)
-	mockClock.Add(time.Minute)
-
-	resetTimer(timer, time.Minute)
-	select {
-	case tick := <-timer.C:
-		t.Fatalf("timer retained stale expiry at %s", tick)
-	default:
-	}
-
-	mockClock.Add(time.Minute)
-	select {
-	case tick := <-timer.C:
-		assert.Equal(t, mockClock.Now(), tick)
-	default:
-		t.Fatal("reset timer did not expire after a full interval")
 	}
 }
 

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -636,13 +636,18 @@ func waitForServiceCollectionCall(t *testing.T, calls <-chan time.Time) time.Tim
 	}
 }
 
+func waitForServiceStartupSignal(t *testing.T, signal <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+	}
+}
+
 func TestCollectServicesSchedulesRegularIntervalFromStartupCollection(t *testing.T) {
 	c := setUpCollectorTest(t, nil, nil, nil)
 	c.mockClock.Set(baseTime)
-	socketPath, _ := startScriptedServiceDiscoveryServer(t, func(_ int, _ core.Params) serviceDiscoveryTestResponse {
-		return serviceDiscoveryTestResponse{response: &model.ServicesResponse{}}
-	})
-	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	processesReady := make(chan struct{})
@@ -651,7 +656,9 @@ func TestCollectServicesSchedulesRegularIntervalFromStartupCollection(t *testing
 	collectionTimer := c.mockClock.Timer(time.Minute)
 	go func() {
 		defer close(done)
-		c.collector.collectServices(ctx, collectionTimer, time.Minute, processesReady, func(context.Context) {
+		c.collector.collectServices(ctx, collectionTimer, time.Minute, processesReady, func(context.Context) error {
+			return nil
+		}, func(context.Context) {
 			calls <- c.mockClock.Now()
 		})
 	}()
@@ -682,13 +689,60 @@ func TestCollectServicesSchedulesRegularIntervalFromStartupCollection(t *testing
 	}
 }
 
+func TestCollectServicesWaitsForSystemProbeStartup(t *testing.T) {
+	c := setUpCollectorTest(t, nil, nil, nil)
+	c.mockClock.Set(baseTime)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	processesReady := make(chan struct{})
+	close(processesReady)
+	waitStarted := make(chan struct{})
+	systemProbeReady := make(chan struct{})
+	calls := make(chan time.Time, 1)
+	done := make(chan struct{})
+	collectionTimer := c.mockClock.Timer(time.Minute)
+	go func() {
+		defer close(done)
+		c.collector.collectServices(ctx, collectionTimer, time.Minute, processesReady, func(ctx context.Context) error {
+			close(waitStarted)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-systemProbeReady:
+				return nil
+			}
+		}, func(context.Context) {
+			calls <- c.mockClock.Now()
+		})
+	}()
+
+	waitForServiceStartupSignal(t, waitStarted, "system-probe startup wait to begin")
+	select {
+	case callTime := <-calls:
+		t.Fatalf("service collection ran before system-probe readiness at %s", callTime)
+	default:
+	}
+
+	close(systemProbeReady)
+	assert.Equal(t, baseTime, waitForServiceCollectionCall(t, calls))
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for service collection to stop")
+	}
+}
+
 func TestCollectServicesDoesNotRunAfterCancellation(t *testing.T) {
 	c := setUpCollectorTest(t, nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
 	called := false
-	c.collector.collectServices(ctx, c.mockClock.Timer(time.Minute), time.Minute, nil, func(context.Context) {
+	c.collector.collectServices(ctx, c.mockClock.Timer(time.Minute), time.Minute, nil, func(ctx context.Context) error {
+		return ctx.Err()
+	}, func(context.Context) {
 		called = true
 	})
 
@@ -709,20 +763,33 @@ func TestCollectServicesRegularIntervalCancelsStartupWait(t *testing.T) {
 	c.mockClock.Set(baseTime)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	processesReady := make(chan struct{})
+	waitStarted := make(chan struct{})
+	waitCanceled := make(chan struct{})
+	systemProbeReady := make(chan struct{})
 	calls := make(chan time.Time, 2)
 	done := make(chan struct{})
 	collectionTimer := c.mockClock.Timer(time.Minute)
 	go func() {
 		defer close(done)
-		c.collector.collectServices(ctx, collectionTimer, time.Minute, processesReady, func(context.Context) {
+		c.collector.collectServices(ctx, collectionTimer, time.Minute, nil, func(ctx context.Context) error {
+			close(waitStarted)
+			select {
+			case <-ctx.Done():
+				close(waitCanceled)
+				return ctx.Err()
+			case <-systemProbeReady:
+				return nil
+			}
+		}, func(context.Context) {
 			calls <- c.mockClock.Now()
 		})
 	}()
 
+	waitForServiceStartupSignal(t, waitStarted, "system-probe startup wait to begin")
 	c.mockClock.Add(time.Minute)
 	assert.Equal(t, baseTime.Add(time.Minute), waitForServiceCollectionCall(t, calls))
-	close(processesReady)
+	waitForServiceStartupSignal(t, waitCanceled, "system-probe startup wait cancellation")
+	close(systemProbeReady)
 	select {
 	case callTime := <-calls:
 		t.Fatalf("unexpected startup collection after periodic collection took over at %s", callTime)

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -384,7 +384,7 @@ func TestServiceDiscoveryPartialBatchFailurePreservesRetries(t *testing.T) {
 	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101, 102, 103, 104, 105})
-	entities, _ := c.collector.updateServices(context.Background(), alivePids, procs)
+	entities, _, _ := c.collector.updateServices(context.Background(), alivePids, procs)
 
 	assert.Equal(t, 2, requests())
 	requestMux.Lock()
@@ -448,7 +448,7 @@ func testServiceDiscoveryConsecutiveTimeoutsDisableRequests(t *testing.T, c coll
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101})
 	for i := 0; i < maxConsecutiveTimeouts; i++ {
-		entities, injectedPids := c.collector.updateServices(context.Background(), alivePids, procs)
+		entities, injectedPids, _ := c.collector.updateServices(context.Background(), alivePids, procs)
 		require.Empty(t, entities)
 		require.Empty(t, injectedPids)
 	}
@@ -457,7 +457,7 @@ func testServiceDiscoveryConsecutiveTimeoutsDisableRequests(t *testing.T, c coll
 	assert.Equal(t, maxConsecutiveTimeouts, c.collector.consecutiveServiceDiscoveryTimeouts)
 	assert.Equal(t, maxConsecutiveTimeouts, requests())
 
-	entities, injectedPids := c.collector.updateServices(context.Background(), alivePids, procs)
+	entities, injectedPids, _ := c.collector.updateServices(context.Background(), alivePids, procs)
 	require.Empty(t, entities)
 	require.Empty(t, injectedPids)
 	assert.Equal(t, maxConsecutiveTimeouts, requests(), "disabled service discovery should not send more requests")
@@ -480,7 +480,7 @@ func TestServiceDiscoverySuccessfulRequestResetsConsecutiveTimeouts(t *testing.T
 	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101})
-	entities, _ := c.collector.updateServices(context.Background(), alivePids, procs)
+	entities, _, _ := c.collector.updateServices(context.Background(), alivePids, procs)
 
 	require.Len(t, entities, 1)
 	assert.Equal(t, int32(101), entities[0].Pid)
@@ -589,7 +589,7 @@ func testServiceDiscoveryPartialBatchTimeoutPreservesSuccessfulPIDsAndResetsPrev
 	)
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101, 102, 103, 104, 105})
-	entities, _ := c.collector.updateServices(context.Background(), alivePids, procs)
+	entities, _, _ := c.collector.updateServices(context.Background(), alivePids, procs)
 
 	assert.Equal(t, 2, requests())
 	requestMux.Lock()
@@ -618,11 +618,189 @@ func TestServiceDiscoverySuccessfulNoServiceIncrementsRetries(t *testing.T) {
 	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101})
-	entities, _ := c.collector.updateServices(context.Background(), alivePids, procs)
+	entities, _, _ := c.collector.updateServices(context.Background(), alivePids, procs)
 
 	require.Len(t, entities, 1)
 	assert.Equal(t, int32(101), entities[0].Pid)
 	assert.Equal(t, uint(1), c.collector.serviceRetries[101])
+}
+
+func waitForServiceCollectionCall(t *testing.T, calls <-chan time.Time) time.Time {
+	t.Helper()
+	select {
+	case callTime := <-calls:
+		return callTime
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for service collection")
+		return time.Time{}
+	}
+}
+
+func TestCollectServicesRunsImmediatelyAndAtRegularInterval(t *testing.T) {
+	c := setUpCollectorTest(t, nil, nil, nil)
+	c.mockClock.Set(baseTime)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := make(chan time.Time, 2)
+	done := make(chan struct{})
+	collectionTicker := c.mockClock.Ticker(time.Minute)
+	go func() {
+		defer close(done)
+		c.collector.collectServices(ctx, collectionTicker, time.Minute, func(context.Context, bool) bool {
+			calls <- c.mockClock.Now()
+			return false
+		})
+	}()
+
+	assert.Equal(t, baseTime, waitForServiceCollectionCall(t, calls))
+	c.mockClock.Add(time.Minute)
+	assert.Equal(t, baseTime.Add(time.Minute), waitForServiceCollectionCall(t, calls))
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for service collection to stop")
+	}
+}
+
+func TestCollectServicesDoesNotRunAfterCancellation(t *testing.T) {
+	c := setUpCollectorTest(t, nil, nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	called := false
+	c.collector.collectServices(ctx, c.mockClock.Ticker(time.Minute), time.Minute, func(context.Context, bool) bool {
+		called = true
+		return false
+	})
+
+	assert.False(t, called)
+}
+
+func TestSendProcessEventStopsWhenCanceled(t *testing.T) {
+	c := setUpCollectorTest(t, nil, nil, nil)
+	c.collector.processEventsCh = make(chan *Event)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assert.False(t, c.collector.sendProcessEvent(ctx, &Event{Type: EventTypeServiceDiscovery}))
+}
+
+func TestCollectServicesRetriesOnlyUntilFirstRegularInterval(t *testing.T) {
+	const collectionInterval = 10 * time.Second
+	c := setUpCollectorTest(t, nil, nil, nil)
+	c.mockClock.Set(baseTime)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := make(chan time.Time, 8)
+	done := make(chan struct{})
+	collectionTicker := c.mockClock.Ticker(collectionInterval)
+	go func() {
+		defer close(done)
+		c.collector.collectServices(ctx, collectionTicker, collectionInterval, func(context.Context, bool) bool {
+			calls <- c.mockClock.Now()
+			return true
+		})
+	}()
+
+	assert.Equal(t, baseTime, waitForServiceCollectionCall(t, calls))
+	for elapsed := serviceCollectionStartupRetryInterval; elapsed < collectionInterval; elapsed += serviceCollectionStartupRetryInterval {
+		c.mockClock.Add(serviceCollectionStartupRetryInterval)
+		assert.Equal(t, baseTime.Add(elapsed), waitForServiceCollectionCall(t, calls))
+	}
+
+	c.mockClock.Add(serviceCollectionStartupRetryInterval)
+	assert.Equal(t, baseTime.Add(collectionInterval), waitForServiceCollectionCall(t, calls))
+	c.mockClock.Add(serviceCollectionStartupRetryInterval)
+	select {
+	case callTime := <-calls:
+		t.Fatalf("unexpected startup retry after the first regular collection at %s", callTime)
+	default:
+	}
+
+	c.mockClock.Add(collectionInterval - serviceCollectionStartupRetryInterval)
+	assert.Equal(t, baseTime.Add(2*collectionInterval), waitForServiceCollectionCall(t, calls))
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for service collection to stop")
+	}
+}
+
+func TestCollectServicesStopsStartupRetriesAfterNonRetryableResult(t *testing.T) {
+	c := setUpCollectorTest(t, nil, nil, nil)
+	c.mockClock.Set(baseTime)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	calls := make(chan time.Time, 3)
+	callCount := 0
+	collectionTicker := c.mockClock.Ticker(time.Minute)
+	go c.collector.collectServices(ctx, collectionTicker, time.Minute, func(context.Context, bool) bool {
+		callCount++
+		calls <- c.mockClock.Now()
+		return callCount < 2
+	})
+
+	assert.Equal(t, baseTime, waitForServiceCollectionCall(t, calls))
+	c.mockClock.Add(serviceCollectionStartupRetryInterval)
+	assert.Equal(t, baseTime.Add(serviceCollectionStartupRetryInterval), waitForServiceCollectionCall(t, calls))
+	c.mockClock.Add(serviceCollectionStartupRetryInterval)
+	select {
+	case callTime := <-calls:
+		t.Fatalf("unexpected startup retry after a non-retryable result at %s", callTime)
+	default:
+	}
+}
+
+func TestCollectServicesCachedRetriesInitiallyEmptyProcessCache(t *testing.T) {
+	c := setUpCollectorTest(t, nil, nil, nil)
+	c.mockClock.Set(baseTime)
+	c.collector.store = c.mockStore
+	c.collector.processEventsCh = make(chan *Event, 1)
+
+	socketPath, requests := startScriptedServiceDiscoveryServer(t, func(_ int, _ core.Params) serviceDiscoveryTestResponse {
+		return serviceDiscoveryTestResponse{response: &model.ServicesResponse{
+			Services: []model.Service{makeModelService(101, "cached-service")},
+		}}
+	})
+	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	attempts := make(chan struct{}, 2)
+	collectionTicker := c.mockClock.Ticker(time.Minute)
+	go c.collector.collectServices(ctx, collectionTicker, time.Minute, func(ctx context.Context, startup bool) bool {
+		retry := c.collector.collectServicesCachedOnce(ctx, startup)
+		attempts <- struct{}{}
+		return retry
+	})
+
+	select {
+	case <-attempts:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial cached service collection")
+	}
+	assert.Equal(t, 0, requests())
+
+	c.collector.mux.Lock()
+	c.collector.lastCollectedProcesses = map[int32]*procutil.Process{
+		101: makeProcess(101, baseTime.Add(-2*time.Minute).UnixMilli(), nil),
+	}
+	c.collector.mux.Unlock()
+	c.mockClock.Add(serviceCollectionStartupRetryInterval)
+
+	select {
+	case event := <-c.collector.processEventsCh:
+		require.Len(t, event.Created, 1)
+		assert.Equal(t, int32(101), event.Created[0].Pid)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for service discovery event")
+	}
+	assert.Equal(t, 1, requests())
 }
 
 func TestCollectServicesCachedReleasesProcessCacheLockBeforeServiceRequests(t *testing.T) {
@@ -653,14 +831,11 @@ func TestCollectServicesCachedReleasesProcessCacheLockBeforeServiceRequests(t *t
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ticker := c.mockClock.Ticker(time.Minute)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		c.collector.collectServicesCached(ctx, ticker)
+		c.collector.collectServicesCached(ctx, c.mockClock.Ticker(time.Minute), time.Minute)
 	}()
-
-	c.mockClock.Add(time.Minute)
 
 	select {
 	case locked := <-lockAvailable:

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -645,6 +645,18 @@ func waitForServiceStartupSignal(t *testing.T, signal <-chan struct{}, descripti
 	}
 }
 
+type resetSignalTimer struct {
+	serviceCollectionTimer
+	reset     chan struct{}
+	resetOnce sync.Once
+}
+
+func (t *resetSignalTimer) Reset(interval time.Duration) bool {
+	active := t.serviceCollectionTimer.Reset(interval)
+	t.resetOnce.Do(func() { close(t.reset) })
+	return active
+}
+
 func TestCollectServicesSchedulesRegularIntervalFromStartupCollection(t *testing.T) {
 	c := setUpCollectorTest(t, nil, nil, nil)
 	c.mockClock.Set(baseTime)
@@ -653,7 +665,10 @@ func TestCollectServicesSchedulesRegularIntervalFromStartupCollection(t *testing
 	processesReady := make(chan struct{})
 	calls := make(chan time.Time, 2)
 	done := make(chan struct{})
-	collectionTimer := c.mockClock.Timer(time.Minute)
+	collectionTimer := &resetSignalTimer{
+		serviceCollectionTimer: clockServiceCollectionTimer{c.mockClock.Timer(time.Minute)},
+		reset:                  make(chan struct{}),
+	}
 	go func() {
 		defer close(done)
 		c.collector.collectServices(ctx, collectionTimer, time.Minute, processesReady, func(context.Context) error {
@@ -671,6 +686,7 @@ func TestCollectServicesSchedulesRegularIntervalFromStartupCollection(t *testing
 	}
 	close(processesReady)
 	assert.Equal(t, baseTime.Add(45*time.Second), waitForServiceCollectionCall(t, calls))
+	waitForServiceStartupSignal(t, collectionTimer.reset, "collection timer reset")
 
 	c.mockClock.Add(59 * time.Second)
 	select {
@@ -700,7 +716,7 @@ func TestCollectServicesWaitsForSystemProbeStartup(t *testing.T) {
 	systemProbeReady := make(chan struct{})
 	calls := make(chan time.Time, 1)
 	done := make(chan struct{})
-	collectionTimer := c.mockClock.Timer(time.Minute)
+	collectionTimer := clockServiceCollectionTimer{c.mockClock.Timer(time.Minute)}
 	go func() {
 		defer close(done)
 		c.collector.collectServices(ctx, collectionTimer, time.Minute, processesReady, func(ctx context.Context) error {
@@ -740,7 +756,7 @@ func TestCollectServicesDoesNotRunAfterCancellation(t *testing.T) {
 	cancel()
 
 	called := false
-	c.collector.collectServices(ctx, c.mockClock.Timer(time.Minute), time.Minute, nil, func(ctx context.Context) error {
+	c.collector.collectServices(ctx, clockServiceCollectionTimer{c.mockClock.Timer(time.Minute)}, time.Minute, nil, func(ctx context.Context) error {
 		return ctx.Err()
 	}, func(context.Context) {
 		called = true
@@ -768,7 +784,7 @@ func TestCollectServicesRegularIntervalCancelsStartupWait(t *testing.T) {
 	systemProbeReady := make(chan struct{})
 	calls := make(chan time.Time, 2)
 	done := make(chan struct{})
-	collectionTimer := c.mockClock.Timer(time.Minute)
+	collectionTimer := clockServiceCollectionTimer{c.mockClock.Timer(time.Minute)}
 	go func() {
 		defer close(done)
 		c.collector.collectServices(ctx, collectionTimer, time.Minute, nil, func(ctx context.Context) error {

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -21,6 +21,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -636,6 +637,36 @@ func waitForServiceCollectionCall(t *testing.T, calls <-chan time.Time) time.Tim
 	}
 }
 
+type tickerRegistrationClock struct {
+	clock.Clock
+	tickerRegistered chan<- time.Duration
+}
+
+func (c *tickerRegistrationClock) Ticker(d time.Duration) *clock.Ticker {
+	ticker := c.Clock.Ticker(d)
+	c.tickerRegistered <- d
+	return ticker
+}
+
+func watchServiceCollectionTickerRegistration(c collectorTest) <-chan time.Duration {
+	tickerRegistered := make(chan time.Duration, 1)
+	c.collector.clock = &tickerRegistrationClock{
+		Clock:            c.mockClock,
+		tickerRegistered: tickerRegistered,
+	}
+	return tickerRegistered
+}
+
+func waitForServiceCollectionTicker(t *testing.T, tickerRegistered <-chan time.Duration) {
+	t.Helper()
+	select {
+	case interval := <-tickerRegistered:
+		require.Equal(t, serviceCollectionStartupRetryInterval, interval)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for startup retry ticker registration")
+	}
+}
+
 func TestCollectServicesRunsImmediatelyAndAtRegularInterval(t *testing.T) {
 	c := setUpCollectorTest(t, nil, nil, nil)
 	c.mockClock.Set(baseTime)
@@ -695,6 +726,7 @@ func TestCollectServicesRetriesOnlyUntilFirstRegularInterval(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	calls := make(chan time.Time, 8)
 	done := make(chan struct{})
+	retryTickerRegistered := watchServiceCollectionTickerRegistration(c)
 	collectionTicker := c.mockClock.Ticker(collectionInterval)
 	go func() {
 		defer close(done)
@@ -705,6 +737,7 @@ func TestCollectServicesRetriesOnlyUntilFirstRegularInterval(t *testing.T) {
 	}()
 
 	assert.Equal(t, baseTime, waitForServiceCollectionCall(t, calls))
+	waitForServiceCollectionTicker(t, retryTickerRegistered)
 	for elapsed := serviceCollectionStartupRetryInterval; elapsed < collectionInterval; elapsed += serviceCollectionStartupRetryInterval {
 		c.mockClock.Add(serviceCollectionStartupRetryInterval)
 		assert.Equal(t, baseTime.Add(elapsed), waitForServiceCollectionCall(t, calls))
@@ -738,6 +771,7 @@ func TestCollectServicesStopsStartupRetriesAfterNonRetryableResult(t *testing.T)
 	defer cancel()
 	calls := make(chan time.Time, 3)
 	callCount := 0
+	retryTickerRegistered := watchServiceCollectionTickerRegistration(c)
 	collectionTicker := c.mockClock.Ticker(time.Minute)
 	go c.collector.collectServices(ctx, collectionTicker, time.Minute, func(context.Context, bool) bool {
 		callCount++
@@ -746,6 +780,7 @@ func TestCollectServicesStopsStartupRetriesAfterNonRetryableResult(t *testing.T)
 	})
 
 	assert.Equal(t, baseTime, waitForServiceCollectionCall(t, calls))
+	waitForServiceCollectionTicker(t, retryTickerRegistered)
 	c.mockClock.Add(serviceCollectionStartupRetryInterval)
 	assert.Equal(t, baseTime.Add(serviceCollectionStartupRetryInterval), waitForServiceCollectionCall(t, calls))
 	c.mockClock.Add(serviceCollectionStartupRetryInterval)
@@ -772,6 +807,7 @@ func TestCollectServicesCachedRetriesInitiallyEmptyProcessCache(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	attempts := make(chan struct{}, 2)
+	retryTickerRegistered := watchServiceCollectionTickerRegistration(c)
 	collectionTicker := c.mockClock.Ticker(time.Minute)
 	go c.collector.collectServices(ctx, collectionTicker, time.Minute, func(ctx context.Context, startup bool) bool {
 		retry := c.collector.collectServicesCachedOnce(ctx, startup)
@@ -784,6 +820,7 @@ func TestCollectServicesCachedRetriesInitiallyEmptyProcessCache(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for initial cached service collection")
 	}
+	waitForServiceCollectionTicker(t, retryTickerRegistered)
 	assert.Equal(t, 0, requests())
 
 	c.collector.mux.Lock()

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -671,7 +671,7 @@ func TestCollectServicesSchedulesRegularIntervalFromStartupCollection(t *testing
 	}
 	go func() {
 		defer close(done)
-		c.collector.collectServices(ctx, collectionTimer, time.Minute, processesReady, func(context.Context) error {
+		c.collector.collectServicesWithTimer(ctx, collectionTimer, time.Minute, processesReady, func(context.Context) error {
 			return nil
 		}, func(context.Context) {
 			calls <- c.mockClock.Now()
@@ -719,7 +719,7 @@ func TestCollectServicesWaitsForSystemProbeStartup(t *testing.T) {
 	collectionTimer := clockServiceCollectionTimer{c.mockClock.Timer(time.Minute)}
 	go func() {
 		defer close(done)
-		c.collector.collectServices(ctx, collectionTimer, time.Minute, processesReady, func(ctx context.Context) error {
+		c.collector.collectServicesWithTimer(ctx, collectionTimer, time.Minute, processesReady, func(ctx context.Context) error {
 			close(waitStarted)
 			select {
 			case <-ctx.Done():
@@ -756,7 +756,7 @@ func TestCollectServicesDoesNotRunAfterCancellation(t *testing.T) {
 	cancel()
 
 	called := false
-	c.collector.collectServices(ctx, clockServiceCollectionTimer{c.mockClock.Timer(time.Minute)}, time.Minute, nil, func(ctx context.Context) error {
+	c.collector.collectServicesWithTimer(ctx, clockServiceCollectionTimer{c.mockClock.Timer(time.Minute)}, time.Minute, nil, func(ctx context.Context) error {
 		return ctx.Err()
 	}, func(context.Context) {
 		called = true
@@ -787,7 +787,7 @@ func TestCollectServicesRegularIntervalCancelsStartupWait(t *testing.T) {
 	collectionTimer := clockServiceCollectionTimer{c.mockClock.Timer(time.Minute)}
 	go func() {
 		defer close(done)
-		c.collector.collectServices(ctx, collectionTimer, time.Minute, nil, func(ctx context.Context) error {
+		c.collector.collectServicesWithTimer(ctx, collectionTimer, time.Minute, nil, func(ctx context.Context) error {
 			close(waitStarted)
 			select {
 			case <-ctx.Done():

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -21,7 +21,6 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -385,7 +384,7 @@ func TestServiceDiscoveryPartialBatchFailurePreservesRetries(t *testing.T) {
 	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101, 102, 103, 104, 105})
-	entities, _, _ := c.collector.updateServices(context.Background(), alivePids, procs)
+	entities, _ := c.collector.updateServices(context.Background(), alivePids, procs)
 
 	assert.Equal(t, 2, requests())
 	requestMux.Lock()
@@ -449,7 +448,7 @@ func testServiceDiscoveryConsecutiveTimeoutsDisableRequests(t *testing.T, c coll
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101})
 	for i := 0; i < maxConsecutiveTimeouts; i++ {
-		entities, injectedPids, _ := c.collector.updateServices(context.Background(), alivePids, procs)
+		entities, injectedPids := c.collector.updateServices(context.Background(), alivePids, procs)
 		require.Empty(t, entities)
 		require.Empty(t, injectedPids)
 	}
@@ -458,7 +457,7 @@ func testServiceDiscoveryConsecutiveTimeoutsDisableRequests(t *testing.T, c coll
 	assert.Equal(t, maxConsecutiveTimeouts, c.collector.consecutiveServiceDiscoveryTimeouts)
 	assert.Equal(t, maxConsecutiveTimeouts, requests())
 
-	entities, injectedPids, _ := c.collector.updateServices(context.Background(), alivePids, procs)
+	entities, injectedPids := c.collector.updateServices(context.Background(), alivePids, procs)
 	require.Empty(t, entities)
 	require.Empty(t, injectedPids)
 	assert.Equal(t, maxConsecutiveTimeouts, requests(), "disabled service discovery should not send more requests")
@@ -481,7 +480,7 @@ func TestServiceDiscoverySuccessfulRequestResetsConsecutiveTimeouts(t *testing.T
 	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101})
-	entities, _, _ := c.collector.updateServices(context.Background(), alivePids, procs)
+	entities, _ := c.collector.updateServices(context.Background(), alivePids, procs)
 
 	require.Len(t, entities, 1)
 	assert.Equal(t, int32(101), entities[0].Pid)
@@ -590,7 +589,7 @@ func testServiceDiscoveryPartialBatchTimeoutPreservesSuccessfulPIDsAndResetsPrev
 	)
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101, 102, 103, 104, 105})
-	entities, _, _ := c.collector.updateServices(context.Background(), alivePids, procs)
+	entities, _ := c.collector.updateServices(context.Background(), alivePids, procs)
 
 	assert.Equal(t, 2, requests())
 	requestMux.Lock()
@@ -619,7 +618,7 @@ func TestServiceDiscoverySuccessfulNoServiceIncrementsRetries(t *testing.T) {
 	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
 
 	alivePids, procs := makeAlivePidsAndProcesses([]int32{101})
-	entities, _, _ := c.collector.updateServices(context.Background(), alivePids, procs)
+	entities, _ := c.collector.updateServices(context.Background(), alivePids, procs)
 
 	require.Len(t, entities, 1)
 	assert.Equal(t, int32(101), entities[0].Pid)
@@ -637,52 +636,32 @@ func waitForServiceCollectionCall(t *testing.T, calls <-chan time.Time) time.Tim
 	}
 }
 
-type tickerRegistrationClock struct {
-	clock.Clock
-	tickerRegistered chan<- time.Duration
-}
-
-func (c *tickerRegistrationClock) Ticker(d time.Duration) *clock.Ticker {
-	ticker := c.Clock.Ticker(d)
-	c.tickerRegistered <- d
-	return ticker
-}
-
-func watchServiceCollectionTickerRegistration(c collectorTest) <-chan time.Duration {
-	tickerRegistered := make(chan time.Duration, 1)
-	c.collector.clock = &tickerRegistrationClock{
-		Clock:            c.mockClock,
-		tickerRegistered: tickerRegistered,
-	}
-	return tickerRegistered
-}
-
-func waitForServiceCollectionTicker(t *testing.T, tickerRegistered <-chan time.Duration) {
-	t.Helper()
-	select {
-	case interval := <-tickerRegistered:
-		require.Equal(t, serviceCollectionStartupRetryInterval, interval)
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for startup retry ticker registration")
-	}
-}
-
-func TestCollectServicesRunsImmediatelyAndAtRegularInterval(t *testing.T) {
+func TestCollectServicesRunsWhenReadyAndAtRegularInterval(t *testing.T) {
 	c := setUpCollectorTest(t, nil, nil, nil)
 	c.mockClock.Set(baseTime)
+	socketPath, _ := startScriptedServiceDiscoveryServer(t, func(_ int, _ core.Params) serviceDiscoveryTestResponse {
+		return serviceDiscoveryTestResponse{response: &model.ServicesResponse{}}
+	})
+	c.collector.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(socketPath))
 
 	ctx, cancel := context.WithCancel(context.Background())
+	processesReady := make(chan struct{})
 	calls := make(chan time.Time, 2)
 	done := make(chan struct{})
 	collectionTicker := c.mockClock.Ticker(time.Minute)
 	go func() {
 		defer close(done)
-		c.collector.collectServices(ctx, collectionTicker, time.Minute, func(context.Context, bool) bool {
+		c.collector.collectServices(ctx, collectionTicker, processesReady, func(context.Context) {
 			calls <- c.mockClock.Now()
-			return false
 		})
 	}()
 
+	select {
+	case callTime := <-calls:
+		t.Fatalf("service collection ran before process readiness at %s", callTime)
+	default:
+	}
+	close(processesReady)
 	assert.Equal(t, baseTime, waitForServiceCollectionCall(t, calls))
 	c.mockClock.Add(time.Minute)
 	assert.Equal(t, baseTime.Add(time.Minute), waitForServiceCollectionCall(t, calls))
@@ -701,9 +680,8 @@ func TestCollectServicesDoesNotRunAfterCancellation(t *testing.T) {
 	cancel()
 
 	called := false
-	c.collector.collectServices(ctx, c.mockClock.Ticker(time.Minute), time.Minute, func(context.Context, bool) bool {
+	c.collector.collectServices(ctx, c.mockClock.Ticker(time.Minute), nil, func(context.Context) {
 		called = true
-		return false
 	})
 
 	assert.False(t, called)
@@ -718,42 +696,30 @@ func TestSendProcessEventStopsWhenCanceled(t *testing.T) {
 	assert.False(t, c.collector.sendProcessEvent(ctx, &Event{Type: EventTypeServiceDiscovery}))
 }
 
-func TestCollectServicesRetriesOnlyUntilFirstRegularInterval(t *testing.T) {
-	const collectionInterval = 10 * time.Second
+func TestCollectServicesRegularIntervalCancelsStartupWait(t *testing.T) {
 	c := setUpCollectorTest(t, nil, nil, nil)
 	c.mockClock.Set(baseTime)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	calls := make(chan time.Time, 8)
+	processesReady := make(chan struct{})
+	calls := make(chan time.Time, 2)
 	done := make(chan struct{})
-	retryTickerRegistered := watchServiceCollectionTickerRegistration(c)
-	collectionTicker := c.mockClock.Ticker(collectionInterval)
+	collectionTicker := c.mockClock.Ticker(time.Minute)
 	go func() {
 		defer close(done)
-		c.collector.collectServices(ctx, collectionTicker, collectionInterval, func(context.Context, bool) bool {
+		c.collector.collectServices(ctx, collectionTicker, processesReady, func(context.Context) {
 			calls <- c.mockClock.Now()
-			return true
 		})
 	}()
 
-	assert.Equal(t, baseTime, waitForServiceCollectionCall(t, calls))
-	waitForServiceCollectionTicker(t, retryTickerRegistered)
-	for elapsed := serviceCollectionStartupRetryInterval; elapsed < collectionInterval; elapsed += serviceCollectionStartupRetryInterval {
-		c.mockClock.Add(serviceCollectionStartupRetryInterval)
-		assert.Equal(t, baseTime.Add(elapsed), waitForServiceCollectionCall(t, calls))
-	}
-
-	c.mockClock.Add(serviceCollectionStartupRetryInterval)
-	assert.Equal(t, baseTime.Add(collectionInterval), waitForServiceCollectionCall(t, calls))
-	c.mockClock.Add(serviceCollectionStartupRetryInterval)
+	c.mockClock.Add(time.Minute)
+	assert.Equal(t, baseTime.Add(time.Minute), waitForServiceCollectionCall(t, calls))
+	close(processesReady)
 	select {
 	case callTime := <-calls:
-		t.Fatalf("unexpected startup retry after the first regular collection at %s", callTime)
+		t.Fatalf("unexpected startup collection after periodic collection took over at %s", callTime)
 	default:
 	}
-
-	c.mockClock.Add(collectionInterval - serviceCollectionStartupRetryInterval)
-	assert.Equal(t, baseTime.Add(2*collectionInterval), waitForServiceCollectionCall(t, calls))
 
 	cancel()
 	select {
@@ -763,35 +729,7 @@ func TestCollectServicesRetriesOnlyUntilFirstRegularInterval(t *testing.T) {
 	}
 }
 
-func TestCollectServicesStopsStartupRetriesAfterNonRetryableResult(t *testing.T) {
-	c := setUpCollectorTest(t, nil, nil, nil)
-	c.mockClock.Set(baseTime)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	calls := make(chan time.Time, 3)
-	callCount := 0
-	retryTickerRegistered := watchServiceCollectionTickerRegistration(c)
-	collectionTicker := c.mockClock.Ticker(time.Minute)
-	go c.collector.collectServices(ctx, collectionTicker, time.Minute, func(context.Context, bool) bool {
-		callCount++
-		calls <- c.mockClock.Now()
-		return callCount < 2
-	})
-
-	assert.Equal(t, baseTime, waitForServiceCollectionCall(t, calls))
-	waitForServiceCollectionTicker(t, retryTickerRegistered)
-	c.mockClock.Add(serviceCollectionStartupRetryInterval)
-	assert.Equal(t, baseTime.Add(serviceCollectionStartupRetryInterval), waitForServiceCollectionCall(t, calls))
-	c.mockClock.Add(serviceCollectionStartupRetryInterval)
-	select {
-	case callTime := <-calls:
-		t.Fatalf("unexpected startup retry after a non-retryable result at %s", callTime)
-	default:
-	}
-}
-
-func TestCollectServicesCachedRetriesInitiallyEmptyProcessCache(t *testing.T) {
+func TestCollectServicesCachedWaitsForProcessCache(t *testing.T) {
 	c := setUpCollectorTest(t, nil, nil, nil)
 	c.mockClock.Set(baseTime)
 	c.collector.store = c.mockStore
@@ -806,21 +744,10 @@ func TestCollectServicesCachedRetriesInitiallyEmptyProcessCache(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	attempts := make(chan struct{}, 2)
-	retryTickerRegistered := watchServiceCollectionTickerRegistration(c)
+	processesReady := make(chan struct{})
 	collectionTicker := c.mockClock.Ticker(time.Minute)
-	go c.collector.collectServices(ctx, collectionTicker, time.Minute, func(ctx context.Context, startup bool) bool {
-		retry := c.collector.collectServicesCachedOnce(ctx, startup)
-		attempts <- struct{}{}
-		return retry
-	})
+	go c.collector.collectServicesCached(ctx, collectionTicker, processesReady)
 
-	select {
-	case <-attempts:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for initial cached service collection")
-	}
-	waitForServiceCollectionTicker(t, retryTickerRegistered)
 	assert.Equal(t, 0, requests())
 
 	c.collector.mux.Lock()
@@ -828,7 +755,7 @@ func TestCollectServicesCachedRetriesInitiallyEmptyProcessCache(t *testing.T) {
 		101: makeProcess(101, baseTime.Add(-2*time.Minute).UnixMilli(), nil),
 	}
 	c.collector.mux.Unlock()
-	c.mockClock.Add(serviceCollectionStartupRetryInterval)
+	close(processesReady)
 
 	select {
 	case event := <-c.collector.processEventsCh:
@@ -869,9 +796,11 @@ func TestCollectServicesCachedReleasesProcessCacheLockBeforeServiceRequests(t *t
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	done := make(chan struct{})
+	processesReady := make(chan struct{})
+	close(processesReady)
 	go func() {
 		defer close(done)
-		c.collector.collectServicesCached(ctx, c.mockClock.Ticker(time.Minute), time.Minute)
+		c.collector.collectServicesCached(ctx, c.mockClock.Ticker(time.Minute), processesReady)
 	}()
 
 	select {

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -21,6 +21,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -636,7 +637,28 @@ func waitForServiceCollectionCall(t *testing.T, calls <-chan time.Time) time.Tim
 	}
 }
 
-func TestCollectServicesRunsWhenReadyAndAtRegularInterval(t *testing.T) {
+func TestResetTimerDiscardsExpiredValue(t *testing.T) {
+	mockClock := clock.NewMock()
+	timer := mockClock.Timer(time.Minute)
+	mockClock.Add(time.Minute)
+
+	resetTimer(timer, time.Minute)
+	select {
+	case tick := <-timer.C:
+		t.Fatalf("timer retained stale expiry at %s", tick)
+	default:
+	}
+
+	mockClock.Add(time.Minute)
+	select {
+	case tick := <-timer.C:
+		assert.Equal(t, mockClock.Now(), tick)
+	default:
+		t.Fatal("reset timer did not expire after a full interval")
+	}
+}
+
+func TestCollectServicesSchedulesRegularIntervalFromStartupCollection(t *testing.T) {
 	c := setUpCollectorTest(t, nil, nil, nil)
 	c.mockClock.Set(baseTime)
 	socketPath, _ := startScriptedServiceDiscoveryServer(t, func(_ int, _ core.Params) serviceDiscoveryTestResponse {
@@ -648,23 +670,31 @@ func TestCollectServicesRunsWhenReadyAndAtRegularInterval(t *testing.T) {
 	processesReady := make(chan struct{})
 	calls := make(chan time.Time, 2)
 	done := make(chan struct{})
-	collectionTicker := c.mockClock.Ticker(time.Minute)
+	collectionTimer := c.mockClock.Timer(time.Minute)
 	go func() {
 		defer close(done)
-		c.collector.collectServices(ctx, collectionTicker, processesReady, func(context.Context) {
+		c.collector.collectServices(ctx, collectionTimer, time.Minute, processesReady, func(context.Context) {
 			calls <- c.mockClock.Now()
 		})
 	}()
 
+	c.mockClock.Add(45 * time.Second)
 	select {
 	case callTime := <-calls:
 		t.Fatalf("service collection ran before process readiness at %s", callTime)
 	default:
 	}
 	close(processesReady)
-	assert.Equal(t, baseTime, waitForServiceCollectionCall(t, calls))
-	c.mockClock.Add(time.Minute)
-	assert.Equal(t, baseTime.Add(time.Minute), waitForServiceCollectionCall(t, calls))
+	assert.Equal(t, baseTime.Add(45*time.Second), waitForServiceCollectionCall(t, calls))
+
+	c.mockClock.Add(59 * time.Second)
+	select {
+	case callTime := <-calls:
+		t.Fatalf("service collection ran before a full interval elapsed at %s", callTime)
+	default:
+	}
+	c.mockClock.Add(time.Second)
+	assert.Equal(t, baseTime.Add(105*time.Second), waitForServiceCollectionCall(t, calls))
 
 	cancel()
 	select {
@@ -680,7 +710,7 @@ func TestCollectServicesDoesNotRunAfterCancellation(t *testing.T) {
 	cancel()
 
 	called := false
-	c.collector.collectServices(ctx, c.mockClock.Ticker(time.Minute), nil, func(context.Context) {
+	c.collector.collectServices(ctx, c.mockClock.Timer(time.Minute), time.Minute, nil, func(context.Context) {
 		called = true
 	})
 
@@ -704,10 +734,10 @@ func TestCollectServicesRegularIntervalCancelsStartupWait(t *testing.T) {
 	processesReady := make(chan struct{})
 	calls := make(chan time.Time, 2)
 	done := make(chan struct{})
-	collectionTicker := c.mockClock.Ticker(time.Minute)
+	collectionTimer := c.mockClock.Timer(time.Minute)
 	go func() {
 		defer close(done)
-		c.collector.collectServices(ctx, collectionTicker, processesReady, func(context.Context) {
+		c.collector.collectServices(ctx, collectionTimer, time.Minute, processesReady, func(context.Context) {
 			calls <- c.mockClock.Now()
 		})
 	}()
@@ -745,8 +775,8 @@ func TestCollectServicesCachedWaitsForProcessCache(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	processesReady := make(chan struct{})
-	collectionTicker := c.mockClock.Ticker(time.Minute)
-	go c.collector.collectServicesCached(ctx, collectionTicker, processesReady)
+	collectionTimer := c.mockClock.Timer(time.Minute)
+	go c.collector.collectServicesCached(ctx, collectionTimer, time.Minute, processesReady)
 
 	assert.Equal(t, 0, requests())
 
@@ -800,7 +830,7 @@ func TestCollectServicesCachedReleasesProcessCacheLockBeforeServiceRequests(t *t
 	close(processesReady)
 	go func() {
 		defer close(done)
-		c.collector.collectServicesCached(ctx, c.mockClock.Ticker(time.Minute), processesReady)
+		c.collector.collectServicesCached(ctx, c.mockClock.Timer(time.Minute), time.Minute, processesReady)
 	}()
 
 	select {

--- a/pkg/system-probe/api/client/BUILD.bazel
+++ b/pkg/system-probe/api/client/BUILD.bazel
@@ -33,6 +33,7 @@ dd_agent_go_test(
     embed = [":client"],
     deps = [
         "//pkg/system-probe/api/server/testutil",
+        "//pkg/util/log",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/system-probe/api/client/BUILD.bazel
+++ b/pkg/system-probe/api/client/BUILD.bazel
@@ -33,7 +33,6 @@ dd_agent_go_test(
     embed = [":client"],
     deps = [
         "//pkg/system-probe/api/server/testutil",
-        "//pkg/util/log",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/system-probe/api/client/check.go
+++ b/pkg/system-probe/api/client/check.go
@@ -52,15 +52,18 @@ type startChecker struct {
 	mutex          sync.Mutex
 	startTime      time.Time
 	startupTimeout time.Duration
+	warningLimit   *log.Limit
 	started        bool
 	inFlight       chan struct{}
 }
 
 // getStartChecker is a memoized function that returns the singleton startChecker.
 var getStartChecker = funcs.MemoizeNoError[*startChecker](func() *startChecker {
+	startupTimeout := pkgconfigsetup.Datadog().GetDuration("check_system_probe_startup_time")
 	return &startChecker{
 		startTime:      time.Now(),
-		startupTimeout: pkgconfigsetup.Datadog().GetDuration("check_system_probe_startup_time"),
+		startupTimeout: startupTimeout,
+		warningLimit:   log.NewLogLimit(1, startupTimeout),
 	}
 })
 
@@ -118,7 +121,9 @@ func (c *startChecker) ensureStarted(ctx context.Context, client *http.Client) e
 			// For the first few minutes after startup, only emit warnings
 			// instead of reporting errors from the check, to allow a reasonable
 			// time for system-probe to become ready to serve requests
-			log.Warnf("system-probe not started yet: %v", err)
+			if c.warningLimit == nil || c.warningLimit.ShouldLog() {
+				log.Warnf("system-probe not started yet: %v", err)
+			}
 
 			// Callers should check for this error and not propagate it to avoid
 			// error logs from the check infrastructure.

--- a/pkg/system-probe/api/client/check.go
+++ b/pkg/system-probe/api/client/check.go
@@ -26,8 +26,10 @@ import (
 )
 
 const (
-	checkLabelName     = "check"
-	telemetrySubsystem = "system_probe__remote_client"
+	checkLabelName              = "check"
+	telemetrySubsystem          = "system_probe__remote_client"
+	startupRetryInitialInterval = 250 * time.Millisecond
+	startupRetryMaxInterval     = 2 * time.Second
 )
 
 var checkTelemetry = struct {
@@ -54,6 +56,7 @@ type startChecker struct {
 	startupTimeout time.Duration
 	warningLimit   *log.Limit
 	started        bool
+	startedCh      chan struct{}
 	inFlight       chan struct{}
 }
 
@@ -64,6 +67,7 @@ var getStartChecker = funcs.MemoizeNoError[*startChecker](func() *startChecker {
 		startTime:      time.Now(),
 		startupTimeout: startupTimeout,
 		warningLimit:   log.NewLogLimit(1, startupTimeout),
+		startedCh:      make(chan struct{}),
 	}
 })
 
@@ -104,8 +108,12 @@ func (c *startChecker) ensureStarted(ctx context.Context, client *http.Client) e
 		}
 
 		c.mutex.Lock()
-		if err == nil {
+		if err == nil && !c.started {
 			c.started = true
+			if c.startedCh == nil {
+				c.startedCh = make(chan struct{})
+			}
+			close(c.startedCh)
 		}
 		c.inFlight = nil
 		close(done)
@@ -130,6 +138,51 @@ func (c *startChecker) ensureStarted(ctx context.Context, client *http.Client) e
 			return ErrNotStartedYet
 		}
 		return err
+	}
+}
+
+type startupRetryWait func(context.Context, <-chan struct{}, time.Duration) error
+
+func waitForStartupRetry(ctx context.Context, started <-chan struct{}, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-started:
+		return nil
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (c *startChecker) waitUntilStarted(ctx context.Context, client *http.Client, wait startupRetryWait) error {
+	retryInterval := startupRetryInitialInterval
+	for {
+		if err := c.ensureStarted(ctx, client); err != nil {
+			if !errors.Is(err, ErrNotStartedYet) {
+				return err
+			}
+		} else {
+			return nil
+		}
+
+		c.mutex.Lock()
+		if c.started {
+			c.mutex.Unlock()
+			return nil
+		}
+		if c.startedCh == nil {
+			c.startedCh = make(chan struct{})
+		}
+		startedCh := c.startedCh
+		c.mutex.Unlock()
+
+		if err := wait(ctx, startedCh, retryInterval); err != nil {
+			return err
+		}
+		retryInterval = min(2*retryInterval, startupRetryMaxInterval)
 	}
 }
 
@@ -195,6 +248,13 @@ func NewCheckClient(checkClient, startupClient *http.Client) *CheckClient {
 		startupClient:  startupClient,
 		startupChecker: getStartChecker(),
 	}
+}
+
+// WaitForStartup waits until system-probe is ready to serve module requests.
+// It probes only the lightweight readiness endpoint and returns when ctx is
+// canceled or the configured startup grace period expires.
+func (client *CheckClient) WaitForStartup(ctx context.Context) error {
+	return client.startupChecker.waitUntilStarted(ctx, client.startupClient, waitForStartupRetry)
 }
 
 // WithCheckTimeout configures the check request timeout. This is

--- a/pkg/system-probe/api/client/check.go
+++ b/pkg/system-probe/api/client/check.go
@@ -61,10 +61,9 @@ type startChecker struct {
 
 // getStartChecker is a memoized function that returns the singleton startChecker.
 var getStartChecker = funcs.MemoizeNoError[*startChecker](func() *startChecker {
-	startupTimeout := pkgconfigsetup.Datadog().GetDuration("check_system_probe_startup_time")
 	return &startChecker{
 		startTime:      time.Now(),
-		startupTimeout: startupTimeout,
+		startupTimeout: pkgconfigsetup.Datadog().GetDuration("check_system_probe_startup_time"),
 		startedCh:      make(chan struct{}),
 	}
 })

--- a/pkg/system-probe/api/client/check.go
+++ b/pkg/system-probe/api/client/check.go
@@ -54,7 +54,6 @@ type startChecker struct {
 	mutex          sync.Mutex
 	startTime      time.Time
 	startupTimeout time.Duration
-	warningLimit   *log.Limit
 	started        bool
 	startedCh      chan struct{}
 	inFlight       chan struct{}
@@ -66,7 +65,6 @@ var getStartChecker = funcs.MemoizeNoError[*startChecker](func() *startChecker {
 	return &startChecker{
 		startTime:      time.Now(),
 		startupTimeout: startupTimeout,
-		warningLimit:   log.NewLogLimit(1, startupTimeout),
 		startedCh:      make(chan struct{}),
 	}
 })
@@ -76,6 +74,10 @@ var getStartChecker = funcs.MemoizeNoError[*startChecker](func() *startChecker {
 // should be checked with IgnoreStartupError(), to avoid propagating errors to
 // the check infrastructure.
 func (c *startChecker) ensureStarted(ctx context.Context, client *http.Client) error {
+	return c.ensureStartedWarn(ctx, client, true)
+}
+
+func (c *startChecker) ensureStartedWarn(ctx context.Context, client *http.Client, warn bool) error {
 	for {
 		c.mutex.Lock()
 		if c.started {
@@ -129,7 +131,7 @@ func (c *startChecker) ensureStarted(ctx context.Context, client *http.Client) e
 			// For the first few minutes after startup, only emit warnings
 			// instead of reporting errors from the check, to allow a reasonable
 			// time for system-probe to become ready to serve requests
-			if c.warningLimit == nil || c.warningLimit.ShouldLog() {
+			if warn {
 				log.Warnf("system-probe not started yet: %v", err)
 			}
 
@@ -160,7 +162,7 @@ func waitForStartupRetry(ctx context.Context, started <-chan struct{}, delay tim
 func (c *startChecker) waitUntilStarted(ctx context.Context, client *http.Client, wait startupRetryWait) error {
 	retryInterval := startupRetryInitialInterval
 	for {
-		if err := c.ensureStarted(ctx, client); err != nil {
+		if err := c.ensureStartedWarn(ctx, client, false); err != nil {
 			if !errors.Is(err, ErrNotStartedYet) {
 				return err
 			}

--- a/pkg/system-probe/api/client/check_test.go
+++ b/pkg/system-probe/api/client/check_test.go
@@ -6,8 +6,6 @@
 package client
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -23,7 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/server/testutil"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func startTestServer(t *testing.T, handler http.Handler) (string, *httptest.Server) {
@@ -44,7 +41,6 @@ func resetStartupChecker() {
 	checker.mutex.Lock()
 	defer checker.mutex.Unlock()
 	checker.startTime = time.Now()
-	checker.warningLimit = log.NewLogLimit(1, checker.startupTimeout)
 	checker.started = false
 	checker.startedCh = make(chan struct{})
 	checker.inFlight = nil
@@ -281,29 +277,6 @@ func TestStartCheckerWaiterRetriesAfterProbeOwnerCancellation(t *testing.T) {
 	mu.Lock()
 	assert.Equal(t, 2, calls)
 	mu.Unlock()
-}
-
-func TestStartCheckerRateLimitsStartupWarnings(t *testing.T) {
-	var logs bytes.Buffer
-	writer := bufio.NewWriter(&logs)
-	logger, err := log.LoggerFromWriterWithMinLevelAndLvlFuncCtxMsgFormat(writer, log.WarnLvl)
-	require.NoError(t, err)
-	log.SetupLogger(logger, log.WarnStr)
-	t.Cleanup(func() { log.SetupLogger(log.Default(), log.InfoStr) })
-
-	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-		return nil, errors.New("system-probe unavailable")
-	})}
-	checker := &startChecker{
-		startTime:      time.Now(),
-		startupTimeout: time.Minute,
-		warningLimit:   log.NewLogLimit(1, time.Hour),
-	}
-
-	require.ErrorIs(t, checker.ensureStarted(context.Background(), httpClient), ErrNotStartedYet)
-	require.ErrorIs(t, checker.ensureStarted(context.Background(), httpClient), ErrNotStartedYet)
-	require.NoError(t, writer.Flush())
-	assert.Equal(t, 1, strings.Count(logs.String(), "system-probe not started yet"))
 }
 
 func TestWaitUntilStartedBacksOffUntilReady(t *testing.T) {

--- a/pkg/system-probe/api/client/check_test.go
+++ b/pkg/system-probe/api/client/check_test.go
@@ -6,8 +6,11 @@
 package client
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -20,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/server/testutil"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func startTestServer(t *testing.T, handler http.Handler) (string, *httptest.Server) {
@@ -40,6 +44,7 @@ func resetStartupChecker() {
 	checker.mutex.Lock()
 	defer checker.mutex.Unlock()
 	checker.startTime = time.Now()
+	checker.warningLimit = log.NewLogLimit(1, checker.startupTimeout)
 	checker.started = false
 	checker.inFlight = nil
 }
@@ -275,6 +280,29 @@ func TestStartCheckerWaiterRetriesAfterProbeOwnerCancellation(t *testing.T) {
 	mu.Lock()
 	assert.Equal(t, 2, calls)
 	mu.Unlock()
+}
+
+func TestStartCheckerRateLimitsStartupWarnings(t *testing.T) {
+	var logs bytes.Buffer
+	writer := bufio.NewWriter(&logs)
+	logger, err := log.LoggerFromWriterWithMinLevelAndLvlFuncCtxMsgFormat(writer, log.WarnLvl)
+	require.NoError(t, err)
+	log.SetupLogger(logger, log.WarnStr)
+	t.Cleanup(func() { log.SetupLogger(log.Default(), log.InfoStr) })
+
+	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("system-probe unavailable")
+	})}
+	checker := &startChecker{
+		startTime:      time.Now(),
+		startupTimeout: time.Minute,
+		warningLimit:   log.NewLogLimit(1, time.Hour),
+	}
+
+	require.ErrorIs(t, checker.ensureStarted(context.Background(), httpClient), ErrNotStartedYet)
+	require.ErrorIs(t, checker.ensureStarted(context.Background(), httpClient), ErrNotStartedYet)
+	require.NoError(t, writer.Flush())
+	assert.Equal(t, 1, strings.Count(logs.String(), "system-probe not started yet"))
 }
 
 func TestGetCheckWithContextCancelsModuleRequest(t *testing.T) {

--- a/pkg/system-probe/api/client/check_test.go
+++ b/pkg/system-probe/api/client/check_test.go
@@ -46,6 +46,7 @@ func resetStartupChecker() {
 	checker.startTime = time.Now()
 	checker.warningLimit = log.NewLogLimit(1, checker.startupTimeout)
 	checker.started = false
+	checker.startedCh = make(chan struct{})
 	checker.inFlight = nil
 }
 
@@ -303,6 +304,120 @@ func TestStartCheckerRateLimitsStartupWarnings(t *testing.T) {
 	require.ErrorIs(t, checker.ensureStarted(context.Background(), httpClient), ErrNotStartedYet)
 	require.NoError(t, writer.Flush())
 	assert.Equal(t, 1, strings.Count(logs.String(), "system-probe not started yet"))
+}
+
+func TestWaitUntilStartedBacksOffUntilReady(t *testing.T) {
+	var mu sync.Mutex
+	calls := 0
+	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		if calls < 6 {
+			return nil, errors.New("system-probe unavailable")
+		}
+		return successfulCheckResponse(), nil
+	})}
+	checker := &startChecker{
+		startTime:      time.Now(),
+		startupTimeout: time.Minute,
+		startedCh:      make(chan struct{}),
+	}
+
+	var delays []time.Duration
+	err := checker.waitUntilStarted(context.Background(), httpClient, func(_ context.Context, _ <-chan struct{}, delay time.Duration) error {
+		delays = append(delays, delay)
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []time.Duration{
+		startupRetryInitialInterval,
+		2 * startupRetryInitialInterval,
+		4 * startupRetryInitialInterval,
+		startupRetryMaxInterval,
+		startupRetryMaxInterval,
+	}, delays)
+	assert.Equal(t, 6, calls)
+}
+
+func TestWaitUntilStartedObservesSharedReadinessNotification(t *testing.T) {
+	firstAttempt := make(chan struct{})
+	waiting := make(chan struct{})
+	failingClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		close(firstAttempt)
+		return nil, errors.New("system-probe unavailable")
+	})}
+	checker := &startChecker{
+		startTime:      time.Now(),
+		startupTimeout: time.Minute,
+		startedCh:      make(chan struct{}),
+	}
+
+	done := make(chan error)
+	go func() {
+		done <- checker.waitUntilStarted(context.Background(), failingClient, func(ctx context.Context, started <-chan struct{}, _ time.Duration) error {
+			close(waiting)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-started:
+				return nil
+			}
+		})
+	}()
+	<-firstAttempt
+	<-waiting
+
+	successfulClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return successfulCheckResponse(), nil
+	})}
+	require.NoError(t, checker.ensureStarted(context.Background(), successfulClient))
+	require.NoError(t, <-done)
+}
+
+func TestWaitUntilStartedStopsAfterGracePeriod(t *testing.T) {
+	expectedErr := errors.New("system-probe unavailable")
+	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, expectedErr
+	})}
+	checker := &startChecker{
+		startTime:      time.Now().Add(-time.Minute),
+		startupTimeout: time.Second,
+		startedCh:      make(chan struct{}),
+	}
+
+	waitCalled := false
+	err := checker.waitUntilStarted(context.Background(), httpClient, func(context.Context, <-chan struct{}, time.Duration) error {
+		waitCalled = true
+		return nil
+	})
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.False(t, waitCalled)
+}
+
+func TestWaitForStartupStopsWhenCanceled(t *testing.T) {
+	requestStarted := make(chan struct{})
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		close(requestStarted)
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})}
+	client := NewCheckClient(httpClient, httpClient)
+	client.startupChecker = &startChecker{
+		startTime:      time.Now(),
+		startupTimeout: time.Minute,
+		startedCh:      make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error)
+	go func() { done <- client.WaitForStartup(ctx) }()
+	<-requestStarted
+	cancel()
+
+	require.ErrorIs(t, <-done, context.Canceled)
 }
 
 func TestGetCheckWithContextCancelsModuleRequest(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Collect services as soon as the startup prerequisites are ready. Cached service discovery waits for the first successful process snapshot, and both cached and non-cached modes wait for the system-probe readiness endpoint before running one startup collection. For system-probe readiness, the lightweight readiness endpoint is polled, using bounded exponential backoff.

If the normal collection deadline arrives first, it cancels startup waiting and takes over. A resettable one-shot timer schedules every later collection a full configured interval after the preceding collection, including a readiness-triggered startup run.

Event delivery uses a context-aware send so producer goroutines do not remain blocked on the unbuffered process-event channel if the stream consumer exits during shutdown; readiness waiting is cancellation-aware as well.

### Motivation

DSCVR-713 tracks reducing the time from Agent startup to the first process-intake POST containing discovered services.

Confirmed on the PR against baseline, measured from container start to the first process-intake POST containing discovered services:

- With process collection disabled: 74.16 seconds baseline, 24.16 seconds with this PR
- With process collection enabled: 64.24 seconds baseline, 14.24 seconds with this PR

Each configuration was run separately in the same arm64 container setup. Redis was already running for longer than the 60-second minimum process age. Both versions used the same host `/proc`, Docker socket, cgroup/debug mounts, and required capabilities. Intake was redirected to an immediate loopback `202` responder; each measurement was accepted only after system-probe returned a non-empty service set, Redis metadata was extracted, and the subsequent process-intake POST succeeded.

### Describe how you validated your changes

Tests added. Manual test vs baseline described above.