### PR TITLE
Drop flavor tests on Linux

### DIFF
--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -61,31 +61,6 @@ tests_linux-x64-py3:
   variables:
     CONDA_ENV: ddpy3
 
-.linux_flavor_tests:
-  extends:
-    - .linux_tests
-    - .linux_x64
-  after_script:
-    - !reference [.upload_junit_source]
-    - !reference [.upload_coverage_datadog]
-  variables:
-    CONDA_ENV: ddpy3
-
-tests_flavor_iot_linux-x64:
-  extends: .linux_flavor_tests
-  variables:
-    FLAVORS: '--flavor iot'
-
-tests_flavor_dogstatsd_linux-x64:
-  extends: .linux_flavor_tests
-  variables:
-    FLAVORS: '--flavor dogstatsd'
-
-tests_flavor_heroku_linux-x64:
-  extends: .linux_flavor_tests
-  variables:
-    FLAVORS: '--flavor heroku'
-
 tests_linux-arm64-py3:
   extends:
     - .linux_tests

--- a/.gitlab/build/source_test/notify.yml
+++ b/.gitlab/build/source_test/notify.yml
@@ -17,7 +17,4 @@ unit_tests_notify:
     - tests_linux-arm64-py3
     - job: tests_windows-x64
       optional: true
-    - tests_flavor_iot_linux-x64
-    - tests_flavor_dogstatsd_linux-x64
-    - tests_flavor_heroku_linux-x64
   allow_failure: true


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

It removes the flavor-specific unit test jobs for Linux.

### Motivation

As we transition to Bazel for running tests, where we're no longer segregating by flavors, we can already drop these, since the tests are already run in the Bazel jobs.

### Describe how you validated your changes

### Additional Notes
