### PR TITLE
[SYNTH-28969] Map Synthetics run types for Network Path (#55746)

### DIFF
--- a/comp/syntheticstestscheduler/impl/worker.go
+++ b/comp/syntheticstestscheduler/impl/worker.go
@@ -367,6 +367,21 @@ func configRequestToResultRequest(req common.ConfigRequest) (common.ResultReques
 	}
 }
 
+// syntheticsRunTypeToNetworkPathTestRunType maps the Synthetics run type to
+// the Network Path run type.
+func syntheticsRunTypeToNetworkPathTestRunType(runType string) payload.TestRunType {
+	switch runType {
+	case common.RunTypeScheduled:
+		return payload.TestRunTypeScheduled
+	case common.RunTypeFast:
+		return payload.TestRunTypeFast
+	case common.RunTypeCI, common.RunTypeTriggered:
+		return payload.TestRunTypeTriggered
+	default:
+		return payload.TestRunTypeTriggered
+	}
+}
+
 // networkPathToTestResult converts a workerResult into the public TestResult structure.
 func (s *syntheticsTestScheduler) networkPathToTestResult(w *workerResult) (*common.TestResult, error) {
 	t := common.Test{
@@ -395,10 +410,7 @@ func (s *syntheticsTestScheduler) networkPathToTestResult(w *workerResult) (*com
 	w.tracerouteResult.TestConfigID = w.testCfg.cfg.PublicID
 	w.tracerouteResult.TestResultID = testResultID
 	w.tracerouteResult.Origin = payload.PathOriginSynthetics
-	w.tracerouteResult.TestRunType = payload.TestRunType(w.testCfg.cfg.RunType)
-	if w.testCfg.cfg.RunType == common.RunTypeCI {
-		w.tracerouteResult.TestRunType = payload.TestRunTypeTriggered
-	}
+	w.tracerouteResult.TestRunType = syntheticsRunTypeToNetworkPathTestRunType(w.testCfg.cfg.RunType)
 	w.tracerouteResult.SourceProduct = payload.SourceProductSynthetics
 	w.tracerouteResult.CollectorType = payload.CollectorTypeAgent
 	w.tracerouteResult.Timestamp = w.finishedAt.UnixMilli()

--- a/comp/syntheticstestscheduler/impl/worker_test.go
+++ b/comp/syntheticstestscheduler/impl/worker_test.go
@@ -529,7 +529,7 @@ func TestNetworkPathToTestResult(t *testing.T) {
 	}
 }
 
-func TestNetworkPathToTestResult_UsesRequestResultIDAndMapsCIRunType(t *testing.T) {
+func TestNetworkPathToTestResult_UsesRequestResultIDAndMapsSyntheticsRunType(t *testing.T) {
 	src := "frontend"
 	dst := "backend"
 	icmpTTL := 5
@@ -544,9 +544,8 @@ func TestNetworkPathToTestResult_UsesRequestResultIDAndMapsCIRunType(t *testing.
 	worker := workerResult{
 		testCfg: SyntheticsTestCtx{
 			cfg: common.SyntheticsTestConfig{
-				PublicID: "pub-triggered",
+				PublicID: "pub-on-demand",
 				ResultID: "backend-result-id",
-				RunType:  string(payload.TestRunTypeTriggered),
 				Type:     "network",
 				Config: struct {
 					Assertions []common.Assertion   `json:"assertions"`
@@ -574,8 +573,9 @@ func TestNetworkPathToTestResult_UsesRequestResultIDAndMapsCIRunType(t *testing.
 	}{
 		{name: "scheduled", runType: common.RunTypeScheduled, expected: payload.TestRunTypeScheduled},
 		{name: "triggered", runType: common.RunTypeTriggered, expected: payload.TestRunTypeTriggered},
-		{name: "fast", runType: common.RunTypeFast, expected: payload.TestRunType(common.RunTypeFast)},
+		{name: "fast", runType: common.RunTypeFast, expected: payload.TestRunTypeFast},
 		{name: "ci", runType: common.RunTypeCI, expected: payload.TestRunTypeTriggered},
+		{name: "unknown", runType: "unknown", expected: payload.TestRunTypeTriggered},
 	}
 
 	for _, tt := range testCases {

--- a/pkg/networkpath/payload/pathevent.go
+++ b/pkg/networkpath/payload/pathevent.go
@@ -114,6 +114,8 @@ const (
 	TestRunTypeScheduled TestRunType = "scheduled"
 	// TestRunTypeDynamic is a dynamic test run.
 	TestRunTypeDynamic TestRunType = "dynamic"
+	// TestRunTypeFast is a fast test run.
+	TestRunTypeFast TestRunType = "fast"
 	// TestRunTypeTriggered is a triggered test run.
 	TestRunTypeTriggered TestRunType = "triggered"
 )


### PR DESCRIPTION
### What does this PR do?

- map each Synthetics run type to a Network Path run type

### Motivation

### Describe how you validated your changes

### Additional Notes
