### PR TITLE
ddprofilingextension: allow sending profiles over a unix socket

### DIFF
--- a/comp/otelcol/ddprofilingextension/impl/BUILD.bazel
+++ b/comp/otelcol/ddprofilingextension/impl/BUILD.bazel
@@ -8,6 +8,8 @@ go_library(
         "extension.go",
         "factory.go",
         "server.go",
+        "unixsocket_nix.go",
+        "unixsocket_windows.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/comp/otelcol/ddprofilingextension/impl",
     visibility = ["//visibility:public"],
@@ -24,7 +26,11 @@ go_library(
 
 dd_agent_go_test(
     name = "impl_test",
-    srcs = ["extension_test.go"],
+    srcs = [
+        "extension_test.go",
+        "extension_unixsocket_test.go",
+        "extension_unixsocket_windows_test.go",
+    ],
     data = [
         "config.schema.yaml",
         "metadata.yaml",

--- a/comp/otelcol/ddprofilingextension/impl/config.go
+++ b/comp/otelcol/ddprofilingextension/impl/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	// it the otel-agent is the only one that cannot be profiled in environments
 	// that expose a socket rather than HTTP egress (the SMP regression sandbox,
 	// for one).
+	// Ignored on Windows, where the trace agent exposes no profiling socket:
+	// profiles are sent over HTTP there as if this were unset.
 	// Default: DD_OTELCOLLECTOR_INTERNAL_PROFILING_UNIX_SOCKET, then unset.
 	UnixSocket string `mapstructure:"unix_socket"`
 }

--- a/comp/otelcol/ddprofilingextension/impl/config.go
+++ b/comp/otelcol/ddprofilingextension/impl/config.go
@@ -19,8 +19,8 @@ type Config struct {
 	// it the otel-agent is the only one that cannot be profiled in environments
 	// that expose a socket rather than HTTP egress (the SMP regression sandbox,
 	// for one).
-	// Ignored on Windows, where the trace agent exposes no profiling socket:
-	// profiles are sent over HTTP there as if this were unset.
+	// Ignored on Windows, where the Agent serves no APM unix socket: profiles
+	// are sent over HTTP there as if this were unset.
 	// Default: DD_OTELCOLLECTOR_INTERNAL_PROFILING_UNIX_SOCKET, then unset.
 	UnixSocket string `mapstructure:"unix_socket"`
 }

--- a/comp/otelcol/ddprofilingextension/impl/config.go
+++ b/comp/otelcol/ddprofilingextension/impl/config.go
@@ -13,6 +13,14 @@ type Config struct {
 	// Endpoint is the local port the profiling HTTP server listens on; used as "localhost:<endpoint>".
 	// Default: "7501"
 	Endpoint string `mapstructure:"endpoint"`
+	// UnixSocket sends profiles straight to a trace agent listening on this unix
+	// socket, bypassing the local forwarding server. Every other agent process
+	// already supports this via <component>.internal_profiling.unix_socket; without
+	// it the otel-agent is the only one that cannot be profiled in environments
+	// that expose a socket rather than HTTP egress (the SMP regression sandbox,
+	// for one).
+	// Default: DD_OTELCOLLECTOR_INTERNAL_PROFILING_UNIX_SOCKET, then unset.
+	UnixSocket string `mapstructure:"unix_socket"`
 }
 
 // ProfilerOptions defines settings relevant to the profiler.

--- a/comp/otelcol/ddprofilingextension/impl/config.schema.yaml
+++ b/comp/otelcol/ddprofilingextension/impl/config.schema.yaml
@@ -29,5 +29,5 @@ properties:
   profiler_options:
     $ref: profiler_options
   unix_socket:
-    description: 'UnixSocket sends profiles straight to a trace agent listening on this unix socket, bypassing the local forwarding server. Ignored on Windows, where the trace agent exposes no profiling socket. Default: DD_OTELCOLLECTOR_INTERNAL_PROFILING_UNIX_SOCKET, then unset.'
+    description: 'UnixSocket sends profiles straight to a trace agent listening on this unix socket, bypassing the local forwarding server. Ignored on Windows, where the Agent serves no APM unix socket. Default: DD_OTELCOLLECTOR_INTERNAL_PROFILING_UNIX_SOCKET, then unset.'
     type: string

--- a/comp/otelcol/ddprofilingextension/impl/config.schema.yaml
+++ b/comp/otelcol/ddprofilingextension/impl/config.schema.yaml
@@ -28,3 +28,6 @@ properties:
     type: string
   profiler_options:
     $ref: profiler_options
+  unix_socket:
+    description: 'UnixSocket sends profiles straight to a trace agent listening on this unix socket, bypassing the local forwarding server. Default: DD_OTELCOLLECTOR_INTERNAL_PROFILING_UNIX_SOCKET, then unset.'
+    type: string

--- a/comp/otelcol/ddprofilingextension/impl/config.schema.yaml
+++ b/comp/otelcol/ddprofilingextension/impl/config.schema.yaml
@@ -29,5 +29,5 @@ properties:
   profiler_options:
     $ref: profiler_options
   unix_socket:
-    description: 'UnixSocket sends profiles straight to a trace agent listening on this unix socket, bypassing the local forwarding server. Default: DD_OTELCOLLECTOR_INTERNAL_PROFILING_UNIX_SOCKET, then unset.'
+    description: 'UnixSocket sends profiles straight to a trace agent listening on this unix socket, bypassing the local forwarding server. Ignored on Windows, where the trace agent exposes no profiling socket. Default: DD_OTELCOLLECTOR_INTERNAL_PROFILING_UNIX_SOCKET, then unset.'
     type: string

--- a/comp/otelcol/ddprofilingextension/impl/extension.go
+++ b/comp/otelcol/ddprofilingextension/impl/extension.go
@@ -32,6 +32,12 @@ const (
 	ddServiceEnvVar = "DD_SERVICE"
 	ddEnvEnvVar     = "DD_ENV"
 	ddVersionEnvVar = "DD_VERSION"
+	// ddUnixSocketEnvVar mirrors the <component>.internal_profiling.unix_socket
+	// setting every other agent process exposes. It is read as an env var, not
+	// only as a config key, so that a collector config carrying it still parses
+	// on agent builds that predate unix_socket -- the collector rejects unknown
+	// config keys outright, which would otherwise make this un-A/B-able.
+	ddUnixSocketEnvVar = "DD_OTELCOLLECTOR_INTERNAL_PROFILING_UNIX_SOCKET"
 )
 
 // ddExtension is a basic OpenTelemetry Collector extension.
@@ -65,14 +71,23 @@ func (e *ddExtension) Start(_ context.Context, host component.Host) error {
 }
 
 func (e *ddExtension) startForAgent(host component.Host) error {
+	profilerOptions := e.buildProfilerOptions()
+
+	// A unix socket is a complete substitute for the local forwarding server:
+	// profiles go straight to the trace agent listening on the socket, so there
+	// is nothing left for the server to forward. Skip starting it rather than
+	// leaving an idle listener on port 7501.
+	if socket := e.unixSocket(); socket != "" {
+		e.log.Info("DD Profiling Extension sending profiles over unix socket: " + socket)
+		return profiler.Start(append(profilerOptions, profiler.WithUDS(socket))...)
+	}
+
 	// start server that handles profiles
 	err := e.newServer()
 	if err != nil {
 		return err
 	}
 	go e.startServer(host)
-
-	profilerOptions := e.buildProfilerOptions()
 
 	// agent
 	profilerOptions = append(profilerOptions, profiler.WithAgentAddr("localhost:"+e.endpoint()))
@@ -84,7 +99,11 @@ func (e *ddExtension) startForAgent(host component.Host) error {
 
 func (e *ddExtension) startForStandalone() error {
 	profilerOptions := e.buildProfilerOptions()
-	if e.cfg.AgentAddr != "" {
+	// A socket and a TCP address are two ways of naming the same trace agent, so
+	// only one can apply. The socket wins: it is the more specific of the two.
+	if socket := e.unixSocket(); socket != "" {
+		profilerOptions = append(profilerOptions, profiler.WithUDS(socket))
+	} else if e.cfg.AgentAddr != "" {
 		profilerOptions = append(profilerOptions, profiler.WithAgentAddr(e.cfg.AgentAddr))
 	}
 	return profiler.Start(profilerOptions...)
@@ -138,6 +157,16 @@ func (e *ddExtension) buildProfilerOptions() []profiler.Option {
 	}
 
 	return profilerOptions
+}
+
+// unixSocket returns the unix socket profiles should be sent to, preferring the
+// config key over the environment.
+func (e *ddExtension) unixSocket() string {
+	if e.cfg.UnixSocket != "" {
+		return e.cfg.UnixSocket
+	}
+	socket, _ := nonBlankEnv(ddUnixSocketEnvVar)
+	return socket
 }
 
 func nonBlankEnv(key string) (string, bool) {

--- a/comp/otelcol/ddprofilingextension/impl/extension.go
+++ b/comp/otelcol/ddprofilingextension/impl/extension.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -48,8 +49,10 @@ type ddExtension struct {
 	info       component.BuildInfo
 	traceAgent traceagent.Component
 	server     *http.Server
-	log        corelog.Component
-	agentMode  bool
+	// log is nil when the extension is built by NewFactory (standalone mode),
+	// which is given no agent components. Every use must be nil-checked.
+	log       corelog.Component
+	agentMode bool
 }
 
 // NewComponent creates a new instance of the extension.
@@ -78,7 +81,9 @@ func (e *ddExtension) startForAgent(host component.Host) error {
 	// is nothing left for the server to forward. Skip starting it rather than
 	// leaving an idle listener on port 7501.
 	if socket := e.unixSocket(); socket != "" {
-		e.log.Info("DD Profiling Extension sending profiles over unix socket: " + socket)
+		if e.log != nil {
+			e.log.Info("DD Profiling Extension sending profiles over unix socket: " + socket)
+		}
 		return profiler.Start(append(profilerOptions, profiler.WithUDS(socket))...)
 	}
 
@@ -161,11 +166,29 @@ func (e *ddExtension) buildProfilerOptions() []profiler.Option {
 
 // unixSocket returns the unix socket profiles should be sent to, preferring the
 // config key over the environment.
+//
+// It also returns "" when a socket is configured on a platform that has no use
+// for one. Callers then take the address-based path they would have taken had
+// the setting been absent, so a socket carried in a config or an environment
+// shared across a mixed fleet degrades to HTTP on Windows rather than pointing
+// the profiler at a path nothing serves.
 func (e *ddExtension) unixSocket() string {
-	if e.cfg.UnixSocket != "" {
-		return e.cfg.UnixSocket
+	socket, source := e.cfg.UnixSocket, "the unix_socket setting"
+	if socket == "" {
+		if fromEnv, ok := nonBlankEnv(ddUnixSocketEnvVar); ok {
+			socket, source = fromEnv, ddUnixSocketEnvVar
+		}
 	}
-	socket, _ := nonBlankEnv(ddUnixSocketEnvVar)
+	if socket == "" {
+		return ""
+	}
+	if !hasUnixSocketSupport() {
+		if e.log != nil {
+			e.log.Warn("DD Profiling Extension ignoring " + source + ": no trace agent profiling socket is " +
+				"available on " + runtime.GOOS + ", falling back to sending profiles over HTTP")
+		}
+		return ""
+	}
 	return socket
 }
 

--- a/comp/otelcol/ddprofilingextension/impl/extension_test.go
+++ b/comp/otelcol/ddprofilingextension/impl/extension_test.go
@@ -9,11 +9,8 @@ package ddprofilingextensionimpl
 import (
 	"context"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -168,126 +165,4 @@ func TestStandaloneExtension(t *testing.T) {
 
 	err = ext.Shutdown(context.Background())
 	require.NoError(t, err)
-}
-
-// newUnixSocketServer serves HTTP on a unix socket and returns its path.
-//
-// The socket is placed under /tmp rather than t.TempDir(): sockaddr_un.sun_path
-// is capped at 104 bytes on darwin and 108 on linux, and t.TempDir() on darwin
-// alone can spend most of that budget before the filename is appended.
-func newUnixSocketServer(t *testing.T, handler http.Handler) string {
-	t.Helper()
-
-	dir, err := os.MkdirTemp("/tmp", "ddprof")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-
-	socket := filepath.Join(dir, "apm.socket")
-	ln, err := net.Listen("unix", socket)
-	require.NoError(t, err)
-
-	server := &httptest.Server{Listener: ln, Config: &http.Server{Handler: handler}}
-	server.Start()
-	t.Cleanup(server.Close)
-
-	return socket
-}
-
-func TestUnixSocket(t *testing.T) {
-	t.Run("config wins over environment", func(t *testing.T) {
-		t.Setenv(ddUnixSocketEnvVar, "/from/env.socket")
-		e := &ddExtension{cfg: &Config{UnixSocket: "/from/config.socket"}}
-		assert.Equal(t, "/from/config.socket", e.unixSocket())
-	})
-
-	t.Run("falls back to the environment", func(t *testing.T) {
-		t.Setenv(ddUnixSocketEnvVar, "/from/env.socket")
-		e := &ddExtension{cfg: &Config{}}
-		assert.Equal(t, "/from/env.socket", e.unixSocket())
-	})
-
-	// A blank env var is how a case config disables the socket without removing
-	// the key, so it must not be mistaken for a socket path.
-	t.Run("blank environment is unset", func(t *testing.T) {
-		t.Setenv(ddUnixSocketEnvVar, "   ")
-		e := &ddExtension{cfg: &Config{}}
-		assert.Empty(t, e.unixSocket())
-	})
-
-	t.Run("unset everywhere", func(t *testing.T) {
-		e := &ddExtension{cfg: &Config{}}
-		assert.Empty(t, e.unixSocket())
-	})
-}
-
-func TestAgentExtensionUnixSocket(t *testing.T) {
-	got := make(chan string, 1)
-	socket := newUnixSocketServer(t, http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		assert.Equal(t, "/profiling/v1/input", req.URL.Path)
-		select {
-		case got <- req.Header.Get("User-Agent"):
-		default:
-		}
-		rw.WriteHeader(http.StatusAccepted)
-	}))
-
-	// testComponent{} carries a nil *pkgagent.Agent, so GetHTTPHandler would
-	// panic if it were called. Passing it here is the assertion that the socket
-	// path never builds the local forwarding server.
-	ext, err := NewComponent(&Config{
-		UnixSocket: socket,
-		ProfilerOptions: ProfilerOptions{
-			Period: 1,
-		},
-	}, component.BuildInfo{}, testComponent{}, log.NewTemporaryLoggerWithoutInit())
-	require.NoError(t, err)
-
-	e, ok := ext.(*ddExtension)
-	require.True(t, ok)
-	require.True(t, e.agentMode, "a non-nil trace agent must still select agent mode")
-
-	require.NoError(t, ext.Start(context.Background(), componenttest.NewNopHost()))
-	t.Cleanup(func() { assert.NoError(t, ext.Shutdown(context.Background())) })
-
-	assert.Nil(t, e.server, "the local forwarding server must not be started when a socket is configured")
-
-	select {
-	case out := <-got:
-		assert.Equal(t, "Go-http-client/1.1", out)
-	case <-time.After(15 * time.Second):
-		t.Fatal("Timed out waiting for a profile on the unix socket")
-	}
-}
-
-func TestStandaloneExtensionUnixSocket(t *testing.T) {
-	got := make(chan struct{}, 1)
-	socket := newUnixSocketServer(t, http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		assert.Equal(t, "/profiling/v1/input", req.URL.Path)
-		select {
-		case got <- struct{}{}:
-		default:
-		}
-		rw.WriteHeader(http.StatusAccepted)
-	}))
-
-	// AgentAddr is deliberately set to an address nothing is listening on: if the
-	// socket did not take precedence, the profile upload would fail instead of
-	// arriving below.
-	ext, err := NewComponent(&Config{
-		UnixSocket: socket,
-		AgentAddr:  "127.0.0.1:1",
-		ProfilerOptions: ProfilerOptions{
-			Period: 1,
-		},
-	}, component.BuildInfo{}, nil, nil)
-	require.NoError(t, err)
-
-	require.NoError(t, ext.Start(context.Background(), componenttest.NewNopHost()))
-	t.Cleanup(func() { assert.NoError(t, ext.Shutdown(context.Background())) })
-
-	select {
-	case <-got:
-	case <-time.After(15 * time.Second):
-		t.Fatal("Timed out waiting for a profile on the unix socket")
-	}
 }

--- a/comp/otelcol/ddprofilingextension/impl/extension_test.go
+++ b/comp/otelcol/ddprofilingextension/impl/extension_test.go
@@ -9,8 +9,11 @@ package ddprofilingextensionimpl
 import (
 	"context"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -165,4 +168,126 @@ func TestStandaloneExtension(t *testing.T) {
 
 	err = ext.Shutdown(context.Background())
 	require.NoError(t, err)
+}
+
+// newUnixSocketServer serves HTTP on a unix socket and returns its path.
+//
+// The socket is placed under /tmp rather than t.TempDir(): sockaddr_un.sun_path
+// is capped at 104 bytes on darwin and 108 on linux, and t.TempDir() on darwin
+// alone can spend most of that budget before the filename is appended.
+func newUnixSocketServer(t *testing.T, handler http.Handler) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("/tmp", "ddprof")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	socket := filepath.Join(dir, "apm.socket")
+	ln, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+
+	server := &httptest.Server{Listener: ln, Config: &http.Server{Handler: handler}}
+	server.Start()
+	t.Cleanup(server.Close)
+
+	return socket
+}
+
+func TestUnixSocket(t *testing.T) {
+	t.Run("config wins over environment", func(t *testing.T) {
+		t.Setenv(ddUnixSocketEnvVar, "/from/env.socket")
+		e := &ddExtension{cfg: &Config{UnixSocket: "/from/config.socket"}}
+		assert.Equal(t, "/from/config.socket", e.unixSocket())
+	})
+
+	t.Run("falls back to the environment", func(t *testing.T) {
+		t.Setenv(ddUnixSocketEnvVar, "/from/env.socket")
+		e := &ddExtension{cfg: &Config{}}
+		assert.Equal(t, "/from/env.socket", e.unixSocket())
+	})
+
+	// A blank env var is how a case config disables the socket without removing
+	// the key, so it must not be mistaken for a socket path.
+	t.Run("blank environment is unset", func(t *testing.T) {
+		t.Setenv(ddUnixSocketEnvVar, "   ")
+		e := &ddExtension{cfg: &Config{}}
+		assert.Empty(t, e.unixSocket())
+	})
+
+	t.Run("unset everywhere", func(t *testing.T) {
+		e := &ddExtension{cfg: &Config{}}
+		assert.Empty(t, e.unixSocket())
+	})
+}
+
+func TestAgentExtensionUnixSocket(t *testing.T) {
+	got := make(chan string, 1)
+	socket := newUnixSocketServer(t, http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/profiling/v1/input", req.URL.Path)
+		select {
+		case got <- req.Header.Get("User-Agent"):
+		default:
+		}
+		rw.WriteHeader(http.StatusAccepted)
+	}))
+
+	// testComponent{} carries a nil *pkgagent.Agent, so GetHTTPHandler would
+	// panic if it were called. Passing it here is the assertion that the socket
+	// path never builds the local forwarding server.
+	ext, err := NewComponent(&Config{
+		UnixSocket: socket,
+		ProfilerOptions: ProfilerOptions{
+			Period: 1,
+		},
+	}, component.BuildInfo{}, testComponent{}, log.NewTemporaryLoggerWithoutInit())
+	require.NoError(t, err)
+
+	e, ok := ext.(*ddExtension)
+	require.True(t, ok)
+	require.True(t, e.agentMode, "a non-nil trace agent must still select agent mode")
+
+	require.NoError(t, ext.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() { assert.NoError(t, ext.Shutdown(context.Background())) })
+
+	assert.Nil(t, e.server, "the local forwarding server must not be started when a socket is configured")
+
+	select {
+	case out := <-got:
+		assert.Equal(t, "Go-http-client/1.1", out)
+	case <-time.After(15 * time.Second):
+		t.Fatal("Timed out waiting for a profile on the unix socket")
+	}
+}
+
+func TestStandaloneExtensionUnixSocket(t *testing.T) {
+	got := make(chan struct{}, 1)
+	socket := newUnixSocketServer(t, http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/profiling/v1/input", req.URL.Path)
+		select {
+		case got <- struct{}{}:
+		default:
+		}
+		rw.WriteHeader(http.StatusAccepted)
+	}))
+
+	// AgentAddr is deliberately set to an address nothing is listening on: if the
+	// socket did not take precedence, the profile upload would fail instead of
+	// arriving below.
+	ext, err := NewComponent(&Config{
+		UnixSocket: socket,
+		AgentAddr:  "127.0.0.1:1",
+		ProfilerOptions: ProfilerOptions{
+			Period: 1,
+		},
+	}, component.BuildInfo{}, nil, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, ext.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() { assert.NoError(t, ext.Shutdown(context.Background())) })
+
+	select {
+	case <-got:
+	case <-time.After(15 * time.Second):
+		t.Fatal("Timed out waiting for a profile on the unix socket")
+	}
 }

--- a/comp/otelcol/ddprofilingextension/impl/extension_unixsocket_test.go
+++ b/comp/otelcol/ddprofilingextension/impl/extension_unixsocket_test.go
@@ -1,0 +1,153 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build !windows
+
+// Package ddprofilingextension defines the OpenTelemetry Extension implementation.
+package ddprofilingextensionimpl
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+
+	log "github.com/DataDog/datadog-agent/comp/core/log/impl"
+)
+
+// newUnixSocketServer serves HTTP on a unix socket and returns its path.
+//
+// The socket is placed under /tmp rather than t.TempDir(): sockaddr_un.sun_path
+// is capped at 104 bytes on darwin and 108 on linux, and TMPDIR on darwin is a
+// long /var/folders/... path that spends most of that budget before a filename
+// is appended. /tmp is safe to assume here only because this file is excluded
+// from Windows by the build tag above.
+func newUnixSocketServer(t *testing.T, handler http.Handler) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("/tmp", "ddprof")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	socket := filepath.Join(dir, "apm.socket")
+	ln, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+
+	server := &httptest.Server{Listener: ln, Config: &http.Server{Handler: handler}}
+	server.Start()
+	t.Cleanup(server.Close)
+
+	return socket
+}
+
+func TestUnixSocket(t *testing.T) {
+	require.True(t, hasUnixSocketSupport(), "every platform this file builds for can dial a unix socket")
+
+	t.Run("config wins over environment", func(t *testing.T) {
+		t.Setenv(ddUnixSocketEnvVar, "/from/env.socket")
+		e := &ddExtension{cfg: &Config{UnixSocket: "/from/config.socket"}}
+		assert.Equal(t, "/from/config.socket", e.unixSocket())
+	})
+
+	t.Run("falls back to the environment", func(t *testing.T) {
+		t.Setenv(ddUnixSocketEnvVar, "/from/env.socket")
+		e := &ddExtension{cfg: &Config{}}
+		assert.Equal(t, "/from/env.socket", e.unixSocket())
+	})
+
+	// A blank env var is how a case config disables the socket without removing
+	// the key, so it must not be mistaken for a socket path.
+	t.Run("blank environment is unset", func(t *testing.T) {
+		t.Setenv(ddUnixSocketEnvVar, "   ")
+		e := &ddExtension{cfg: &Config{}}
+		assert.Empty(t, e.unixSocket())
+	})
+
+	t.Run("unset everywhere", func(t *testing.T) {
+		e := &ddExtension{cfg: &Config{}}
+		assert.Empty(t, e.unixSocket())
+	})
+}
+
+func TestAgentExtensionUnixSocket(t *testing.T) {
+	got := make(chan string, 1)
+	socket := newUnixSocketServer(t, http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/profiling/v1/input", req.URL.Path)
+		select {
+		case got <- req.Header.Get("User-Agent"):
+		default:
+		}
+		rw.WriteHeader(http.StatusAccepted)
+	}))
+
+	// testComponent{} carries a nil *pkgagent.Agent, so GetHTTPHandler would
+	// panic if it were called. Passing it here is the assertion that the socket
+	// path never builds the local forwarding server.
+	ext, err := NewComponent(&Config{
+		UnixSocket: socket,
+		ProfilerOptions: ProfilerOptions{
+			Period: 1,
+		},
+	}, component.BuildInfo{}, testComponent{}, log.NewTemporaryLoggerWithoutInit())
+	require.NoError(t, err)
+
+	e, ok := ext.(*ddExtension)
+	require.True(t, ok)
+	require.True(t, e.agentMode, "a non-nil trace agent must still select agent mode")
+
+	require.NoError(t, ext.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() { assert.NoError(t, ext.Shutdown(context.Background())) })
+
+	assert.Nil(t, e.server, "the local forwarding server must not be started when a socket is configured")
+
+	select {
+	case out := <-got:
+		assert.Equal(t, "Go-http-client/1.1", out)
+	case <-time.After(15 * time.Second):
+		t.Fatal("Timed out waiting for a profile on the unix socket")
+	}
+}
+
+func TestStandaloneExtensionUnixSocket(t *testing.T) {
+	got := make(chan struct{}, 1)
+	socket := newUnixSocketServer(t, http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/profiling/v1/input", req.URL.Path)
+		select {
+		case got <- struct{}{}:
+		default:
+		}
+		rw.WriteHeader(http.StatusAccepted)
+	}))
+
+	// AgentAddr is deliberately set to an address nothing is listening on: if the
+	// socket did not take precedence, the profile upload would fail instead of
+	// arriving below.
+	ext, err := NewComponent(&Config{
+		UnixSocket: socket,
+		AgentAddr:  "127.0.0.1:1",
+		ProfilerOptions: ProfilerOptions{
+			Period: 1,
+		},
+	}, component.BuildInfo{}, nil, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, ext.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() { assert.NoError(t, ext.Shutdown(context.Background())) })
+
+	select {
+	case <-got:
+	case <-time.After(15 * time.Second):
+		t.Fatal("Timed out waiting for a profile on the unix socket")
+	}
+}

--- a/comp/otelcol/ddprofilingextension/impl/extension_unixsocket_windows_test.go
+++ b/comp/otelcol/ddprofilingextension/impl/extension_unixsocket_windows_test.go
@@ -33,7 +33,7 @@ import (
 // is a complete proof that agent mode still builds its local forwarding server
 // and standalone mode still honours agent_addr.
 func TestUnixSocketUnsupported(t *testing.T) {
-	require.False(t, hasUnixSocketSupport(), "the trace agent exposes no profiling socket on Windows")
+	require.False(t, hasUnixSocketSupport(), "no Windows Agent serves an APM unix socket")
 
 	t.Run("config key is ignored", func(t *testing.T) {
 		e := &ddExtension{cfg: &Config{UnixSocket: `C:\ProgramData\Datadog\apm.socket`}, log: log.NewTemporaryLoggerWithoutInit()}

--- a/comp/otelcol/ddprofilingextension/impl/extension_unixsocket_windows_test.go
+++ b/comp/otelcol/ddprofilingextension/impl/extension_unixsocket_windows_test.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build windows
+
+// Package ddprofilingextension defines the OpenTelemetry Extension implementation.
+package ddprofilingextensionimpl
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+
+	log "github.com/DataDog/datadog-agent/comp/core/log/impl"
+)
+
+// TestUnixSocketUnsupported covers the Windows half of the platform split. A
+// socket reaches this process the same way it reaches a Linux one -- a shared
+// collector config, or an environment set across a mixed fleet -- so what
+// matters is that it is discarded rather than acted on.
+//
+// Discarding it is also what keeps the rest of the extension on its normal
+// path: both start functions branch on unixSocket() != "", so an empty result
+// is a complete proof that agent mode still builds its local forwarding server
+// and standalone mode still honours agent_addr.
+func TestUnixSocketUnsupported(t *testing.T) {
+	require.False(t, hasUnixSocketSupport(), "the trace agent exposes no profiling socket on Windows")
+
+	t.Run("config key is ignored", func(t *testing.T) {
+		e := &ddExtension{cfg: &Config{UnixSocket: `C:\ProgramData\Datadog\apm.socket`}, log: log.NewTemporaryLoggerWithoutInit()}
+		assert.Empty(t, e.unixSocket())
+	})
+
+	t.Run("environment is ignored", func(t *testing.T) {
+		t.Setenv(ddUnixSocketEnvVar, "/var/run/datadog/apm.socket")
+		e := &ddExtension{cfg: &Config{}, log: log.NewTemporaryLoggerWithoutInit()}
+		assert.Empty(t, e.unixSocket())
+	})
+
+	// Standalone mode is constructed without a logger, so the ignore path has to
+	// survive a nil one. Reaching the assertion at all is the test.
+	t.Run("nil logger does not panic", func(t *testing.T) {
+		t.Setenv(ddUnixSocketEnvVar, "/var/run/datadog/apm.socket")
+		e := &ddExtension{cfg: &Config{UnixSocket: "/var/run/datadog/apm.socket"}}
+		assert.Empty(t, e.unixSocket())
+	})
+}
+
+// TestStandaloneExtensionUnixSocketFallsBackToHTTP is the end-to-end statement
+// of the same thing: configuring a socket on Windows must degrade to the
+// address-based transport, not disable profiling.
+func TestStandaloneExtensionUnixSocketFallsBackToHTTP(t *testing.T) {
+	got := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/profiling/v1/input", req.URL.Path)
+		select {
+		case got <- struct{}{}:
+		default:
+		}
+		rw.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	// A nil logger, as NewFactory would supply.
+	ext, err := NewComponent(&Config{
+		UnixSocket: `C:\ProgramData\Datadog\apm.socket`,
+		AgentAddr:  server.Listener.Addr().String(),
+		ProfilerOptions: ProfilerOptions{
+			Period: 1,
+		},
+	}, component.BuildInfo{}, nil, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, ext.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() { assert.NoError(t, ext.Shutdown(context.Background())) })
+
+	select {
+	case <-got:
+	case <-time.After(15 * time.Second):
+		t.Fatal("Timed out waiting for a profile over HTTP")
+	}
+}

--- a/comp/otelcol/ddprofilingextension/impl/unixsocket_nix.go
+++ b/comp/otelcol/ddprofilingextension/impl/unixsocket_nix.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build !windows
+
+// Package ddprofilingextensionimpl defines the OpenTelemetry Profiling implementation
+package ddprofilingextensionimpl
+
+// hasUnixSocketSupport reports whether profiles can be sent to a trace agent
+// over a unix socket on this platform.
+func hasUnixSocketSupport() bool {
+	return true
+}

--- a/comp/otelcol/ddprofilingextension/impl/unixsocket_windows.go
+++ b/comp/otelcol/ddprofilingextension/impl/unixsocket_windows.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build windows
+
+// Package ddprofilingextensionimpl defines the OpenTelemetry Profiling implementation
+package ddprofilingextensionimpl
+
+// hasUnixSocketSupport reports whether a trace agent profiling socket can be
+// reached on this platform.
+//
+// It is false on Windows, and not because the dial would fail to compile or to
+// resolve: recent Windows builds implement AF_UNIX and Go dials it happily. It
+// is false because no Windows Agent ever serves one. apm_config.receiver_socket
+// has no default on Windows (defaultpaths.GetDefaultReceiverSocket returns ""),
+// and fixupLinuxSockets -- the only code that fills it in -- runs on linux and
+// aix alone (pkg/config/setup/fixup_init.go).
+//
+// What makes that worth guarding is how the failure would present. WithUDS only
+// installs a dialer, so a path nothing serves is not an error at Start: it is a
+// failed upload once per profiling period, forever, in the profiler's own logs.
+// Worse, startForAgent treats a configured socket as a complete substitute for
+// the local forwarding server and skips starting it, so the HTTP path that
+// would otherwise have carried these profiles is gone too.
+//
+// Returning false costs a Windows host nothing it had: profiles take the HTTP
+// transport they would have taken had the setting been absent.
+func hasUnixSocketSupport() bool {
+	return false
+}

--- a/releasenotes/notes/ddprofiling-unix-socket-4c1f8ab27e9d3506.yaml
+++ b/releasenotes/notes/ddprofiling-unix-socket-4c1f8ab27e9d3506.yaml
@@ -14,3 +14,5 @@ enhancements:
     This matches ``internal_profiling.unix_socket``, already supported by the
     other Agent processes, and makes the OTel Agent profileable in environments
     that expose a socket rather than HTTP egress to the profiling intake.
+    The setting is ignored on Windows, where the trace agent exposes no
+    profiling socket; profiles are sent over HTTP there instead.

--- a/releasenotes/notes/ddprofiling-unix-socket-4c1f8ab27e9d3506.yaml
+++ b/releasenotes/notes/ddprofiling-unix-socket-4c1f8ab27e9d3506.yaml
@@ -14,5 +14,5 @@ enhancements:
     This matches ``internal_profiling.unix_socket``, already supported by the
     other Agent processes, and makes the OTel Agent profileable in environments
     that expose a socket rather than HTTP egress to the profiling intake.
-    The setting is ignored on Windows, where the trace agent exposes no
-    profiling socket; profiles are sent over HTTP there instead.
+    The setting has no effect on Windows, where the Agent does not serve an
+    APM unix socket; profiles are sent over HTTP there instead.

--- a/releasenotes/notes/ddprofiling-unix-socket-4c1f8ab27e9d3506.yaml
+++ b/releasenotes/notes/ddprofiling-unix-socket-4c1f8ab27e9d3506.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    OTel Agent: the ``ddprofiling`` extension can now send profiles directly to a
+    trace agent listening on a unix socket, via the ``unix_socket`` config key or
+    the ``DD_OTELCOLLECTOR_INTERNAL_PROFILING_UNIX_SOCKET`` environment variable.
+    This matches ``internal_profiling.unix_socket``, already supported by the
+    other Agent processes, and makes the OTel Agent profileable in environments
+    that expose a socket rather than HTTP egress to the profiling intake.


### PR DESCRIPTION
### What does this PR do?

Adds a `unix_socket` option to the `ddprofiling` extension. When set, the
extension sends profiles straight to a trace agent listening on that socket via
`profiler.WithUDS`, instead of standing up the local forwarding server on port
7501 and proxying through the embedded trace agent over HTTP.

The socket is read from either:

- the `unix_socket` config key, or
- the `DD_OTELCOLLECTOR_INTERNAL_PROFILING_UNIX_SOCKET` environment variable.

The config key wins when both are set. A socket and `agent_addr` are two ways of
naming the same trace agent, so only one can apply; the socket is the more
specific of the two and takes precedence. When no socket is configured, nothing
changes — the existing agent-mode and standalone-mode paths are untouched.

The setting is ignored on Windows, where no Agent serves an APM socket; profiles
go over HTTP there as if it were unset. See *Platform handling* below.

```yaml
extensions:
  ddprofiling:
    unix_socket: /var/run/datadog/apm.socket
```

### Motivation

Every other Agent process can already send its internal profiles over a unix
socket — that is `<component>.internal_profiling.unix_socket`, wired through
`pkg/util/profiling`. The OTel Agent is the exception. `cmd/otel-agent` never
calls `pkg/util/profiling` (it passes `DisableInternalProfiling: true` to its
embedded trace agent in `subcommands/run/command.go`) and starts no profiler of
its own, so the `ddprofiling` extension is its only in-process profiler. In
agent mode that extension has exactly one egress: a local HTTP server routed to
the trace agent's `/profiling/v1/input` handler, which posts to
`apm_config.profiling_dd_url` over a plain `net.Dialer`.

The result is that in any environment that exposes a socket rather than HTTP
egress to the profiling intake, the OTel Agent is the one Agent process that
cannot be profiled at all.

That is not hypothetical. It is why the DDOT regression cases in
`single-machine-performance` upload core-agent profiles and nothing from the
collector: the process under test is the one process the suite cannot see into.
Those cases have had internal profiling enabled since they were written, and
not one profile they have ever produced contains a collector frame. This change
is what makes DDOT profileable there, which in turn is what lets a CPU
regression in the collector be attributed to a function rather than guessed at.

### Describe how you validated your changes

Unit tests are split by platform, following the convention the rest of the repo
uses for unix socket tests (`comp/dogstatsd/listeners/uds_*_test.go`,
`comp/api/api/apiimpl/listener/listener_{nix,other}_test.go`).

`extension_unixsocket_test.go` (`//go:build !windows`):

- `TestUnixSocket` — four subtests covering resolution precedence: config key
  wins over the environment, falls back to the environment when unset, treats a
  blank environment value as unset, and reports unset when neither is present.
- `TestAgentExtensionUnixSocket` — starts the agent-mode extension against a
  real unix socket while passing a nil `*pkgagent.Agent`. Passing nil is the
  assertion: the socket path must never build the local forwarding server,
  because building it would dereference the trace agent and panic.
- `TestStandaloneExtensionUnixSocket` — starts the standalone extension with
  both a socket and `agent_addr: 127.0.0.1:1`. The address is deliberately dead,
  so the test only passes if the socket takes precedence.

`extension_unixsocket_windows_test.go` (`//go:build windows`):

- `TestUnixSocketUnsupported` — a socket from the config key and a socket from
  the environment are both discarded, and the discard path survives a nil
  logger. An empty result is a complete proof that the rest of the extension
  stays on its normal path, since both start functions branch on
  `unixSocket() != ""`.
- `TestStandaloneExtensionUnixSocketFallsBackToHTTP` — configures a
  Windows-style socket path *and* a live `httptest` `agent_addr`, with a nil
  logger, and asserts a profile actually arrives over HTTP.

```
dda inv test --targets=./comp/otelcol/ddprofilingextension/impl        # 9 pass (darwin)
dda inv linter.go --module=comp/otelcol/ddprofilingextension/impl      # 0 issues
GOOS=windows GOARCH=amd64 \
  dda inv linter.go --module=comp/otelcol/ddprofilingextension/impl    # 0 issues
```

The Windows lint is a cross-typecheck of the Windows-only sources, which the
host test run cannot reach. I confirmed it is not vacuous by temporarily
introducing an undefined symbol into `extension_unixsocket_windows_test.go` and
watching the linter report it. (`bazel build --platforms=...windows_amd64`
compiles the library but cannot build `:impl_test` — Bazel requires exec
platform == target platform for test rules — hence the linter route.)

### Additional Notes

#### Platform handling

`hasUnixSocketSupport()` splits along `!windows` / `windows`
(`unixsocket_nix.go` / `unixsocket_windows.go`), mirroring
`comp/api/api/apiimpl/listener`. `unixSocket()` drops a configured socket where
it is unsupported, warns once, and returns `""` so the caller takes the HTTP
path it would have taken had the setting been absent.

Degrading rather than rejecting is deliberate. `Config.Validate()` has
precedent in `ddflareextension`, but a fleet-wide `DD_..._UNIX_SOCKET` must not
refuse to start a Windows collector; silent fallback matches `GetIPCServerPath`.

Windows is false not because the dial would fail to compile or resolve — recent
Windows builds implement AF_UNIX and Go dials it — but because no Windows Agent
serves one: `apm_config.receiver_socket` has no default there, and
`fixupLinuxSockets`, the only code that fills it in, runs on linux and aix
alone. What makes it worth guarding is how the failure would present.
`WithUDS` only installs a dialer, so a path nothing serves is not an error at
`Start`; it is a failed upload once per profiling period, forever. And
`startForAgent` treats a configured socket as a complete substitute for the
local forwarding server and skips starting it — so the HTTP path that would
otherwise have carried those profiles is gone too. Profiles would silently go
nowhere.

Related: `e.log` is nil whenever the extension is built by `NewFactory`, which
is given no agent components (`otel_col_factories.go`, `provider_test.go`). The
new warning would have panicked on exactly the path that has no forwarding
server to fall back on, so every use is nil-checked and the invariant is
documented on the field.

The environment variable is not redundant with the config key, and it is the
reason this is usable for A/B measurement. The OTel collector rejects unknown
config keys outright, so a collector config carrying `unix_socket` fails to
start on any Agent build that predates this PR. An A/B experiment has to hand
the same config to both variants, so a config key alone cannot be used to
profile a released baseline against a patched build. An env var is invisible to
the config unmarshaller and so parses fine on both.

The variable is named to match the `internal_profiling.unix_socket` setting the
other components expose, under the `otelcollector` component prefix.

`Shutdown` already tolerates a nil server, so skipping the forwarding server
needs no change there.



The `GOOS`-prefixed cross-typecheck used above is documented separately in
#56026, which was split out of this PR so this one carries only its own code.
No dependency in either direction.
