### PR TITLE
Reduce agentic PR description noise

### DIFF
--- a/bazel/AGENTS.md
+++ b/bazel/AGENTS.md
@@ -271,6 +271,7 @@ case-sensitive filesystem — Docker Desktop can expose the two as the same inod
 - Standalone comments (not attached to a specific rule) require an empty line after them; attached comments do not.
 - Single blank line between top-level definitions.
 - No strict line length limit — labels can be long and tools generate BUILD files.
+- Use of `buildifier`, `gazelle` are enforced with unit tests, and the task is mechanical, so it is not noteworthy.  Don't note it in a PR's "how you validated your changes" section.
 
 ### Syntax restrictions
 

--- a/bazel/codereview_guideline.md
+++ b/bazel/codereview_guideline.md
@@ -8,9 +8,8 @@ case-insensitive filesystem collisions.
 
 ## Formatting
 
-`buildifier` is mandatory before committing. Flag any PR that modifies `BUILD.bazel` or `.bzl` files with no evidence
-of having run `bazel run //bazel/buildifier`. Missing formatting indicates the file was edited without the required
-toolchain step.
+`buildifier` is mandatory before committing. Flag any PR that modifies `BUILD.bazel` or `.bzl` files and
+is failling tests related to buildifier.
 
 ## Dependencies
 


### PR DESCRIPTION
### What does this PR do?
Try to stop agents from writing the meaningless statement of "I ran buildifier and gazelle" in the "how it was tested" part of a PR description.

### Motivation
It wastes reviewer time to read text that provides irrelevant information.
It costs tokens for automatic review to check for that same trivial information.