### PR TITLE
[ACIX-1708] Add triage-ci-failure skill

### DIFF
--- a/.agents/skills/follow-pr/SKILL.md
+++ b/.agents/skills/follow-pr/SKILL.md
@@ -83,21 +83,53 @@ You may see:
 ## Step 4: Act on the outcome
 
 - **Pipeline Success:** stop monitoring and report the pipeline succeeded.
-- **Some job failed, but the pipeline is still running**: 
-    Note that most jobs on `datadog-agent` CI have at least one retry for combating flakiness - especially jobs running e2e tests, kmt etc.
-    Unit test, linter or build failures are less likely to be flakes. If you think it is likely the job's failure is just a flake, continue monitoring - gitlab will retry the job once automatically.
-    Otherwise, ask the user whether to continue monitoring, or if this job failure is already a problem. In the latter case, move to [Step 5](#step-5-follow-up-on-failures)
+- **Some job failed, but the pipeline is still running**:
+    Most jobs on `datadog-agent` CI retry once automatically on any failure (`.gitlab-ci.yml`'s
+    default `retry: max: 1, when: always`), so a first-attempt failure alone isn't yet evidence
+    of anything — GitLab will retry it once. A minority of jobs (most e2e, Windows, macOS —
+    `.retry_only_infra_failure`) retry only on GitLab's infra-flavoured `failure_reason` values,
+    so a `script_failure` there gets no automatic retry at all and is worth a closer look sooner.
+    Unit test, linter, and build failures are less likely to be flakes regardless of policy.
+    If you're unsure which policy a job is on: `grep -rn '<job-name>' .gitlab/ .gitlab-ci.yml`.
+    Otherwise, ask the user whether to continue monitoring, or if this job failure is already a
+    problem. In the latter case, move to [Step 5](#step-5-follow-up-on-failures).
 - **Pipeline failed or canceled:** Stop monitoring, report the status, and move to [Step 5](#step-5-follow-up-on-failures).
 - **Timeout `[FINAL]`:** re-invoke `ddgl attach` as in Step 2; this is not a true terminal outcome.
 - **Unexpected error** (from `ddgl` itself, or from the monitoring tool): report what happened. Do not attempt a recovery action.
 
 ## Step 5: follow-up on failures
-Use other `ddgl` features to investigate failures on the pipeline that failed
-Using the pipeline id from the `[FINAL]` line:
-1. `ddgl jobs get --pipeline <id> --failed --json` — failed-job metadata.
-2. `mkdir -p failures && ddgl logs --pipeline <id> --failed --output failures/` — export failed-job log output to `failures/`
-3. Compare the failure evidence against the current PR's diff. Decide
-    whether the failure is likely caused by this PR, needs more evidence, or
-    is unrelated (e.g. flaky infra, an unrelated pre-existing failure).
-4. If PR-caused, propose the smallest concrete fix — do not apply it. If
-    not, or inconclusive, report the evidence and your reasoning.
+
+Invoke `/triage-ci-failure` on the pipeline id from the `[FINAL]` line. It classifies each
+failed job as caused by an active incident, infra/platform flakiness, a code regression, or
+ordinary flakiness, and ends with a verdict plus an `Incident: ...` line per job.
+
+Act on the verdict in context — there is no file or schema to read back, only the
+conversation. If any job's verdict names an **unresolved** incident, continue to
+[Step 6](#step-6-watch-an-unresolved-incident). Otherwise this is where the investigation
+ends: report the verdict, and if it's PR-caused, the proposed fix (still don't apply it).
+
+## Step 6: watch an unresolved incident
+
+Only entered when `/triage-ci-failure` reported `Incident: IR-xxxxx (... unresolved)` for a
+failed job — this is the other half of watching a PR through: the pipeline is red because
+of something outside the PR, and it will stay red until that something is fixed.
+
+Poll the incident on an interval (a few minutes is reasonable; don't busy-loop):
+
+```bash
+.agents/skills/triage-ci-failure/scripts/incidents.py timeline <IR-nnnnn>
+```
+
+Watch for a state transition to `stable`/`resolved`, or a note describing a rollback or a
+merged fix. Once the timeline says it's fixed, confirm recovery before telling the user to
+act — check that the job is passing again on `main`:
+
+```bash
+pup cicd events aggregate \
+  --query='ci_level:job @ci.pipeline.name:DataDog/datadog-agent @git.branch:main @ci.job.name:"<job name>"' \
+  --compute=count --group-by='@ci.status' --from='2h'
+```
+
+Once `main` is clean, tell the user the incident is resolved and it's time to rebase onto
+`main` and re-run. If the incident stays open for a long time, periodically restate its
+current state rather than going silent.

--- a/.agents/skills/follow-pr/SKILL.md
+++ b/.agents/skills/follow-pr/SKILL.md
@@ -103,16 +103,17 @@ Invoke `/triage-ci-failure` on the pipeline id from the `[FINAL]` line. It class
 failed job as caused by an active incident, infra/platform flakiness, a code regression, or
 ordinary flakiness, and ends with a verdict plus an `Incident: ...` line per job.
 
-Act on the verdict in context — there is no file or schema to read back, only the
-conversation. If any job's verdict names an **unresolved** incident, continue to
-[Step 6](#step-6-watch-an-unresolved-incident). Otherwise this is where the investigation
-ends: report the verdict, and if it's PR-caused, the proposed fix (still don't apply it).
+Act on the verdict in context — there is no file or schema to read back, only the conversation.
+The `Incident:` line tells you what to do next:
+- **active, still breaking** — continue to [Step 6](#step-6-watch-an-unresolved-incident) andwait it out.
+- **stable** or **resolved** — tell the user it's safe to rebase onto `main` and re-run, saying plainly that `stable` is a weaker signal than `resolved` (the fix may still be in progress).
+  Investigation ends here.
+- **none, or no incident at all** — report the verdict, and if it's PR-caused, the proposed fix (still don't apply it). Investigation ends here.
 
 ## Step 6: watch an unresolved incident
 
-Only entered when `/triage-ci-failure` reported `Incident: IR-xxxxx (... unresolved)` for a
-failed job — this is the other half of watching a PR through: the pipeline is red because
-of something outside the PR, and it will stay red until that something is fixed.
+Only entered when `/triage-ci-failure` reported an incident that's still **active and breaking** for a failed job — this is the other half of watching a PR through:
+the pipeline is red because of something outside the PR, and it will stay red until that something changes.
 
 Poll the incident on an interval (a few minutes is reasonable; don't busy-loop):
 
@@ -120,9 +121,8 @@ Poll the incident on an interval (a few minutes is reasonable; don't busy-loop):
 .agents/skills/triage-ci-failure/scripts/incidents.py timeline <IR-nnnnn>
 ```
 
-Watch for a state transition to `stable`/`resolved`, or a note describing a rollback or a
-merged fix. Once the timeline says it's fixed, confirm recovery before telling the user to
-act — check that the job is passing again on `main`:
+Watch for a state transition off `active` — to `stable` (a rollback or workaround has likely landed; rebasing is probably safe even if the root cause isn't fully fixed yet) or `resolved`/`completed` (the stronger signal).
+Once either happens, confirm recovery before telling the user to act — check that the job is passing again on `main`:
 
 ```bash
 pup cicd events aggregate \
@@ -130,6 +130,4 @@ pup cicd events aggregate \
   --compute=count --group-by='@ci.status' --from='2h'
 ```
 
-Once `main` is clean, tell the user the incident is resolved and it's time to rebase onto
-`main` and re-run. If the incident stays open for a long time, periodically restate its
-current state rather than going silent.
+Once `main` is clean, tell the user it's time to rebase onto `main` and re-run.

--- a/.agents/skills/triage-ci-failure/SKILL.md
+++ b/.agents/skills/triage-ci-failure/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: triage-ci-failure
 description: >-
-  Classify a failed GitLab CI job as caused by an active incident, infra/platform
-  flakiness, a code regression, or ordinary flakiness, backed by evidence, before
-  proposing a fix or a retry. Use when a PR's pipeline is red and it isn't obvious
-  whether the PR's own changes are at fault — trigger phrases include "triage this
-  CI failure", "is this failure my fault", "why did this job fail", "is there an
-  incident affecting CI", "should I retry or fix this", "is this job flaky". Also
-  invoked by /follow-pr once a pipeline is confirmed failed.
+  Classify a failed CI as either caused by an active incident, flakiness, or a true code regression. 
+  Use when a PR's pipeline is red and it isn't obvious whether the PR's own changes are at fault.
+  Trigger phrases include:
+  - "investigate this CI failure"
+  - "please fix CI"
+  - "why did this job fail"
+  - "is there an incident affecting CI"
+  - "should I retry this"
+  This should also be invoked whenever the user asks you to investigate _or fix_ a failing CI, to ensure we don't spend hours trying to fix something broken upstream.
 model: sonnet
 ---
 
@@ -15,40 +17,22 @@ model: sonnet
 
 ## Goal
 
-Answer one question with evidence, not a hunch: **is this failure caused by this
-PR's own changes, or by something outside it** (an incident, a platform blip,
-ordinary flakiness)? Two failure modes to avoid: burning an hour investigating a
-platform outage as if it were a code bug, and waving away a real regression as
-"probably flaky" because CI is noisy. Every verdict below must cite the evidence
-that produced it — a bare "looks flaky, retry" or "looks broken, fix it" is not an
-acceptable output.
+Answer one question: **is this failure caused by this PR's own changes ?** with hard evidence.
+Every verdict below must cite the evidence that produced it — a bare "looks flaky, retry" or "looks broken, fix it" is not an acceptable output.
 
-This skill only diagnoses. It proposes a fix, a retry, or a wait — it never applies
-a fix, retries a job, or rebases on its own. `.agents/skills/follow-pr/SKILL.md`
-invokes this skill once a pipeline is confirmed failed and acts on the verdict from
-there, including watching an unresolved incident through to resolution.
+This skill only diagnoses. Never take action (writing a fix, retrying a job) on your own: only present your investigation results to the user.
 
 ## Step 0 — Preflight
 
-Both `ddgl` and `pup` are required, and both live in the same places: locally, or
-inside a `dda env dev`. Reuse the fallback already written for `ddgl` in
-`.agents/skills/follow-pr/SKILL.md` ("Step 0: Ensure correct environment") rather
-than re-deriving it — `pup` lives alongside it, so one fallback covers both tools.
+Both `ddgl` and `pup` are required, and both live in the same places: locally, or inside a `dda env dev`.
 
 ```bash
 which ddgl pup
 ```
 
-This skill requires a `ddgl` build where `--failed` excludes `allow_failure: true`
-jobs and `--json` prints `[]` rather than a sentence on an empty result. If Step 1
-doesn't behave as documented, upgrade `ddgl` — don't work around it here.
-
-If `pup` is present but not authenticated, either run `pup auth login` (browser
-prompts started inside a dev env are forwarded back to the host) or use the
-`dd-auth` skill for the non-interactive `DD_API_KEY`/`DD_APP_KEY` path. If `pup`
-can't be made to work, say so and continue with Steps 1 and 4 only — Steps 2 and 3
-are unavailable, and the verdict should state that limitation rather than silently
-producing a weaker one.
+If `pup` is present but not authenticated, either run `pup auth login` or use the `dd-auth` skill.
+If `pup` can't be made to work, say so and continue with Steps 1 and 4 only:
+Steps 2 and 3 are unavailable, and the verdict should state that limitation rather than silently producing a weaker one.
 
 ## Step 1 — Collect the failures
 
@@ -64,23 +48,16 @@ Also fetch pipeline state:
 ddgl pipelines get --json [--ref <ref> | --pipeline <id>]
 ```
 
-If the pipeline is **still running**, a job you're about to triage may yet be
-auto-retried into success — note that in the verdict rather than treating the
-failure as final.
+If the pipeline is **still running**, a job you're about to triage may yet be auto-retried into success.
+Note that in the verdict rather than treating the failure as final.
 
-For each failed job, look at its `failure_reason`. Treat it as **one input, not a
-verdict** — see `references/signals.md` for why (`runner_system_failure` is also
-exactly what a misspelled `image:` reference produces). If `failure_reason` is one
-of GitLab's infra-flavoured values *and* the PR touches no CI config and no test
-setup, that conjunction is decent evidence the failure is unrelated to the diff.
-Either way, continue to Step 2 — nothing here should end the investigation early.
+For each failed job, look at its `failure_reason`, i.e. the failure reason as determined by gitlab.
+Treat it as an aditionnal data point, not the be-all-end-all. For example, a `runner_system_failure` can be caused by a change of this PR (e.g. a malformed `image:`).
+See @references/signal.md for more details.
 
 ## Step 2 — CI Visibility baseline
 
-This is usually the most decisive step, and it comes before incident search on
-purpose: a job failing on `main` right now is broken for everyone whether or not
-anyone has declared an incident yet, and a job that's flaky everywhere doesn't need
-an incident to explain it.
+Check if this job is failing _everywhere_ (i.e. on `main`), or if it is often flaky using CI Visibility.
 
 For each failed job, ask how it behaves elsewhere:
 
@@ -90,22 +67,14 @@ pup cicd events aggregate \
   --compute=count --group-by='@ci.status' --from='2d'
 ```
 
-Load `references/signals.md` here for the full recipe — the parallel-job wildcard
-form, the infra-exclusion pass, the three-baseline comparison (`main`, all
-branches, this branch), and how to read the counts. Come out of this step with a
-working hypothesis (`upstream`, `flake`, or `pr-code`) for later steps to confirm
-or overturn — not a final verdict.
+Check @references/signals.md for additional queries that can help if this first one is inconclusive.
+Come out of this step with a working hypothesis (`upstream`, `flake`, or `pr-code`) for later steps to confirm or overturn — not a final verdict.
 
 ## Step 3 — Incident correlation
 
-Worth doing thoroughly if Step 2 pointed at `upstream` or `flake`. If Step 2
-pointed cleanly at `pr-code`, skip to Step 4 unless something else is nagging at
-you.
+If Step 2 pointed clearly at `pr-code`, skip to Step 4.
 
-`scripts/incidents.py`, colocated with this file, owns the fiddly parts: turning a
-failure timestamp and window into the right Datadog queries, and matching a job
-name against an incident's auto-generated title. Run it rather than reimplementing
-the query logic by hand:
+Use the helper script to search for an active CI incident matching the failing job:
 
 ```bash
 .agents/skills/triage-ci-failure/scripts/incidents.py search \
@@ -113,51 +82,40 @@ the query logic by hand:
   --job '<exact failing job name>' [--job '<another one>' ...]
 ```
 
-Read the match tier in the output (`exact`, `base`, `prefix`, `token`, `none`) —
-anything but `none` is worth reading the timeline for:
+Read the match tier in the output (`exact`, `base`, `prefix`, `token`, `none`) — anything but `none` is worth reading the timeline for:
 
 ```bash
 .agents/skills/triage-ci-failure/scripts/incidents.py timeline <IR-nnnnn>
 ```
 
-This collapses tens of KB of Slack-mirror noise down to the handful of lines that
-matter: state transitions and human notes. This is where you find out whether the
-incident is already fixed (look for a rollback, a merged fix PR, a transition to
-`stable`/`resolved`) or still open. **`state != active` does not mean fixed** —
-`stable` just means "under control", and `resolved` (null or not) is the field
-that actually says whether anyone has closed it out.
+This is where you find out whether the incident is already fixed (look for a rollback, a merged fix PR, a transition to `stable`/`resolved`) or still open.
 
-If nothing matches, widen deliberately rather than re-running the same call —
-escalate through the tier ladder in `references/signals.md`:
+If nothing matches, widen deliberately rather than re-running the same call — escalate through the tier ladder in `references/signals.md`:
 1. *(default, above)* `services:datadog-agent-ci`, default window.
-2. Same, a much wider window — for old branches whose failure was fixed on `main`
-   long before you rebased onto them.
-3. Drop the service filter, search free text instead, using a keyword pulled from
-   the job log in Step 4 (an image reference, a host, an endpoint, a bucket name).
+2. Same, a much wider window — for old branches whose failure was fixed on `main` long before you rebased onto them.
+3. Drop the service filter, search free text instead, using a keyword pulled from the job log in Step 4 (an image reference, a host, an endpoint, a bucket name).
 
 ## Step 4 — Read the log
 
 Skip this if Step 3 already produced a confident, timeline-corroborated verdict.
-Otherwise, work through `references/evidence.md`'s cookbook — it's ordered
-cheapest-first specifically so you never dump a 50,000-line trace into context.
-You're looking for two things: the command that actually failed and its exit
-status, and whether the failure happened in the job's own work or in its setup/
-teardown. Prefer error text that names something concrete — that's exactly what
-tier 3 of Step 3 needs if you end up going back to it.
+
+Otherwise, work through @references/evidence.md's cookbook.
+
+You're looking for two things:
+1. the command that actually failed and its exit status
+2. whether the failure happened in the job's own work or in its setup/teardown.
+
 
 ## Step 5 — Verdict
 
-State two things separately, because they answer different questions and
-collapsing them loses information: **blame** (`pr-code`, `upstream`, `infra`,
-`flake`, or `inconclusive`) and, if relevant, **which incident** — with its ID and
-state, or explicitly `none`.
+State your verdict among the below options, as well as a recommended course of action and the linked incident if any.
 
-| blame | incident | Say this |
+| blame | incident status | Suggested action |
 |---|---|---|
 | `pr-code` | — | Propose the smallest concrete fix. Don't apply it. |
 | `upstream` | unresolved | Don't suggest rebasing yet. Report the incident. |
 | `upstream` | resolved | Rebase onto latest `main` and re-run. Name the fixing commit/PR if the timeline gave you one. |
-| `upstream` | none declared | Say CI is broken on `main` with nothing declared for it — worth surfacing loudly. |
+| `upstream` | none declared | Say CI looks broken on `main` with nothing declared for it — worth surfacing loudly. |
 | `infra` | any | Suggest a retry. Note whether the job already burned its one automatic retry (`references/signals.md`). |
 | `flake` | any | Suggest a retry, citing the measured cross-branch failure rate from Step 2 as the reason — not just a feeling. |
 | `inconclusive` | any | Present the evidence and the two most likely readings. Don't guess past what you found. |
@@ -170,13 +128,3 @@ reasoning:
 Incident: IR-59848 (stable, unresolved) — https://app.datadoghq.com/incidents/59848
 Incident: none
 ```
-
-## Reference material
-
-- `references/signals.md` — the retry-policy prior and its exceptions, why
-  `failure_reason` is a hint and not a verdict, and the full CI Visibility query
-  recipe with the three baselines and how to read them, plus the incident-search
-  tier ladder. Load it in Step 1 (retry policy, `failure_reason`) and Steps 2–3
-  (CI Visibility, tier ladder).
-- `references/evidence.md` — the log-reading cookbook and what to look for. Load
-  it in Step 4.

--- a/.agents/skills/triage-ci-failure/SKILL.md
+++ b/.agents/skills/triage-ci-failure/SKILL.md
@@ -53,7 +53,7 @@ Note that in the verdict rather than treating the failure as final.
 
 For each failed job, look at its `failure_reason`, i.e. the failure reason as determined by gitlab.
 Treat it as an aditionnal data point, not the be-all-end-all. For example, a `runner_system_failure` can be caused by a change of this PR (e.g. a malformed `image:`).
-See @references/signal.md for more details.
+See @references/signals.md for more details.
 
 ## Step 2 — CI Visibility baseline
 
@@ -88,7 +88,11 @@ Read the match tier in the output (`exact`, `base`, `prefix`, `token`, `none`) �
 .agents/skills/triage-ci-failure/scripts/incidents.py timeline <IR-nnnnn>
 ```
 
-This is where you find out whether the incident is already fixed (look for a rollback, a merged fix PR, a transition to `stable`/`resolved`) or still open.
+This is where you find out how far along the fix is — not just whether one exists.
+- `stable` usually means a rollback or workaround has already landed and the affected job(s) should pass again on a rebase.
+- `resolved` (or `completed`) is the stronger signal: the incident is fully closed out.
+
+Look for a rollback, a merged fix PR, or an explicit state transition to tell which.
 
 If nothing matches, widen deliberately rather than re-running the same call — escalate through the tier ladder in `references/signals.md`:
 1. *(default, above)* `services:datadog-agent-ci`, default window.
@@ -97,14 +101,20 @@ If nothing matches, widen deliberately rather than re-running the same call — 
 
 ## Step 4 — Read the log
 
-Skip this if Step 3 already produced a confident, timeline-corroborated verdict.
+Always do a quick sanity check here, even when Step 3 was conclusive — a time-and-name correlation is strong evidence but not proof.
+Skim the job's diff against `main` and the last ~50 lines of its log, and confirm the failure signature actually looks like what the incident describes.
 
-Otherwise, work through @references/evidence.md's cookbook.
+You can obtain the job's log via `ddgl`:
+```bash
+ddgl logs --job <ID> [--output <some_file>]
+```
+
+If it lines up, you're done — the full cookbook below is skippable.
+If it doesn't, or Step 3 didn't produce a confident match at all, work through @references/evidence.md's cookbook.
 
 You're looking for two things:
 1. the command that actually failed and its exit status
 2. whether the failure happened in the job's own work or in its setup/teardown.
-
 
 ## Step 5 — Verdict
 
@@ -113,8 +123,9 @@ State your verdict among the below options, as well as a recommended course of a
 | blame | incident status | Suggested action |
 |---|---|---|
 | `pr-code` | — | Propose the smallest concrete fix. Don't apply it. |
-| `upstream` | unresolved | Don't suggest rebasing yet. Report the incident. |
-| `upstream` | resolved | Rebase onto latest `main` and re-run. Name the fixing commit/PR if the timeline gave you one. |
+| `upstream` | active, still breaking | Don't suggest rebasing yet. Report the incident. |
+| `upstream` | stable | Suggest a rebase and retry — `stable` usually means a rollback or workaround already landed — but say plainly that this is a weaker signal than `resolved`: the underlying fix may still be in progress. |
+| `upstream` | resolved | Rebase onto latest `main` and re-run with confidence. Name the fixing commit/PR if the timeline gave you one. |
 | `upstream` | none declared | Say CI looks broken on `main` with nothing declared for it — worth surfacing loudly. |
 | `infra` | any | Suggest a retry. Note whether the job already burned its one automatic retry (`references/signals.md`). |
 | `flake` | any | Suggest a retry, citing the measured cross-branch failure rate from Step 2 as the reason — not just a feeling. |
@@ -125,6 +136,8 @@ these, so a caller like `/follow-pr` can act on it without re-deriving your
 reasoning:
 
 ```
-Incident: IR-59848 (stable, unresolved) — https://app.datadoghq.com/incidents/59848
+Incident: IR-59848 (active, still breaking) — https://app.datadoghq.com/incidents/59848
+Incident: IR-59848 (stable, probably safe to retry) — https://app.datadoghq.com/incidents/59848
+Incident: IR-59848 (resolved) — https://app.datadoghq.com/incidents/59848
 Incident: none
 ```

--- a/.agents/skills/triage-ci-failure/SKILL.md
+++ b/.agents/skills/triage-ci-failure/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: triage-ci-failure
+description: >-
+  Classify a failed GitLab CI job as caused by an active incident, infra/platform
+  flakiness, a code regression, or ordinary flakiness, backed by evidence, before
+  proposing a fix or a retry. Use when a PR's pipeline is red and it isn't obvious
+  whether the PR's own changes are at fault — trigger phrases include "triage this
+  CI failure", "is this failure my fault", "why did this job fail", "is there an
+  incident affecting CI", "should I retry or fix this", "is this job flaky". Also
+  invoked by /follow-pr once a pipeline is confirmed failed.
+model: sonnet
+---
+
+# Triage CI failure
+
+## Goal
+
+Answer one question with evidence, not a hunch: **is this failure caused by this
+PR's own changes, or by something outside it** (an incident, a platform blip,
+ordinary flakiness)? Two failure modes to avoid: burning an hour investigating a
+platform outage as if it were a code bug, and waving away a real regression as
+"probably flaky" because CI is noisy. Every verdict below must cite the evidence
+that produced it — a bare "looks flaky, retry" or "looks broken, fix it" is not an
+acceptable output.
+
+This skill only diagnoses. It proposes a fix, a retry, or a wait — it never applies
+a fix, retries a job, or rebases on its own. `.agents/skills/follow-pr/SKILL.md`
+invokes this skill once a pipeline is confirmed failed and acts on the verdict from
+there, including watching an unresolved incident through to resolution.
+
+## Step 0 — Preflight
+
+Both `ddgl` and `pup` are required, and both live in the same places: locally, or
+inside a `dda env dev`. Reuse the fallback already written for `ddgl` in
+`.agents/skills/follow-pr/SKILL.md` ("Step 0: Ensure correct environment") rather
+than re-deriving it — `pup` lives alongside it, so one fallback covers both tools.
+
+```bash
+which ddgl pup
+```
+
+This skill requires a `ddgl` build where `--failed` excludes `allow_failure: true`
+jobs and `--json` prints `[]` rather than a sentence on an empty result. If Step 1
+doesn't behave as documented, upgrade `ddgl` — don't work around it here.
+
+If `pup` is present but not authenticated, either run `pup auth login` (browser
+prompts started inside a dev env are forwarded back to the host) or use the
+`dd-auth` skill for the non-interactive `DD_API_KEY`/`DD_APP_KEY` path. If `pup`
+can't be made to work, say so and continue with Steps 1 and 4 only — Steps 2 and 3
+are unavailable, and the verdict should state that limitation rather than silently
+producing a weaker one.
+
+## Step 1 — Collect the failures
+
+```bash
+ddgl jobs list --failed --json --no-pager [--ref <ref> | --pipeline <id>]
+```
+
+An empty `[]` means there's nothing to triage — stop here.
+
+Also fetch pipeline state:
+
+```bash
+ddgl pipelines get --json [--ref <ref> | --pipeline <id>]
+```
+
+If the pipeline is **still running**, a job you're about to triage may yet be
+auto-retried into success — note that in the verdict rather than treating the
+failure as final.
+
+For each failed job, look at its `failure_reason`. Treat it as **one input, not a
+verdict** — see `references/signals.md` for why (`runner_system_failure` is also
+exactly what a misspelled `image:` reference produces). If `failure_reason` is one
+of GitLab's infra-flavoured values *and* the PR touches no CI config and no test
+setup, that conjunction is decent evidence the failure is unrelated to the diff.
+Either way, continue to Step 2 — nothing here should end the investigation early.
+
+## Step 2 — CI Visibility baseline
+
+This is usually the most decisive step, and it comes before incident search on
+purpose: a job failing on `main` right now is broken for everyone whether or not
+anyone has declared an incident yet, and a job that's flaky everywhere doesn't need
+an incident to explain it.
+
+For each failed job, ask how it behaves elsewhere:
+
+```bash
+pup cicd events aggregate \
+  --query='ci_level:job @ci.pipeline.name:DataDog/datadog-agent @git.branch:main @ci.job.name:"<exact job name>"' \
+  --compute=count --group-by='@ci.status' --from='2d'
+```
+
+Load `references/signals.md` here for the full recipe — the parallel-job wildcard
+form, the infra-exclusion pass, the three-baseline comparison (`main`, all
+branches, this branch), and how to read the counts. Come out of this step with a
+working hypothesis (`upstream`, `flake`, or `pr-code`) for later steps to confirm
+or overturn — not a final verdict.
+
+## Step 3 — Incident correlation
+
+Worth doing thoroughly if Step 2 pointed at `upstream` or `flake`. If Step 2
+pointed cleanly at `pr-code`, skip to Step 4 unless something else is nagging at
+you.
+
+`scripts/incidents.py`, colocated with this file, owns the fiddly parts: turning a
+failure timestamp and window into the right Datadog queries, and matching a job
+name against an incident's auto-generated title. Run it rather than reimplementing
+the query logic by hand:
+
+```bash
+.agents/skills/triage-ci-failure/scripts/incidents.py search \
+  --at <job-failure-ISO8601-timestamp> \
+  --job '<exact failing job name>' [--job '<another one>' ...]
+```
+
+Read the match tier in the output (`exact`, `base`, `prefix`, `token`, `none`) —
+anything but `none` is worth reading the timeline for:
+
+```bash
+.agents/skills/triage-ci-failure/scripts/incidents.py timeline <IR-nnnnn>
+```
+
+This collapses tens of KB of Slack-mirror noise down to the handful of lines that
+matter: state transitions and human notes. This is where you find out whether the
+incident is already fixed (look for a rollback, a merged fix PR, a transition to
+`stable`/`resolved`) or still open. **`state != active` does not mean fixed** —
+`stable` just means "under control", and `resolved` (null or not) is the field
+that actually says whether anyone has closed it out.
+
+If nothing matches, widen deliberately rather than re-running the same call —
+escalate through the tier ladder in `references/signals.md`:
+1. *(default, above)* `services:datadog-agent-ci`, default window.
+2. Same, a much wider window — for old branches whose failure was fixed on `main`
+   long before you rebased onto them.
+3. Drop the service filter, search free text instead, using a keyword pulled from
+   the job log in Step 4 (an image reference, a host, an endpoint, a bucket name).
+
+## Step 4 — Read the log
+
+Skip this if Step 3 already produced a confident, timeline-corroborated verdict.
+Otherwise, work through `references/evidence.md`'s cookbook — it's ordered
+cheapest-first specifically so you never dump a 50,000-line trace into context.
+You're looking for two things: the command that actually failed and its exit
+status, and whether the failure happened in the job's own work or in its setup/
+teardown. Prefer error text that names something concrete — that's exactly what
+tier 3 of Step 3 needs if you end up going back to it.
+
+## Step 5 — Verdict
+
+State two things separately, because they answer different questions and
+collapsing them loses information: **blame** (`pr-code`, `upstream`, `infra`,
+`flake`, or `inconclusive`) and, if relevant, **which incident** — with its ID and
+state, or explicitly `none`.
+
+| blame | incident | Say this |
+|---|---|---|
+| `pr-code` | — | Propose the smallest concrete fix. Don't apply it. |
+| `upstream` | unresolved | Don't suggest rebasing yet. Report the incident. |
+| `upstream` | resolved | Rebase onto latest `main` and re-run. Name the fixing commit/PR if the timeline gave you one. |
+| `upstream` | none declared | Say CI is broken on `main` with nothing declared for it — worth surfacing loudly. |
+| `infra` | any | Suggest a retry. Note whether the job already burned its one automatic retry (`references/signals.md`). |
+| `flake` | any | Suggest a retry, citing the measured cross-branch failure rate from Step 2 as the reason — not just a feeling. |
+| `inconclusive` | any | Present the evidence and the two most likely readings. Don't guess past what you found. |
+
+End with a line stating the incident outcome on its own, exactly like one of
+these, so a caller like `/follow-pr` can act on it without re-deriving your
+reasoning:
+
+```
+Incident: IR-59848 (stable, unresolved) — https://app.datadoghq.com/incidents/59848
+Incident: none
+```
+
+## Reference material
+
+- `references/signals.md` — the retry-policy prior and its exceptions, why
+  `failure_reason` is a hint and not a verdict, and the full CI Visibility query
+  recipe with the three baselines and how to read them, plus the incident-search
+  tier ladder. Load it in Step 1 (retry policy, `failure_reason`) and Steps 2–3
+  (CI Visibility, tier ladder).
+- `references/evidence.md` — the log-reading cookbook and what to look for. Load
+  it in Step 4.

--- a/.agents/skills/triage-ci-failure/references/evidence.md
+++ b/.agents/skills/triage-ci-failure/references/evidence.md
@@ -1,0 +1,47 @@
+# Evidence reference — reading a job log without dumping it into context
+
+Load this when working through Step 4 of `SKILL.md`.
+
+A failed `new-e2e-*` trace is easily 50,000+ lines. Work through these in order;
+each one is cheap, and most triage runs never need to go past step 3.
+
+```bash
+# 1. Section map — the cheapest possible structural overview.
+ddgl logs --job <id> --no-pager --no-color | grep -n '^───'
+
+# 2. The end, where the failure actually surfaces.
+ddgl logs --job <id> --raw --no-pager | tail -200
+
+# 3. Error lines, in case the interesting one scrolled past the tail.
+ddgl logs --job <id> --raw --no-pager \
+  | grep -nEi '(error|fatal|panic|FAIL|Traceback|exit code|assertion)' | tail -60
+
+# 4. Go test failures specifically.
+ddgl logs --job <id> --raw --no-pager | grep -nE '^\s*--- FAIL:|^FAIL\s' | head -40
+
+# 5. A targeted read once you have a line number from any of the above.
+ddgl logs --job <id> --raw --no-pager | sed -n '<n>,<n+80>p'
+```
+
+If you're exporting logs for several jobs at once instead of reading one at a
+time, `mkdir -p` the output directory first — `ddgl logs --output <dir>` silently
+concatenates every job's log into a single file (rather than one file per job) if
+the directory doesn't already exist:
+
+```bash
+mkdir -p failures && ddgl logs --pipeline <id> --failed --output failures/
+```
+
+## What to look for
+
+Deliberately general rather than a pattern list, because pattern lists rot the
+moment CI infrastructure changes underneath them:
+
+- **The command that actually failed, and its exit status.** Most job scripts run
+  several steps; the trace usually says which one exited non-zero.
+- **Whether it failed in the job's own work, or in setup/teardown.** A failure
+  before the job's real script even starts is a much stronger infra signal than
+  one inside the test itself.
+- **Error text that names something concrete** — an image reference, a hostname,
+  an endpoint, a bucket, a package version. That string is exactly what feeds tier
+  3 of the incident search (`references/signals.md`) if you end up needing it.

--- a/.agents/skills/triage-ci-failure/references/signals.md
+++ b/.agents/skills/triage-ci-failure/references/signals.md
@@ -1,0 +1,116 @@
+# Signals reference — retry policy, `failure_reason`, and CI Visibility baselines
+
+Load this when working through Step 1 (retry policy, `failure_reason`) or Steps
+2–3 (CI Visibility baseline, incident search tier ladder) of `SKILL.md`.
+
+## The default retry policy, and why it changes the flake prior
+
+`.gitlab-ci.yml:172-175` retries every job once on any failure by default:
+
+```yaml
+default:
+  retry:
+    max: 1
+    when: always
+```
+
+GitLab only surfaces the latest attempt, so **a job showing `failed` in a terminal
+pipeline has usually already failed twice.** "It's probably just a flake" is a
+weaker hypothesis than it looks — a job doesn't get to stay `failed` by flaking
+once.
+
+Two exceptions retry on a narrower trigger, so a `script_failure` there was only
+attempted once:
+- `.gitlab-ci.yml:1454-1466` `.retry_only_infra_failure` — used by most e2e,
+  Windows, and macOS jobs. Retries only on GitLab's infra-flavoured
+  `failure_reason` values (below).
+- `.gitlab/test/kernel_matrix_testing/common.yml:258-268` — same idea, plus
+  `job_execution_timeout`.
+
+When it matters whether a specific job got the default policy or the infra-only
+one, grep for it rather than resolving the full CI config — the pipeline
+definition is tens of thousands of lines:
+
+```bash
+grep -rn '<job-name>' .gitlab/ .gitlab-ci.yml
+```
+
+There's no way to see this from `ddgl` either: GitLab's job-list endpoint doesn't
+return retried attempts unless asked to, and `ddgl` doesn't ask, so there's no
+`retried` field and no history of earlier attempts to inspect there.
+
+## `failure_reason` is a hint, not a verdict
+
+GitLab's infra-flavoured `failure_reason` values:
+
+| Value | Meaning |
+|---|---|
+| `runner_system_failure` | Runner died or never started |
+| `stuck_or_timeout_failure` | GitLab gave up waiting |
+| `unknown_failure`, `api_failure`, `scheduler_failure`, `stale_schedule`, `data_integrity_failure` | GitLab-side |
+
+These look infra-flavoured, and often are — but `runner_system_failure` is also
+exactly what a misspelled `image:` reference produces, and any of them can equally
+be a symptom of an active incident rather than a cause. Treat one of these values
+as *suggestive*, and only read it as *conclusive* in conjunction with the PR's
+diff: an infra-flavoured `failure_reason` on a PR that touches no CI config and no
+test setup is real evidence the failure is unrelated to the diff. On a PR that
+*does* touch CI config, it's evidence of nothing yet — go look at what changed.
+
+## CI Visibility baseline: how the job behaves elsewhere
+
+The single most decisive signal available, and cheap to get. For each failed job:
+
+```bash
+pup cicd events aggregate \
+  --query='ci_level:job @ci.pipeline.name:DataDog/datadog-agent @git.branch:main @ci.job.name:"<exact job name>"' \
+  --compute=count --group-by='@ci.status' --from='2d'
+```
+
+For parallel/matrix jobs, also run the base-name wildcard form to pull in the whole
+shard family (strip from the first `:`, append `*`):
+
+```
+@ci.job.name:new-e2e-sbom*  →  error: 31, success: 732, skipped: 30, running: 4, canceled: 1
+```
+
+A second pass with `@ci.status:error -@error.domain:provider` excludes
+infrastructure-attributed errors, mirroring the convention `tasks/libs/notify/
+utils.py:11` already uses for its own CI Visibility deep links.
+
+Run the same query three times, varying only the branch clause:
+
+| Query | Answers |
+|---|---|
+| `@git.branch:main` | Is it broken on the branch everyone merges into? |
+| *(no branch clause)* | Overall flakiness across all branches — a better estimate than `main` alone, which sees comparatively few runs of any one job. |
+| `@git.branch:<this branch>` | Did it also fail on earlier pushes of this branch? A failure predating your latest commit points away from that commit. |
+
+**Interpretation** — these are heuristic bands, not thresholds anyone has
+calibrated; always report the raw counts alongside whichever band you invoke:
+
+| Signal | Hypothesis |
+|---|---|
+| high error rate on `main` (roughly half of runs or more) | `upstream` — broken for everyone. Go find the incident. |
+| low but persistent error rate across all branches | `flake` — but weigh the retry prior above; a job that burned its one retry and still failed isn't obviously flaky. |
+| error rate **rose sharply** in the last day or two | `upstream`, and go straight to incident search. A flakiness spike is itself one of the most common reasons an incident gets declared — it may say "job X is flaky" rather than "job X is broken". |
+| reliable everywhere, failing only here | `pr-code` — dependable elsewhere, failed on your branch. |
+| no data, or the job never runs on `main` | No baseline. Fall through to reading the log. |
+
+## Incident search tier ladder
+
+`scripts/incidents.py search` takes a job-failure timestamp and window and returns
+scored candidate incidents — see the script's own docstring for the mechanics (two
+time-bounded queries, unioned, matched against job names). Escalate through these
+tiers by changing its flags, not by re-running the same call hoping for a
+different answer:
+
+1. **(default)** `--service datadog-agent-ci`, default window (48h back, 6h
+   grace).
+2. Same, `--window-hours 336` (2 weeks) — covers a branch that's been open long
+   enough that its failure was already fixed on `main` well before you looked.
+3. `--no-service --text <keyword>` — drops the service filter entirely and
+   searches free text instead, using a keyword pulled from the job log (Step 4 of
+   `SKILL.md`). This is broader than it sounds but still well-scoped in practice:
+   an unfiltered `state:active` query across the whole org returns 800+ incidents,
+   but a free-text query like `ECR` or `gitlab runner` returns a few dozen.

--- a/.agents/skills/triage-ci-failure/scripts/incidents.py
+++ b/.agents/skills/triage-ci-failure/scripts/incidents.py
@@ -37,7 +37,6 @@ import sys
 from dataclasses import dataclass, field
 from enum import IntEnum
 from functools import cached_property
-from typing import override
 
 # ============================== CONSTANTS ============================== #
 
@@ -75,7 +74,6 @@ class MatchTier(IntEnum):
     TOKEN = 3  # share at least one distinctive token
     NONE = 4  # no relationship found
 
-    @override
     def __str__(self) -> str:
         return self.name.lower()
 
@@ -223,7 +221,6 @@ class Incident:
             "url": self.url,
         }
 
-    @override
     def __str__(self) -> str:
         """The three-line block `search` prints per incident."""
         resolved = self.resolved[:19] if self.resolved else "-"

--- a/.agents/skills/triage-ci-failure/scripts/incidents.py
+++ b/.agents/skills/triage-ci-failure/scripts/incidents.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""Search Datadog incidents and render timelines, for CI-failure triage.
+
+`pup incidents list` has no server-side "incident active at time T" filter and no way to
+express the OR in "still open, or resolved after the failure" in one query. This script
+owns that arithmetic: it turns a job-failure timestamp and a window into two bounded
+`pup` queries, unions the results, and scores each incident against the failing job names
+by parsing the auto-generated `[INTERNAL] <job> job is broken on the <branch> branch...`
+title format.
+
+`pup incidents get` also doesn't return the timeline despite its own help text advertising
+`.data.timeline` — the real endpoint is `/api/v2/incidents/<id>/timeline` via `pup api`, and
+it's mostly a Slack mirror (tens of KB per incident). `timeline` collapses that to the
+handful of lines that matter: state transitions and human notes.
+
+Every `pup` call is made with `--no-agent` so the output shape is the plain Datadog API
+response regardless of who or what invokes this script.
+
+Usage:
+    incidents.py search --at <iso8601> [--job NAME]... [--window-hours 48] [--grace-hours 6]
+                         [--service datadog-agent-ci | --no-service] [--text KEYWORD]
+                         [--limit 100] [--json]
+    incidents.py timeline <IR-nnnnn | numeric id | uuid> [--max-chars 400] [--json]
+
+See /.agents/skills/triage-ci-failure/SKILL.md for how this fits into the wider triage flow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import html
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from enum import IntEnum
+from functools import cached_property
+from typing import override
+
+# ============================== CONSTANTS ============================== #
+
+INCIDENT_URL_FMT = "https://app.datadoghq.com/incidents/{public_id}"
+
+# Auto-declared incident titles embed the job name verbatim, e.g.:
+#   [INTERNAL] new-e2e-sbom: [--run &quot;TestSBOMKubeadmCrioSuite&quot;] job is broken on
+#   the main branch of the `datadog-agent` repository
+# Titles are HTML-escaped and the job name is *not* truncated at declaration time, but a
+# future change to the (external) automation could start truncating it — see MatchTier.PREFIX.
+TITLE_RE = re.compile(
+    r"^\[INTERNAL\]\s+(?P<job>.+?)\s+job is broken on the (?P<branch>\S+) branch of the",
+    re.IGNORECASE,
+)
+
+# Timeline `incident_status_change` cells carry field-level diffs as a generic `selections`
+# list (see `_selection_values`). Most of them are noise for triage (team routing, slug,
+# services) — only surface a diff if it touches one of these.
+STATUS_FIELD_ALLOWLIST = {"severity", "state", "state_category", "root_cause", "summary"}
+
+
+# ============================== MODEL ============================== #
+
+
+class MatchTier(IntEnum):
+    """How confidently an incident's title job maps onto a failing GitLab job.
+
+    Ordered best-to-worst so that `min()` picks the strongest match and plain sorting puts
+    the most relevant incidents first.
+    """
+
+    EXACT = 0  # identical job names
+    BASE = 1  # identical once the parallel/matrix suffix is stripped
+    PREFIX = 2  # one name is a prefix of the other (title truncation)
+    TOKEN = 3  # share at least one distinctive token
+    NONE = 4  # no relationship found
+
+    @override
+    def __str__(self) -> str:
+        return self.name.lower()
+
+
+def parse_iso(ts: str) -> float:
+    """Parse an API timestamp to a POSIX timestamp.
+
+    Datadog is inconsistent about the suffix — incident records use `Z`, timeline cells use
+    `+00:00` — so comparisons have to go through real datetimes rather than string ordering.
+    """
+    return dt.datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+
+
+def _base_name(job_name: str) -> str:
+    """Strip a parallel/matrix suffix: `foo: [shard 1/5]` -> `foo`."""
+    return job_name.split(":", 1)[0].strip()
+
+
+def _tokens(job_name: str) -> set[str]:
+    return {t for t in re.split(r"[^a-zA-Z0-9]+", job_name.lower()) if len(t) >= 4}
+
+
+def classify_pair(incident_job: str, failed_job: str) -> MatchTier:
+    """Rate how strongly one incident-title job name corresponds to one failing job name."""
+    if incident_job == failed_job:
+        return MatchTier.EXACT
+    if _base_name(incident_job) == _base_name(failed_job):
+        return MatchTier.BASE
+    if incident_job.startswith(failed_job) or failed_job.startswith(incident_job):
+        return MatchTier.PREFIX
+    if _tokens(incident_job) & _tokens(failed_job):
+        return MatchTier.TOKEN
+    return MatchTier.NONE
+
+
+@dataclass
+class Incident:
+    """One Datadog incident, slimmed to the fields triage actually reads."""
+
+    uuid: str
+    public_id: int
+    slug: str
+    state: str
+    severity: str
+    created: str
+    resolved: str | None
+    title: str
+    # Populated by `match_against`; empty until then, and empty means "matched nothing".
+    matches: dict[str, MatchTier] = field(default_factory=dict)
+
+    @classmethod
+    def from_api(cls, raw: dict) -> Incident:
+        """Build from one `data` element of a `pup incidents list` response."""
+        attrs = raw["attributes"]
+        return cls(
+            uuid=raw["id"],
+            public_id=attrs["public_id"],
+            slug=attrs["fields"]["slug"]["value"],
+            state=attrs["state"],
+            severity=attrs["severity"],
+            created=attrs["created"],
+            resolved=attrs.get("resolved"),
+            title=html.unescape(attrs.get("title") or ""),
+        )
+
+    @cached_property
+    def _parsed_title(self) -> tuple[str | None, str | None]:
+        match = TITLE_RE.match(html.unescape(self.title))
+        if not match:
+            return None, None
+        return match.group("job").strip(), match.group("branch")
+
+    @property
+    def parsed_job(self) -> str | None:
+        """The job name named in an auto-declared title, if this is one."""
+        return self._parsed_title[0]
+
+    @property
+    def parsed_branch(self) -> str | None:
+        """The branch named in an auto-declared title, if this is one."""
+        return self._parsed_title[1]
+
+    @property
+    def url(self) -> str:
+        return INCIDENT_URL_FMT.format(public_id=self.public_id)
+
+    @property
+    def best_tier(self) -> MatchTier:
+        return min(self.matches.values(), default=MatchTier.NONE)
+
+    def was_active_at(self, t_fail: float, window_s: float, grace_s: float) -> bool:
+        """Was this incident plausibly active when the job failed?
+
+        Incidents are declared *after* their first casualties, so the window is asymmetric:
+        an incident created up to `grace_s` after the failure is still a candidate, and an
+        incident is only ruled out by resolution if it resolved more than `window_s`
+        *before* the failure.
+        """
+        if parse_iso(self.created) > t_fail + grace_s:
+            return False
+        if self.resolved is not None and parse_iso(self.resolved) < t_fail - window_s:
+            return False
+        return True
+
+    def match_against(self, failed_jobs: list[str]) -> dict[str, MatchTier]:
+        """Rate this incident against every failing job, keeping only the ones that match.
+
+        An `[INTERNAL]` title names exactly one job, but that one job can legitimately
+        correspond to several failing jobs at once — sibling shards of a parallel job all
+        match its base name — so every match is reported rather than just the first found.
+        """
+        if not self.parsed_job:
+            return {}
+        rated = {job: classify_pair(self.parsed_job, job) for job in failed_jobs}
+        return dict(rated.items())
+
+    def _match_summary(self) -> str:
+        tier = self.best_tier
+        # `matches` retains jobs rated NONE, so "which jobs sit at the best tier" only names
+        # real matches once NONE is ruled out — otherwise it would list the jobs that failed
+        # to match and present them as though they had.
+        if tier is MatchTier.NONE:
+            return f"match={tier}"
+        best = sorted(job for job, t in self.matches.items() if t == tier)
+        if len(best) == 1:
+            return f"match={tier} ({best[0]})"
+        return f"match={tier} ({len(best)} jobs: {', '.join(best)})"
+
+    def to_dict(self) -> dict:
+        """Serialise for `--json`. Derived fields are included explicitly, since the
+        properties backing them are invisible to generic dataclass serialisation."""
+        return {
+            "uuid": self.uuid,
+            "public_id": self.public_id,
+            "slug": self.slug,
+            "state": self.state,
+            "severity": self.severity,
+            "created": self.created,
+            "resolved": self.resolved,
+            "title": self.title,
+            "parsed_job": self.parsed_job,
+            "parsed_branch": self.parsed_branch,
+            "matches": {job: str(tier) for job, tier in self.matches.items()},
+            "best_tier": str(self.best_tier),
+            "url": self.url,
+        }
+
+    @override
+    def __str__(self) -> str:
+        """The three-line block `search` prints per incident."""
+        resolved = self.resolved[:19] if self.resolved else "-"
+        header = (
+            f"{self.slug:<10} {self.state:<10} declared {self.created[:19]}  "
+            f"resolved {resolved:<20} {self.severity:<6} {self._match_summary()}"
+        )
+        return f"{header}\n           {self.title}\n           {self.url}"
+
+
+# ============================== PUP I/O ============================== #
+
+
+class PupError(RuntimeError):
+    """`pup` exited non-zero, or produced output that wasn't the JSON we expected."""
+
+
+def run_pup(args: list[str]) -> dict:
+    """Run `pup --no-agent <args>` and parse its stdout as JSON.
+
+    `--no-agent` matters: without it `pup` wraps every response in a `{status, data,
+    metadata}` envelope meant for agent consumption, which is not the shape this script
+    (or a human running it outside an agent) expects.
+    """
+    proc = subprocess.run(
+        ["pup", "--no-agent", *args],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise PupError(proc.stderr.strip() or proc.stdout.strip() or f"pup exited {proc.returncode}")
+    text = proc.stdout.strip()
+    if not text:
+        return {}
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise PupError(f"pup returned non-JSON output: {text[:200]!r}") from exc
+
+
+def build_search_queries(window_start: int, window_end: int, service: str | None, text: str | None) -> tuple[str, str]:
+    """The two time-bounded queries whose union covers "active when the job failed".
+
+    The API can bound `created`/`resolved` server-side but cannot express "still open OR
+    resolved after X" in a single query, so the disjunction is split across two calls:
+    (a) incidents declared anywhere near the failure, and (b) older incidents still open.
+    """
+    prefix = ""
+    if service:
+        prefix += f"services:{service} "
+    if text:
+        prefix += f"{text} "
+    declared_near_failure = f"{prefix}created_after:{window_start} created_before:{window_end}".strip()
+    older_still_open = f"{prefix}state:(active OR stable) created_before:{window_start}".strip()
+    return declared_near_failure, older_still_open
+
+
+def fetch_incidents(query: str, limit: int) -> dict[str, dict]:
+    """Run one incident query, returning raw `data` elements keyed by incident UUID."""
+    resp = run_pup(["incidents", "list", "--query", query, "--limit", str(limit)])
+    incidents = resp.get("data", {}).get("attributes", {}).get("incidents", [])
+    return {item["data"]["id"]: item["data"] for item in incidents}
+
+
+def fetch_timeline_cells(incident_ref: str) -> list[dict]:
+    """Fetch an incident's timeline cells.
+
+    The endpoint accepts a bare numeric public ID as well as a UUID, so `IR-` slugs only
+    need their prefix stripped. It also defaults to 25 cells per page, which silently
+    truncates most real incidents — hence the explicit page size.
+    """
+    numeric_id = incident_ref.strip()
+    if numeric_id.upper().startswith("IR-"):
+        numeric_id = numeric_id[3:]
+    resp = run_pup(["api", f"/api/v2/incidents/{numeric_id}/timeline", "-F", "page[size]=200"])
+    return resp.get("data", [])
+
+
+# ============================== TIMELINE DIGEST ============================== #
+
+
+def _selection_values(selections: list[dict]) -> dict[str, list]:
+    return {sel["field"]["name"]: [c.get("value") for c in sel.get("choices", [])] for sel in selections}
+
+
+def describe_status_change(cell: dict) -> str | None:
+    """Render an `incident_status_change` cell, or None if it's routing/labelling noise."""
+    content = cell["attributes"]["content"]
+    if content.get("action") == "created":
+        after = content.get("after") or {}
+        return f"declared ({after.get('state', '?')}, {after.get('severity', '?')})"
+
+    before = content.get("before") or {}
+    after = content.get("after") or {}
+
+    # Direct state transitions (active -> stable -> resolved/completed) carry `state`
+    # directly, not via `selections`.
+    if "state" in before or "state" in after:
+        if before.get("state") != after.get("state"):
+            return f"{before.get('state', '?')} \u2192 {after.get('state', '?')}"
+        return None
+
+    if "selections" in before or "selections" in after:
+        before_vals = _selection_values(before.get("selections", []))
+        after_vals = _selection_values(after.get("selections", []))
+        changed = {k for k in set(before_vals) | set(after_vals) if before_vals.get(k) != after_vals.get(k)}
+        changed &= STATUS_FIELD_ALLOWLIST
+        if not changed:
+            return None
+        return "; ".join(
+            f"{field_name}: {before_vals.get(field_name)} \u2192 {after_vals.get(field_name)}"
+            for field_name in sorted(changed)
+        )
+
+    return None
+
+
+def render_markdown_cell(cell: dict, max_chars: int) -> tuple[str, str]:
+    """Flatten one Slack-mirrored note to a (author, single-line text) pair."""
+    content = cell["attributes"]["content"]
+    author = content.get("author") or {}
+    who = author.get("name") or author.get("email") or "unknown"
+    text = html.unescape(content.get("content") or "")
+    text = " ".join(text.split())
+    if len(text) > max_chars:
+        text = text[:max_chars].rstrip() + "\u2026"
+    return who, text
+
+
+def slim_timeline(raw_cells: list[dict], max_chars: int) -> list[dict]:
+    """Collapse the raw timeline (tens of KB, mostly Slack-mirror noise) to state
+    transitions and human notes, chronologically ordered."""
+    entries: list[dict] = []
+    for cell in raw_cells:
+        attrs = cell["attributes"]
+        ts = attrs.get("created") or attrs.get("display_time")
+        cell_type = attrs["cell_type"]
+        if cell_type == "markdown":
+            who, text = render_markdown_cell(cell, max_chars)
+            if text:
+                entries.append({"ts": ts, "kind": "note", "author": who, "text": text})
+        elif cell_type == "incident_status_change":
+            desc = describe_status_change(cell)
+            if desc:
+                entries.append({"ts": ts, "kind": "status", "text": desc})
+        # incident_role_assignment_change / incident_integration_change /
+        # incident_workstream_change: never useful for triage, dropped.
+    entries.sort(key=lambda e: parse_iso(e["ts"]))
+    return entries
+
+
+# ============================== CLI ============================== #
+
+
+def cmd_search(args: argparse.Namespace) -> int:
+    """Find incidents that could explain a job failing at `--at`.
+
+    Fetches the union of the two bounded queries, discards anything that wasn't actually
+    active at the failure, then rates whatever survives against the failing job names.
+    """
+    t_fail = parse_iso(args.at)
+    window_s = args.window_hours * 3600
+    grace_s = args.grace_hours * 3600
+
+    queries = build_search_queries(
+        window_start=int(t_fail - window_s),
+        window_end=int(t_fail + grace_s),
+        service=None if args.no_service else args.service,
+        text=args.text,
+    )
+    raw_by_id: dict[str, dict] = {}
+    for query in queries:
+        # Keyed by UUID, so the overlap between the two queries collapses on its own.
+        raw_by_id.update(fetch_incidents(query, args.limit))
+
+    incidents = [Incident.from_api(raw) for raw in raw_by_id.values()]
+    incidents = [inc for inc in incidents if inc.was_active_at(t_fail, window_s, grace_s)]
+    for inc in incidents:
+        inc.matches = inc.match_against(args.job)
+
+    # Strongest match first; ties broken by most recently declared. MatchTier is an IntEnum
+    # ordered best-to-worst, so it sorts ascending, while recency has to be negated.
+    incidents.sort(key=lambda inc: (inc.best_tier, -parse_iso(inc.created)))
+
+    if args.json:
+        print(json.dumps([inc.to_dict() for inc in incidents], indent=2))
+    elif not incidents:
+        print("No candidate incidents found in the window.")
+    else:
+        for inc in incidents:
+            print(inc)
+    return 0
+
+
+def cmd_timeline(args: argparse.Namespace) -> int:
+    """Render one incident's timeline as a compact, chronological digest."""
+    entries = slim_timeline(fetch_timeline_cells(args.incident), args.max_chars)
+
+    if args.json:
+        print(json.dumps(entries, indent=2))
+    elif not entries:
+        print("No timeline entries.")
+    else:
+        for entry in entries:
+            ts = entry["ts"][:19]
+            if entry["kind"] == "status":
+                print(f"{ts}  \u25cf  {entry['text']}")
+            else:
+                print(f"{ts}  {entry['author']:<20} {entry['text']}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    search = sub.add_parser("search", help="Find incidents that may explain a CI job failure")
+    search.add_argument("--at", required=True, help="ISO8601 timestamp the job failed at")
+    search.add_argument(
+        "--job", action="append", default=[], help="GitLab job name to match against incident titles (repeatable)"
+    )
+    search.add_argument(
+        "--window-hours",
+        type=float,
+        default=48.0,
+        help="How far back an incident may have resolved and still count (default: 48)",
+    )
+    search.add_argument(
+        "--grace-hours",
+        type=float,
+        default=6.0,
+        help="How long after the failure an incident may still have been declared (default: 6)",
+    )
+    search.add_argument(
+        "--service", default="datadog-agent-ci", help="Datadog incident service filter (default: datadog-agent-ci)"
+    )
+    search.add_argument("--no-service", action="store_true", help="Drop the service filter (tier-3 broad search)")
+    search.add_argument("--text", default=None, help="Extra free-text filter, e.g. a keyword pulled from the job log")
+    search.add_argument("--limit", type=int, default=100, help="Max incidents per underlying query (default: 100)")
+    search.add_argument("--json", action="store_true")
+    search.set_defaults(func=cmd_search)
+
+    timeline = sub.add_parser("timeline", help="Render an incident's timeline as a compact, chronological digest")
+    timeline.add_argument("incident", help="Incident slug (IR-nnnnn), numeric public ID, or UUID")
+    timeline.add_argument(
+        "--max-chars", type=int, default=400, help="Truncate each note to this many characters (default: 400)"
+    )
+    timeline.add_argument("--json", action="store_true")
+    timeline.set_defaults(func=cmd_timeline)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return args.func(args)
+    except PupError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/triage-ci-failure/scripts/test_incidents.py
+++ b/.agents/skills/triage-ci-failure/scripts/test_incidents.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Unit tests for incidents.py's pure logic, against captured real fixture shapes.
+
+No `pup` calls here — everything below is JSON shapes captured live against real incidents
+(IR-59848, IR-59770, IR-58327) and trimmed to the fields each test cares about. Stdlib only,
+so this runs identically via `python3 test_incidents.py` or `python3 -m pytest
+test_incidents.py` — no dependency on which one happens to be installed.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from incidents import (
+    Incident,
+    MatchTier,
+    build_search_queries,
+    classify_pair,
+    describe_status_change,
+    parse_iso,
+    render_markdown_cell,
+    slim_timeline,
+)
+
+# Trimmed real shape from `pup --no-agent incidents list` (IR-59848), reused across tests.
+IR_59848_TITLE = (
+    '[INTERNAL] new-e2e-sbom: [--run &quot;TestSBOMKubeadmCrioSuite&quot;] job is '
+    "broken on the main branch of the `datadog-agent` repository"
+)
+
+
+def make_incident(*, title: str = IR_59848_TITLE, created: str = "2026-08-27T13:05:22.790651Z", resolved=None):
+    """An Incident built the way production builds them — through `from_api`, so the
+    fixture exercises the real field mapping and title unescaping rather than bypassing it."""
+    return Incident.from_api(
+        {
+            "id": "2150a8f5-14e2-45bc-ad9c-2de3eaa67e58",
+            "attributes": {
+                "public_id": 59848,
+                "fields": {"slug": {"value": "IR-59848"}},
+                "state": "stable",
+                "severity": "SEV-4",
+                "created": created,
+                "resolved": resolved,
+                "title": title,
+            },
+        }
+    )
+
+
+class ParsedTitleTests(unittest.TestCase):
+    def test_html_escaped_matrix_job(self):
+        # Real title from IR-59848. Parallel/matrix suffixes are preserved verbatim, and
+        # the title is HTML-escaped at declaration time.
+        inc = make_incident()
+        self.assertEqual(inc.parsed_job, 'new-e2e-sbom: [--run "TestSBOMKubeadmCrioSuite"]')
+        self.assertEqual(inc.parsed_branch, "main")
+
+    def test_non_main_branch(self):
+        # Real title from IR-59770.
+        inc = make_incident(
+            title=(
+                "[INTERNAL] new-e2e-containers-k8s-latest job is broken on the 7.83.x branch "
+                "of the `datadog-agent` repository"
+            )
+        )
+        self.assertEqual(inc.parsed_job, "new-e2e-containers-k8s-latest")
+        self.assertEqual(inc.parsed_branch, "7.83.x")
+
+    def test_human_declared_title_does_not_match(self):
+        # Real title from IR-58327 — a human-declared incident, not the [INTERNAL] bot.
+        inc = make_incident(
+            title="cloudregistry CrashLoopBackOff on mudkip-b - Egress gateway blocking ECR us-east-2 authentication"
+        )
+        self.assertIsNone(inc.parsed_job)
+        self.assertIsNone(inc.parsed_branch)
+
+
+class ClassifyPairTests(unittest.TestCase):
+    def test_exact(self):
+        self.assertIs(classify_pair("go_e2e_test_binaries", "go_e2e_test_binaries"), MatchTier.EXACT)
+
+    def test_base_strips_parallel_suffix(self):
+        tier = classify_pair('new-e2e-sbom: [--run "TestSBOMKubeadmCrioSuite"]', "new-e2e-sbom")
+        self.assertIs(tier, MatchTier.BASE)
+
+    def test_prefix_when_title_is_truncated(self):
+        # Simulates a future truncated-title regime: title has a clipped name, GitLab has
+        # the real, longer one.
+        tier = classify_pair("kmt_run_secagent_tests_ubuntu_2004", "kmt_run_secagent_tests_ubuntu_2004_x64_extra")
+        self.assertIs(tier, MatchTier.PREFIX)
+
+    def test_token_fallback(self):
+        self.assertIs(classify_pair("new-e2e-containers-k8s-latest", "new-e2e-containers-k8s-oldest"), MatchTier.TOKEN)
+
+    def test_none_when_nothing_lines_up(self):
+        self.assertIs(classify_pair("go_e2e_test_binaries", "docker_build_agent7_full_arm64"), MatchTier.NONE)
+
+    def test_tiers_order_best_first(self):
+        # The enum's ordering is load-bearing: cmd_search sorts on it directly and
+        # best_tier is a min(), so nothing may sort better than EXACT or worse than NONE.
+        self.assertEqual(
+            sorted([MatchTier.NONE, MatchTier.BASE, MatchTier.EXACT, MatchTier.TOKEN, MatchTier.PREFIX]),
+            [MatchTier.EXACT, MatchTier.BASE, MatchTier.PREFIX, MatchTier.TOKEN, MatchTier.NONE],
+        )
+
+
+class MatchAgainstTests(unittest.TestCase):
+    def test_rates_every_job_not_just_the_first_match(self):
+        # One [INTERNAL] title names a single job, but sibling shards of a parallel job all
+        # legitimately correspond to it, so every one is rated rather than just the first.
+        inc = make_incident()
+        matches = inc.match_against(["new-e2e-sbom: [shard 1/2]", "new-e2e-sbom: [shard 2/2]", "unrelated_job"])
+        self.assertEqual(matches["new-e2e-sbom: [shard 1/2]"], MatchTier.BASE)
+        self.assertEqual(matches["new-e2e-sbom: [shard 2/2]"], MatchTier.BASE)
+        self.assertEqual(matches["unrelated_job"], MatchTier.NONE)
+
+    def test_exact_wins_over_base_for_best_tier(self):
+        inc = make_incident()
+        inc.matches = inc.match_against(['new-e2e-sbom: [--run "TestSBOMKubeadmCrioSuite"]', "new-e2e-sbom: [other]"])
+        self.assertIs(inc.best_tier, MatchTier.EXACT)
+
+    def test_best_tier_is_none_when_no_job_matches(self):
+        inc = make_incident()
+        inc.matches = inc.match_against(["docker_build_agent7_full_arm64"])
+        self.assertIs(inc.best_tier, MatchTier.NONE)
+
+    def test_no_matches_when_title_did_not_parse(self):
+        inc = make_incident(title="a human-written title")
+        self.assertEqual(inc.match_against(["go_e2e_test_binaries"]), {})
+        self.assertIs(inc.best_tier, MatchTier.NONE)
+
+    def test_best_tier_is_none_when_no_jobs_were_supplied(self):
+        # The tier-3 broad search runs without --job at all.
+        inc = make_incident()
+        inc.matches = inc.match_against([])
+        self.assertIs(inc.best_tier, MatchTier.NONE)
+
+
+class WasActiveAtTests(unittest.TestCase):
+    WINDOW_S = 48 * 3600
+    GRACE_S = 6 * 3600
+    T_FAIL = parse_iso("2026-08-27T12:45:00Z")
+
+    def test_declared_shortly_after_the_failure_still_counts(self):
+        # Incidents are declared after their first casualties, so this is the common case.
+        inc = make_incident(created="2026-08-27T13:05:22Z")
+        self.assertTrue(inc.was_active_at(self.T_FAIL, self.WINDOW_S, self.GRACE_S))
+
+    def test_declared_past_the_grace_period_does_not_count(self):
+        inc = make_incident(created="2026-08-27T20:00:00Z")  # 7h15 later, past the 6h grace
+        self.assertFalse(inc.was_active_at(self.T_FAIL, self.WINDOW_S, self.GRACE_S))
+
+    def test_resolved_well_before_the_window_does_not_count(self):
+        inc = make_incident(created="2026-08-20T00:00:00Z", resolved="2026-08-24T00:00:00Z")
+        self.assertFalse(inc.was_active_at(self.T_FAIL, self.WINDOW_S, self.GRACE_S))
+
+    def test_resolved_inside_the_window_still_counts(self):
+        inc = make_incident(created="2026-08-20T00:00:00Z", resolved="2026-08-26T12:00:00Z")
+        self.assertTrue(inc.was_active_at(self.T_FAIL, self.WINDOW_S, self.GRACE_S))
+
+
+class IncidentSerialisationTests(unittest.TestCase):
+    def test_from_api_unescapes_title_and_derives_fields(self):
+        inc = make_incident()
+        self.assertEqual(inc.slug, "IR-59848")
+        self.assertEqual(inc.public_id, 59848)
+        self.assertEqual(inc.severity, "SEV-4")
+        self.assertIsNone(inc.resolved)
+        self.assertIn('"TestSBOMKubeadmCrioSuite"', inc.title)  # unescaped, not &quot;
+        self.assertEqual(inc.parsed_job, 'new-e2e-sbom: [--run "TestSBOMKubeadmCrioSuite"]')
+        self.assertEqual(inc.parsed_branch, "main")
+        self.assertEqual(inc.url, "https://app.datadoghq.com/incidents/59848")
+
+    def test_to_dict_is_json_serialisable_and_carries_derived_fields(self):
+        # Guards the --json path: derived values live on properties, which generic
+        # dataclass serialisation would silently drop.
+        import json
+
+        inc = make_incident()
+        inc.matches = inc.match_against(["new-e2e-sbom"])
+        payload = json.loads(json.dumps(inc.to_dict()))
+        self.assertEqual(payload["parsed_job"], 'new-e2e-sbom: [--run "TestSBOMKubeadmCrioSuite"]')
+        self.assertEqual(payload["best_tier"], "base")
+        self.assertEqual(payload["matches"], {"new-e2e-sbom": "base"})
+        self.assertEqual(payload["url"], "https://app.datadoghq.com/incidents/59848")
+
+    def test_str_renders_three_lines_with_title_and_url(self):
+        inc = make_incident()
+        inc.matches = inc.match_against(["new-e2e-sbom"])
+        lines = str(inc).splitlines()
+        self.assertEqual(len(lines), 3)
+        self.assertIn("IR-59848", lines[0])
+        self.assertIn("match=base (new-e2e-sbom)", lines[0])
+        self.assertIn("resolved -", lines[0])
+        self.assertIn("https://app.datadoghq.com/incidents/59848", lines[2])
+
+    def test_str_summarises_multiple_matches_at_the_same_tier(self):
+        inc = make_incident()
+        inc.matches = inc.match_against(["new-e2e-sbom: [shard 1/2]", "new-e2e-sbom: [shard 2/2]"])
+        self.assertIn("match=base (2 jobs:", str(inc).splitlines()[0])
+
+    def test_str_names_no_job_when_nothing_matched(self):
+        # `matches` keeps jobs rated NONE, so the summary must not name them as matches.
+        inc = make_incident()
+        inc.matches = inc.match_against(["docker_build_agent7_full_arm64"])
+        header = str(inc).splitlines()[0]
+        self.assertTrue(header.rstrip().endswith("match=none"), header)
+        self.assertNotIn("docker_build_agent7_full_arm64", header)
+
+    def test_str_names_no_job_when_no_jobs_were_supplied(self):
+        # The tier-3 broad search runs without --job, so there is nothing to count.
+        inc = make_incident()
+        inc.matches = inc.match_against([])
+        header = str(inc).splitlines()[0]
+        self.assertTrue(header.rstrip().endswith("match=none"), header)
+        self.assertNotIn("0 jobs", header)
+
+
+class BuildSearchQueriesTests(unittest.TestCase):
+    def test_default_service_scoped_pair(self):
+        declared, still_open = build_search_queries(1000, 2000, service="datadog-agent-ci", text=None)
+        self.assertEqual(declared, "services:datadog-agent-ci created_after:1000 created_before:2000")
+        self.assertEqual(still_open, "services:datadog-agent-ci state:(active OR stable) created_before:1000")
+
+    def test_tier_three_drops_service_and_adds_text(self):
+        declared, still_open = build_search_queries(1000, 2000, service=None, text="ECR")
+        self.assertEqual(declared, "ECR created_after:1000 created_before:2000")
+        self.assertEqual(still_open, "ECR state:(active OR stable) created_before:1000")
+
+
+class DescribeStatusChangeTests(unittest.TestCase):
+    def test_declared(self):
+        cell = {"attributes": {"content": {"action": "created", "after": {"state": "active", "severity": "SEV-4"}}}}
+        self.assertEqual(describe_status_change(cell), "declared (active, SEV-4)")
+
+    def test_direct_state_transition(self):
+        # Real shape: IR-59848's active -> stable cell.
+        cell = {
+            "attributes": {
+                "content": {"action": "updated", "before": {"state": "active"}, "after": {"state": "stable"}}
+            }
+        }
+        self.assertEqual(describe_status_change(cell), "active \u2192 stable")
+
+    def test_selections_diff_on_routing_fields_is_noise(self):
+        # Real shape: a `teams` selections diff — routing/labelling, not triage-relevant.
+        cell = {
+            "attributes": {
+                "content": {
+                    "action": "updated",
+                    "before": {"selections": [{"field": {"name": "teams"}, "choices": [{"value": "agent-devx"}]}]},
+                    "after": {
+                        "selections": [
+                            {
+                                "field": {"name": "teams"},
+                                "choices": [{"value": "agent-devx"}, {"value": "ci-execution"}],
+                            }
+                        ]
+                    },
+                }
+            }
+        }
+        self.assertIsNone(describe_status_change(cell))
+
+    def test_selections_diff_on_severity_is_reported(self):
+        cell = {
+            "attributes": {
+                "content": {
+                    "action": "updated",
+                    "before": {"selections": [{"field": {"name": "severity"}, "choices": [{"value": "SEV-4"}]}]},
+                    "after": {"selections": [{"field": {"name": "severity"}, "choices": [{"value": "SEV-2"}]}]},
+                }
+            }
+        }
+        self.assertEqual(describe_status_change(cell), "severity: ['SEV-4'] \u2192 ['SEV-2']")
+
+
+class MarkdownCellTests(unittest.TestCase):
+    def test_truncates_and_unescapes(self):
+        cell = {"attributes": {"content": {"author": {"name": "Kevin Fairise"}, "content": "a" * 500 + " &amp; more"}}}
+        who, text = render_markdown_cell(cell, max_chars=50)
+        self.assertEqual(who, "Kevin Fairise")
+        self.assertTrue(text.endswith("\u2026"))
+        self.assertLessEqual(len(text), 51)
+
+    def test_falls_back_to_email_then_unknown(self):
+        cell = {"attributes": {"content": {"author": {"email": "regis@example.com"}, "content": "hi"}}}
+        who, _ = render_markdown_cell(cell, max_chars=50)
+        self.assertEqual(who, "regis@example.com")
+
+
+class SlimTimelineTests(unittest.TestCase):
+    def test_drops_routing_cells_and_sorts_chronologically(self):
+        cells = [
+            {
+                "attributes": {
+                    "created": "2026-08-27T13:19:22Z",
+                    "cell_type": "markdown",
+                    "content": {"author": {"name": "Kevin"}, "content": "Trying to replicate"},
+                }
+            },
+            {
+                "attributes": {
+                    "created": "2026-08-27T13:05:22.790651+00:00",
+                    "cell_type": "incident_status_change",
+                    "content": {"action": "created", "after": {"state": "active", "severity": "SEV-4"}},
+                }
+            },
+            {
+                "attributes": {
+                    "created": "2026-08-27T13:05:26+00:00",
+                    "cell_type": "incident_workstream_change",
+                    "content": {"action": "created"},
+                }
+            },
+        ]
+        entries = slim_timeline(cells, max_chars=400)
+        # The workstream_change cell is dropped; the remaining two are chronological.
+        # Note the mixed `Z` / `+00:00` suffixes: ordering must not rely on string compare.
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0]["kind"], "status")
+        self.assertEqual(entries[1]["kind"], "note")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What does this PR do?

Adds a new `/triage-ci-failure` skill that can be invoked manually, when the user requests it (trigger phrases) or as a sub-skill of `/follow-pr`

The skill gives agents guidance for determining whether a given CI job failure is:
- Due to the PR code
- Due to an active incident on main
- Due to an infra flake
- Due to a test flake

### Motivation

Making `/follow-pr` more useful

### Describe how you validated your changes

Trying out the skill on a random PR with failures + unit tests for the script

### Additional Notes
