### PR TITLE
fix(ci): revert #55439 and instead cap `go_e2e_test_binaries` CPU quota

### DIFF
--- a/.gitlab/test/e2e/e2e_devx.yml
+++ b/.gitlab/test/e2e/e2e_devx.yml
@@ -13,8 +13,9 @@ go_e2e_test_binaries:
     - go_e2e_deps
   variables:
     KUBERNETES_CPU_REQUEST: 4
-    KUBERNETES_MEMORY_REQUEST: 72Gi
-    KUBERNETES_MEMORY_LIMIT: 72Gi
+    KUBERNETES_CPU_LIMIT: 4
+    KUBERNETES_MEMORY_REQUEST: 64Gi
+    KUBERNETES_MEMORY_LIMIT: 64Gi
   before_script:
     - !reference [.retrieve_linux_go_e2e_deps]
   script:


### PR DESCRIPTION
### What does this PR do?
Revert `KUBERNETES_MEMORY_REQUEST`/`KUBERNETES_MEMORY_LIMIT` from 72Gi back to 64Gi (prior to #55439) for the `go_e2e_test_binaries` job, and instead set `KUBERNETES_CPU_LIMIT: 4`, matching its `KUBERNETES_CPU_REQUEST` value.

### Motivation
While bumping `pulumi-kubernetes/sdk/v4` from v4.33.0 to v4.34.0, the Renovate-generated PR #55859 still faced repeated OOM-kills (exit 137) in the `go_e2e_test_binaries` job, despite the exceptionally large memory quota granted by #55439.

That is at least the 3rd time this exact job has OOM-killed since it was created:
- PR #38083 created it on 2025-06-24 with `CPU_REQUEST: 8` and `MEMORY: 64Gi`,
- it OOM-killed the very next day, and PR #38205 halved `CPU_REQUEST` to 4, the only lever available since Go was still on 1.23 and had no cgroup awareness at all,
- the repo moved to Go **1.25** on 2025-12-15 (PR #43774), which made `GOMAXPROCS` **cgroup-aware**, but **only against a CPU limit**, and this job has never set one,
- it OOM-killed again in August 2026, and PR #55439 raised `KUBERNETES_MEMORY_*` from 64Gi to 72Gi instead, most likely triggered by `pulumi-gcp/sdk/v9`'s bump in PR #55344 (rather than the macOS pooling PR its own message cites),

In all 3 cases the actual defect was the same: `KUBERNETES_CPU_REQUEST: 4` with no `KUBERNETES_CPU_LIMIT` leaves the pod's cgroup CPU quota **unbounded**, so each of the 4 concurrent `orchestrion go test -c` processes spawned by `_build_single_binary`'s thread pool defaults its own internal Go build parallelism to the node's **full core count** instead of 4.

Every fix so far adjusted the outer worker count or the memory ceiling, never that uncapped variable.

### Describe how you validated your changes
Reproduced the failure directly: PR #55859's pipeline OOM-killed `go_e2e_test_binaries` (exit 137) on every retry at 72Gi, mid-build, right after `Found 63 test packages to build`.

A first fix pinned `GOMAXPROCS=1` on every subprocess: that eliminated the OOM at 64Gi but made the job about 2.5 times slower (~44m vs a ~17m baseline on `main`), since it hard-caps every process to a single core instead of just removing the unbounded burst above the job's real 4-core budget.

Setting `KUBERNETES_CPU_LIMIT: 4` instead lets Go size each process's own `GOMAXPROCS` from the pod's real quota.

Tested on the same PR at 64Gi: `go_e2e_test_binaries` completed in ~16m, faster than the original 72Gi baseline, with no OOM.

### Additional Notes
`go_e2e_test_binaries` is the only job that calls `new-e2e-tests.build-binaries` or `_build_single_binary`, so no other job is affected by this change.
