### PR TITLE
Disable failing OpenShift E2E jobs

### DIFF
--- a/.gitlab/test/e2e/e2e_containers.yml
+++ b/.gitlab/test/e2e/e2e_containers.yml
@@ -144,6 +144,7 @@ new-e2e-containers-openshift-init:
     - go_e2e_deps
     - !reference [.needs_fakeintake_publish]
   rules:
+    - when: never # disabled — OpenShift job is consistently failing
     - !reference [.on_e2e_main_release_or_rc]
     - changes:
         paths:
@@ -170,6 +171,7 @@ new-e2e-containers-openshift-init:
 new-e2e-containers-openshift:
   extends: .new_e2e_template_needs_container_deploy_linux
   rules:
+    - when: never # disabled — OpenShift job is consistently failing
     - !reference [.on_e2e_main_release_or_rc]
     - changes:
         paths:

--- a/.gitlab/test/e2e/e2e_ssi.yml
+++ b/.gitlab/test/e2e/e2e_ssi.yml
@@ -135,6 +135,8 @@ new-e2e-ssi-gke-autopilot:
 new-e2e-ssi-openshift-init:
   extends: .new-e2e_ssi_extra_distribution_init
   timeout: 1h 05m
+  rules:
+    - when: never # disabled — OpenShift job is consistently failing
   before_script:
     # We need to also fetch the OpenShift CRC pull secret and write it to a temp file, so we reference the new_e2e_template before_script first
     - !reference [.new_e2e_template, before_script]
@@ -146,6 +148,8 @@ new-e2e-ssi-openshift-init:
 
 new-e2e-ssi-openshift:
   extends: .new-e2e_ssi_extra_distribution
+  rules:
+    - when: never # disabled — OpenShift job is consistently failing
   needs:
     - !reference [.new-e2e_ssi_extra_distribution, needs]
     - new-e2e-ssi-openshift-init


### PR DESCRIPTION
The containers OpenShift job has been failing constantly for two months: https://app.datadoghq.com/dashboard/eff-6nu-vkg?fromUser=false&refresh_mode=sliding&storage=flex_tier&tpl_var_ci.job.name%5B0%5D=new-e2e-containers-openshift%2A&from_ts=1780933122065&to_ts=1788795522065&live=true

The SSI OpenShift job has been failing constantly for one month: https://app.datadoghq.com/dashboard/eff-6nu-vkg?fromUser=false&refresh_mode=sliding&storage=flex_tier&tpl_var_ci.job.name%5B0%5D=new-e2e-ssi-openshift%2A&from_ts=1780934447039&to_ts=1788796847039&live=true

Disabling the jobs to avoid spending ressources for those tests while they get fixed.