### PR TITLE
test(serverless-init): remove liveness timing probes

### DIFF
--- a/cmd/serverless-init/mode/initcontainer_mode_test.go
+++ b/cmd/serverless-init/mode/initcontainer_mode_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/spf13/afero"
 
@@ -125,16 +126,21 @@ func waitForAlive(t *testing.T, alive <-chan struct{}, result <-chan error) {
 	case <-alive:
 	case err := <-result:
 		t.Fatalf("command returned before OnAlive: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for OnAlive")
 	}
 }
 
-// On a successful run, execute must call OnAlive after cmd.Start and OnDead
-// via defer after cmd.Wait. The OnAlive hook holds execution until the test
-// observes the state, avoiding a scheduler-dependent mid-run probe.
-func TestExecute_SuccessfulRun_InvokesHooksInOrder(t *testing.T) {
-	child := lifecycle.NewChild()
+func blockingLivenessHooks(child *lifecycle.Child) (*ProcessHooks, <-chan struct{}, func()) {
 	alive := make(chan struct{})
 	release := make(chan struct{})
+	releaseChild := func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	}
 	hooks := &ProcessHooks{
 		OnAlive: func() {
 			child.MarkAlive()
@@ -143,13 +149,23 @@ func TestExecute_SuccessfulRun_InvokesHooksInOrder(t *testing.T) {
 		},
 		OnDead: child.MarkDead,
 	}
+	return hooks, alive, releaseChild
+}
+
+// On a successful run, execute must call OnAlive after cmd.Start and OnDead
+// via defer after cmd.Wait. The OnAlive hook holds execution until the test
+// observes the state, avoiding a scheduler-dependent mid-run probe.
+func TestExecute_SuccessfulRun_InvokesHooksInOrder(t *testing.T) {
+	child := lifecycle.NewChild()
+	hooks, alive, releaseChild := blockingLivenessHooks(child)
+	defer releaseChild()
 	result := make(chan error, 1)
 	go func() {
 		result <- execute(&serverlessLog.Config{}, []string{"sh", "-c", "sleep 0.5"}, hooks)
 	}()
 	waitForAlive(t, alive, result)
 	assert.True(t, child.IsAlive(), "OnAlive must fire before cmd.Wait returns")
-	close(release)
+	releaseChild()
 	err := <-result
 	assert.NoError(t, err)
 	assert.False(t, child.IsAlive(), "OnDead must fire after cmd.Wait returns")
@@ -164,23 +180,15 @@ func TestRunInit_MicroVM_ChildSupplied_TracksLiveness(t *testing.T) {
 	os.Args = []string{"datadog-init", "sh", "-c", "sleep 0.5"}
 
 	child := lifecycle.NewChild()
-	alive := make(chan struct{})
-	release := make(chan struct{})
-	hooks := &ProcessHooks{
-		OnAlive: func() {
-			child.MarkAlive()
-			close(alive)
-			<-release
-		},
-		OnDead: child.MarkDead,
-	}
+	hooks, alive, releaseChild := blockingLivenessHooks(child)
+	defer releaseChild()
 	result := make(chan error, 1)
 	go func() {
 		result <- RunInit(&serverlessLog.Config{}, hooks)
 	}()
 	waitForAlive(t, alive, result)
 	assert.True(t, child.IsAlive(), "child must be marked alive while RunInit is blocked")
-	close(release)
+	releaseChild()
 	err := <-result
 	assert.NoError(t, err)
 	assert.False(t, child.IsAlive(), "child must be marked dead after RunInit returns")

--- a/cmd/serverless-init/mode/initcontainer_mode_test.go
+++ b/cmd/serverless-init/mode/initcontainer_mode_test.go
@@ -12,10 +12,8 @@ import (
 	"os/exec"
 	"runtime"
 	"strconv"
-	"sync/atomic"
 	"syscall"
 	"testing"
-	"time"
 
 	"github.com/spf13/afero"
 
@@ -121,46 +119,60 @@ func TestExecute_StartFailure_NeverCallsOnAlive(t *testing.T) {
 }
 
 // On a successful run, execute must call OnAlive after cmd.Start and OnDead
-// via defer after cmd.Wait. The mid-run probe pins the ordering.
+// via defer after cmd.Wait. The OnAlive hook holds execution until the test
+// observes the state, avoiding a scheduler-dependent mid-run probe.
 func TestExecute_SuccessfulRun_InvokesHooksInOrder(t *testing.T) {
 	child := lifecycle.NewChild()
+	alive := make(chan struct{})
+	release := make(chan struct{})
 	hooks := &ProcessHooks{
-		OnAlive: child.MarkAlive,
-		OnDead:  child.MarkDead,
+		OnAlive: func() {
+			child.MarkAlive()
+			close(alive)
+			<-release
+		},
+		OnDead: child.MarkDead,
 	}
-	var midRunAlive atomic.Bool
-	probeDone := make(chan struct{})
+	result := make(chan error, 1)
 	go func() {
-		defer close(probeDone)
-		time.Sleep(100 * time.Millisecond)
-		midRunAlive.Store(child.IsAlive())
+		result <- execute(&serverlessLog.Config{}, []string{"sh", "-c", "sleep 0.5"}, hooks)
 	}()
-	err := execute(&serverlessLog.Config{}, []string{"sh", "-c", "sleep 0.5"}, hooks)
-	<-probeDone
+	<-alive
+	assert.True(t, child.IsAlive(), "OnAlive must fire before cmd.Wait returns")
+	close(release)
+	err := <-result
 	assert.NoError(t, err)
-	assert.True(t, midRunAlive.Load(), "OnAlive must fire before cmd.Wait returns")
 	assert.False(t, child.IsAlive(), "OnDead must fire after cmd.Wait returns")
 }
 
 // MicroVM init-container mode: ProcessHooks drive liveness tracking through
-// the public RunInit entry point. Pins the alive→dead transition.
+// the public RunInit entry point. OnAlive holds execution until the test has
+// observed liveness, so the assertion does not depend on startup timing.
 func TestRunInit_MicroVM_ChildSupplied_TracksLiveness(t *testing.T) {
 	saved := os.Args
 	defer func() { os.Args = saved }()
 	os.Args = []string{"datadog-init", "sh", "-c", "sleep 0.5"}
 
 	child := lifecycle.NewChild()
-	var midRunAlive atomic.Bool
-	probeDone := make(chan struct{})
+	alive := make(chan struct{})
+	release := make(chan struct{})
+	hooks := &ProcessHooks{
+		OnAlive: func() {
+			child.MarkAlive()
+			close(alive)
+			<-release
+		},
+		OnDead: child.MarkDead,
+	}
+	result := make(chan error, 1)
 	go func() {
-		defer close(probeDone)
-		time.Sleep(100 * time.Millisecond)
-		midRunAlive.Store(child.IsAlive())
+		result <- RunInit(&serverlessLog.Config{}, hooks)
 	}()
-	err := RunInit(&serverlessLog.Config{}, &ProcessHooks{OnAlive: child.MarkAlive, OnDead: child.MarkDead})
-	<-probeDone
+	<-alive
+	assert.True(t, child.IsAlive(), "child must be marked alive while RunInit is blocked")
+	close(release)
+	err := <-result
 	assert.NoError(t, err)
-	assert.True(t, midRunAlive.Load(), "child must be marked alive while RunInit is blocked")
 	assert.False(t, child.IsAlive(), "child must be marked dead after RunInit returns")
 }
 

--- a/cmd/serverless-init/mode/initcontainer_mode_test.go
+++ b/cmd/serverless-init/mode/initcontainer_mode_test.go
@@ -118,6 +118,16 @@ func TestExecute_StartFailure_NeverCallsOnAlive(t *testing.T) {
 	assert.False(t, onAliveCalled, "OnAlive must not be called when cmd.Start fails")
 }
 
+func waitForAlive(t *testing.T, alive <-chan struct{}, result <-chan error) {
+	t.Helper()
+
+	select {
+	case <-alive:
+	case err := <-result:
+		t.Fatalf("command returned before OnAlive: %v", err)
+	}
+}
+
 // On a successful run, execute must call OnAlive after cmd.Start and OnDead
 // via defer after cmd.Wait. The OnAlive hook holds execution until the test
 // observes the state, avoiding a scheduler-dependent mid-run probe.
@@ -137,7 +147,7 @@ func TestExecute_SuccessfulRun_InvokesHooksInOrder(t *testing.T) {
 	go func() {
 		result <- execute(&serverlessLog.Config{}, []string{"sh", "-c", "sleep 0.5"}, hooks)
 	}()
-	<-alive
+	waitForAlive(t, alive, result)
 	assert.True(t, child.IsAlive(), "OnAlive must fire before cmd.Wait returns")
 	close(release)
 	err := <-result
@@ -168,7 +178,7 @@ func TestRunInit_MicroVM_ChildSupplied_TracksLiveness(t *testing.T) {
 	go func() {
 		result <- RunInit(&serverlessLog.Config{}, hooks)
 	}()
-	<-alive
+	waitForAlive(t, alive, result)
 	assert.True(t, child.IsAlive(), "child must be marked alive while RunInit is blocked")
 	close(release)
 	err := <-result


### PR DESCRIPTION
### What does this PR do?

Replaces fixed 100 ms liveness probes in the serverless-init lifecycle tests with explicit OnAlive/release channel handshakes to make test robust. 

### Motivation

[SVLS-9753](https://datadoghq.atlassian.net/browse/SVLS-9753) tracks recurring TestRunInit_MicroVM_ChildSupplied_TracksLiveness failures. The probe began before RunInit; on a delayed worker, tracer discovery and cmd.Start could take longer than 100 ms, so it observed the child before OnAlive marked it running. The test now synchronizes on that callback instead of scheduler timing.

[CI/CD test history](https://app.datadoghq.com/ci/ci-cd/explorer?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.status%3Afail%20%40test.full_name%3A%22github.com%2FDataDog%2Fdatadog-agent%2Fcmd%2Fserverless-init%2Fmode.TestRunInit_MicroVM_ChildSupplied_TracksLiveness%22&agg_m=count&agg_m_source=base&agg_t=count&ci_cd_explorer_tab=tests&currentTab=overview&eventStack=&fromUser=true&index=citest&refresh_mode=sliding&start=1788702862945&end=1788875662945&paused=false)

### Describe how you validated your changes

- Ran both affected tests 20 times with Bazel; all runs passed.
- Ran bazel test //cmd/serverless-init/mode:mode_test.

[SVLS-9753]: https://datadoghq.atlassian.net/browse/SVLS-9753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ