### PR TITLE
[procmgr] extract spawn behind platform::spawn_child_handle

### DIFF
--- a/pkg/procmgr/rust/src/env.rs
+++ b/pkg/procmgr/rust/src/env.rs
@@ -4,9 +4,64 @@
 // Copyright 2026-present Datadog, Inc.
 
 use anyhow::{Context, Result};
+use log::warn;
 
-/// Parse a systemd-style environment file into key-value pairs.
-/// Supports `KEY=VALUE`, `KEY="VALUE"`, `KEY='VALUE'`, comments (#), and blank lines.
+pub(crate) fn expand_env_vars(input: &str) -> String {
+    expand_vars_with(input, |name| std::env::var(name).ok())
+}
+
+pub(crate) fn try_expand_env_vars(input: &str) -> Option<String> {
+    try_expand_vars_with(input, |name| std::env::var(name).ok())
+}
+
+pub(crate) fn expand_vars_with(input: &str, lookup: impl Fn(&str) -> Option<String>) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(start) = rest.find("${") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        match after.find('}') {
+            Some(end) => {
+                let name = &after[..end];
+                match lookup(name) {
+                    Some(val) => out.push_str(&val),
+                    None => {
+                        warn!(
+                            "process config references unset variable ${{{name}}}, leaving it literal"
+                        );
+                        out.push_str(&rest[start..start + 2 + end + 1]);
+                    }
+                }
+                rest = &after[end + 1..];
+            }
+            None => {
+                out.push_str(&rest[start..]);
+                return out;
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+pub(crate) fn try_expand_vars_with(
+    input: &str,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Option<String> {
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(start) = rest.find("${") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        let end = after.find('}')?;
+        let name = &after[..end];
+        out.push_str(&lookup(name)?);
+        rest = &after[end + 1..];
+    }
+    out.push_str(rest);
+    Some(out)
+}
+
 pub fn parse_environment_file(path: &str) -> Result<Vec<(String, String)>> {
     let contents = std::fs::read_to_string(path)
         .with_context(|| format!("reading environment file: {path}"))?;
@@ -66,5 +121,61 @@ LANG=en_US.UTF-8
     #[test]
     fn test_parse_missing_file() {
         assert!(parse_environment_file("/nonexistent/env").is_err());
+    }
+
+    #[test]
+    fn test_expand_vars_substitutes_known() {
+        let lookup = |name: &str| match name {
+            "DD_CONF_DIR" => Some("/etc/datadog-agent-exp".to_string()),
+            _ => None,
+        };
+        assert_eq!(
+            expand_vars_with("${DD_CONF_DIR}/otel-config.yaml", lookup),
+            "/etc/datadog-agent-exp/otel-config.yaml"
+        );
+        assert_eq!(
+            expand_vars_with("-${DD_CONF_DIR}/environment", lookup),
+            "-/etc/datadog-agent-exp/environment"
+        );
+    }
+
+    #[test]
+    fn test_expand_vars_leaves_unknown_literal() {
+        let lookup = |_: &str| None;
+        assert_eq!(
+            expand_vars_with("${MISSING}/x", lookup),
+            "${MISSING}/x",
+            "unset variables must be left literal so misconfiguration fails loudly"
+        );
+    }
+
+    #[test]
+    fn test_try_expand_vars_substitutes_known() {
+        let lookup = |name: &str| match name {
+            "DD_INVENTORIES_FIRST_RUN_DELAY" => Some("5".to_string()),
+            _ => None,
+        };
+        assert_eq!(
+            try_expand_vars_with("${DD_INVENTORIES_FIRST_RUN_DELAY}", lookup),
+            Some("5".to_string())
+        );
+    }
+
+    #[test]
+    fn test_try_expand_vars_none_when_unset() {
+        let lookup = |_: &str| None;
+        assert_eq!(
+            try_expand_vars_with("${DD_INVENTORIES_FIRST_RUN_DELAY}", lookup),
+            None,
+            "an unset optional variable must yield None so the caller can omit the env var"
+        );
+    }
+
+    #[test]
+    fn test_expand_vars_no_placeholder_untouched() {
+        let lookup = |_: &str| Some("should-not-be-used".to_string());
+        let path = "/opt/datadog-packages/datadog-agent/stable/embedded/bin/otel-agent";
+        assert_eq!(expand_vars_with(path, lookup), path);
+        assert_eq!(expand_vars_with("a ${ b", lookup), "a ${ b");
     }
 }

--- a/pkg/procmgr/rust/src/grpc/mod.rs
+++ b/pkg/procmgr/rust/src/grpc/mod.rs
@@ -72,7 +72,7 @@ mod tests {
             drop(dir);
         });
 
-        let (exit_tx, mut exit_rx) = mpsc::channel::<crate::manager::ExitEvent>(256);
+        let (exit_tx, mut exit_rx) = mpsc::channel::<crate::process::ExitEvent>(256);
         let mgr_loop = mgr.clone();
         let exit_tx_loop = exit_tx.clone();
         tokio::spawn(async move {

--- a/pkg/procmgr/rust/src/grpc/service.rs
+++ b/pkg/procmgr/rust/src/grpc/service.rs
@@ -357,6 +357,7 @@ fn process_detail_fields(proc: &ManagedProcess) -> proto::ProcessDetail {
 mod tests {
     use super::*;
     use crate::config::ProcessConfig;
+    use crate::process::test_exit_channel;
     use crate::test_helpers;
 
     #[test]
@@ -472,7 +473,7 @@ mod tests {
         };
         let mut proc =
             ManagedProcess::new_config("sleeper".to_string(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
+        proc.spawn(test_exit_channel().0).unwrap();
 
         let proto = process_to_proto(&proc);
         assert_eq!(proto.name, "sleeper");
@@ -496,10 +497,13 @@ mod tests {
         };
         let mut proc =
             ManagedProcess::new_config("fail-proc".to_string(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
+        let mut exit_rx = {
+            let (tx, rx) = test_exit_channel();
+            proc.spawn(tx).unwrap();
+            rx
+        };
 
-        let mut child = proc.take_child().unwrap();
-        let status = child.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         proc.set_last_status(status);
 
         let proto = process_to_proto(&proc);

--- a/pkg/procmgr/rust/src/handle.rs
+++ b/pkg/procmgr/rust/src/handle.rs
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use anyhow::Result;
+use std::process::ExitStatus;
+use tokio::process::Child;
+
+pub(crate) struct ProcessHandle {
+    child: Child,
+}
+
+impl ProcessHandle {
+    pub(crate) fn from_child(child: Child) -> Self {
+        Self { child }
+    }
+
+    pub(crate) fn id(&self) -> Option<u32> {
+        self.child.id()
+    }
+
+    pub(crate) async fn wait(&mut self) -> Result<ExitStatus> {
+        Ok(self.child.wait().await?)
+    }
+
+    pub(crate) async fn kill(&mut self) -> Result<()> {
+        self.child.kill().await?;
+        Ok(())
+    }
+}

--- a/pkg/procmgr/rust/src/lib.rs
+++ b/pkg/procmgr/rust/src/lib.rs
@@ -7,6 +7,7 @@ pub mod command;
 pub mod config;
 pub mod env;
 pub mod grpc;
+mod handle;
 pub mod manager;
 pub mod ordering;
 pub mod platform;
@@ -14,7 +15,7 @@ pub mod process;
 #[cfg(windows)]
 pub mod service;
 pub mod shutdown;
-pub mod spawn;
+mod spawn;
 pub mod state;
 #[cfg(any(test, feature = "test-helpers"))]
 pub mod test_helpers;

--- a/pkg/procmgr/rust/src/manager.rs
+++ b/pkg/procmgr/rust/src/manager.rs
@@ -10,7 +10,7 @@ use crate::config::{self, ConfigLoader, ProcessDefinition};
 use crate::grpc;
 use crate::ordering;
 use crate::platform;
-use crate::process::{ManagedProcess, ProcessOrigin};
+use crate::process::{ExitEvent, ManagedProcess, ProcessOrigin};
 use crate::shutdown;
 use crate::uuid_gen::UuidGenerator;
 use anyhow::Result;
@@ -18,12 +18,6 @@ use log::{debug, info, warn};
 use std::sync::Arc;
 use tokio::sync::{RwLock, mpsc, oneshot};
 use tonic::Status;
-
-pub(crate) struct ExitEvent {
-    pub name: String,
-    pub pid: u32,
-    pub status: std::process::ExitStatus,
-}
 
 #[derive(Clone)]
 pub struct ProcessManager {
@@ -56,11 +50,10 @@ impl ProcessManager {
         let mut procs = self.processes.write().await;
         for &idx in order.iter() {
             let proc = &mut procs[idx];
-            if proc.should_start() {
-                match proc.spawn() {
-                    Ok(()) => spawn_watcher(proc, exit_tx.clone()),
-                    Err(e) => warn!("{e:#}"),
-                }
+            if proc.should_start()
+                && let Err(e) = proc.spawn(exit_tx.clone())
+            {
+                warn!("{e:#}");
             }
         }
     }
@@ -178,9 +171,8 @@ impl ProcessManager {
             info!("[{name}] already running, skipping queued restart");
             return;
         }
-        match proc.spawn() {
-            Ok(()) => spawn_watcher(proc, exit_tx.clone()),
-            Err(e) => warn!("[{}] restart failed: {e:#}", proc.name()),
+        if let Err(e) = proc.spawn(exit_tx.clone()) {
+            warn!("[{}] restart failed: {e:#}", proc.name());
         }
     }
 
@@ -217,11 +209,10 @@ impl ProcessManager {
             info!("[{name}] created via RPC (uuid={uuid})");
             procs.push(proc);
             let proc = procs.last_mut().unwrap();
-            if proc.should_start() {
-                match proc.spawn() {
-                    Ok(()) => spawn_watcher(proc, exit_tx.clone()),
-                    Err(e) => warn!("[{name}] auto-start failed: {e:#}"),
-                }
+            if proc.should_start()
+                && let Err(e) = proc.spawn(exit_tx.clone())
+            {
+                warn!("[{name}] auto-start failed: {e:#}");
             }
         }
         let warnings = self.update_startup_order().await;
@@ -243,12 +234,11 @@ impl ProcessManager {
                 proc.name()
             )));
         }
-        proc.spawn()
+        proc.spawn(exit_tx.clone())
             .map_err(|e| Status::internal(format!("failed to start '{}': {e:#}", proc.name())))?;
         let uuid = proc.uuid().to_owned();
         let pid = proc.pid();
         let state = proc.state();
-        spawn_watcher(proc, exit_tx.clone());
         Ok(StartResult { uuid, pid, state })
     }
 
@@ -330,12 +320,10 @@ impl ProcessManager {
                         self.uuid_gen.generate(),
                         np.config,
                     );
-                    if proc.should_start() {
-                        if let Err(e) = proc.spawn() {
-                            warn!("[{}] failed to start: {e:#}", np.name);
-                        } else {
-                            spawn_watcher(&mut proc, exit_tx.clone());
-                        }
+                    if proc.should_start()
+                        && let Err(e) = proc.spawn(exit_tx.clone())
+                    {
+                        warn!("[{}] failed to start: {e:#}", np.name);
                     }
                     added.push(np.name);
                     procs.push(proc);
@@ -351,10 +339,8 @@ impl ProcessManager {
                 if let Some(proc) = procs.iter_mut().find(|p| p.name() == *name) {
                     proc.wait_for_stop().await;
                     info!("[{name}] restarting with updated config");
-                    if let Err(e) = proc.spawn() {
+                    if let Err(e) = proc.spawn(exit_tx.clone()) {
                         warn!("[{name}] failed to restart: {e:#}");
-                    } else {
-                        spawn_watcher(proc, exit_tx.clone());
                     }
                 }
             }
@@ -422,37 +408,6 @@ fn resolve_index(procs: &[ManagedProcess], name_or_uuid: &str) -> Result<usize, 
         .ok_or_else(|| Status::not_found(format!("process '{name_or_uuid}' not found")))
 }
 
-/// Spawn a background task that awaits the child's exit and sends the result.
-fn spawn_watcher(proc: &mut ManagedProcess, tx: mpsc::Sender<ExitEvent>) {
-    if let Some(child) = proc.take_child() {
-        let name = proc.name().to_owned();
-        let pid = proc.pid().unwrap_or(0);
-        let handle = tokio::spawn(async move {
-            let mut child = child;
-            let status = match child.wait().await {
-                Ok(status) => status,
-                Err(e) => {
-                    warn!("[{name}] wait error: {e}, killing process");
-                    let _ = child.kill().await;
-                    match child.wait().await {
-                        Ok(s) => s,
-                        Err(e2) => {
-                            warn!("[{name}] failed to reap after kill: {e2}");
-                            return;
-                        }
-                    }
-                }
-            };
-            let _ = tx.try_send(ExitEvent {
-                name: name.clone(),
-                pid,
-                status,
-            });
-        });
-        proc.set_watcher_handle(handle);
-    }
-}
-
 /// Build `ProcessDefinition`s from the live processes Vec and resolve their
 /// dependency order. Because the definitions are built in the same index order
 /// as the Vec, the returned indices can be used directly for indexing into it.
@@ -488,6 +443,7 @@ fn recompute_startup_order(procs: &[ManagedProcess]) -> StartupOrderResult {
 mod tests {
     use super::*;
     use crate::config::{MutableConfigLoader, ProcessConfig, StaticConfigLoader};
+    use crate::process::ExitEvent;
     use crate::test_helpers;
     use crate::uuid_gen::{SequentialUuidGenerator, V4UuidGenerator};
 

--- a/pkg/procmgr/rust/src/platform/unix.rs
+++ b/pkg/procmgr/rust/src/platform/unix.rs
@@ -3,6 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+mod spawn;
+
+pub(crate) use spawn::spawn_child_handle;
+
 use anyhow::{Context, Result};
 use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;

--- a/pkg/procmgr/rust/src/platform/unix/spawn.rs
+++ b/pkg/procmgr/rust/src/platform/unix/spawn.rs
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use anyhow::{Context, Result};
+
+use crate::config::ProcessConfig;
+use crate::handle::ProcessHandle;
+use crate::spawn::SpawnRequest;
+
+use super::{setup_process_group, stderr_inheritable, stdout_inheritable};
+
+pub(crate) fn spawn_child_handle(name: &str, config: &ProcessConfig) -> Result<ProcessHandle> {
+    let request = SpawnRequest::from_config(name, config)?;
+    let mut cmd = request.to_command(stdout_inheritable(), stderr_inheritable());
+    setup_process_group(&mut cmd);
+    let child = cmd
+        .spawn()
+        .with_context(|| format!("[{name}] failed to spawn: {}", config.command))?;
+    Ok(ProcessHandle::from_child(child))
+}

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -3,6 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+mod spawn;
+
+pub(crate) use spawn::spawn_child_handle;
+
 use crate::spawn::SpawnProfile;
 use anyhow::{Context, Result};
 use std::ffi::c_void;

--- a/pkg/procmgr/rust/src/platform/windows/spawn.rs
+++ b/pkg/procmgr/rust/src/platform/windows/spawn.rs
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use anyhow::{Context, Result};
+use std::process::Stdio;
+
+use crate::config::ProcessConfig;
+use crate::handle::ProcessHandle;
+use crate::spawn::SpawnRequest;
+
+use super::{setup_process_group, stderr_inheritable, stdout_inheritable};
+
+pub(crate) fn spawn_child_handle(name: &str, config: &ProcessConfig) -> Result<ProcessHandle> {
+    let request = SpawnRequest::from_config(name, config)?;
+    let mut cmd = request.to_command(stdout_inheritable(), stderr_inheritable());
+    cmd.stdin(Stdio::null());
+    setup_process_group(&mut cmd);
+    let child = cmd
+        .spawn()
+        .with_context(|| format!("[{name}] failed to spawn: {}", config.command))?;
+    Ok(ProcessHandle::from_child(child))
+}

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -4,21 +4,28 @@
 // Copyright 2026-present Datadog, Inc.
 
 use crate::config::{ProcessConfig, RestartPolicy};
-use crate::env::parse_environment_file;
+use crate::env::expand_env_vars;
+use crate::handle::ProcessHandle;
 use crate::platform;
 use crate::spawn::SpawnProfile;
 use crate::state::ProcessState;
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use log::{info, warn};
 use std::collections::VecDeque;
-use std::process::Stdio;
-use tokio::process::{Child, Command};
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio::time::{self, Duration, Instant};
 
-// ---------------------------------------------------------------------------
-// RestartTracker
-// ---------------------------------------------------------------------------
+pub(crate) struct ExitEvent {
+    pub name: String,
+    pub pid: u32,
+    pub status: std::process::ExitStatus,
+}
+
+#[cfg(test)]
+pub(crate) fn test_exit_channel() -> (mpsc::Sender<ExitEvent>, mpsc::Receiver<ExitEvent>) {
+    mpsc::channel(8)
+}
 
 struct RestartTracker {
     count: u32,
@@ -50,7 +57,6 @@ impl RestartTracker {
         recent >= burst
     }
 
-    /// Record a restart. Resets backoff if the process ran long enough.
     fn record(&mut self, base_delay: f64, runtime_success: Duration) {
         if let Some(spawn_time) = self.last_spawn_time
             && spawn_time.elapsed() >= runtime_success
@@ -74,34 +80,25 @@ impl RestartTracker {
     }
 }
 
-// ---------------------------------------------------------------------------
-// ProcessOrigin
-// ---------------------------------------------------------------------------
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProcessOrigin {
     Config,
     Runtime,
 }
 
-// ---------------------------------------------------------------------------
-// ManagedProcess
-// ---------------------------------------------------------------------------
-
 pub struct ManagedProcess {
     name: String,
     uuid: String,
     config: ProcessConfig,
+    profile: SpawnProfile,
+    user: String,
     state: ProcessState,
     pid: Option<u32>,
-    child: Option<Child>,
     watcher_handle: Option<JoinHandle<()>>,
     restarts: RestartTracker,
     stop_requested: bool,
     origin: ProcessOrigin,
     last_exit_status: Option<std::process::ExitStatus>,
-    profile: SpawnProfile,
-    user: String,
     #[cfg(windows)]
     job_object: Option<platform::JobObject>,
 }
@@ -125,16 +122,15 @@ impl ManagedProcess {
             name,
             uuid,
             config,
+            profile,
+            user,
             state: ProcessState::Created,
             pid: None,
-            child: None,
             watcher_handle: None,
             restarts,
             stop_requested: false,
             origin,
             last_exit_status: None,
-            profile,
-            user,
             #[cfg(windows)]
             job_object: None,
         }
@@ -221,32 +217,54 @@ impl ManagedProcess {
         true
     }
 
-    pub fn spawn(&mut self) -> Result<()> {
+    pub(crate) fn spawn(&mut self, exit_tx: mpsc::Sender<ExitEvent>) -> Result<()> {
         if !self.state.can_transition_to(ProcessState::Starting) {
             bail!("[{}] cannot spawn: invalid state {}", self.name, self.state);
         }
         self.stop_requested = false;
         self.transition_to(ProcessState::Starting);
-        let result = self.try_spawn();
-        if result.is_err() {
-            self.transition_to(ProcessState::Failed);
+        match self.try_spawn() {
+            Ok(handle) => {
+                self.start_exit_watcher(handle, exit_tx);
+                Ok(())
+            }
+            Err(e) => {
+                self.transition_to(ProcessState::Failed);
+                Err(e)
+            }
         }
-        result
     }
 
-    fn try_spawn(&mut self) -> Result<()> {
-        // Through CreateProcess: std-handle reads for inherit and handle inheritance
-        // must not race with AttachConsole/FreeConsole on another thread.
+    fn start_exit_watcher(&mut self, mut handle: ProcessHandle, tx: mpsc::Sender<ExitEvent>) {
+        let name = self.name().to_owned();
+        let pid = self.pid().unwrap_or(0);
+        self.watcher_handle = Some(tokio::spawn(async move {
+            let status = match handle.wait().await {
+                Ok(status) => status,
+                Err(e) => {
+                    warn!("[{name}] wait error: {e}, killing process");
+                    let _ = handle.kill().await;
+                    match handle.wait().await {
+                        Ok(s) => s,
+                        Err(e2) => {
+                            warn!("[{name}] failed to reap after kill: {e2}");
+                            return;
+                        }
+                    }
+                }
+            };
+            let _ = tx.try_send(ExitEvent { name, pid, status });
+        }));
+    }
+
+    fn try_spawn(&mut self) -> Result<ProcessHandle> {
         #[cfg(windows)]
         let _console_guard = platform::console_lock();
 
-        let mut cmd = self.build_command()?;
+        info!("[{}] spawn profile: {}", self.name, self.profile);
+        let handle = platform::spawn_child_handle(self.name(), self.config())?;
 
-        let child = cmd
-            .spawn()
-            .with_context(|| format!("[{}] failed to spawn: {}", self.name, self.config.command))?;
-
-        self.pid = child.id();
+        self.pid = handle.id();
         info!(
             "[{}] spawned (pid={}, cmd={})",
             self.name,
@@ -254,82 +272,30 @@ impl ManagedProcess {
             self.config.command
         );
 
-        // Assign the child to a Job Object so TerminateJobObject can kill
-        // the entire descendant tree.  Ideally we would assign the job
-        // *atomically at creation time* via PROC_THREAD_ATTRIBUTE_JOB_LIST,
-        // eliminating the small race window where a very fast child could
-        // fork before assignment.  Rust's CommandExt::raw_attribute() is
-        // nightly-only (rust-lang/rust#114854), so we assign post-spawn
-        // for now.  In practice the window is negligible as managed
-        // processes are long-running services that don't immediately fork.
         #[cfg(windows)]
         if let Some(pid) = self.pid {
             match platform::JobObject::new() {
                 Ok(job) => match job.assign_process(pid) {
-                    Ok(()) => {
-                        self.job_object = Some(job);
-                    }
-                    Err(e) => {
-                        warn!("[{}] failed to assign to job object: {e:#}", self.name);
-                    }
+                    Ok(()) => self.job_object = Some(job),
+                    Err(e) => warn!("[{}] failed to assign to job object: {e:#}", self.name),
                 },
-                Err(e) => {
-                    warn!("[{}] failed to create job object: {e:#}", self.name);
-                }
+                Err(e) => warn!("[{}] failed to create job object: {e:#}", self.name),
             }
         }
 
-        self.child = Some(child);
         self.transition_to(ProcessState::Running);
         self.restarts.mark_spawned();
-        Ok(())
-    }
-
-    fn build_command(&self) -> Result<Command> {
-        let mut cmd = Command::new(expand_env_vars(&self.config.command));
-        cmd.args(self.config.args.iter().map(|a| expand_env_vars(a)));
-
-        apply_child_environment(&mut cmd, self.name(), &self.config)?;
-
-        if let Some(ref dir) = self.config.working_dir {
-            cmd.current_dir(expand_env_vars(dir));
-        }
-
-        apply_child_stdio(&mut cmd, &self.config);
-
-        platform::setup_process_group(&mut cmd);
-
-        Ok(cmd)
+        Ok(handle)
     }
 
     pub fn is_running(&self) -> bool {
         self.state.is_alive()
     }
 
-    /// Hand the child handle to a watcher task.
-    /// The process remains in `Running` state — only the handle moves.
-    pub fn take_child(&mut self) -> Option<Child> {
-        self.child.take()
-    }
-
-    fn has_child_handle(&self) -> bool {
-        self.child.is_some()
-    }
-
-    pub(crate) fn set_watcher_handle(&mut self, handle: JoinHandle<()>) {
-        self.watcher_handle = Some(handle);
-    }
-
-    fn take_watcher_handle(&mut self) -> Option<JoinHandle<()>> {
-        self.watcher_handle.take()
-    }
-
-    /// Record that the child exited. If a stop was explicitly requested via
-    /// `request_stop`, the process transitions to Stopped (skipping restarts).
-    /// Otherwise it transitions to Exited or Failed based on the exit code.
     pub fn set_last_status(&mut self, status: std::process::ExitStatus) {
         self.last_exit_status = Some(status);
         self.pid = None;
+        self.watcher_handle = None;
         #[cfg(windows)]
         {
             self.job_object = None;
@@ -344,8 +310,6 @@ impl ManagedProcess {
         }
     }
 
-    /// Mark the process for stop and send a graceful-stop signal. The watcher
-    /// will observe the exit and `set_last_status` will transition to Stopped.
     pub fn request_stop(&mut self) {
         if self.is_running() {
             self.stop_requested = true;
@@ -354,7 +318,6 @@ impl ManagedProcess {
         }
     }
 
-    /// Send a graceful-stop signal (SIGTERM on Unix, CTRL_BREAK on Windows).
     fn graceful_stop(&self) {
         if let Some(pid) = self.pid
             && let Err(e) = platform::send_graceful_stop(pid)
@@ -363,11 +326,6 @@ impl ManagedProcess {
         }
     }
 
-    /// Force-kill the process and all descendants.
-    ///
-    /// On Unix this sends SIGKILL to the entire process group.
-    /// On Windows this terminates the Job Object (all descendants), falling
-    /// back to `TerminateProcess` on the direct child if no job is available.
     fn force_kill(&mut self) {
         #[cfg(windows)]
         if let Some(ref job) = self.job_object {
@@ -386,8 +344,6 @@ impl ManagedProcess {
         }
     }
 
-    /// Send a Unix signal to the entire process group (works even after take_child).
-    /// Used by tests that need to send specific signals for cleanup.
     #[cfg(unix)]
     pub fn send_signal(&self, sig: nix::sys::signal::Signal) {
         if let Some(pid) = self.pid {
@@ -404,27 +360,16 @@ impl ManagedProcess {
         }
     }
 
-    /// Wait for the child to exit. Only works when we still hold the handle.
-    pub async fn wait(&mut self) -> Result<std::process::ExitStatus> {
-        let child = self.child.as_mut().context("no child handle to wait on")?;
-        let status = child.wait().await?;
-        info!("[{}] exited with {status}", self.name);
-        self.child = None;
-        Ok(status)
-    }
-
     fn stop_timeout(&self) -> Duration {
         self.config.stop_timeout()
     }
 
-    /// Wait for the process to stop after a graceful-stop signal has been sent.
-    /// Escalates to force-kill if the process doesn't exit within `stop_timeout`.
     pub async fn wait_for_stop(&mut self) {
         if !self.is_running() {
             return;
         }
         let stop = self.stop_timeout();
-        if let Some(handle) = self.take_watcher_handle() {
+        if let Some(handle) = self.watcher_handle.take() {
             tokio::pin!(handle);
             if time::timeout(stop, &mut handle).await.is_err() {
                 warn!(
@@ -439,19 +384,6 @@ impl ManagedProcess {
                 {
                     warn!("[{}] still running after force-kill, giving up", self.name);
                 }
-            }
-        } else if self.has_child_handle() && time::timeout(stop, self.wait()).await.is_err() {
-            warn!(
-                "[{}] stop timeout ({}s) reached, force-killing",
-                self.name,
-                stop.as_secs()
-            );
-            self.force_kill();
-            if time::timeout(Self::FORCE_KILL_TIMEOUT, self.wait())
-                .await
-                .is_err()
-            {
-                warn!("[{}] still running after force-kill, giving up", self.name);
             }
         }
         self.mark_stopped();
@@ -482,10 +414,6 @@ impl ManagedProcess {
         &self.config.restart
     }
 
-    /// Check restart policy and burst limits. If a restart is warranted,
-    /// record the attempt, advance the backoff, and return the delay the
-    /// caller should sleep before calling [`spawn`]. Returns `None` if the
-    /// process should not be restarted.
     #[must_use]
     pub fn handle_restart(&mut self) -> Option<Duration> {
         let should_restart = match (self.state, &self.config.restart) {
@@ -529,169 +457,6 @@ impl ManagedProcess {
     }
 }
 
-fn apply_child_environment(cmd: &mut Command, name: &str, config: &ProcessConfig) -> Result<()> {
-    cmd.env_clear();
-    #[cfg(windows)]
-    platform::apply_child_baseline_env(cmd);
-
-    if let Some(ref raw_path) = config.environment_file {
-        let raw_path = expand_env_vars(raw_path);
-        let (optional, path) = if let Some(stripped) = raw_path.strip_prefix('-') {
-            (true, stripped)
-        } else {
-            (false, raw_path.as_str())
-        };
-        if optional && !std::path::Path::new(path).exists() {
-            info!("[{name}] optional environment file not found, skipping: {path}");
-        } else {
-            let vars = parse_environment_file(path)
-                .with_context(|| format!("[{name}] failed to read environment file: {path}"))?;
-            for (k, v) in &vars {
-                cmd.env(k, v);
-            }
-        }
-    }
-    for (k, v) in &config.env {
-        match v.strip_prefix('-') {
-            Some(template) => match try_expand_env_vars(template) {
-                Some(val) => {
-                    cmd.env(k, val);
-                }
-                None => {
-                    info!("[{name}] optional env var {k} references an unset variable, omitting");
-                }
-            },
-            None => {
-                cmd.env(k, expand_env_vars(v));
-            }
-        }
-    }
-    Ok(())
-}
-
-/// Expand `${VAR}` references in `input` using dd-procmgr's own environment.
-///
-/// This lets a single process definition be pointed at the stable or experiment configuration
-/// directory by the supervising dd-procmgr, which exports the target directory in its own
-/// environment (the stable and experiment procmgr units export different values). It mirrors how
-/// the datadog-agent stable/experiment units each select their own config directory, so the
-/// experiment collector reads the experiment config while the process definition stays identical.
-/// Unknown variables are left as the literal `${VAR}` and logged, so a misconfiguration surfaces
-/// as a startup failure rather than silently resolving to an empty path.
-fn expand_env_vars(input: &str) -> String {
-    expand_vars_with(input, |name| std::env::var(name).ok())
-}
-
-/// Like [`expand_env_vars`], but for values prefixed with `-` in an `env:` map entry: returns
-/// `None` (instead of a string with a literal `${VAR}` left in place) if any referenced variable
-/// is unset, so the caller can omit the env var entirely. This lets a single process definition
-/// shared by the stable and experiment dd-procmgr export an env var only when the supervising
-/// dd-procmgr itself has it set, without the child seeing an unresolved placeholder.
-fn try_expand_env_vars(input: &str) -> Option<String> {
-    try_expand_vars_with(input, |name| std::env::var(name).ok())
-}
-
-/// Core of [`expand_env_vars`] with the variable lookup injected, so it can be unit-tested without
-/// mutating the process environment.
-fn expand_vars_with(input: &str, lookup: impl Fn(&str) -> Option<String>) -> String {
-    let mut out = String::with_capacity(input.len());
-    let mut rest = input;
-    while let Some(start) = rest.find("${") {
-        out.push_str(&rest[..start]);
-        let after = &rest[start + 2..];
-        match after.find('}') {
-            Some(end) => {
-                let name = &after[..end];
-                match lookup(name) {
-                    Some(val) => out.push_str(&val),
-                    None => {
-                        warn!(
-                            "process config references unset variable ${{{name}}}, leaving it literal"
-                        );
-                        out.push_str(&rest[start..start + 2 + end + 1]);
-                    }
-                }
-                rest = &after[end + 1..];
-            }
-            None => {
-                // No closing brace: emit the remainder verbatim.
-                out.push_str(&rest[start..]);
-                return out;
-            }
-        }
-    }
-    out.push_str(rest);
-    out
-}
-
-/// Core of [`try_expand_env_vars`] with the variable lookup injected, so it can be
-/// unit-tested without mutating the process environment. Unlike [`expand_vars_with`], this does
-/// not warn on an unresolved variable and returns `None` for the whole input as soon as one is
-/// found, since the caller treats that as "omit this optional value" rather than a
-/// misconfiguration.
-fn try_expand_vars_with(input: &str, lookup: impl Fn(&str) -> Option<String>) -> Option<String> {
-    let mut out = String::with_capacity(input.len());
-    let mut rest = input;
-    while let Some(start) = rest.find("${") {
-        out.push_str(&rest[..start]);
-        let after = &rest[start + 2..];
-        let end = after.find('}')?;
-        let name = &after[..end];
-        out.push_str(&lookup(name)?);
-        rest = &after[end + 1..];
-    }
-    out.push_str(rest);
-    Some(out)
-}
-
-fn apply_child_stdio(cmd: &mut Command, config: &ProcessConfig) {
-    #[cfg(windows)]
-    {
-        // Don't inherit stdin: invalid after AttachConsole/FreeConsole on stop.
-        cmd.stdin(Stdio::null());
-    }
-    cmd.stdout(stdio_from_config(
-        &config.stdout,
-        platform::stdout_inheritable(),
-    ));
-    cmd.stderr(stdio_from_config(
-        &config.stderr,
-        platform::stderr_inheritable(),
-    ));
-}
-
-fn stdio_from_path(path: &str) -> Stdio {
-    match std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-    {
-        Ok(f) => f.into(),
-        Err(e) => {
-            warn!("failed to open stdio file {path}: {e}, falling back to inherit");
-            Stdio::inherit()
-        }
-    }
-}
-
-fn stdio_from_str(s: &str) -> Stdio {
-    match s {
-        "null" => Stdio::null(),
-        "inherit" | "" => Stdio::inherit(),
-        path => stdio_from_path(path),
-    }
-}
-
-fn stdio_from_config(yaml_value: &str, inheritable: bool) -> Stdio {
-    #[cfg(not(windows))]
-    let _ = inheritable;
-    #[cfg(windows)]
-    if !inheritable && (yaml_value == "inherit" || yaml_value.is_empty()) {
-        return Stdio::null();
-    }
-    stdio_from_str(yaml_value)
-}
-
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -700,67 +465,11 @@ pub mod tests {
     #[cfg(unix)]
     use nix::sys::signal::Signal;
 
-    // -- ${VAR} expansion tests --
-
-    #[test]
-    fn test_expand_vars_substitutes_known() {
-        let lookup = |name: &str| match name {
-            "DD_CONF_DIR" => Some("/etc/datadog-agent-exp".to_string()),
-            _ => None,
-        };
-        assert_eq!(
-            expand_vars_with("${DD_CONF_DIR}/otel-config.yaml", lookup),
-            "/etc/datadog-agent-exp/otel-config.yaml"
-        );
-        // Multiple references and a leading dash (optional environment_file form) are preserved.
-        assert_eq!(
-            expand_vars_with("-${DD_CONF_DIR}/environment", lookup),
-            "-/etc/datadog-agent-exp/environment"
-        );
+    fn spawn_ok(proc: &mut ManagedProcess) -> mpsc::Receiver<ExitEvent> {
+        let (tx, rx) = test_exit_channel();
+        proc.spawn(tx).unwrap();
+        rx
     }
-
-    #[test]
-    fn test_expand_vars_leaves_unknown_literal() {
-        let lookup = |_: &str| None;
-        assert_eq!(
-            expand_vars_with("${MISSING}/x", lookup),
-            "${MISSING}/x",
-            "unset variables must be left literal so misconfiguration fails loudly"
-        );
-    }
-
-    #[test]
-    fn test_try_expand_vars_substitutes_known() {
-        let lookup = |name: &str| match name {
-            "DD_INVENTORIES_FIRST_RUN_DELAY" => Some("5".to_string()),
-            _ => None,
-        };
-        assert_eq!(
-            try_expand_vars_with("${DD_INVENTORIES_FIRST_RUN_DELAY}", lookup),
-            Some("5".to_string())
-        );
-    }
-
-    #[test]
-    fn test_try_expand_vars_none_when_unset() {
-        let lookup = |_: &str| None;
-        assert_eq!(
-            try_expand_vars_with("${DD_INVENTORIES_FIRST_RUN_DELAY}", lookup),
-            None,
-            "an unset optional variable must yield None so the caller can omit the env var"
-        );
-    }
-
-    #[test]
-    fn test_expand_vars_no_placeholder_untouched() {
-        let lookup = |_: &str| Some("should-not-be-used".to_string());
-        let path = "/opt/datadog-packages/datadog-agent/stable/embedded/bin/otel-agent";
-        assert_eq!(expand_vars_with(path, lookup), path);
-        // A dangling `${` with no closing brace is emitted verbatim.
-        assert_eq!(expand_vars_with("a ${ b", lookup), "a ${ b");
-    }
-
-    // -- state lifecycle tests --
 
     #[test]
     fn test_initial_state_is_created() {
@@ -784,11 +493,11 @@ pub mod tests {
         );
         assert_eq!(proc.state(), ProcessState::Created);
 
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
         assert_eq!(proc.state(), ProcessState::Running);
         assert!(proc.is_running());
 
-        let status = proc.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert!(status.success());
         proc.set_last_status(status);
         assert_eq!(proc.state(), ProcessState::Exited);
@@ -803,63 +512,51 @@ pub mod tests {
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
         assert_eq!(proc.state(), ProcessState::Running);
 
-        let status = proc.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert!(!status.success());
         proc.set_last_status(status);
         assert_eq!(proc.state(), ProcessState::Failed);
     }
 
     #[tokio::test]
-    async fn test_state_after_take_child_still_running() {
+    async fn test_state_after_spawn_watcher_owns_handle() {
         let (cmd, args) = test_helpers::sleep_cmd(60);
         let mut proc = ManagedProcess::new_config(
             "t".into(),
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
+        let _exit_rx = spawn_ok(&mut proc);
         assert_eq!(proc.state(), ProcessState::Running);
-
-        let child = proc.take_child();
-        assert!(child.is_some());
-        assert_eq!(
-            proc.state(),
-            ProcessState::Running,
-            "state should remain Running after take_child"
-        );
         assert!(proc.is_running());
+        assert!(proc.pid().is_some());
 
         if let Some(pid) = proc.pid() {
             test_helpers::cleanup_process(pid);
         }
-        let mut child = child.unwrap();
-        let _ = child.wait().await;
     }
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn test_send_signal_works_after_take_child() {
+    async fn test_send_signal_works_after_spawn() {
         let (cmd, args) = test_helpers::sleep_cmd(60);
         let mut proc = ManagedProcess::new_config(
             "t".into(),
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
-        let mut child = proc.take_child().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
 
         proc.send_signal(Signal::SIGTERM);
-        let status = child.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert!(
             !status.success(),
-            "signal by stored PID should reach child after take_child"
+            "signal by stored PID should reach child after spawn (watcher owns the handle)"
         );
     }
-
-    // -- should_start tests --
 
     #[test]
     fn test_should_start_auto_start_true_no_condition() {
@@ -900,8 +597,6 @@ pub mod tests {
         assert!(!proc.should_start());
     }
 
-    // -- spawn tests --
-
     #[tokio::test]
     async fn test_spawn_and_is_running() {
         let (cmd, args) = test_helpers::sleep_cmd(60);
@@ -912,11 +607,11 @@ pub mod tests {
         );
 
         assert!(!proc.is_running());
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
         assert!(proc.is_running());
 
         proc.request_stop();
-        let status = proc.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         proc.set_last_status(status);
         assert_eq!(proc.state(), ProcessState::Stopped);
     }
@@ -925,7 +620,7 @@ pub mod tests {
     async fn test_spawn_nonexistent_binary() {
         let cfg = test_helpers::make_config("/nonexistent/binary", vec![]);
         let mut proc = ManagedProcess::new_config("bad".into(), test_helpers::test_uuid(), cfg);
-        assert!(proc.spawn().is_err());
+        assert!(proc.spawn(test_exit_channel().0).is_err());
         assert!(!proc.is_running());
         assert_eq!(proc.state(), ProcessState::Failed);
     }
@@ -938,17 +633,16 @@ pub mod tests {
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
         proc.request_stop();
-        let mut child = proc.take_child().unwrap();
-        let status = child.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         proc.set_last_status(status);
         assert_eq!(proc.state(), ProcessState::Stopped);
 
         let mut bad_cfg = proc.config().clone();
         bad_cfg.command = "/nonexistent/binary".to_string();
         proc.set_config(bad_cfg);
-        assert!(proc.spawn().is_err());
+        assert!(proc.spawn(test_exit_channel().0).is_err());
         assert_eq!(
             proc.state(),
             ProcessState::Failed,
@@ -964,8 +658,8 @@ pub mod tests {
 
         let mut proc =
             ManagedProcess::new_config("env-test".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
-        let status = proc.wait().await.unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert_eq!(status.code(), Some(42));
     }
 
@@ -977,12 +671,10 @@ pub mod tests {
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
-        let status = proc.wait().await.unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert_eq!(status.code(), Some(7));
     }
-
-    // -- signal tests (Unix-only: test the raw send_signal API) --
 
     #[cfg(unix)]
     #[tokio::test]
@@ -993,10 +685,10 @@ pub mod tests {
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
 
         proc.send_signal(Signal::SIGTERM);
-        let status = proc.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert!(!status.success());
     }
 
@@ -1012,11 +704,8 @@ pub mod tests {
         proc.send_signal(Signal::SIGTERM);
     }
 
-    // -- env tests --
-
     #[tokio::test]
     async fn test_spawn_does_not_inherit_parent_env() {
-        // SAFETY: single-threaded test runtime; no concurrent env access.
         unsafe { std::env::set_var("PROCMGRD_TEST_SECRET", "leaked") };
         let (sh, flag) = test_helpers::shell_cmd();
         #[cfg(unix)]
@@ -1026,8 +715,8 @@ pub mod tests {
         let cfg = test_helpers::make_config(sh, vec![flag.into(), script.into()]);
         let mut proc =
             ManagedProcess::new_config("clean-env".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
-        let status = proc.wait().await.unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert_eq!(
             status.code(),
             Some(0),
@@ -1051,8 +740,8 @@ pub mod tests {
         cfg.environment_file = Some(env_file.to_str().unwrap().to_string());
 
         let mut proc = ManagedProcess::new_config("envfile".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
-        let status = proc.wait().await.unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert_eq!(
             status.code(),
             Some(0),
@@ -1078,8 +767,8 @@ pub mod tests {
 
         let mut proc =
             ManagedProcess::new_config("override".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
-        let status = proc.wait().await.unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert_eq!(
             status.code(),
             Some(0),
@@ -1095,7 +784,7 @@ pub mod tests {
         let mut proc =
             ManagedProcess::new_config("bad-envfile".into(), test_helpers::test_uuid(), cfg);
         assert!(
-            proc.spawn().is_err(),
+            proc.spawn(test_exit_channel().0).is_err(),
             "spawn should fail if environment_file is missing without - prefix"
         );
         assert!(!proc.is_running());
@@ -1108,15 +797,13 @@ pub mod tests {
         cfg.environment_file = Some("-/nonexistent/env".to_string());
         let mut proc =
             ManagedProcess::new_config("optional-envfile".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
-        let status = proc.wait().await.unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
+        let status = exit_rx.recv().await.expect("exit event").status;
         assert!(
             status.success(),
             "spawn should succeed when optional environment_file (- prefix) is missing"
         );
     }
-
-    // -- restart policy tests --
 
     #[test]
     fn test_should_restart_never() {
@@ -1297,12 +984,11 @@ runtime_success_sec: 5
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
         assert_eq!(proc.state(), ProcessState::Running);
 
         proc.request_stop();
-        let mut child = proc.take_child().unwrap();
-        let status = child.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         proc.set_last_status(status);
 
         assert_eq!(proc.state(), ProcessState::Stopped);
@@ -1314,18 +1000,15 @@ runtime_success_sec: 5
         let mut cfg = test_helpers::make_config(cmd, args);
         cfg.restart = RestartPolicy::OnFailure;
         let mut proc = ManagedProcess::new_config("svc".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
 
         proc.request_stop();
-        let _ = proc.take_child();
-        // Mirrors handle_stop: wait_for_stop may call mark_stopped before the exit
-        // watcher runs set_last_status, leaving stop_requested set without this clear.
-        proc.mark_stopped();
+        proc.wait_for_stop().await;
+        let _ = exit_rx.try_recv();
 
-        proc.spawn().unwrap();
-        let mut child = proc.take_child().unwrap();
-        child.kill().await.expect("kill child");
-        let status = child.wait().await.unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
+        test_helpers::cleanup_process(proc.pid().expect("running pid"));
+        let status = exit_rx.recv().await.expect("exit event").status;
         proc.set_last_status(status);
 
         assert_eq!(proc.state(), ProcessState::Failed);
@@ -1341,11 +1024,10 @@ runtime_success_sec: 5
         let mut cfg = test_helpers::make_config(cmd, args);
         cfg.restart = RestartPolicy::Always;
         let mut proc = ManagedProcess::new_config("svc".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
 
         proc.request_stop();
-        let mut child = proc.take_child().unwrap();
-        let status = child.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         proc.set_last_status(status);
 
         assert_eq!(proc.state(), ProcessState::Stopped);
@@ -1363,10 +1045,9 @@ runtime_success_sec: 5
             test_helpers::test_uuid(),
             test_helpers::make_config(cmd, args),
         );
-        proc.spawn().unwrap();
+        let mut exit_rx = spawn_ok(&mut proc);
 
-        let mut child = proc.take_child().unwrap();
-        let status = child.wait().await.unwrap();
+        let status = exit_rx.recv().await.expect("exit event").status;
         proc.set_last_status(status);
 
         assert_eq!(
@@ -1374,106 +1055,5 @@ runtime_success_sec: 5
             ProcessState::Failed,
             "without stop_requested, non-zero exit should be Failed"
         );
-    }
-
-    // -- stdio_from_str (YAML stdout/stderr: inherit, "", null, file path, unopenable path) --
-
-    #[test]
-    fn test_stdio_from_str_inherit_spawns() {
-        let (cmd, args) = test_helpers::true_cmd();
-        let status = std::process::Command::new(cmd)
-            .args(&args)
-            .stdout(super::stdio_from_str("inherit"))
-            .stderr(super::stdio_from_str("inherit"))
-            .status()
-            .unwrap();
-        assert!(status.success());
-    }
-
-    #[test]
-    fn test_stdio_from_str_empty_string_matches_inherit() {
-        let (cmd, args) = test_helpers::true_cmd();
-        let status = std::process::Command::new(cmd)
-            .args(&args)
-            .stdout(super::stdio_from_str(""))
-            .status()
-            .unwrap();
-        assert!(status.success());
-    }
-
-    #[test]
-    fn test_stdio_from_str_null_discards_child_stdout() {
-        let (sh, flag) = test_helpers::shell_cmd();
-        let out = std::process::Command::new(sh)
-            .arg(flag)
-            .arg("echo hello")
-            .stdout(super::stdio_from_str("null"))
-            .output()
-            .unwrap();
-        assert!(
-            out.stdout.is_empty(),
-            "stdout should be discarded, got {:?}",
-            String::from_utf8_lossy(&out.stdout)
-        );
-    }
-
-    #[test]
-    fn test_stdio_from_str_writable_path_redirect() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("pmgr_stdio_redirect.log");
-        let path_str = path.to_str().unwrap();
-        let (sh, flag) = test_helpers::shell_cmd();
-        let status = std::process::Command::new(sh)
-            .arg(flag)
-            .arg("echo fileline")
-            .stdout(super::stdio_from_str(path_str))
-            .status()
-            .unwrap();
-        assert!(status.success());
-        let contents = std::fs::read_to_string(&path).unwrap();
-        assert!(
-            contents.contains("fileline"),
-            "expected fileline in log, got {contents:?}"
-        );
-    }
-
-    #[test]
-    fn test_stdio_from_str_path_appends_on_respawn() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("pmgr_stdio_append.log");
-        let path_str = path.to_str().unwrap();
-        let (sh, flag) = test_helpers::shell_cmd();
-        for msg in ["first", "second"] {
-            let status = std::process::Command::new(sh)
-                .arg(flag)
-                .arg(format!("echo {msg}"))
-                .stdout(super::stdio_from_str(path_str))
-                .status()
-                .unwrap();
-            assert!(status.success());
-        }
-        let contents = std::fs::read_to_string(&path).unwrap();
-        assert!(contents.contains("first"), "got {contents:?}");
-        assert!(contents.contains("second"), "got {contents:?}");
-    }
-
-    #[test]
-    fn test_stdio_from_str_unopenable_path_falls_back_to_inherit() {
-        let (sh, flag) = test_helpers::shell_cmd();
-        #[cfg(unix)]
-        let bad_path = "/nonexistent_dir_pmgr_stdio/out.log";
-        #[cfg(windows)]
-        let bad_path = r"C:\nonexistent_dir_pmgr_stdio\out.log";
-        let out = std::process::Command::new(sh)
-            .arg(flag)
-            .arg("echo fallback_ok")
-            .stdout(super::stdio_from_str(bad_path))
-            .output()
-            .unwrap();
-        assert!(
-            out.status.success(),
-            "spawn with unopenable stdout path should still succeed (falls back to inherit)"
-        );
-        // Child stdout is inherited (not piped), so `out.stdout` is empty; success is the signal.
     }
 }

--- a/pkg/procmgr/rust/src/shutdown.rs
+++ b/pkg/procmgr/rust/src/shutdown.rs
@@ -4,9 +4,9 @@
 // Copyright 2026-present Datadog, Inc.
 
 use crate::process::ManagedProcess;
+#[cfg(test)]
+use crate::process::test_exit_channel;
 
-/// Shut down processes in the given index order (typically reverse startup order).
-/// Sends SIGTERM to all first, then waits for each in order.
 pub async fn shutdown_ordered(processes: &mut [ManagedProcess], order: &[usize]) {
     for &idx in order {
         processes[idx].request_stop();
@@ -16,7 +16,6 @@ pub async fn shutdown_ordered(processes: &mut [ManagedProcess], order: &[usize])
     }
 }
 
-/// Convenience wrapper: shut down all processes in forward index order.
 #[cfg(test)]
 pub async fn shutdown_all(processes: &mut [ManagedProcess]) {
     let order: Vec<usize> = (0..processes.len()).collect();
@@ -41,8 +40,8 @@ mod tests {
 
         let mut p1 = ManagedProcess::new_config("p1".into(), test_helpers::test_uuid(), cfg1);
         let mut p2 = ManagedProcess::new_config("p2".into(), test_helpers::test_uuid(), cfg2);
-        p1.spawn().unwrap();
-        p2.spawn().unwrap();
+        p1.spawn(test_exit_channel().0).unwrap();
+        p2.spawn(test_exit_channel().0).unwrap();
 
         let mut procs = vec![p1, p2];
         shutdown_all(&mut procs).await;
@@ -66,7 +65,7 @@ mod tests {
         cfg.stop_timeout = Some(1);
         let mut proc =
             ManagedProcess::new_config("stubborn".into(), test_helpers::test_uuid(), cfg);
-        proc.spawn().unwrap();
+        proc.spawn(test_exit_channel().0).unwrap();
 
         let mut procs = vec![proc];
         shutdown_all(&mut procs).await;
@@ -75,19 +74,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_shutdown_all_after_take_child() {
+    async fn test_shutdown_all_after_spawn_watcher_owns_handle() {
         let mut proc =
             ManagedProcess::new_config("t".into(), test_helpers::test_uuid(), sleep_config());
-        proc.spawn().unwrap();
-        let _child = proc.take_child();
-
+        proc.spawn(test_exit_channel().0).unwrap();
         assert!(proc.is_running(), "state should still be Running");
         let mut procs = vec![proc];
         shutdown_all(&mut procs).await;
         assert_eq!(
             procs[0].state(),
             ProcessState::Stopped,
-            "shutdown should transition to Stopped even without child handle"
+            "shutdown should transition to Stopped via exit watcher"
         );
     }
 
@@ -99,12 +96,11 @@ mod tests {
             ManagedProcess::new_config("p2".into(), test_helpers::test_uuid(), sleep_config());
         let mut p3 =
             ManagedProcess::new_config("p3".into(), test_helpers::test_uuid(), sleep_config());
-        p1.spawn().unwrap();
-        p2.spawn().unwrap();
-        p3.spawn().unwrap();
+        p1.spawn(test_exit_channel().0).unwrap();
+        p2.spawn(test_exit_channel().0).unwrap();
+        p3.spawn(test_exit_channel().0).unwrap();
 
         let mut procs = vec![p1, p2, p3];
-        // Reverse order: p3, p2, p1
         shutdown_ordered(&mut procs, &[2, 1, 0]).await;
 
         assert_eq!(procs[0].state(), ProcessState::Stopped);

--- a/pkg/procmgr/rust/src/spawn/mod.rs
+++ b/pkg/procmgr/rust/src/spawn/mod.rs
@@ -4,5 +4,8 @@
 // Copyright 2026-present Datadog, Inc.
 
 mod profile;
+mod request;
+mod stdio;
 
 pub(crate) use profile::SpawnProfile;
+pub(crate) use request::SpawnRequest;

--- a/pkg/procmgr/rust/src/spawn/request.rs
+++ b/pkg/procmgr/rust/src/spawn/request.rs
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use anyhow::{Context, Result};
+use log::info;
+use std::path::PathBuf;
+use tokio::process::Command;
+
+use crate::config::ProcessConfig;
+use crate::env::{expand_env_vars, parse_environment_file, try_expand_env_vars};
+
+use super::stdio::{StdioSetting, parse_stdio_setting, to_command_stdio};
+
+pub(crate) struct SpawnRequest {
+    command: String,
+    args: Vec<String>,
+    env: Vec<(String, String)>,
+    working_dir: Option<PathBuf>,
+    stdout_setting: StdioSetting,
+    stderr_setting: StdioSetting,
+}
+
+impl SpawnRequest {
+    pub(crate) fn from_config(process_name: &str, config: &ProcessConfig) -> Result<Self> {
+        Ok(Self {
+            command: expand_env_vars(&config.command),
+            args: config.args.iter().map(|a| expand_env_vars(a)).collect(),
+            env: collect_env(process_name, config)?,
+            working_dir: config
+                .working_dir
+                .as_ref()
+                .map(|dir| PathBuf::from(expand_env_vars(dir))),
+            stdout_setting: parse_stdio_setting(&config.stdout),
+            stderr_setting: parse_stdio_setting(&config.stderr),
+        })
+    }
+
+    pub(crate) fn to_command(&self, stdout_inheritable: bool, stderr_inheritable: bool) -> Command {
+        let mut cmd = Command::new(&self.command);
+        cmd.args(&self.args);
+        cmd.env_clear();
+        #[cfg(windows)]
+        crate::platform::apply_child_baseline_env(&mut cmd);
+        for (k, v) in &self.env {
+            cmd.env(k, v);
+        }
+        if let Some(dir) = &self.working_dir {
+            cmd.current_dir(dir);
+        }
+        cmd.stdout(to_command_stdio(&self.stdout_setting, stdout_inheritable));
+        cmd.stderr(to_command_stdio(&self.stderr_setting, stderr_inheritable));
+        cmd
+    }
+}
+
+fn collect_env(process_name: &str, config: &ProcessConfig) -> Result<Vec<(String, String)>> {
+    let mut env = Vec::new();
+
+    if let Some(ref raw_path) = config.environment_file {
+        let raw_path = expand_env_vars(raw_path);
+        let (optional, path) = if let Some(stripped) = raw_path.strip_prefix('-') {
+            (true, stripped)
+        } else {
+            (false, raw_path.as_str())
+        };
+
+        if optional && !std::path::Path::new(path).exists() {
+            info!("[{process_name}] optional environment file not found, skipping: {path}");
+        } else {
+            let vars = parse_environment_file(path).with_context(|| {
+                format!("[{process_name}] failed to read environment file: {path}")
+            })?;
+            env.extend(vars);
+        }
+    }
+
+    for (k, v) in &config.env {
+        match v.strip_prefix('-') {
+            Some(template) => match try_expand_env_vars(template) {
+                Some(val) => env.push((k.clone(), val)),
+                None => info!(
+                    "[{process_name}] optional env var {k} references an unset variable, omitting"
+                ),
+            },
+            None => env.push((k.clone(), expand_env_vars(v))),
+        }
+    }
+
+    Ok(env)
+}

--- a/pkg/procmgr/rust/src/spawn/stdio.rs
+++ b/pkg/procmgr/rust/src/spawn/stdio.rs
@@ -1,0 +1,186 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use log::warn;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum StdioSetting {
+    Inherit,
+    Null,
+    File(PathBuf),
+}
+
+pub(crate) fn parse_stdio_setting(yaml_value: &str) -> StdioSetting {
+    match yaml_value {
+        "null" => StdioSetting::Null,
+        "inherit" | "" => StdioSetting::Inherit,
+        path => StdioSetting::File(PathBuf::from(path)),
+    }
+}
+
+pub(crate) fn to_command_stdio(setting: &StdioSetting, inheritable: bool) -> Stdio {
+    match setting {
+        StdioSetting::Null => Stdio::null(),
+        StdioSetting::Inherit => {
+            if inheritable {
+                Stdio::inherit()
+            } else {
+                Stdio::null()
+            }
+        }
+        StdioSetting::File(path) => file_to_stdio(path),
+    }
+}
+
+fn file_to_stdio(path: &Path) -> Stdio {
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    {
+        Ok(f) => f.into(),
+        Err(e) => {
+            warn!(
+                "failed to open stdio file {}: {e}, falling back to inherit",
+                path.display()
+            );
+            Stdio::inherit()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers;
+
+    fn command_stdio(yaml: &str) -> Stdio {
+        to_command_stdio(&parse_stdio_setting(yaml), true)
+    }
+
+    #[test]
+    fn parse_stdio_setting_maps_keywords_and_paths() {
+        assert_eq!(parse_stdio_setting("inherit"), StdioSetting::Inherit);
+        assert_eq!(parse_stdio_setting(""), StdioSetting::Inherit);
+        assert_eq!(parse_stdio_setting("null"), StdioSetting::Null);
+        assert_eq!(
+            parse_stdio_setting(r"C:\logs\out.log"),
+            StdioSetting::File(PathBuf::from(r"C:\logs\out.log"))
+        );
+    }
+
+    #[test]
+    fn inherit_spawns() {
+        let (cmd, args) = test_helpers::true_cmd();
+        let status = std::process::Command::new(cmd)
+            .args(&args)
+            .stdout(command_stdio("inherit"))
+            .stderr(command_stdio("inherit"))
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    #[test]
+    fn empty_string_matches_inherit() {
+        let (cmd, args) = test_helpers::true_cmd();
+        let status = std::process::Command::new(cmd)
+            .args(&args)
+            .stdout(command_stdio(""))
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    #[test]
+    fn inherit_without_console_maps_to_null() {
+        let stdio = to_command_stdio(&StdioSetting::Inherit, false);
+        let (cmd, args) = test_helpers::true_cmd();
+        let status = std::process::Command::new(cmd)
+            .args(&args)
+            .stdout(stdio)
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    #[test]
+    fn null_discards_child_stdout() {
+        let (sh, flag) = test_helpers::shell_cmd();
+        let out = std::process::Command::new(sh)
+            .arg(flag)
+            .arg("echo hello")
+            .stdout(command_stdio("null"))
+            .output()
+            .unwrap();
+        assert!(
+            out.stdout.is_empty(),
+            "stdout should be discarded, got {:?}",
+            String::from_utf8_lossy(&out.stdout)
+        );
+    }
+
+    #[test]
+    fn writable_path_redirect() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pmgr_stdio_redirect.log");
+        let path_str = path.to_str().unwrap();
+        let (sh, flag) = test_helpers::shell_cmd();
+        let status = std::process::Command::new(sh)
+            .arg(flag)
+            .arg("echo fileline")
+            .stdout(command_stdio(path_str))
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            contents.contains("fileline"),
+            "expected fileline in log, got {contents:?}"
+        );
+    }
+
+    #[test]
+    fn path_appends_on_respawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pmgr_stdio_append.log");
+        let path_str = path.to_str().unwrap();
+        let (sh, flag) = test_helpers::shell_cmd();
+        for msg in ["first", "second"] {
+            let status = std::process::Command::new(sh)
+                .arg(flag)
+                .arg(format!("echo {msg}"))
+                .stdout(command_stdio(path_str))
+                .status()
+                .unwrap();
+            assert!(status.success());
+        }
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("first"), "got {contents:?}");
+        assert!(contents.contains("second"), "got {contents:?}");
+    }
+
+    #[test]
+    fn unopenable_path_falls_back_to_inherit() {
+        let (sh, flag) = test_helpers::shell_cmd();
+        let bad_path = if cfg!(windows) {
+            r"C:\nonexistent_dir_pmgr_stdio\out.log"
+        } else {
+            "/nonexistent_dir_pmgr_stdio/out.log"
+        };
+        let out = std::process::Command::new(sh)
+            .arg(flag)
+            .arg("echo fallback_ok")
+            .stdout(command_stdio(bad_path))
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "spawn with unopenable stdout path should still succeed (falls back to inherit)"
+        );
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Extracts spawn behind `platform::spawn_child_handle()` and introduces `ProcessHandle` and `SpawnRequest`. Unix and Windows still use `Command::spawn`. Successful `ManagedProcess::spawn` starts the exit watcher itself, so the manager no longer calls `spawn` then `spawn_watcher` as two steps. Spawn behavior is unchanged.

### Motivation

Reviewer-requested split of #55834. This lands the cross-platform spawn plumbing first. Windows LogonUser agent-profile spawn stays in #55834.

### Describe how you validated your changes

- `cargo test -p dd-procmgrd`
- `cargo clippy -p dd-procmgrd --all-targets -- -D warnings`
- `cargo test -p dd-procmgrd --test e2e --features test-helpers reload_`
- `cargo test -p dd-procmgrd --test e2e --features test-helpers list`
- `cargo test -p dd-procmgrd --test e2e --features test-helpers describe`
- `dda inv test --targets=./pkg/procmgr/coat/...`

Bazel `//pkg/procmgr/rust:dd-procmgrd_test` is linux/windows only (skipped locally).

### Additional Notes

Mechanical refactor only. No LogonUser, no password read, no change to privileged spawn. Keep #55834 open. After this PR merges, rebase #55834 onto `main` so that diff is LogonUser-only.