### PR TITLE
otel: use shared helper to compute build flags

### DIFF
--- a/omnibus/config/software/datadog-otel-agent.rb
+++ b/omnibus/config/software/datadog-otel-agent.rb
@@ -50,17 +50,6 @@ build do
 
     env = with_standard_compiler_flags(env)
 
-    # Set CC/CXX explicitly so CGo uses the glibc cross-compiler (DD_CC).
-    # The CI build image uses musl libc by default, which lacks tm_gmtoff in
-    # struct tm. The glibc cross-compiler has tm_gmtoff in its sysroot headers,
-    # which is required by internal/coreinternal/timeutils/strptime_cgo_testlib.go.
-    unless ENV["DD_CC"].nil? || ENV["DD_CC"].empty?
-        env["CC"] = ENV["DD_CC"]
-    end
-    unless ENV["DD_CXX"].nil? || ENV["DD_CXX"].empty?
-        env["CXX"] = ENV["DD_CXX"]
-    end
-
     if fips_mode?
       add_msgo_to_env(env)
     end

--- a/tasks/otel_agent.py
+++ b/tasks/otel_agent.py
@@ -10,7 +10,7 @@ from tasks.build_tags import get_default_build_tags
 from tasks.flavor import AgentFlavor
 from tasks.libs.build.bazel import build_binary_with_bazel
 from tasks.libs.common.go import go_build
-from tasks.libs.common.utils import REPO_PATH, bin_name, get_version_ldflags
+from tasks.libs.common.utils import REPO_PATH, bin_name, get_build_flags
 from tasks.windows_resources import build_messagetable, build_rc, versioninfo_vars
 
 BIN_NAME = "otel-agent"
@@ -65,14 +65,9 @@ def build(ctx, byoc=False, flavor=AgentFlavor.base.name, enable_bazel=False):
         bazel_args = [f"--//packages/agent:flavor={flavor.name}"]
         build_binary_with_bazel("//cmd/otel-agent:otel-agent", args=bazel_args, bin_path=bin_path)
     else:
-        env = {"GO111MODULE": "on"}
+        ldflags, gcflags, env = get_build_flags(ctx)
         build_tags = get_default_build_tags(build="otel-agent", flavor=flavor)
-        ldflags = get_version_ldflags(ctx)
         ldflags += f' -X github.com/DataDog/datadog-agent/cmd/otel-agent/command.BYOC={byoc}'
-        if os.environ.get("DELVE"):
-            gcflags = "all=-N -l"
-        else:
-            gcflags = ""
 
         # generate windows resources
         if sys.platform == 'win32' or cross_compiling_windows:


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Reuse existing helpers to compute otel-agent build flags

### Motivation

Reduce build related code duplication

### Describe how you validated your changes

Local builds & CI

### Additional Notes
