### PR TITLE
Remove redundant rtloader test jobs

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -30,7 +30,6 @@ tests_windows_sysprobe*                 @DataDog/windows-products
 tests_windows_secagent*                 @DataDog/windows-products @DataDog/agent-security
 tests_flavor_*                          @DataDog/agent-runtimes
 tests_flavor_dogstatsd*                 @DataDog/agent-metric-pipelines
-tests_rtloader*                         @DataDog/agent-runtimes
 tests_serverless-init*                  @DataDog/serverless-azure-and-gcp
 security_go_generate_check              @DataDog/agent-security
 prepare_sysprobe_ebpf_functional_tests* @DataDog/ebpf-platform

--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -1,14 +1,4 @@
 ---
-.rtloader_tests:
-  stage: source_test
-  extends: .unit_test_base
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  rules:
-    - !reference [.except_disable_unit_tests]
-    - !reference [.fast_on_dev_branch_only]
-  script:
-    - bazel test //rtloader/...
-
 .linux_tests:
   stage: source_test
   extends: .unit_test_base
@@ -76,22 +66,6 @@ tests_linux-arm64-py3:
   tags: ["arch:arm64", "specific:true"]
   variables:
     CONDA_ENV: ddpy3
-
-tests_rtloader-x64:
-  extends: .rtloader_tests
-  needs: ["go_deps", "go_tools_deps"]
-  before_script:
-    - !reference [.retrieve_linux_go_deps]
-    - !reference [.retrieve_linux_go_tools_deps]
-  tags: ["arch:amd64", "specific:true"]
-
-tests_rtloader-arm64:
-  extends: .rtloader_tests
-  needs: ["go_deps", "go_tools_deps_arm64"]
-  before_script:
-    - !reference [.retrieve_linux_go_deps]
-    - !reference [.retrieve_linux_go_tools_deps_arm64]
-  tags: ["arch:arm64", "specific:true"]
 
 
 tests_serverless-init:


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

It removes rtloader test jobs that are already covered by `bazel:test` jobs without adding anything to them.

### Motivation

Remove redundant jobs.

### Describe how you validated your changes

### Additional Notes
