### PR TITLE
change agent version from {version}_git to {version}-git for semver

### DIFF
--- a/tasks/host_profiler.py
+++ b/tasks/host_profiler.py
@@ -33,9 +33,9 @@ def _get_profiler_agent_version(ctx):
     Two deployment contexts are handled:
       - Nightly (same condition as nightly relenv trigger):
           DDR_WORKFLOW_ID set + CI_COMMIT_BRANCH == "main" + BUCKET_BRANCH in nightly set
-          → "7.79.0-nightly_git.101.89faa04"
+          → "7.79.0-nightly-git.101.89faa04"
       - Dev branch (BUCKET_BRANCH == "dev", covers both branch standalone and devtest):
-          → "7.79.0-devel_git.101.89faa04.<branch_slug>"
+          → "7.79.0-devel-git.101.89faa04.<branch_slug>"
 
     Returns None for stable/beta/release builds and local builds.
     """
@@ -55,11 +55,11 @@ def _get_profiler_agent_version(ctx):
     version, pre, commits, git_sha, _ = query_version(ctx, major_version=major_version)
 
     if is_nightly:
-        return f"{version}-nightly_git.{commits}.{git_sha}"
+        return f"{version}-nightly-git.{commits}.{git_sha}"
 
     branch = os.environ.get("CI_COMMIT_REF_SLUG")
     pre_label = pre if pre else "devel"
-    return f"{version}-{pre_label}_git.{commits}.{git_sha}.{branch}"
+    return f"{version}-{pre_label}-git.{commits}.{git_sha}.{branch}"
 
 
 @task

--- a/tasks/unit_tests/host_profiler_tests.py
+++ b/tasks/unit_tests/host_profiler_tests.py
@@ -1,0 +1,35 @@
+import os
+import unittest
+from unittest.mock import Mock, patch
+
+import semver
+
+from tasks import host_profiler
+
+
+class TestGetProfilerAgentVersion(unittest.TestCase):
+    def test_underscore_version_is_not_semver(self):
+        version = "7.81.0-devel_git.356.09ad4bc.hp-preview-1-0"
+
+        self.assertFalse(semver.VersionInfo.isvalid(version))
+
+    def test_preview_version_returned_by_function_is_semver(self):
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "BUCKET_BRANCH": "dev",
+                    "CI_COMMIT_REF_SLUG": "hp-preview-1-0",
+                },
+                clear=True,
+            ),
+            patch.object(host_profiler, "get_current_milestone", return_value="7.81.0"),
+            patch.object(
+                host_profiler,
+                "query_version",
+                return_value=("7.81.0", "", 356, "09ad4bc", None),
+            ),
+        ):
+            version = host_profiler._get_profiler_agent_version(Mock())
+
+        self.assertTrue(semver.VersionInfo.isvalid(version))

--- a/tasks/unit_tests/host_profiler_tests.py
+++ b/tasks/unit_tests/host_profiler_tests.py
@@ -8,11 +8,6 @@ from tasks import host_profiler
 
 
 class TestGetProfilerAgentVersion(unittest.TestCase):
-    def test_underscore_version_is_not_semver(self):
-        version = "7.81.0-devel_git.356.09ad4bc.hp-preview-1-0"
-
-        self.assertFalse(semver.VersionInfo.isvalid(version))
-
     def test_preview_version_returned_by_function_is_semver(self):
         with (
             patch.dict(
@@ -32,4 +27,5 @@ class TestGetProfilerAgentVersion(unittest.TestCase):
         ):
             version = host_profiler._get_profiler_agent_version(Mock())
 
+        # generated version should always be semver compliant (no '_' for example)
         self.assertTrue(semver.VersionInfo.isvalid(version))


### PR DESCRIPTION
### What does this PR do?

Makes agent version (the field used by the profiler to report its version) semver compliant

### Motivation

#incident-60361

### Describe how you validated your changes

### Additional Notes
