### PR TITLE
Limit concurrent calls to gopsutil disk usage for same mountpoint

### DIFF
--- a/pkg/collector/corechecks/system/disk/diskv2/disk.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk.go
@@ -665,8 +665,10 @@ func (c *Check) getDiskPartitionsWithTimeout(includeAllDevices bool) ([]gopsutil
 		ctx = context.WithValue(ctx, common.EnvKey, common.EnvMap{common.HostProcMountinfo: c.instanceConfig.ProcMountInfoPath})
 	}
 	go func() {
+		defer func() {
+			c.partitionEnumInFlight.Store(false)
+		}()
 		partitions, err := c.diskPartitionsWithContext(ctx, includeAllDevices)
-		c.partitionEnumInFlight.Store(false)
 		resultCh <- partitionsResult{partitions, err}
 	}()
 	select {
@@ -691,9 +693,11 @@ func (c *Check) getDiskUsageWithTimeout(mountpoint string) (*gopsutil_disk.Usage
 	timeoutCh := c.clock.After(timeout)
 	// Start the disk usage call in a separate goroutine.
 	go func() {
+		defer func() {
+			c.diskUsageInFlight.Delete(mountpoint)
+		}()
 		// UsageWithContext in gopsutil ignores the context for now (PR opened: https://github.com/shirou/gopsutil/pull/1837)
 		usage, err := c.diskUsage(mountpoint)
-		c.diskUsageInFlight.Delete(mountpoint)
 		resultCh <- usageResult{usage, err}
 	}()
 	// Use select to wait for either the disk usage result or a timeout.

--- a/pkg/collector/corechecks/system/disk/diskv2/disk.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -148,6 +149,7 @@ type Check struct {
 	goos                      string // OS name, defaults to runtime.GOOS, injectable for testing
 
 	partitionEnumInFlight atomic.Bool
+	diskUsageInFlight     sync.Map // map[string]struct{}
 
 	initConfig          diskInitConfig
 	instanceConfig      diskInstanceConfig
@@ -676,6 +678,10 @@ func (c *Check) getDiskPartitionsWithTimeout(includeAllDevices bool) ([]gopsutil
 }
 
 func (c *Check) getDiskUsageWithTimeout(mountpoint string) (*gopsutil_disk.UsageStat, error) {
+	if _, loaded := c.diskUsageInFlight.LoadOrStore(mountpoint, struct{}{}); loaded {
+		return nil, fmt.Errorf("disk usage call for mountpoint %s skipped — a previous call is still in progress, which may indicate an inaccessible or orphaned volume on the system", mountpoint)
+	}
+
 	type usageResult struct {
 		usage *gopsutil_disk.UsageStat
 		err   error
@@ -687,11 +693,8 @@ func (c *Check) getDiskUsageWithTimeout(mountpoint string) (*gopsutil_disk.Usage
 	go func() {
 		// UsageWithContext in gopsutil ignores the context for now (PR opened: https://github.com/shirou/gopsutil/pull/1837)
 		usage, err := c.diskUsage(mountpoint)
-		// Use select to avoid writing to resultCh if timeout already occurred.
-		select {
-		case resultCh <- usageResult{usage, err}:
-		case <-timeoutCh:
-		}
+		c.diskUsageInFlight.Delete(mountpoint)
+		resultCh <- usageResult{usage, err}
 	}()
 	// Use select to wait for either the disk usage result or a timeout.
 	select {

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -1355,6 +1355,9 @@ func TestGivenADiskCheckWithDefaultConfig_WhenUsageCalledConcurrentlyForSameMoun
 
 	// Calling Run one after the other (not concurrently) for the same
 	// mountpoint is fine and reports metrics each time.
+	diskCheck = diskv2.WithDiskUsage(diskCheck, func(_ string) (*gopsutil_disk.UsageStat, error) {
+		return &gopsutil_disk.UsageStat{Path: "/", Total: 1024, Free: 512, Used: 512}, nil
+	})
 	assert.Nil(t, diskCheck.Run())
 	assert.Equal(t, 2, totalCalls())
 	assert.Nil(t, diskCheck.Run())

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -1311,6 +1311,56 @@ func TestGivenADiskCheckWithDefaultConfig_WhenUsagePartitionTimeout_ThenUsageMet
 	m.AssertNotCalled(t, "Gauge", "system.disk.in_use", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
 }
 
+func TestGivenADiskCheckWithDefaultConfig_WhenUsageCalledConcurrentlyForSameMountpoint_ThenOnlyOneCallProceedsButSequentialCallsAreFine(t *testing.T) {
+	setupDefaultMocks()
+	entered := make(chan struct{}, 1)
+	unblock := make(chan struct{})
+	diskCheck := createDiskCheck(t)
+	diskCheck = diskv2.WithDiskPartitionsWithContext(diskv2.WithDiskUsage(diskCheck, func(_ string) (*gopsutil_disk.UsageStat, error) {
+		entered <- struct{}{}
+		<-unblock
+		return &gopsutil_disk.UsageStat{Path: "/", Total: 1024, Free: 512, Used: 512}, nil
+	}), func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
+		return []gopsutil_disk.PartitionStat{partitionsTrue[0]}, nil
+	})
+	m := configureCheck(t, diskCheck, nil, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- diskCheck.Run()
+	}()
+	// Wait until the first Run has started calling diskUsage for "/" and is blocked in it.
+	<-entered
+
+	// A second, concurrent Run for the same mountpoint should be skipped rather
+	// than calling diskUsage again, so no metrics are reported for it yet.
+	err := diskCheck.Run()
+	assert.Nil(t, err)
+	m.AssertNotCalled(t, "Gauge", "system.disk.total", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
+
+	close(unblock)
+	assert.Nil(t, <-done)
+	// "system.disk.total" is reported once per successful diskUsage call for "/",
+	// so counting it tells us how many of the Run calls actually got through.
+	totalCalls := func() int {
+		count := 0
+		for _, call := range m.Calls {
+			if call.Method == "Gauge" && call.Arguments.String(0) == "system.disk.total" {
+				count++
+			}
+		}
+		return count
+	}
+	assert.Equal(t, 1, totalCalls(), "the concurrent Run should have been skipped, not called diskUsage again")
+
+	// Calling Run one after the other (not concurrently) for the same
+	// mountpoint is fine and reports metrics each time.
+	assert.Nil(t, diskCheck.Run())
+	assert.Equal(t, 2, totalCalls())
+	assert.Nil(t, diskCheck.Run())
+	assert.Equal(t, 3, totalCalls())
+}
+
 func TestGivenADiskCheckWithDefaultConfig_WhenPartitionDiscoveryTimeout_ThenErrorReturned(t *testing.T) {
 	setupDefaultMocks()
 	// Use an explicit unblock channel to simulate a syscall that ignores

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -1313,7 +1313,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenUsagePartitionTimeout_ThenUsageMet
 
 func TestGivenADiskCheckWithDefaultConfig_WhenUsageCalledConcurrentlyForSameMountpoint_ThenOnlyOneCallProceedsButSequentialCallsAreFine(t *testing.T) {
 	setupDefaultMocks()
-	entered := make(chan struct{}, 1)
+	entered := make(chan struct{}, 3)
 	unblock := make(chan struct{})
 	diskCheck := createDiskCheck(t)
 	diskCheck = diskv2.WithDiskPartitionsWithContext(diskv2.WithDiskUsage(diskCheck, func(_ string) (*gopsutil_disk.UsageStat, error) {


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Limit calls to gopsutil disk `Usage` to avoid calling again if a previous call is still blocked.

### Motivation
The call can block for some slow / remote filesystems, this avoids creating a new goroutine which will block every time until the previous call succeeds.
Same pattern which is already applied for listing partitions.

### Describe how you validated your changes
CI

### Additional Notes
Came up in a support case.