### PR TITLE
[AXT] fix(nvlink): fix NVLink fields collector on devices with inactive ports

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/helpers.go
+++ b/pkg/collector/corechecks/gpu/nvidia/helpers.go
@@ -246,6 +246,12 @@ func portIsAlwaysSupported(_ int) ([]Sample, error) {
 	return []Sample{&Metric{Name: "always_supported"}}, nil
 }
 
+// getSupportedNvlinkPorts probes each NVLink port with sampleCollector and returns
+// the ports that succeeded. sampleCollector must return errUnsupportedDevice when
+// a port has no supported metrics (e.g. inactive NVLink). Transient NVML failures
+// during discovery must be logged and not returned as errors, so enrollment can
+// continue on other ports. Any other error is treated as fatal and returned
+// (joined across ports), even when some ports succeeded.
 func getSupportedNvlinkPorts(device ddnvml.Device, sampleCollector func(int) ([]Sample, error)) ([]int, error) {
 	totalPorts := device.GetDeviceInfo().NVLinkLinkCount
 	if totalPorts <= 0 {
@@ -258,12 +264,11 @@ func getSupportedNvlinkPorts(device ddnvml.Device, sampleCollector func(int) ([]
 		_, err := sampleCollector(port)
 		if err != nil {
 			if !ddnvml.IsAPIUnsupportedOnDevice(err, device) && !errors.Is(err, errUnsupportedDevice) {
-				// Inactive or unsupported NVLink ports are expected on some
-				// devices, so it should not be considered a full failure.
+				// Genuine NVML failures (e.g. unexpected field IDs) must propagate.
 				fatalErrors = append(fatalErrors, fmt.Errorf("collect samples for port %d: %w", port, err))
 			}
 
-			// do not append a port to the list if there was an error of any kind
+			// Inactive or unsupported NVLink ports are expected on some devices and are skipped below.
 			continue
 		}
 

--- a/pkg/collector/corechecks/gpu/nvidia/helpers.go
+++ b/pkg/collector/corechecks/gpu/nvidia/helpers.go
@@ -257,12 +257,13 @@ func getSupportedNvlinkPorts(device ddnvml.Device, sampleCollector func(int) ([]
 	for port := 1; port <= totalPorts; port++ {
 		_, err := sampleCollector(port)
 		if err != nil {
-			if ddnvml.IsAPIUnsupportedOnDevice(err, device) || errors.Is(err, errUnsupportedDevice) {
-				// Inactive or unsupported NVLink ports are expected on some devices.
-				continue
+			if !ddnvml.IsAPIUnsupportedOnDevice(err, device) && !errors.Is(err, errUnsupportedDevice) {
+				// Inactive or unsupported NVLink ports are expected on some
+				// devices, so it should not be considered a full failure.
+				fatalErrors = append(fatalErrors, fmt.Errorf("collect samples for port %d: %w", port, err))
 			}
 
-			fatalErrors = append(fatalErrors, fmt.Errorf("collect samples for port %d: %w", port, err))
+			// do not append a port to the list if there was an error of any kind
 			continue
 		}
 

--- a/pkg/collector/corechecks/gpu/nvidia/helpers.go
+++ b/pkg/collector/corechecks/gpu/nvidia/helpers.go
@@ -253,16 +253,17 @@ func getSupportedNvlinkPorts(device ddnvml.Device, sampleCollector func(int) ([]
 	}
 
 	var ports []int
-	var portErrors []error
+	var fatalErrors []error
 	for port := 1; port <= totalPorts; port++ {
 		_, err := sampleCollector(port)
 		if err != nil {
-			portErrors = append(portErrors, fmt.Errorf("collect samples for port %d: %w", port, err))
-
 			if ddnvml.IsAPIUnsupportedOnDevice(err, device) || errors.Is(err, errUnsupportedDevice) {
-				// only ignore ports if the error is because the API is unsupported
+				// Inactive or unsupported NVLink ports are expected on some devices.
 				continue
 			}
+
+			fatalErrors = append(fatalErrors, fmt.Errorf("collect samples for port %d: %w", port, err))
+			continue
 		}
 
 		ports = append(ports, port)
@@ -272,5 +273,5 @@ func getSupportedNvlinkPorts(device ddnvml.Device, sampleCollector func(int) ([]
 		return nil, fmt.Errorf("%w: no supported NVLink ports found", errUnsupportedDevice)
 	}
 
-	return ports, errors.Join(portErrors...)
+	return ports, errors.Join(fatalErrors...)
 }

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
@@ -125,9 +125,6 @@ func newNVLinkFieldsCollectorWithMetrics(device ddnvml.Device, metrics map[uint3
 		}
 		return nil, fmt.Errorf("%w: no supported NVLink field metrics found", errUnsupportedDevice)
 	}
-	if err != nil {
-		return nil, fmt.Errorf("get supported NVLink ports: %w", err)
-	}
 
 	return c, nil
 }
@@ -235,12 +232,11 @@ func (c *nvlinkFieldsCollector) discoverPortMetrics(port int) ([]Sample, error) 
 		return nil, err
 	}
 
-	var errs []error
-	var pendingMetrics []nvlinkFieldValueMetric
+	var addedRequests int
 	for _, val := range fields {
 		fieldValueMetric, ok := c.metrics[val.FieldId]
 		if !ok {
-			errs = append(errs, fmt.Errorf("unexpected field value ID %d", val.FieldId))
+			log.Warnf("nvlink: fields collector skipping unexpected field value ID %d for port %d", val.FieldId, port)
 			continue
 		}
 
@@ -255,24 +251,18 @@ func (c *nvlinkFieldsCollector) discoverPortMetrics(port int) ([]Sample, error) 
 			log.Warnf("nvlink: fields collector removing metric %s because it's not supported, error: %s", fieldValueMetric.name, nvml.ErrorString(nvml.Return(val.NvmlReturn)))
 			delete(c.metrics, val.FieldId)
 			continue
-		} else if val.NvmlReturn != uint32(nvml.SUCCESS) {
-			errs = append(errs, fmt.Errorf("failed to get field value %s for port %d: %s", fieldValueMetric.name, port, nvml.ErrorString(nvml.Return(val.NvmlReturn))))
+		}
+		if val.NvmlReturn != uint32(nvml.SUCCESS) {
+			log.Warnf("nvlink: fields collector skipping metric %s for port %d during discovery: %s", fieldValueMetric.name, port, nvml.ErrorString(nvml.Return(val.NvmlReturn)))
 			continue
 		}
 
-		pendingMetrics = append(pendingMetrics, fieldValueMetric)
+		c.addRequest(fieldValueMetric, port)
+		addedRequests++
 	}
 
-	if len(pendingMetrics) == 0 {
-		// All metrics were removed, so we return an error to indicate that the device is unsupported.
+	if addedRequests == 0 {
 		return nil, fmt.Errorf("%w: no metrics to collect", errUnsupportedDevice)
-	}
-	if len(errs) > 0 {
-		return nil, errors.Join(errs...)
-	}
-
-	for _, metric := range pendingMetrics {
-		c.addRequest(metric, port)
 	}
 
 	return nil, nil

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
@@ -252,10 +252,6 @@ func (c *nvlinkFieldsCollector) discoverPortMetrics(port int) ([]Sample, error) 
 			delete(c.metrics, val.FieldId)
 			continue
 		}
-		if val.NvmlReturn != uint32(nvml.SUCCESS) {
-			log.Warnf("nvlink: fields collector skipping metric %s for port %d during discovery: %s", fieldValueMetric.name, port, nvml.ErrorString(nvml.Return(val.NvmlReturn)))
-			continue
-		}
 
 		c.addRequest(fieldValueMetric, port)
 		addedRequests++

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
@@ -124,6 +124,8 @@ func newNVLinkFieldsCollectorWithMetrics(device ddnvml.Device, metrics map[uint3
 			return nil, fmt.Errorf("get supported NVLink ports: %w", err)
 		}
 		return nil, fmt.Errorf("%w: no supported NVLink field metrics found", errUnsupportedDevice)
+	} else if err != nil {
+		log.Warnf("nvlink: errors while discovering port support, still continuing with %d metrics: %v", len(c.requests), err)
 	}
 
 	return c, nil
@@ -240,17 +242,14 @@ func (c *nvlinkFieldsCollector) discoverPortMetrics(port int) ([]Sample, error) 
 			continue
 		}
 
-		// Skip unsupported field/port combinations. Inactive NVLink ports can report
-		// NOT_SUPPORTED even when the same field works on active ports, so do not remove
-		// the metric globally here. Fields that are unsupported on every port simply
-		// never get a request added below.
-		if val.NvmlReturn == uint32(nvml.ERROR_NOT_SUPPORTED) {
+		// We assume that a metric that returns "unsupported" is a permanent failure, so we
+		// skip it for this port. Other ports might still be supported (e.g., inactive ports).
+		// Other failures can be transient, so we keep collecting them later.
+		if val.NvmlReturn == uint32(nvml.ERROR_NOT_SUPPORTED) || (val.NvmlReturn == uint32(nvml.ERROR_INVALID_ARGUMENT) && fieldValueMetric.markUnsupportedOnInvalidArgument) {
+			log.Warnf("nvlink: fields collector skipping metric %s for port %d because it's not supported, error: %s", fieldValueMetric.name, port, nvml.ErrorString(nvml.Return(val.NvmlReturn)))
 			continue
-		}
-		if val.NvmlReturn == uint32(nvml.ERROR_INVALID_ARGUMENT) && fieldValueMetric.markUnsupportedOnInvalidArgument {
-			log.Warnf("nvlink: fields collector removing metric %s because it's not supported, error: %s", fieldValueMetric.name, nvml.ErrorString(nvml.Return(val.NvmlReturn)))
-			delete(c.metrics, val.FieldId)
-			continue
+		} else if val.NvmlReturn != uint32(nvml.SUCCESS) {
+			log.Warnf("nvlink: fields collector saw error %s for metric %s, port %d. Will keep collecting it later", nvml.ErrorString(nvml.Return(val.NvmlReturn)), fieldValueMetric.name, port)
 		}
 
 		c.addRequest(fieldValueMetric, port)

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
@@ -119,13 +119,16 @@ func newNVLinkFieldsCollectorWithMetrics(device ddnvml.Device, metrics map[uint3
 	c.metrics = maps.Clone(metrics)
 
 	_, err := getSupportedNvlinkPorts(device, c.discoverPortMetrics)
+	if err != nil {
+		// errors from getSupportedNvlinkPorts need to be propagated. It's
+		// either "no supported collection" or a critical runtime error.
+		return nil, fmt.Errorf("get supported NVLink ports: %w", err)
+	}
+
+	// Defensive: if no field metrics were enrolled, the device is unsupported.
+	// getSupportedNvlinkPorts should already return errUnsupportedDevice in that case.
 	if len(c.requests) == 0 {
-		if err != nil {
-			return nil, fmt.Errorf("get supported NVLink ports: %w", err)
-		}
 		return nil, fmt.Errorf("%w: no supported NVLink field metrics found", errUnsupportedDevice)
-	} else if err != nil {
-		log.Warnf("nvlink: errors while discovering port support, still continuing with %d metrics: %v", len(c.requests), err)
 	}
 
 	return c, nil
@@ -234,11 +237,12 @@ func (c *nvlinkFieldsCollector) discoverPortMetrics(port int) ([]Sample, error) 
 		return nil, err
 	}
 
+	var errs []error
 	var addedRequests int
 	for _, val := range fields {
 		fieldValueMetric, ok := c.metrics[val.FieldId]
 		if !ok {
-			log.Warnf("nvlink: fields collector skipping unexpected field value ID %d for port %d", val.FieldId, port)
+			errs = append(errs, fmt.Errorf("unexpected field value ID %d for port %d", val.FieldId, port))
 			continue
 		}
 
@@ -256,11 +260,12 @@ func (c *nvlinkFieldsCollector) discoverPortMetrics(port int) ([]Sample, error) 
 		addedRequests++
 	}
 
+	// No fields were supported on this port, so we return an error to indicate that the port is unsupported.
 	if addedRequests == 0 {
 		return nil, fmt.Errorf("%w: no metrics to collect", errUnsupportedDevice)
 	}
 
-	return nil, nil
+	return nil, errors.Join(errs...)
 }
 
 // addRequest adds a request for a metric to the collector. If the request already exists, it adds the port to the existing request.

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
@@ -119,8 +119,11 @@ func newNVLinkFieldsCollectorWithMetrics(device ddnvml.Device, metrics map[uint3
 	c.metrics = maps.Clone(metrics)
 
 	_, err := getSupportedNvlinkPorts(device, c.discoverPortMetrics)
-	if err != nil {
-		return nil, fmt.Errorf("get supported NVLink ports: %w", err)
+	if len(c.requests) == 0 {
+		if err != nil {
+			return nil, fmt.Errorf("get supported NVLink ports: %w", err)
+		}
+		return nil, fmt.Errorf("%w: no supported NVLink field metrics found", errUnsupportedDevice)
 	}
 
 	return c, nil
@@ -238,13 +241,15 @@ func (c *nvlinkFieldsCollector) discoverPortMetrics(port int) ([]Sample, error) 
 			continue
 		}
 
-		// Check first if the field returned unsupported. If it's not supported, we remove
-		// this metric from the collector, even if it's after a later run. The assumption here
-		// is that unsupported fields are returned from the start, and their status does not change.
-		// This way, we avoid having different functions to collect metrics and to check for support.
-		// We also assume that if a field is not supported for a port, it's not supported for any other port.
-		if val.NvmlReturn == uint32(nvml.ERROR_NOT_SUPPORTED) || (val.NvmlReturn == uint32(nvml.ERROR_INVALID_ARGUMENT) && fieldValueMetric.markUnsupportedOnInvalidArgument) {
-			log.Warnf("nvlink: fields collector removing metric %s for port %d because it's not supported, error: %s", fieldValueMetric.name, port, nvml.ErrorString(nvml.Return(val.NvmlReturn)))
+		// Skip unsupported field/port combinations. Inactive NVLink ports can report
+		// NOT_SUPPORTED even when the same field works on active ports, so do not remove
+		// the metric globally here. Fields that are unsupported on every port simply
+		// never get a request added below.
+		if val.NvmlReturn == uint32(nvml.ERROR_NOT_SUPPORTED) {
+			continue
+		}
+		if val.NvmlReturn == uint32(nvml.ERROR_INVALID_ARGUMENT) && fieldValueMetric.markUnsupportedOnInvalidArgument {
+			log.Warnf("nvlink: fields collector removing metric %s because it's not supported, error: %s", fieldValueMetric.name, nvml.ErrorString(nvml.Return(val.NvmlReturn)))
 			delete(c.metrics, val.FieldId)
 			continue
 		} else if val.NvmlReturn != uint32(nvml.SUCCESS) {

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
@@ -125,6 +125,9 @@ func newNVLinkFieldsCollectorWithMetrics(device ddnvml.Device, metrics map[uint3
 		}
 		return nil, fmt.Errorf("%w: no supported NVLink field metrics found", errUnsupportedDevice)
 	}
+	if err != nil {
+		return nil, fmt.Errorf("get supported NVLink ports: %w", err)
+	}
 
 	return c, nil
 }
@@ -233,7 +236,7 @@ func (c *nvlinkFieldsCollector) discoverPortMetrics(port int) ([]Sample, error) 
 	}
 
 	var errs []error
-	addedRequests := 0
+	var pendingMetrics []nvlinkFieldValueMetric
 	for _, val := range fields {
 		fieldValueMetric, ok := c.metrics[val.FieldId]
 		if !ok {
@@ -257,16 +260,22 @@ func (c *nvlinkFieldsCollector) discoverPortMetrics(port int) ([]Sample, error) 
 			continue
 		}
 
-		c.addRequest(fieldValueMetric, port)
-		addedRequests++
+		pendingMetrics = append(pendingMetrics, fieldValueMetric)
 	}
 
-	if addedRequests == 0 {
+	if len(pendingMetrics) == 0 {
 		// All metrics were removed, so we return an error to indicate that the device is unsupported.
 		return nil, fmt.Errorf("%w: no metrics to collect", errUnsupportedDevice)
 	}
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
 
-	return nil, errors.Join(errs...)
+	for _, metric := range pendingMetrics {
+		c.addRequest(metric, port)
+	}
+
+	return nil, nil
 }
 
 // addRequest adds a request for a metric to the collector. If the request already exists, it adds the port to the existing request.

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
@@ -438,13 +438,10 @@ func TestNVlinkFieldsCollectorTreatsInvalidArgumentAsUnsupportedOnlyWhenConfigur
 
 	fc, ok := collector.(*nvlinkFieldsCollector)
 	require.True(t, ok, "expected *nvlinkFieldsCollector")
+	require.NotEmpty(t, fc.requests)
 
-	foundNvlinkEffective := false
-	for _, metric := range fc.metrics {
-		if metric.name == "nvlink.errors.effective" {
-			foundNvlinkEffective = true
-		}
+	for _, request := range fc.requests {
+		require.NotEqual(t, uint32(nvml.FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS), request.field.FieldId,
+			"nvlink.errors.effective should not be enrolled when INVALID_ARGUMENT is mapped to unsupported")
 	}
-
-	require.False(t, foundNvlinkEffective, "nvlink.errors.effective should be removed when INVALID_ARGUMENT is explicitly mapped to unsupported")
 }

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
@@ -296,7 +296,7 @@ func TestNVLinkFieldsCollectorInactivePortsDoNotRemoveActivePortMetrics(t *testi
 	require.Equal(t, 4, speedMetrics, "active NVLink ports should still emit nvlink.speed")
 }
 
-func TestNVLinkFieldsCollectorSkipsTransientDiscoveryErrorsPerField(t *testing.T) {
+func TestNVLinkFieldsCollectorEnrollsFieldsDespiteTransientDiscoveryErrors(t *testing.T) {
 	device := setupMockDevice(t, testutil.WithCustomHook(func(d *testutil.MockDevice) {
 		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
 			for i := range fv {
@@ -321,38 +321,12 @@ func TestNVLinkFieldsCollectorSkipsTransientDiscoveryErrorsPerField(t *testing.T
 			priority:     MediumLow,
 			metricType:   metrics.GaugeType,
 		},
-		nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX: {
-			name:                "nvlink.throughput.data.rx",
-			fieldValueID:        nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX,
-			addTotalMetric:      true,
-			metricType:          metrics.GaugeType,
-			rateCalculationMode: PerSecondRateCalculation,
-		},
 	})
 	require.NoError(t, err)
 
-	collected, err := collector.Collect()
-	require.NoError(t, err)
-
-	speedByPort := make(map[string]int)
-	throughputByPort := make(map[string]int)
-	for _, metric := range requireMetrics(t, collected) {
-		switch metric.Name {
-		case "nvlink.speed":
-			for _, tag := range metric.Tags() {
-				speedByPort[tag]++
-			}
-		case "nvlink.throughput.data.rx":
-			for _, tag := range metric.Tags() {
-				throughputByPort[tag]++
-			}
-		}
-	}
-
-	require.Equal(t, 1, speedByPort["nvlink_port:1"])
-	require.NotContains(t, speedByPort, "nvlink_port:2")
-	require.Equal(t, 1, throughputByPort["nvlink_port:1"])
-	require.Equal(t, 1, throughputByPort["nvlink_port:2"])
+	_, err = collector.Collect()
+	require.Error(t, err)
+	require.ErrorContains(t, err, nvml.ErrorString(nvml.ERROR_UNKNOWN))
 }
 
 func TestNVLinkFieldsCollectorReturnsErrorsForUnsupportedCollectedFields(t *testing.T) {

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
@@ -296,7 +296,7 @@ func TestNVLinkFieldsCollectorInactivePortsDoNotRemoveActivePortMetrics(t *testi
 	require.Equal(t, 4, speedMetrics, "active NVLink ports should still emit nvlink.speed")
 }
 
-func TestNVLinkFieldsCollectorReturnsDiscoveryErrorsWhenSomeRequestsSucceed(t *testing.T) {
+func TestNVLinkFieldsCollectorSkipsTransientDiscoveryErrorsPerField(t *testing.T) {
 	device := setupMockDevice(t, testutil.WithCustomHook(func(d *testutil.MockDevice) {
 		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
 			for i := range fv {
@@ -314,7 +314,7 @@ func TestNVLinkFieldsCollectorReturnsDiscoveryErrorsWhenSomeRequestsSucceed(t *t
 		}
 	}), testutil.WithNVLinkLinkCount(2))
 
-	_, err := newNVLinkFieldsCollectorWithMetrics(device, map[uint32]nvlinkFieldValueMetric{
+	collector, err := newNVLinkFieldsCollectorWithMetrics(device, map[uint32]nvlinkFieldValueMetric{
 		nvml.FI_DEV_NVLINK_GET_SPEED: {
 			name:         "nvlink.speed",
 			fieldValueID: nvml.FI_DEV_NVLINK_GET_SPEED,
@@ -329,9 +329,30 @@ func TestNVLinkFieldsCollectorReturnsDiscoveryErrorsWhenSomeRequestsSucceed(t *t
 			rateCalculationMode: PerSecondRateCalculation,
 		},
 	})
-	require.Error(t, err)
-	require.ErrorContains(t, err, "get supported NVLink ports")
-	require.ErrorContains(t, err, nvml.ErrorString(nvml.ERROR_UNKNOWN))
+	require.NoError(t, err)
+
+	collected, err := collector.Collect()
+	require.NoError(t, err)
+
+	speedByPort := make(map[string]int)
+	throughputByPort := make(map[string]int)
+	for _, metric := range requireMetrics(t, collected) {
+		switch metric.Name {
+		case "nvlink.speed":
+			for _, tag := range metric.Tags() {
+				speedByPort[tag]++
+			}
+		case "nvlink.throughput.data.rx":
+			for _, tag := range metric.Tags() {
+				throughputByPort[tag]++
+			}
+		}
+	}
+
+	require.Equal(t, 1, speedByPort["nvlink_port:1"])
+	require.NotContains(t, speedByPort, "nvlink_port:2")
+	require.Equal(t, 1, throughputByPort["nvlink_port:1"])
+	require.Equal(t, 1, throughputByPort["nvlink_port:2"])
 }
 
 func TestNVLinkFieldsCollectorReturnsErrorsForUnsupportedCollectedFields(t *testing.T) {

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
@@ -253,7 +253,47 @@ func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
 	}
 
 	require.Contains(t, requestedFieldsByScope[0], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
-	require.NotContains(t, requestedFieldsByScope[1], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
+	require.Contains(t, requestedFieldsByScope[1], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
+}
+
+func TestNVLinkFieldsCollectorInactivePortsDoNotRemoveActivePortMetrics(t *testing.T) {
+	device := setupMockDevice(t, testutil.WithCustomHook(func(d *testutil.MockDevice) {
+		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
+			for i := range fv {
+				if fv[i].FieldId == nvml.FI_DEV_NVLINK_LINK_COUNT {
+					testutil.ApplyMockFieldValue(&fv[i], testutil.NewFieldValue(6))
+					continue
+				}
+				if fv[i].ScopeId >= 4 {
+					fv[i].NvmlReturn = uint32(nvml.ERROR_NOT_SUPPORTED)
+					continue
+				}
+				testutil.ApplyMockFieldValue(&fv[i], testutil.DefaultFieldValues[fv[i].FieldId])
+			}
+			return nvml.SUCCESS
+		}
+	}), testutil.WithNVLinkLinkCount(6))
+
+	collector, err := newNVLinkFieldsCollectorWithMetrics(device, map[uint32]nvlinkFieldValueMetric{
+		nvml.FI_DEV_NVLINK_GET_SPEED: {
+			name:         "nvlink.speed",
+			fieldValueID: nvml.FI_DEV_NVLINK_GET_SPEED,
+			priority:     MediumLow,
+			metricType:   metrics.GaugeType,
+		},
+	})
+	require.NoError(t, err)
+
+	collected, err := collector.Collect()
+	require.NoError(t, err)
+
+	speedMetrics := 0
+	for _, metric := range requireMetrics(t, collected) {
+		if metric.Name == "nvlink.speed" {
+			speedMetrics++
+		}
+	}
+	require.Equal(t, 4, speedMetrics, "active NVLink ports should still emit nvlink.speed")
 }
 
 func TestNVLinkFieldsCollectorReturnsErrorsForUnsupportedCollectedFields(t *testing.T) {

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
@@ -209,7 +209,7 @@ func TestNVLinkFieldsCollectorAddsTotals(t *testing.T) {
 	require.Equal(t, 1, rawTXTotalCount, "expected exactly one raw TX total metric")
 }
 
-func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
+func TestNVLinkFieldsCollectorSkipsUnsupportedFieldEnrollment(t *testing.T) {
 	var requestedFieldsByScope = make(map[uint32][]uint32)
 	device := setupMockDevice(t, testutil.WithCustomHook(func(d *testutil.MockDevice) {
 		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
@@ -245,6 +245,12 @@ func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+
+	for _, request := range collector.requests {
+		require.NotEqual(t, uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS), request.field.FieldId,
+			"unsupported fields should not be enrolled")
+	}
+
 	collected, err := collector.Collect()
 	require.NoError(t, err)
 
@@ -323,6 +329,15 @@ func TestNVLinkFieldsCollectorEnrollsFieldsDespiteTransientDiscoveryErrors(t *te
 		},
 	})
 	require.NoError(t, err)
+
+	var enrolledPort2Speed bool
+	for _, request := range collector.requests {
+		if request.field.FieldId == nvml.FI_DEV_NVLINK_GET_SPEED && request.field.ScopeId == 1 {
+			enrolledPort2Speed = true
+			require.Contains(t, request.ports, 2)
+		}
+	}
+	require.True(t, enrolledPort2Speed, "port 2 speed should be enrolled despite transient discovery error")
 
 	_, err = collector.Collect()
 	require.Error(t, err)

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
@@ -296,6 +296,44 @@ func TestNVLinkFieldsCollectorInactivePortsDoNotRemoveActivePortMetrics(t *testi
 	require.Equal(t, 4, speedMetrics, "active NVLink ports should still emit nvlink.speed")
 }
 
+func TestNVLinkFieldsCollectorReturnsDiscoveryErrorsWhenSomeRequestsSucceed(t *testing.T) {
+	device := setupMockDevice(t, testutil.WithCustomHook(func(d *testutil.MockDevice) {
+		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
+			for i := range fv {
+				if fv[i].FieldId == nvml.FI_DEV_NVLINK_LINK_COUNT {
+					testutil.ApplyMockFieldValue(&fv[i], testutil.NewFieldValue(2))
+					continue
+				}
+				if fv[i].ScopeId == 1 && fv[i].FieldId == nvml.FI_DEV_NVLINK_GET_SPEED {
+					fv[i].NvmlReturn = uint32(nvml.ERROR_UNKNOWN)
+					continue
+				}
+				testutil.ApplyMockFieldValue(&fv[i], testutil.DefaultFieldValues[fv[i].FieldId])
+			}
+			return nvml.SUCCESS
+		}
+	}), testutil.WithNVLinkLinkCount(2))
+
+	_, err := newNVLinkFieldsCollectorWithMetrics(device, map[uint32]nvlinkFieldValueMetric{
+		nvml.FI_DEV_NVLINK_GET_SPEED: {
+			name:         "nvlink.speed",
+			fieldValueID: nvml.FI_DEV_NVLINK_GET_SPEED,
+			priority:     MediumLow,
+			metricType:   metrics.GaugeType,
+		},
+		nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX: {
+			name:                "nvlink.throughput.data.rx",
+			fieldValueID:        nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX,
+			addTotalMetric:      true,
+			metricType:          metrics.GaugeType,
+			rateCalculationMode: PerSecondRateCalculation,
+		},
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "get supported NVLink ports")
+	require.ErrorContains(t, err, nvml.ErrorString(nvml.ERROR_UNKNOWN))
+}
+
 func TestNVLinkFieldsCollectorReturnsErrorsForUnsupportedCollectedFields(t *testing.T) {
 	collecting := false
 	device := setupMockDevice(t, testutil.WithCustomHook(func(d *testutil.MockDevice) {


### PR DESCRIPTION
### What does this PR do?

Restores NVLink field metrics on GPUs where some NVLink ports are inactive but others are active. The logic for detecting support in NVLink collectors is also clarified in comments/code.

### Motivation

Inactive NVLink ports can return `NOT_SUPPORTED` for field IDs that work on active ports. The collector treated that as globally unsupported and dropped metrics such as throughput and speed.

### Describe how you validated your changes

Unit tests added. GPU integration tests on H100 NVL: 172 passed; remaining failures are unrelated Hopper legacy error-counter fields (follow-up PR).

### Additional Notes