### PR TITLE
Fix `target_compatible_with` for Windows e2e tests

### DIFF
--- a/test/new-e2e/tests/agent-log-pipelines/windows-log/file-tailing/BUILD.bazel
+++ b/test/new-e2e/tests/agent-log-pipelines/windows-log/file-tailing/BUILD.bazel
@@ -5,7 +5,6 @@ dd_agent_go_test(
     srcs = ["file_tailing_test.go"],
     data = ["log-config/config.yaml"],
     embedsrcs = ["log-config/config.yaml"],
-    target_compatible_with = ["@platforms//os:windows"],
     deps = [
         "//test/e2e-framework/components/datadog/agentparams",
         "//test/e2e-framework/components/os",

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/BUILD.bazel
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "remote_windows_service_asserts.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/remote-host-assertions",
-    target_compatible_with = ["@platforms//os:windows"],
     visibility = ["//visibility:public"],
     deps = [
         "//test/e2e-framework/testing/components",

--- a/test/new-e2e/tests/installer/windows/suite-assertions/BUILD.bazel
+++ b/test/new-e2e/tests/installer/windows/suite-assertions/BUILD.bazel
@@ -4,7 +4,6 @@ go_library(
     name = "suite-assertions",
     srcs = ["suite_assertions.go"],
     importpath = "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/suite-assertions",
-    target_compatible_with = ["@platforms//os:windows"],
     visibility = ["//visibility:public"],
     deps = [
         "//test/e2e-framework/testing/components",

--- a/test/new-e2e/tests/windows/BUILD.bazel
+++ b/test/new-e2e/tests/windows/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     data = ["scripts/installiis.ps1"],
     embedsrcs = ["scripts/installiis.ps1"],
     importpath = "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows",
-    target_compatible_with = ["@platforms//os:windows"],
     visibility = ["//visibility:public"],
     deps = [
         "//test/e2e-framework/testing/components",

--- a/test/new-e2e/tests/windows/common/BUILD.bazel
+++ b/test/new-e2e/tests/windows/common/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
     data = ["fixtures/get-acl-helpers.ps1"],
     embedsrcs = ["fixtures/get-acl-helpers.ps1"],
     importpath = "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common",
-    target_compatible_with = ["@platforms//os:windows"],
     visibility = ["//visibility:public"],
     deps = [
         "//test/e2e-framework/testing/components",

--- a/test/new-e2e/tests/windows/common/agent/BUILD.bazel
+++ b/test/new-e2e/tests/windows/common/agent/BUILD.bazel
@@ -31,7 +31,6 @@ go_test(
     embed = [":agent"],
     gotags = ["test"],
     tags = ["manual"],
-    target_compatible_with = ["@platforms//os:windows"],
     deps = [
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//mock",

--- a/test/new-e2e/tests/windows/domain-test/BUILD.bazel
+++ b/test/new-e2e/tests/windows/domain-test/BUILD.bazel
@@ -3,7 +3,6 @@ load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 dd_agent_go_test(
     name = "domain-test_test",
     srcs = ["domain_test.go"],
-    target_compatible_with = ["@platforms//os:windows"],
     deps = [
         "//test/e2e-framework/components/activedirectory",
         "//test/e2e-framework/scenarios/aws/ec2/windows",

--- a/test/new-e2e/tests/windows/fips-test/BUILD.bazel
+++ b/test/new-e2e/tests/windows/fips-test/BUILD.bazel
@@ -6,7 +6,6 @@ dd_agent_go_test(
         "fips_test.go",
         "mutually_exclusive_product_test.go",
     ],
-    target_compatible_with = ["@platforms//os:windows"],
     deps = [
         "//test/e2e-framework/testing/e2e",
         "//test/e2e-framework/testing/environments",

--- a/test/new-e2e/tests/windows/install-test/BUILD.bazel
+++ b/test/new-e2e/tests/windows/install-test/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "system_file_tester.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/install-test",
-    target_compatible_with = ["@platforms//os:windows"],
     visibility = ["//visibility:public"],
     deps = [
         "//test/e2e-framework/testing/components",

--- a/test/new-e2e/tests/windows/install-test/service-test/BUILD.bazel
+++ b/test/new-e2e/tests/windows/install-test/service-test/BUILD.bazel
@@ -4,7 +4,6 @@ go_library(
     name = "service-test",
     srcs = ["tester.go"],
     importpath = "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/install-test/service-test",
-    target_compatible_with = ["@platforms//os:windows"],
     visibility = ["//visibility:public"],
     deps = [
         "//test/e2e-framework/common",

--- a/test/new-e2e/tests/windows/service-test/BUILD.bazel
+++ b/test/new-e2e/tests/windows/service-test/BUILD.bazel
@@ -5,7 +5,6 @@ go_library(
     name = "service-test",
     srcs = ["diagnostics.go"],
     importpath = "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/service-test",
-    target_compatible_with = ["@platforms//os:windows"],
     visibility = ["//visibility:public"],
     deps = ["//test/e2e-framework/testing/components"],
 )
@@ -38,7 +37,6 @@ dd_agent_go_test(
         "fixtures/system-probe-nofim.yaml",
         "fixtures/system-probe.yaml",
     ],
-    target_compatible_with = ["@platforms//os:windows"],
     deps = [
         "//pkg/util/testutil/flake",
         "//test/e2e-framework/components/datadog/agentparams",

--- a/test/new-e2e/tests/windows/windows-certificate/BUILD.bazel
+++ b/test/new-e2e/tests/windows/windows-certificate/BUILD.bazel
@@ -3,7 +3,6 @@ load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 dd_agent_go_test(
     name = "windows-certificate_test",
     srcs = ["windows_certificate_remote_test.go"],
-    target_compatible_with = ["@platforms//os:windows"],
     deps = [
         "//pkg/util/testutil/flake",
         "//test/e2e-framework/components/os",


### PR DESCRIPTION
### What does this PR do?
Drop `target_compatible_with = ["@platforms//os:windows"]` from every `BUILD.bazel` whose sources lack a `//go:build windows` constraint and whose filenames do not end in `_windows.go`/`_windows_test.go`:
- `test/new-e2e/tests/agent-log-pipelines/windows-log/file-tailing/BUILD.bazel`
- `test/new-e2e/tests/installer/windows/remote-host-assertions/BUILD.bazel`
- `test/new-e2e/tests/installer/windows/suite-assertions/BUILD.bazel`
- `test/new-e2e/tests/windows/BUILD.bazel`
- `test/new-e2e/tests/windows/common/BUILD.bazel`
- `test/new-e2e/tests/windows/common/agent/BUILD.bazel`
- `test/new-e2e/tests/windows/domain-test/BUILD.bazel`
- `test/new-e2e/tests/windows/fips-test/BUILD.bazel`
- `test/new-e2e/tests/windows/install-test/BUILD.bazel`
- `test/new-e2e/tests/windows/install-test/service-test/BUILD.bazel`
- `test/new-e2e/tests/windows/service-test/BUILD.bazel`
- `test/new-e2e/tests/windows/windows-certificate/BUILD.bazel`

### Motivation
They are all test-driver code that **may also run on Linux and macOS** and interacts with Windows hosts over SSH/WinRM.

The constraint on the `test/new-e2e/tests/windows` tree traces back to #48417, likely LLM-aided, which added it instead of/in addition to `gazelle`-generated BUILD.bazel files.
#54286 later added BUILD.bazel files for the rest of `test/new-e2e` but excluded them from execution, so this mistake stayed latent there and spread to the two `installer/windows` packages that import `test/new-e2e/tests/windows/common{,/agent}` directly.

Every other `target_compatible_with = ["@platforms//os:windows"]` in the repository is genuine Windows-only source (cgo/syscall packages under `pkg/util/winutil`, `pkg/fleet/installer`, etc.) and is left untouched, as are `test/new-e2e/system-probe/{connector,vm-metrics}`, which use the inverse `select()` pattern under a `# keep` gazelle pragma to exclude Windows for POSIX-only deps (libvirt, ssh).

### Describe how you validated your changes
Ran `bazel run //:gazelle -- <package>` on every touched package and confirmed it left each `BUILD.bazel` unchanged, then ran `bazel build //<package>/...` on each to confirm it compiles on Linux.

### Additional Notes
Practically speaking, the following command **used to evict a number of source files on Linux and macOS**:
```
bazel build //test/new-e2e/tests/windows/... //test/new-e2e/tests/agent-log-pipelines/windows-log/file-tailing/... //test/new-e2e/tests/installer/windows/remote-host-assertions/... //test/new-e2e/tests/installer/windows/suite-assertions/...
```
For instance, these were missing from the Linux/macOS builds:
* `test/new-e2e/tests/agent-log-pipelines/windows-log/file-tailing/file_tailing_test.go`,
* `test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_service_asserts.go`,
* `test/new-e2e/tests/installer/windows/suite-assertions/suite_assertions.go`,
* etc.

With the change, the above command now includes them on Linux and macOS **too** - i.e. unchanged on Windows.