### PR TITLE
[CWS] Allow disabling core agent IPC in isolated agents

### DIFF
--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -54,7 +54,7 @@ import (
 	sysprobeconfigfx "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/fx"
 	sysprobeconfigimpl "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/impl"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
-	remoteTaggerFx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote"
+	optionalRemoteTaggerFx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-optional-remote"
 	telemetryfx "github.com/DataDog/datadog-agent/comp/core/telemetry/fx"
 	remoteWorkloadfilterfx "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx-remote"
 	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-remote"
@@ -171,7 +171,16 @@ func getSharedFxOption() fx.Option {
 		}),
 		remoteWorkloadfilterfx.Module(),
 		ipcfx.ModuleReadWrite(),
-		remoteTaggerFx.Module(tagger.NewRemoteParams()),
+		// The remote tagger talks to the core agent; fall back to the noop tagger when this
+		// system-probe runs isolated from it (e.g. inside a microVM).
+		optionalRemoteTaggerFx.Module(
+			tagger.OptionalRemoteParams{
+				Disable: func(c config.Component) bool {
+					return !c.GetBool("remote_agent.core_agent_ipc.enabled")
+				},
+			},
+			tagger.NewRemoteParams(),
+		),
 		autoexitfx.Module(),
 		fx.Provide(func(sysprobeconfig sysprobeconfig.Component) settings.Params {
 			profilingGoRoutines := commonsettings.NewProfilingGoroutines()

--- a/comp/core/configstreamconsumer/impl/bootstrap.go
+++ b/comp/core/configstreamconsumer/impl/bootstrap.go
@@ -17,15 +17,53 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 )
 
-const enabledEnvVar = "DD_REMOTE_AGENT_CONFIGSTREAM_CONSUMER_ENABLED"
+const (
+	enabledEnvVar      = "DD_REMOTE_AGENT_CONFIGSTREAM_CONSUMER_ENABLED"
+	coreAgentIPCEnvVar = "DD_REMOTE_AGENT_CORE_AGENT_IPC_ENABLED"
+)
 
-// Mirrors the remote_agent.configstream.consumer.enabled schema default; bootstrap runs before
-// schema-backed defaults are loaded, so the two have to be kept in sync by hand.
-const defaultEnabled = true
+// Mirror the remote_agent.configstream.consumer.enabled and
+// remote_agent.core_agent_ipc.enabled schema defaults; bootstrap runs before
+// schema-backed defaults are loaded, so these have to be kept in sync by hand.
+const (
+	defaultEnabled             = true
+	defaultCoreAgentIPCEnabled = true
+)
+
+// bootstrapToggles holds the remote_agent booleans isEnabled needs before the config
+// component (and therefore the schema-backed defaults) exists.
+type bootstrapToggles struct {
+	RemoteAgent struct {
+		ConfigStream struct {
+			Consumer struct {
+				Enabled *bool `yaml:"enabled"`
+			} `yaml:"consumer"`
+		} `yaml:"configstream"`
+		CoreAgentIPC struct {
+			Enabled *bool `yaml:"enabled"`
+		} `yaml:"core_agent_ipc"`
+	} `yaml:"remote_agent"`
+}
 
 // isEnabled reports whether the consumer should run, from env or datadog.yaml.
 func isEnabled(cliConfigPath string) bool {
-	if v, ok := os.LookupEnv(enabledEnvVar); ok {
+	// The consumer exists to stream config from the core agent, so it cannot run at all
+	// when this agent is isolated from it by design (e.g. system-probe inside a microVM).
+	// Checked first because the consumer requires the RAR, which is off in that case.
+	coreAgentIPC := boolSetting(cliConfigPath, coreAgentIPCEnvVar, defaultCoreAgentIPCEnabled,
+		func(t bootstrapToggles) *bool { return t.RemoteAgent.CoreAgentIPC.Enabled })
+	if !coreAgentIPC {
+		return false
+	}
+
+	return boolSetting(cliConfigPath, enabledEnvVar, defaultEnabled,
+		func(t bootstrapToggles) *bool { return t.RemoteAgent.ConfigStream.Consumer.Enabled })
+}
+
+// boolSetting resolves one bootstrap boolean: env var first, then the first readable
+// datadog.yaml candidate, then the schema default.
+func boolSetting(cliConfigPath, envVar string, defaultValue bool, pick func(bootstrapToggles) *bool) bool {
+	if v, ok := os.LookupEnv(envVar); ok {
 		if enabled, err := strconv.ParseBool(v); err == nil {
 			return enabled
 		}
@@ -35,22 +73,14 @@ func isEnabled(cliConfigPath string) bool {
 		if err != nil {
 			continue
 		}
-		var cfg struct {
-			RemoteAgent struct {
-				ConfigStream struct {
-					Consumer struct {
-						Enabled *bool `yaml:"enabled"`
-					} `yaml:"consumer"`
-				} `yaml:"configstream"`
-			} `yaml:"remote_agent"`
-		}
-		_ = yaml.Unmarshal(data, &cfg)
-		if enabled := cfg.RemoteAgent.ConfigStream.Consumer.Enabled; enabled != nil {
+		var toggles bootstrapToggles
+		_ = yaml.Unmarshal(data, &toggles)
+		if enabled := pick(toggles); enabled != nil {
 			return *enabled
 		}
-		return defaultEnabled
+		return defaultValue
 	}
-	return defaultEnabled
+	return defaultValue
 }
 
 // readSettings overlays values from datadog.yaml onto a subset of the global config (defaults+env).

--- a/comp/core/configstreamconsumer/impl/enabled_test.go
+++ b/comp/core/configstreamconsumer/impl/enabled_test.go
@@ -66,3 +66,48 @@ remote_agent:
 		require.True(t, isEnabled("/does/not/exist/datadog.yaml"))
 	})
 }
+
+func TestIsEnabledCoreAgentIPCDisabled(t *testing.T) {
+	t.Run("yaml disabling core agent IPC disables the consumer", func(t *testing.T) {
+		os.Unsetenv(enabledEnvVar)
+		os.Unsetenv(coreAgentIPCEnvVar)
+		path := writeYAML(t, `
+remote_agent:
+  core_agent_ipc:
+    enabled: false
+`)
+		require.False(t, isEnabled(path))
+	})
+
+	t.Run("core agent IPC wins over an explicitly enabled consumer", func(t *testing.T) {
+		os.Unsetenv(enabledEnvVar)
+		os.Unsetenv(coreAgentIPCEnvVar)
+		path := writeYAML(t, `
+remote_agent:
+  core_agent_ipc:
+    enabled: false
+  configstream:
+    consumer:
+      enabled: true
+`)
+		require.False(t, isEnabled(path))
+	})
+
+	t.Run("env var disabling core agent IPC disables the consumer", func(t *testing.T) {
+		t.Setenv(enabledEnvVar, "true")
+		t.Setenv(coreAgentIPCEnvVar, "false")
+		path := writeYAML(t, "")
+		require.False(t, isEnabled(path))
+	})
+
+	t.Run("core agent IPC enabled leaves the consumer default untouched", func(t *testing.T) {
+		os.Unsetenv(enabledEnvVar)
+		os.Unsetenv(coreAgentIPCEnvVar)
+		path := writeYAML(t, `
+remote_agent:
+  core_agent_ipc:
+    enabled: true
+`)
+		require.True(t, isEnabled(path))
+	})
+}

--- a/comp/core/configsync/impl/module.go
+++ b/comp/core/configsync/impl/module.go
@@ -45,6 +45,13 @@ type configSync struct {
 
 // NewComponent creates a new configsync component.
 func NewComponent(deps Requires) (configsync.Component, error) {
+	// Nothing to sync from when this agent cannot reach the core agent by design
+	// (e.g. system-probe inside a microVM).
+	if !deps.Config.GetBool("remote_agent.core_agent_ipc.enabled") {
+		deps.Log.Info("configsync disabled: core agent IPC is disabled")
+		return configSync{}, nil
+	}
+
 	configRefreshIntervalSec := deps.Config.GetInt("agent_ipc.config_refresh_interval")
 	if configRefreshIntervalSec <= 0 {
 		deps.Log.Infof("configsync disabled: agent_ipc.config_refresh_interval invalid: %d)", configRefreshIntervalSec)

--- a/comp/core/hostname/remotehostnameimpl/hostname.go
+++ b/comp/core/hostname/remotehostnameimpl/hostname.go
@@ -25,6 +25,7 @@ import (
 	cache "github.com/patrickmn/go-cache"
 	"go.uber.org/fx"
 
+	hostnameimpl "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 )
@@ -85,6 +86,14 @@ type dependencies struct {
 }
 
 func newRemoteHostImpl(deps dependencies) hostnameinterface.Component {
+	// Agents isolated from the core agent by design (e.g. system-probe inside a microVM)
+	// resolve their hostname locally instead of retrying a core-agent lookup that cannot
+	// succeed.
+	if !pkgconfigsetup.Datadog().GetBool("remote_agent.core_agent_ipc.enabled") {
+		log.Info("core agent IPC is disabled, resolving the hostname locally")
+		return hostnameimpl.NewHostnameService()
+	}
+
 	r := &remotehostimpl{
 		cache:       cache.New(defaultExpire, defaultPurge),
 		ipc:         deps.IPC,

--- a/comp/core/remoteagent/impl-systemprobe/remoteagent.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent.go
@@ -44,8 +44,11 @@ type Provides struct {
 
 // NewComponent creates a new remoteagent component
 func NewComponent(reqs Requires) (Provides, error) {
-	// Check if the remoteAgentRegistry is enabled
-	if !reqs.Config.GetBool("remote_agent.registry.enabled") {
+	// Check if the remoteAgentRegistry is enabled. It also requires reaching the core
+	// agent, so agents isolated from it by design (e.g. system-probe inside a microVM)
+	// never register.
+	if !reqs.Config.GetBool("remote_agent.registry.enabled") ||
+		!reqs.Config.GetBool("remote_agent.core_agent_ipc.enabled") {
 		return Provides{}, nil
 	}
 

--- a/comp/core/workloadfilter/remoteimpl/remote.go
+++ b/comp/core/workloadfilter/remoteimpl/remote.go
@@ -26,6 +26,7 @@ import (
 	baseimpl "github.com/DataDog/datadog-agent/comp/core/workloadfilter/baseimpl"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/catalog"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	workloadfilterimpl "github.com/DataDog/datadog-agent/comp/core/workloadfilter/impl"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
@@ -90,6 +91,25 @@ type Provides struct {
 
 // NewComponent returns a new remote filter client
 func NewComponent(req Requires) (Provides, error) {
+	// Agents that cannot reach the core agent by design (e.g. system-probe inside a
+	// microVM) get the local store instead: it evaluates the same CEL programs from
+	// their own config rather than querying a core agent that is not there.
+	if !req.Config.GetBool("remote_agent.core_agent_ipc.enabled") {
+		req.Log.Info("core agent IPC is disabled, using the local workloadfilter")
+		local, err := workloadfilterimpl.NewComponent(workloadfilterimpl.Requires{
+			Config:    req.Config,
+			Log:       req.Log,
+			Telemetry: req.Telemetry,
+		})
+		if err != nil {
+			return Provides{}, err
+		}
+		return Provides{
+			Comp:          local.Comp,
+			FlareProvider: local.FlareProvider,
+		}, nil
+	}
+
 	remoteFilter := newFilter(req.Config, req.Log, req.Telemetry, req.IPC)
 
 	req.Lc.Append(compdef.Hook{

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
@@ -155,9 +155,12 @@ func (s *streamHandler) NewClient(cc grpc.ClientConnInterface) remote.GrpcClient
 	}
 }
 
-// IsEnabled always return true for the remote workloadmeta because it uses the remote catalog
+// IsEnabled reports whether the remote collector should run. It is on by default for
+// every agent that uses the remote catalog, and only opts out when this agent cannot
+// reach the core agent by design (e.g. system-probe inside a microVM) — retrying a
+// connection that can never succeed just fills the logs.
 func (s *streamHandler) IsEnabled() bool {
-	return true
+	return s.Reader.GetBool("remote_agent.core_agent_ipc.enabled")
 }
 
 func (s *streamHandler) HandleResponse(_ workloadmeta.Component, resp interface{}) ([]workloadmeta.CollectorEvent, error) {

--- a/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/proto"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/server"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -105,6 +106,45 @@ func TestNewCollector(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestIsEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		set      bool
+		value    bool
+		expected bool
+	}{
+		{
+			name:     "enabled by default",
+			set:      false,
+			expected: true,
+		},
+		{
+			name:     "core agent IPC explicitly enabled",
+			set:      true,
+			value:    true,
+			expected: true,
+		},
+		{
+			name:     "core agent IPC disabled",
+			set:      true,
+			value:    false,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := configmock.New(t)
+			if test.set {
+				cfg.Set("remote_agent.core_agent_ipc.enabled", test.value, model.SourceAgentRuntime)
+			}
+
+			handler := &streamHandler{Reader: cfg}
+			assert.Equal(t, test.expected, handler.IsEnabled())
 		})
 	}
 }
@@ -219,14 +259,16 @@ func TestCollection(t *testing.T) {
 	require.NoError(t, err)
 
 	// gRPC client
+	cfg := configmock.New(t)
 	collector := &remote.GenericCollector{
 		CollectorID: "generic-test-collector",
 		Catalog:     workloadmeta.Remote,
 		StreamHandler: &streamHandler{
-			port: port,
-			ipc:  ipcComp,
+			port:   port,
+			ipc:    ipcComp,
+			Reader: cfg,
 		},
-		Config: configmock.New(t),
+		Config: cfg,
 		IPC:    ipcComp,
 	}
 

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -8659,6 +8659,24 @@ properties:
             format: duration
             tags:
             - golang_type:duration
+      core_agent_ipc:
+        node_type: section
+        type: object
+        properties:
+          enabled:
+            node_type: setting
+            type: boolean
+            default: true
+            comment: |-
+              Whether this agent is allowed to talk to the core agent over IPC.
+              Set to false for agents that run isolated from the core agent and cannot reach
+              it by design (for example system-probe inside a microVM, forwarding its events
+              to a system-probe on the host instead of to the local core agent). When false,
+              the components that would otherwise stream from the core agent fall back to a
+              local or no-op implementation instead of retrying a connection that can never
+              succeed: remote workloadmeta, remote tagger, remote workloadfilter and remote
+              hostname, plus configsync, the remote agent registry and the config stream
+              consumer, which all stay off.
       registry:
         node_type: section
         type: object

--- a/releasenotes/notes/core-agent-ipc-toggle-d011fe596f7070a1.yaml
+++ b/releasenotes/notes/core-agent-ipc-toggle-d011fe596f7070a1.yaml
@@ -1,0 +1,23 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added the ``remote_agent.core_agent_ipc.enabled`` setting (environment
+    variable ``DD_REMOTE_AGENT_CORE_AGENT_IPC_ENABLED``), enabled by default.
+    Set it to ``false`` on agents that run isolated from the core Agent and
+    cannot reach it by design, such as ``system-probe`` inside a microVM that
+    forwards its events to a ``system-probe`` on the host. When disabled, the
+    components that would otherwise stream from the core Agent fall back to a
+    local or no-op implementation instead of endlessly retrying a connection
+    that cannot succeed: remote workloadmeta, remote tagger, remote
+    workloadfilter and remote hostname resolution, while config sync, the
+    remote agent registry and the config stream consumer stay off entirely.
+    This removes the repeated ``unable to establish stream`` and
+    ``error received trying to start stream`` connection errors those agents
+    used to log.


### PR DESCRIPTION
### What does this PR do?

Add remote_agent.core_agent_ipc.enabled (default true) for agents that cannot reach the core agent by design, such as system-probe running in a microVM that forwards its events to a system-probe on the host.

When disabled, the components that stream from the core agent fall back to a local or no-op implementation instead of endlessly retrying a connection that can never succeed: remote workloadmeta, remote tagger, remote workloadfilter and remote hostname. Config sync, the remote agent registry and the config stream consumer stay off entirely.

The config stream consumer reads the setting from its bootstrap YAML parse since it runs before the config component exists; it has to be gated because it refuses to start without the registry.

### Motivation

This is useful for agents that cannot reach the core agent by design, such as system-probe running in a microVM that forwards its events to a system-probe on the host.

### Describe how you validated your changes

### Additional Notes
