### PR TITLE
Silence warnings for go-nvml build

### DIFF
--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -527,6 +527,14 @@ go_deps.gazelle_override(
     path = "github.com/DataDog/zstd",
 )
 
+# go-nvml exposes generated cgo bindings for the full NVML API surface, including
+# functions that NVIDIA marks deprecated in nvml.h. Compiling those bindings emits
+# -Wdeprecated-declarations warnings.
+go_deps.gazelle_override(
+    directives = ["gazelle:go_copts -Wno-deprecated-declarations"],
+    path = "github.com/NVIDIA/go-nvml",
+)
+
 # sdjournal wraps journald's C API and `#include <systemd/sd-journal.h>` at compile
 # time, but the hermetic toolchain sysroot ships no libsystemd headers. Patch the
 # Gazelle-generated BUILD to pull them from the vendored @systemd archive via cdeps.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Gets rid of compiler warnings for the go-nvml dependency by adding `-Wnodeprecated-=declarations` to it.

### Motivation

Thousands of lines of warnings are produced on bazel test runs ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/2022260739/viewer#L687)). These warnings are not valuable to us as they pertain to a third party dependency.

### Describe how you validated your changes

CI passes with the warnings being gone.

### Additional Notes
