### PR TITLE
[DATASEC-314] Allow group read/exec when loading shared-library checks

### DIFF
--- a/pkg/util/filesystem/permission_check.go
+++ b/pkg/util/filesystem/permission_check.go
@@ -5,6 +5,8 @@
 
 package filesystem
 
+import "runtime"
+
 // CheckOwnerIsTrusted verifies that path is owned by a trusted user:
 // root or dd-agent (nix), Administrators/SYSTEM/dd-agent (Windows).
 func (p *Permission) CheckOwnerIsTrusted(path string) error {
@@ -14,10 +16,10 @@ func (p *Permission) CheckOwnerIsTrusted(path string) error {
 // CheckOwnerAndPermissionsAreRestricted verifies that path satisfies the agent's security requirements:
 //
 //   - Owner: must be root or dd-agent (nix) - or Administrators, SYSTEM, or dd-agent (Windows).
-//   - Permissions: group and others must have no access rights.
+//   - Permissions: others must have no access; group may read/exec (except Windows).
 func (p *Permission) CheckOwnerAndPermissionsAreRestricted(path string) error {
 	if err := p.checkOwner(path); err != nil {
 		return err
 	}
-	return CheckRights(path, false)
+	return CheckRights(path, runtime.GOOS != "windows")
 }


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Allow group read/exec on Unix in `CheckOwnerAndPermissionsAreRestricted`. That is the check used when [loading a shared library](https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/sharedlibrary/ffi/library_loader.go#L112). Others still have no access; group still cannot write. Windows is unchanged (`allowGroupExec` is not supported there).

### Motivation

[#55466](https://github.com/DataDog/datadog-agent/pull/55466) **broke** shared-library loading. It packaged built-in checks as `0550` (OpenShift init containers need group read), but [`CheckOwnerAndPermissionsAreRestricted`](https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/sharedlibrary/ffi/library_loader.go#L112) still rejected any group bits. The loader then failed with `'group' or 'others' have rights on it`.

This PR fixes that mismatch so `0550` libraries can load.

### Why backport is needed

[#55466](https://github.com/DataDog/datadog-agent/pull/55466) has been merged and backported to 7.83.0, so Data Security is no longer functioning on that release. This fix needs to land on already released 7.83.x (target 7.83.1) and the planned 7.84.0 release.

### Describe how you validated your changes

Loaded `datasecurity` against a `0550` `libdatadog-agent-datasecurity.so`. Tested image `registry.ddbuild.io/ci/datadog-agent/agent:v135836489-1cd4d4ab-7-amd64`; shared-library loading worked successfully.