### PR TITLE
ci: fix openshift crc download url.

### DIFF
--- a/.gitlab/test/e2e/e2e_containers.yml
+++ b/.gitlab/test/e2e/e2e_containers.yml
@@ -144,7 +144,6 @@ new-e2e-containers-openshift-init:
     - go_e2e_deps
     - !reference [.needs_fakeintake_publish]
   rules:
-    - when: never # disabled — OpenShift job is consistently failing
     - !reference [.on_e2e_main_release_or_rc]
     - changes:
         paths:
@@ -171,7 +170,6 @@ new-e2e-containers-openshift-init:
 new-e2e-containers-openshift:
   extends: .new_e2e_template_needs_container_deploy_linux
   rules:
-    - when: never # disabled — OpenShift job is consistently failing
     - !reference [.on_e2e_main_release_or_rc]
     - changes:
         paths:

--- a/.gitlab/test/e2e/e2e_ssi.yml
+++ b/.gitlab/test/e2e/e2e_ssi.yml
@@ -135,8 +135,6 @@ new-e2e-ssi-gke-autopilot:
 new-e2e-ssi-openshift-init:
   extends: .new-e2e_ssi_extra_distribution_init
   timeout: 1h 05m
-  rules:
-    - when: never # disabled — OpenShift job is consistently failing
   before_script:
     # We need to also fetch the OpenShift CRC pull secret and write it to a temp file, so we reference the new_e2e_template before_script first
     - !reference [.new_e2e_template, before_script]
@@ -148,8 +146,6 @@ new-e2e-ssi-openshift-init:
 
 new-e2e-ssi-openshift:
   extends: .new-e2e_ssi_extra_distribution
-  rules:
-    - when: never # disabled — OpenShift job is consistently failing
   needs:
     - !reference [.new-e2e_ssi_extra_distribution, needs]
     - new-e2e-ssi-openshift-init

--- a/test/e2e-framework/components/kubernetes/openshift.go
+++ b/test/e2e-framework/components/kubernetes/openshift.go
@@ -231,7 +231,7 @@ func InstallOpenShiftBinary(env config.Env, vm *remote.Host, opts ...pulumi.Reso
 	return vm.OS.Runner().Command(
 		env.CommonNamer().ResourceName("crc-install"),
 		&command.Args{
-			Create: pulumi.Sprintf(`curl -fsSL https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/%s/crc-linux-%s.tar.xz | \
+			Create: pulumi.Sprintf(`curl --fail -sL https://mirror.openshift.com/pub/openshift-v4/clients/crc/%s/crc-linux-%s.tar.xz | \
 	sudo tar -xJ -C /usr/local/bin --strip-components=1 crc-linux-%s-%s/crc`, crcVersion, openShiftArch, crcVersion, openShiftArch),
 		}, opts...)
 }


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Update the URL to download openshift crc, previously used URL does not work anymore.

### Motivation

make openshift ~great again~ test work again.

### Describe how you validated your changes

### Additional Notes

found the download link here: https://www.redhat.com/en/blog/codeready-containers

simplified the curl command.