### PR TITLE
Full clone for bazel jobs that upload junit data via datadog-ci

### DIFF
--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -16,7 +16,7 @@
     EXTERNAL_LINKS_PATH: external_links_$CI_JOB_ID.json
     BEP_FILE: $CI_PROJECT_DIR/bazel-bep.json
     RESULT_JSON: test_output.json
-    GIT_DEPTH: 1000  # Needed by datadog-ci to collect git metadata
+    GIT_DEPTH: 0  # Needed by datadog-ci to collect git metadata
   after_script:
     - dda inv -- -e bazel.process-test-results --bep-file=$BEP_FILE --junit-tar=junit-${CI_JOB_NAME}.tgz --result-json=$RESULT_JSON
     - !reference [.upload_junit_source]


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Sets `GIT_DEPTH: 0` on bazel jobs using `datadog-ci` to upload junit data, to get full clones available. This makes the setting match the ones currently used for existing unit test jobs.

### Motivation

Same as https://github.com/DataDog/datadog-agent/pull/55043, which apparently didn't really solve the problem. 

See https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/2022804044#L1107, where the junit upload step takes more than 2 minutes and shows failures related to git and git metadata, compared to the 9 seconds it takes on a run from this PR ([link](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/2023139241#L2283)). We pay half of that back by requiring a full clone (instead of a shallow one), but that's still better in total and we get correct and more predictable behavior.

### Describe how you validated your changes

### Additional Notes

There might be ways to get this to work while avoiding a full clone, but for now this improves the situation.