### PR TITLE
[#incident-60368] Set `go_e2e_test_binaries` memory back to 72Gi

### DIFF
--- a/.gitlab/test/e2e/e2e_devx.yml
+++ b/.gitlab/test/e2e/e2e_devx.yml
@@ -14,8 +14,8 @@ go_e2e_test_binaries:
   variables:
     KUBERNETES_CPU_REQUEST: 4
     KUBERNETES_CPU_LIMIT: 4
-    KUBERNETES_MEMORY_REQUEST: 64Gi
-    KUBERNETES_MEMORY_LIMIT: 64Gi
+    KUBERNETES_MEMORY_REQUEST: 72Gi
+    KUBERNETES_MEMORY_LIMIT: 72Gi
   before_script:
     - !reference [.retrieve_linux_go_e2e_deps]
   script:


### PR DESCRIPTION
### What does this PR do?
Revert `KUBERNETES_MEMORY_REQUEST`/`KUBERNETES_MEMORY_LIMIT` for `go_e2e_test_binaries` from 64Gi back to 72Gi, keeping `KUBERNETES_CPU_LIMIT: 4` from PR #55974.

### Motivation
#incident-60368: `go_e2e_test_binaries` OOM-killed (exit 137) on `main` at least 8 times since PR #55974 merged at 11:38 UTC today, first flagged on commit a68ea9992 (`Add mirror for bullseye`, #55976), an unrelated change.

PR #55974 dropped the job's memory from 72Gi to 64Gi on the theory that capping `KUBERNETES_CPU_LIMIT` at 4 would keep Go's own build parallelism bounded enough to no longer need the extra headroom, validated by two clean runs at the time.

Those two runs were not enough: at 64Gi it is OOM-killing again on `main` under real, varied conditions, so the CPU-quota fix alone does not yet hold up.

Restoring 72Gi is a mitigation to stop the incident, not a reversal of the CPU-quota fix, which stays in place since it is still the right lever, just not sufficient alone at 64Gi.

### Describe how you validated your changes
Confirmed PR #55974's merge commit is an ancestor of the first commit #incident-60368 flagged as failing, and that the job's config on `main` still has `KUBERNETES_CPU_LIMIT: 4` at 64Gi going into every one of the incident's failures.

### Additional Notes
The actual fix in progress is a Bazel rewrite of this build step that removes the instrumentation's memory cost entirely rather than tuning the pod's resource envelope around it.