### PR TITLE
fix(windows): pin `SystemRoot` casing to avoid Bazel cache misses

### DIFF
--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -2,6 +2,9 @@
 setlocal EnableDelayedExpansion
 >nul chcp 65001
 
+:: Bazel hashes `SystemRoot` verbatim, so pin it to CI's de facto casing to avoid cache misses on dev machines
+set "SystemRoot=%SystemRoot:WINDOWS=Windows%"
+
 :: Check `bazelisk` properly bootstraps `bazel` or fail with instructions
 if defined BAZEL_REAL if "%BAZELISK_SKIP_WRAPPER%"=="true" goto :bazelisk_ok
 >&2 type "%~dp0bazelisk.md"


### PR DESCRIPTION
### What does this PR do?
Pin `%SystemRoot%`'s casing in `tools/bazel.bat` before Bazel launches, replacing any casing of the `WINDOWS` substring in its value with the more frequently observed `Windows`, also used in CI.

### Motivation
#[incident-59017](https://dd.enterprise.slack.com/archives/C0BP3MYT951) reports OpenSSL/CPython Windows builds falling back to a full local rebuild instead of hitting Buildbarn, even well after CI built the exact same commit.

Diffing every input to the two affected actions (args, env vars, platform properties, and all ~15k tool and input file digests) between a local repro and CI's own execution log showed a single difference: `PATH`, which Bazel builds from `%SystemRoot%` verbatim, see:
https://github.com/bazelbuild/bazel/blob/2600d1f76fda0b8c33e17c4121b22fd9fd07b70b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java#L374.

Windows resolves `C:\WINDOWS` and `C:\Windows` to the same directory, but they hash to different remote-cache digests, so a machine whose OS reports the other casing than CI's gets a permanent, otherwise unexplainable cache miss on every action using that default `PATH`.

### Describe how you validated your changes
Reproduced on a Windows VM: with a fresh `output_base`, a fresh disk cache, and a valid Buildbarn token, building `@openssl//:openssl` and `@cpython//:python_win` still executed both actions locally instead of hitting the remote cache CI had already populated.

After applying this fix, the identical command against a freshly wiped `output_base` resolved every action from cache, matching CI's own result:
```
21 processes: 10 remote cache hit, 11 internal.
```

Decoding the resulting execution log confirmed `PATH` now reads `C:\Windows` on both machines, byte-for-byte.

### Additional Notes
Substring substitution in `cmd.exe` is **case-insensitive**, so this pins whatever the OS already reports in place, rather than assuming a standard `%SystemDrive%\Windows` install location.