### PR TITLE
[EBPF] Fix uprobe attacher test cleanup

### DIFF
--- a/pkg/ebpf/uprobes/BUILD.bazel
+++ b/pkg/ebpf/uprobes/BUILD.bazel
@@ -160,3 +160,20 @@ dd_agent_go_test(
         "//conditions:default": [],
     }),
 )
+
+dd_agent_go_test(
+    name = "testutil_attacher_runner_test",
+    srcs = ["testutil_attacher_runner_test.go"],
+    embed = [":uprobes"],
+    gotags_sets = [["bpf"]],
+    include_default = False,
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/pkg/ebpf/uprobes/testutil_attacher_runner.go
+++ b/pkg/ebpf/uprobes/testutil_attacher_runner.go
@@ -270,8 +270,9 @@ func (r *FmapperRunner) GetTargetPid(_ *testing.T) int {
 
 // Stop terminates the target process
 func (r *FmapperRunner) Stop(t *testing.T) {
-	err := r.cmd.Process.Kill()
-	require.NoError(t, err, "failed to kill fmapper")
+	require.NoError(t, r.cmd.Process.Kill(), "failed to kill fmapper")
+	_, err := r.cmd.Process.Wait()
+	require.NoError(t, err, "failed to wait for fmapper to exit")
 }
 
 // SameProcessAttacherRunner runs the attacher in the same process as the caller code

--- a/pkg/ebpf/uprobes/testutil_attacher_runner_test.go
+++ b/pkg/ebpf/uprobes/testutil_attacher_runner_test.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build linux && bpf && test
+
+package uprobes
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFmapperRunnerStopReapsProcess(t *testing.T) {
+	cmd := exec.Command("sleep", "60")
+	require.NoError(t, cmd.Start())
+
+	runner := &FmapperRunner{cmd: cmd}
+	pid := runner.GetTargetPid(t)
+	runner.Stop(t)
+
+	_, err := os.Stat(filepath.Join("/proc", fmt.Sprint(pid)))
+	require.ErrorIs(t, err, os.ErrNotExist, "fmapper process should be reaped")
+}

--- a/pkg/ebpf/uprobes/testutil_attacher_runner_test.go
+++ b/pkg/ebpf/uprobes/testutil_attacher_runner_test.go
@@ -8,10 +8,10 @@
 package uprobes
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,6 +25,6 @@ func TestFmapperRunnerStopReapsProcess(t *testing.T) {
 	pid := runner.GetTargetPid(t)
 	runner.Stop(t)
 
-	_, err := os.Stat(filepath.Join("/proc", fmt.Sprint(pid)))
+	_, err := os.Stat(filepath.Join("/proc", strconv.Itoa(pid)))
 	require.ErrorIs(t, err, os.ErrNotExist, "fmapper process should be reaped")
 }


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Reaps the uprobe attacher test target after terminating it, allowing periodic process reconciliation to detect its exit reliably.

### Motivation

When the event stream misses an exit event, the attacher does not automatically detach. While there is a fallback for those cases, via a re-scan of process, there is a bug in the test setup: an unreaped zombie remains visible in `/proc` and prevents probe detachment. 

This should fix [EBPF-1016](https://datadoghq.atlassian.net/browse/EBPF-1016), [EBPF-965](https://datadoghq.atlassian.net/browse/EBPF-965), and [EBPF-913](https://datadoghq.atlassian.net/browse/EBPF-913).

### Describe how you validated your changes

Ran the flaky test several times to validate that the failure did not reproduce, and added a test to ensure that the test process is always reaped after being killed.

### Additional Notes


[EBPF-1016]: https://datadoghq.atlassian.net/browse/EBPF-1016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EBPF-965]: https://datadoghq.atlassian.net/browse/EBPF-965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EBPF-913]: https://datadoghq.atlassian.net/browse/EBPF-913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ