### PR TITLE
[WP] Fix fallback offset task_struct_tgid

### DIFF
--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -1248,7 +1248,7 @@ func getTaskStructTGIDOffset(kv *kernel.Version) uint64 {
 	case kv.IsUbuntuKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_11, kernel.Kernel5_12):
 		return 2332
 	case kv.IsDebianKernel() && kv.IsInRangeCloseOpen(kernel.Kernel4_19, kernel.Kernel4_20):
-		return 2236
+		return 1236
 	case kv.IsSLESKernel() && kv.Code != 0 && kv.Code < kernel.Kernel4_12:
 		return 2220
 	case kv.IsSLESKernel() && kv.IsInRangeCloseOpen(kernel.Kernel4_12, kernel.Kernel4_13):


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
This PR fix an offset fallback for debian 10 for `task_struct_tgid`

### Motivation
There was a conflict between the fallback and btfhub values for this offset on debian 10.