### PR TITLE
Remove memory re-overrides from `new-e2e-unit-tests`

### DIFF
--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -189,8 +189,6 @@ new-e2e-unit-tests:
   after_script:
     - !reference [.upload_junit_source]
   variables:
-    KUBERNETES_MEMORY_REQUEST: 12Gi
-    KUBERNETES_MEMORY_LIMIT: 16Gi
     KUBERNETES_CPU_REQUEST: 6
     GIT_DEPTH: 1  # Overrides .linux_tests: this job does not use --only-impacted-packages or coverage cache
   timeout: 20m  # Not less than 20m because job startup can take time.


### PR DESCRIPTION
### What does this PR do?
Remove the `KUBERNETES_MEMORY_REQUEST` and `KUBERNETES_MEMORY_LIMIT` overrides on the `new-e2e-unit-tests` job in `.gitlab/build/source_test/linux.yml`.

The job now honors its base template's (`.linux_tests`) memory defaults of `32Gi` request and `32Gi` limit.

### Motivation
`new-e2e-unit-tests` set its `KUBERNETES_MEMORY_REQUEST` and `KUBERNETES_MEMORY_LIMIT` override in #25090 (2024-05-06), when `.linux_tests`'s own defaults were `16Gi` request and `16Gi` limit.
At that point the override's `16Gi` limit matched the template exactly, only trimming the request down to `12Gi`.

`.linux_tests`'s limit was later raised to `24Gi` in #49251 (2026-04-13), explicitly to fix observed `OOMKilled` failures on Linux source_test jobs, and to `32Gi` in #53439 (2026-07-16). `new-e2e-unit-tests`'s override was not revisited either time, leaving it at a third of the template's current limit.

The job's `build` container has since been observed failing with `exit code 137` (`OOMKilled`) while compiling `test/e2e-framework`, which depends on the large auto-generated `pulumi-kubernetes/sdk/v4` bindings.

Simply bumping `pulumi-kubernetes/sdk/v4` (#55859) had been hitting this failure on a dozen consecutive attempts.
A dependency version bump on that module invalidates the compiler's cached build artifacts for it, forcing a full rebuild that can spike peak memory well above the job's current `16Gi` ceiling.

### Describe how you validated your changes
Confirmed via `git log -L` on the exact override lines that they were never touched since #25090, while `.linux_tests`'s defaults grew twice in the meantime.
This is a resource-sizing change with no functional test coverage, validated by whether `new-e2e-unit-tests` stops hitting `OOMKilled` once it lands.

### Additional Notes
`KUBERNETES_CPU_REQUEST: 6` is untouched, since nothing observed points at CPU being a problem.
`GIT_DEPTH: 1` is unrelated to this memory fix and is kept unchanged.