### PR TITLE
CONTINT-5548 - expose control plane component status

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
-	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -514,6 +514,7 @@ func (k *KubeASCheck) parseComponentStatus(sender sender.Sender, componentsStatu
 		for _, condition := range component.Conditions {
 			statusCheck := servicecheck.ServiceCheckUnknown
 			message := ""
+			statusValue := 0.0
 
 			// We only expect the Healthy condition. May change in the future. https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties
 			if condition.Type != "Healthy" {
@@ -526,6 +527,7 @@ func (k *KubeASCheck) parseComponentStatus(sender sender.Sender, componentsStatu
 			case "True":
 				statusCheck = servicecheck.ServiceCheckOK
 				message = condition.Message
+				statusValue = 1.0
 			case "False":
 				statusCheck = servicecheck.ServiceCheckCritical
 				message = condition.Error
@@ -536,6 +538,7 @@ func (k *KubeASCheck) parseComponentStatus(sender sender.Sender, componentsStatu
 
 			tags := []string{"component:" + component.Name}
 			sender.ServiceCheck(KubeControlPaneCheck, statusCheck, "", tags, message)
+			sender.Gauge("datadog.cluster_agent."+component.Name+".component_status", statusValue, "", tags)
 		}
 	}
 	return nil

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver_test.go
@@ -90,6 +90,7 @@ func TestParseComponentStatus(t *testing.T) {
 
 	mocked := mocksender.NewMockSender(t, kubeASCheck.ID())
 	mocked.On("ServiceCheck", "kube_apiserver_controlplane.up", servicecheck.ServiceCheckOK, "", []string{"component:Zookeeper"}, "imok")
+	mocked.On("Gauge", "datadog.cluster_agent.Zookeeper.component_status", 1.0, "", []string{"component:Zookeeper"})
 	kubeASCheck.parseComponentStatus(mocked, expected)
 
 	mocked.AssertNumberOfCalls(t, "ServiceCheck", 1)
@@ -100,11 +101,13 @@ func TestParseComponentStatus(t *testing.T) {
 	mocked.AssertNotCalled(t, "ServiceCheck", "kube_apiserver_controlplane.up")
 
 	mocked.On("ServiceCheck", "kube_apiserver_controlplane.up", servicecheck.ServiceCheckCritical, "", []string{"component:ETCD"}, "Connection closed")
+	mocked.On("Gauge", "datadog.cluster_agent.ETCD.component_status", 0.0, "", []string{"component:ETCD"})
 	kubeASCheck.parseComponentStatus(mocked, unHealthy)
 	mocked.AssertNumberOfCalls(t, "ServiceCheck", 2)
 	mocked.AssertServiceCheck(t, "kube_apiserver_controlplane.up", servicecheck.ServiceCheckCritical, "", []string{"component:ETCD"}, "Connection closed")
 
 	mocked.On("ServiceCheck", "kube_apiserver_controlplane.up", servicecheck.ServiceCheckUnknown, "", []string{"component:DCA"}, "")
+	mocked.On("Gauge", "datadog.cluster_agent.DCA.component_status", 0.0, "", []string{"component:DCA"})
 	kubeASCheck.parseComponentStatus(mocked, unknown)
 	mocked.AssertNumberOfCalls(t, "ServiceCheck", 3)
 	mocked.AssertServiceCheck(t, "kube_apiserver_controlplane.up", servicecheck.ServiceCheckUnknown, "", []string{"component:DCA"}, "")


### PR DESCRIPTION
### What does this PR do?

Expose the component statuses using metric.

1 -> component is up
0 (default) -> component is down/unknown

This will be used later by the mcp server to validate if a user's control-plane has some components down.

### Motivation

easily retrieve component status from backend rapid service. 

### Describe how you validated your changes

run the kube api server check, it show the metrics:

```
=== Series ===
METRIC                                                    TYPE  TIMESTAMP  VALUE TAGS
datadog.cluster_agent.controller-manager.component_status gauge 1788784549 1     kube_cluster_name:kind-alexandre-lavigne-crayon-dev, orch_cluster_id:81636793-808d-43cf-b07c-3754fa3f5cab, component:controller-manager
datadog.cluster_agent.controller-manager.component_status gauge 1788784552 1     kube_cluster_name:kind-alexandre-lavigne-crayon-dev, orch_cluster_id:81636793-808d-43cf-b07c-3754fa3f5cab, component:controller-manager
datadog.cluster_agent.etcd-0.component_status             gauge 1788784549 1     kube_cluster_name:kind-alexandre-lavigne-crayon-dev, orch_cluster_id:81636793-808d-43cf-b07c-3754fa3f5cab, component:etcd-0
datadog.cluster_agent.etcd-0.component_status             gauge 1788784552 1     kube_cluster_name:kind-alexandre-lavigne-crayon-dev, orch_cluster_id:81636793-808d-43cf-b07c-3754fa3f5cab, component:etcd-0
datadog.cluster_agent.scheduler.component_status          gauge 1788784549 1     kube_cluster_name:kind-alexandre-lavigne-crayon-dev, orch_cluster_id:81636793-808d-43cf-b07c-3754fa3f5cab, component:scheduler
datadog.cluster_agent.scheduler.component_status          gauge 1788784552 1     kube_cluster_name:kind-alexandre-lavigne-crayon-dev, orch_cluster_id:81636793-808d-43cf-b07c-3754fa3f5cab, component:scheduler
```

### Additional Notes

**Warning**: for those who might comment that we already send the component status as a servcie check....
we can't query service check result from a backend service.

That's why we send a metric instead.