### PR TITLE
bound demultiplexer Stop() lock wait to avoid hanging on a stuck flush

### DIFF
--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -486,7 +486,13 @@ func (d *AgentDemultiplexer) Stop() {
 		}
 	}
 
-	d.m.Lock()
+	// A timed-out flush above may still be running in the background, holding d.m's
+	// read lock. Reuse the same deadline here so that case can't turn Stop() into an
+	// indefinite hang: give up on the write lock too, and skip cleanup below.
+	if !d.acquireLockOrTimeout(stopCtx) {
+		d.log.Errorf("timed out waiting for aggregator lock on Stop(), skipping resource cleanup")
+		return
+	}
 	defer d.m.Unlock()
 
 	// aggregated data
@@ -514,6 +520,24 @@ func (d *AgentDemultiplexer) Stop() {
 
 	d.dataOutputs.sharedSerializer = nil
 	d.senders = nil
+}
+
+// acquireLockOrTimeout takes d.m's write lock, giving up once ctx expires.
+// On timeout, the locking goroutine is left running rather than killed: it's harmless
+// since only Stop() calls this, and Stop()'s contract already forbids using d afterward.
+func (d *AgentDemultiplexer) acquireLockOrTimeout(ctx context.Context) bool {
+	acquired := make(chan struct{})
+	go func() {
+		d.m.Lock()
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // ForceFlushToSerializer triggers the execution of a flush from all data of samplers

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -524,8 +524,16 @@ func (d *AgentDemultiplexer) Stop() {
 
 // acquireLockOrTimeout takes d.m's write lock, giving up once ctx expires.
 // On timeout, the locking goroutine is left running rather than killed: it's harmless
-// since only Stop() calls this, and Stop()'s contract already forbids using d afterward.
+// since only Stop() calls this, and Stop()'s contract already forbids using d afterward -
+// but the lock it eventually acquires is released so it isn't held forever.
 func (d *AgentDemultiplexer) acquireLockOrTimeout(ctx context.Context) bool {
+	// Try the uncontended case synchronously first: with a zero (or already expired)
+	// deadline, racing a fresh goroutine against ctx.Done() in the select below could
+	// pick the already-ready Done() case even though the lock was actually free.
+	if d.m.TryLock() {
+		return true
+	}
+
 	acquired := make(chan struct{})
 	go func() {
 		d.m.Lock()
@@ -536,6 +544,10 @@ func (d *AgentDemultiplexer) acquireLockOrTimeout(ctx context.Context) bool {
 	case <-acquired:
 		return true
 	case <-ctx.Done():
+		go func() {
+			<-acquired
+			d.m.Unlock()
+		}()
 		return false
 	}
 }

--- a/pkg/aggregator/demultiplexer_agent_test.go
+++ b/pkg/aggregator/demultiplexer_agent_test.go
@@ -8,6 +8,7 @@
 package aggregator
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -323,6 +324,34 @@ func TestAddAgentStartupTelemetrySendsShutdownEventOnFinalStop(t *testing.T) {
 	require.Equal(t, "Agent Shutdown", shutdownEvent.EventType)
 
 	s.AssertExpectations(t)
+}
+
+func TestAcquireLockOrTimeout(t *testing.T) {
+	t.Run("uncontended lock with an already-expired deadline", func(t *testing.T) {
+		d := &AgentDemultiplexer{}
+		ctx, cancel := context.WithTimeout(context.Background(), 0)
+		defer cancel()
+
+		require.True(t, d.acquireLockOrTimeout(ctx), "an uncontended lock must be acquired even past the deadline (aggregator_stop_timeout: 0)")
+		d.m.Unlock()
+	})
+
+	t.Run("contended lock released after the deadline expires", func(t *testing.T) {
+		d := &AgentDemultiplexer{}
+		d.m.Lock()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		defer cancel()
+
+		require.False(t, d.acquireLockOrTimeout(ctx), "should give up once the deadline expires")
+
+		d.m.Unlock()
+
+		require.Eventually(t, func() bool {
+			return d.m.TryLock()
+		}, time.Second, time.Millisecond, "the lock acquired after giving up must still be released, not held forever")
+		d.m.Unlock()
+	})
 }
 
 func newShutdownTelemetryTestDemux(t *testing.T, hostname string) (*AgentDemultiplexer, *MockSerializerIterableSerie) {


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
This PR addresses an issue of agent shutdown hang that can cause Windows upgrade/install failures.

### Motivation
[WINA-3080](https://datadoghq.atlassian.net/browse/WINA-3080)

### Describe how you validated your changes
Stress test the specific test case and ensure CI pipeline pass.

### Additional Notes


[WINA-3080]: https://datadoghq.atlassian.net/browse/WINA-3080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ