### PR TITLE
Route kubernetes-experiences Slack notifications to #kxp-ops and #kxp-prs

### DIFF
--- a/tasks/libs/pipeline/github_slack_map.yaml
+++ b/tasks/libs/pipeline/github_slack_map.yaml
@@ -323,11 +323,11 @@
     id: 'C06UEUW9A75'
 '@datadog/kubernetes-experiences':
   notification:
-    name: '#kubernetes-experiences'
-    id: 'CSY06FKSP'
+    name: '#kxp-ops'
+    id: 'C0135179MGA'
   review:
-    name: '#kubernetes-experiences'
-    id: 'CSY06FKSP'
+    name: '#kxp-prs'
+    id: 'C03LTNY5Q5N'
 '@datadog/metrics-aggregation':
   notification:
     name: '#metrics-aggregation'


### PR DESCRIPTION
### What does this PR do?

Changes the Slack channels mapped to `@datadog/kubernetes-experiences` in `tasks/libs/pipeline/github_slack_map.yaml`:

| Sub-key | Before | After |
|---|---|---|
| `notification` (CI and pipeline alerts) | `#kubernetes-experiences` | `#kxp-ops` |
| `review` (PR review requests) | `#kubernetes-experiences` | `#kxp-prs` |

### Motivation

`#kubernetes-experiences` is not where either audience looks. The team triages CI and pipeline alerts in `#kxp-ops` and PR review requests in `#kxp-prs`, alongside the review requests from every other repo the team owns.

### Describe how you validated your changes

`github_slack_map.yaml` parses and both sub-keys resolve to the new channels:

```
{'notification': {'name': '#kxp-ops', 'id': 'C0135179MGA'}, 'review': {'name': '#kxp-prs', 'id': 'C03LTNY5Q5N'}}
```

Channel IDs confirmed against Slack. No other file in the repo references the old channel name or ID.

### Additional Notes

Data-only change to a config file owned by the team it affects. `notification` feeds `GITHUB_SLACK_MAP` (`tasks/libs/pipeline/notifications.py`), `review` feeds `GITHUB_SLACK_REVIEW_MAP`, consumed by `tasks/issue.py`. The `id` field is not read by any task code; it is kept accurate to match the rest of the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)