### PR TITLE
feat(logs): Reuse Logs Agent stream for Observer POC

### DIFF
--- a/comp/anomalydetection/AGENTS.md
+++ b/comp/anomalydetection/AGENTS.md
@@ -26,7 +26,7 @@ comp/anomalydetection/
       patterns/          ← log tokenizer/clusterer subpackage
     scenarios/           ← replay scenario directories (testbench)
   logssource/
-    def/ fx/ impl/       ← container + kubelet journald log ingestion
+    def/ fx/ impl/       ← Logs Agent stream reuse + standalone collection fallback
     fx/fx_noop.go        ← IoT / !python stub
   reporter/
     def/
@@ -51,7 +51,7 @@ Wired in `cmd/agent/subcommands/run/command.go`:
 | Module | Package | Role |
 |--------|---------|------|
 | Observer | `observer/fx` | Analysis pipeline (`python` build tag) |
-| Log source | `logssource/fx` | Container + kubelet logs (`python` tag) |
+| Log source | `logssource/fx` | Logs Agent stream reuse or standalone container + kubelet logs (`python` tag) |
 | Reporter | `reporter/fx` | Stdout reporter + optional event reporter |
 | Recorder | `recorder/fx-noop` | No-op (parquet middleware not shipped yet) |
 
@@ -111,11 +111,12 @@ Production callers of `observer.GetHandle()` use statically-defined source names
 |--------|------------|
 | `dogstatsd` | `pkg/aggregator/demultiplexer_agent.go` (DogStatsD workers) |
 | `check` | `pkg/aggregator/demultiplexer_agent.go` (core check aggregator) |
-| `logs` | `logssource/impl/logssource.go` |
+| `logs` | `logssource/impl/logssource.go` (Logs Agent processor tap, or standalone fallback) |
 | `agent_logs` | `observer/impl/observer.go` (pkg/util/log tap) |
 
 **Log ingestion split:**
-- **Container + kubelet logs** → `logssource` component
+- **Logs Agent enabled** → `logssource` taps messages after processing and before encoding; decoder-side adaptive sampling has already run
+- **Logs Agent disabled** → `logssource` starts its standalone container + kubelet collection pipeline
 - **Agent internal logs** → `observer` taps `pkg/util/log` directly via `agent_logs`
 
 Both paths share filtering primitives from `internal/logsfilter/`.

--- a/comp/anomalydetection/logssource/def/component.go
+++ b/comp/anomalydetection/logssource/def/component.go
@@ -3,8 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package logssource provides a component that feeds container and kubelet
-// journald logs into the observer without requiring the logs agent to be enabled.
+// Package logssource feeds logs into the observer. It reuses the Logs Agent
+// message stream when available and otherwise starts a standalone container and
+// kubelet collection path.
 package logssource
 
 // team: agent-anomaly-detection

--- a/comp/anomalydetection/logssource/impl/BUILD.bazel
+++ b/comp/anomalydetection/logssource/impl/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//comp/logs-library/metrics",
         "//comp/logs-library/processor",
         "//comp/logs/agent/config",
+        "//comp/logs/agent/def",
         "//comp/logs/agent/flare",
         "//comp/logs/auditor/def",
         "//pkg/config/model",

--- a/comp/anomalydetection/logssource/impl/logssource.go
+++ b/comp/anomalydetection/logssource/impl/logssource.go
@@ -22,7 +22,9 @@ import (
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
+	"github.com/DataDog/datadog-agent/comp/logs-library/processor"
 	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	logsagent "github.com/DataDog/datadog-agent/comp/logs/agent/def"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/flare"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
@@ -51,6 +53,7 @@ type Requires struct {
 	Tagger      tagger.Component
 	Auditor     auditor.Component
 	Observer    option.Option[observer.Component]
+	LogsAgent   option.Option[logsagent.Component]
 	FilterStore option.Option[workloadfilter.Component]
 
 	// Autodiscovery is optional: when absent the AD scheduler is simply not started
@@ -77,6 +80,11 @@ type logssourceComponent struct{}
 // Agent-internal logs are wired separately by the observer via
 // anomaly_detection.logs.internal.enabled (see observer/impl/observer.go).
 //
+// When the Logs Agent is enabled, the component taps its processed message
+// stream and does not create launchers, tailers, or a second processor. When it
+// is disabled, the standalone container/kubelet collection path remains as a
+// fallback.
+//
 // The component is a no-op when any of these are true:
 //   - the observer is unavailable
 //   - no observer-requiring gate is enabled and anomaly_detection.recording.enabled is false
@@ -99,11 +107,10 @@ func NewComponent(deps Requires) (Provides, error) {
 	recordingEnabled := anomalydetectionconfig.RecordingEnabled(deps.Config)
 
 	// Skip when the observer is absent, neither logs ingestion nor recording is
-	// requested, or no enabled source can start.
-	if !logSourceSettings.shouldStart(obsOk, wmetaOk, observerRequired, recordingEnabled) {
+	// requested, or all source gates are disabled.
+	if !logSourceSettings.shouldObserve(obsOk, observerRequired, recordingEnabled) {
 		return Provides{Comp: &logssourceComponent{}}, nil
 	}
-	containerSourcesActive := logSourceSettings.containerSourcesEnabled && wmetaOk
 
 	observerHandle := obs.GetHandle("logs")
 
@@ -113,6 +120,30 @@ func NewComponent(deps Requires) (Provides, error) {
 		logging.Warnf("logssource %s: invalid rules, proceeding without log filtering: %v", logsProcessingRulesKey, err)
 		logsRules = &logsfilter.Rules{}
 	}
+
+	var samplerOnDropped func(source, priority string)
+	if obsOk {
+		samplerOnDropped = obs.RecordSamplerDropped
+	}
+	sampler := newLogSamplerFromConfig(deps.Config, samplerOnDropped)
+
+	if _, logsAgentEnabled := deps.LogsAgent.Get(); logsAgentEnabled {
+		processor.SetMessageTap(newLogsAgentMessageTap(observerHandle, sampler, logsRules, logSourceSettings))
+		deps.Lc.Append(compdef.Hook{
+			OnStop: func(_ context.Context) error {
+				processor.SetMessageTap(nil)
+				return nil
+			},
+		})
+		logging.Infof("logssource using the Logs Agent message stream")
+		return Provides{Comp: &logssourceComponent{}}, nil
+	}
+
+	// Without the Logs Agent, retain the existing standalone collection path.
+	if !logSourceSettings.shouldStart(obsOk, wmetaOk, observerRequired, recordingEnabled) {
+		return Provides{Comp: &logssourceComponent{}}, nil
+	}
+	containerSourcesActive := logSourceSettings.containerSourcesEnabled && wmetaOk
 
 	processingRules, err := logsconfig.GlobalProcessingRules(deps.Config)
 	if err != nil {
@@ -125,11 +156,6 @@ func NewComponent(deps Requires) (Provides, error) {
 		pauseFilter = fs.GetContainerPausedFilters()
 	}
 
-	var samplerOnDropped func(source, priority string)
-	if obsOk {
-		samplerOnDropped = obs.RecordSamplerDropped
-	}
-	sampler := newLogSamplerFromConfig(deps.Config, samplerOnDropped)
 	pipeline := newObserverPipeline(deps.Config, processingRules, deps.Hostname, observerHandle, sampler, logsRules)
 	logSources := sources.NewLogSources()
 	tracker := tailers.NewTailerTracker()

--- a/comp/anomalydetection/logssource/impl/pipeline.go
+++ b/comp/anomalydetection/logssource/impl/pipeline.go
@@ -6,9 +6,11 @@
 package logssourceimpl
 
 import (
+	"bytes"
 	"context"
 	"slices"
 
+	"github.com/DataDog/datadog-agent/comp/anomalydetection/internal/logging"
 	"github.com/DataDog/datadog-agent/comp/anomalydetection/internal/logsfilter"
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
@@ -81,22 +83,49 @@ func (p *observerPipeline) start() {
 func (p *observerPipeline) drainOutputChan() {
 	defer close(p.drainDone)
 	for msg := range p.outputChan {
-		// Note: msg.Origin.Source() returns the user-defined source from an AD log
-		// config when one is set (e.g. "nginx"), overriding the container runtime.
-		// Rules using source: containerd/docker will not match AD-scheduled container
-		// logs that carry a custom source.
-		msgTags := msg.Tags()
-		if p.rules.NeedsSortedTags() {
-			msgTags = slices.Sorted(slices.Values(msgTags))
-		}
-		if !p.rules.IsAllowed(msg.Origin.Source(), msgTags) {
-			continue
-		}
-		if p.sampler != nil && !p.sampler.ShouldForward(msg) {
-			continue
-		}
-		p.observerHandle.ObserveLog(&messageLogView{msg: msg})
+		forwardLogToObserver(p.observerHandle, p.sampler, p.rules, msg)
 	}
+}
+
+// newLogsAgentMessageTap returns a tap for the existing Logs Agent processor.
+// Its input has already passed decoder-side adaptive sampling and the regular
+// Logs Agent processing rules. Non-kubelet inputs use the container source
+// controls so the POC can consume arbitrary sources without adding new config.
+func newLogsAgentMessageTap(
+	observerHandle observer.Handle,
+	sampler *logSampler,
+	rules *logsfilter.Rules,
+	settings logSourceSettings,
+) processor.MessageTap {
+	return func(msg *message.Message) {
+		if bytes.Contains(msg.GetContent(), []byte(logging.Prefix)) {
+			return
+		}
+		if isKubeletMessage(msg) {
+			if !settings.kubeletSourceEnabled {
+				return
+			}
+		} else if !settings.containerSourcesEnabled {
+			return
+		}
+		forwardLogToObserver(observerHandle, sampler, rules, msg)
+	}
+}
+
+func forwardLogToObserver(observerHandle observer.Handle, sampler *logSampler, rules *logsfilter.Rules, msg *message.Message) {
+	// Note: msg.Origin.Source() returns the user-defined source from a log config
+	// when one is set (e.g. "nginx"), overriding the container runtime.
+	msgTags := msg.Tags()
+	if rules.NeedsSortedTags() {
+		msgTags = slices.Sorted(slices.Values(msgTags))
+	}
+	if !rules.IsAllowed(msg.Origin.Source(), msgTags) {
+		return
+	}
+	if sampler != nil && !sampler.ShouldForward(msg) {
+		return
+	}
+	observerHandle.ObserveLog(&messageLogView{msg: msg})
 }
 
 // NextPipelineChan implements pipeline.Provider.

--- a/comp/anomalydetection/logssource/impl/pipeline_test.go
+++ b/comp/anomalydetection/logssource/impl/pipeline_test.go
@@ -158,3 +158,41 @@ func TestPipeline_IncludeBeforeExcludeAllowsMatching(t *testing.T) {
 	require.Len(t, handle.logs, 1)
 	assert.Equal(t, "prod log", string(handle.logs[0].GetContent()))
 }
+
+func TestLogsAgentMessageTapForwardsArbitrarySources(t *testing.T) {
+	handle := &captureObserverHandle{}
+	tap := newLogsAgentMessageTap(handle, nil, nil, logSourceSettings{
+		containerSourcesEnabled: true,
+		kubeletSourceEnabled:    true,
+	})
+
+	tap(newLogMessage(t, "application log", "custom-file-source", "app.log", []string{"env:test"}))
+
+	require.Len(t, handle.logs, 1)
+	assert.Equal(t, "application log", handle.logs[0].GetContent())
+}
+
+func TestLogsAgentMessageTapHonorsSourceGates(t *testing.T) {
+	handle := &captureObserverHandle{}
+	tap := newLogsAgentMessageTap(handle, nil, nil, logSourceSettings{
+		kubeletSourceEnabled: true,
+	})
+
+	tap(newLogMessage(t, "application log", "custom-file-source", "app.log", nil))
+	tap(newLogMessage(t, "kubelet log", "kubelet", "kubelet", []string{"source:kubelet"}))
+
+	require.Len(t, handle.logs, 1)
+	assert.Equal(t, "kubelet log", handle.logs[0].GetContent())
+}
+
+func TestLogsAgentMessageTapDropsAnomalySubsystemLogs(t *testing.T) {
+	handle := &captureObserverHandle{}
+	tap := newLogsAgentMessageTap(handle, nil, nil, logSourceSettings{
+		containerSourcesEnabled: true,
+		kubeletSourceEnabled:    true,
+	})
+
+	tap(newLogMessage(t, "2026-09-08 INFO [anomalydetection] feedback", "agent", "agent.log", nil))
+
+	assert.Empty(t, handle.logs)
+}

--- a/comp/anomalydetection/logssource/impl/source_settings.go
+++ b/comp/anomalydetection/logssource/impl/source_settings.go
@@ -32,11 +32,18 @@ func configBoolDefaultTrue(cfg config.Component, key string) bool {
 }
 
 func (s logSourceSettings) shouldStart(observerAvailable, workloadmetaAvailable, observerRequired, recordingEnabled bool) bool {
+	if !s.shouldObserve(observerAvailable, observerRequired, recordingEnabled) {
+		return false
+	}
+	return s.kubeletSourceEnabled || (s.containerSourcesEnabled && workloadmetaAvailable)
+}
+
+func (s logSourceSettings) shouldObserve(observerAvailable, observerRequired, recordingEnabled bool) bool {
 	if !observerAvailable {
 		return false
 	}
 	if !recordingEnabled && (!observerRequired || !s.logsEnabled) {
 		return false
 	}
-	return s.kubeletSourceEnabled || (s.containerSourcesEnabled && workloadmetaAvailable)
+	return s.kubeletSourceEnabled || s.containerSourcesEnabled
 }

--- a/comp/anomalydetection/logssource/impl/source_settings_test.go
+++ b/comp/anomalydetection/logssource/impl/source_settings_test.go
@@ -180,3 +180,13 @@ func TestLogSourceSettingsShouldStart(t *testing.T) {
 		})
 	}
 }
+
+func TestLogSourceSettingsShouldObserveDoesNotRequireWorkloadmeta(t *testing.T) {
+	settings := logSourceSettings{
+		logsEnabled:             true,
+		containerSourcesEnabled: true,
+	}
+
+	assert.True(t, settings.shouldObserve(true, true, false))
+	assert.False(t, settings.shouldStart(true, false, true, false))
+}

--- a/comp/logs-library/processor/BUILD.bazel
+++ b/comp/logs-library/processor/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "encoder.go",
         "json.go",
         "json_serverless_init.go",
+        "message_tap.go",
         "passthrough.go",
         "processor.go",
         "proto.go",
@@ -35,6 +36,8 @@ dd_agent_go_test(
     embed = [":processor"],
     deps = [
         "//comp/core/hostname/hostnameinterface/mock",
+        "//comp/logs-library/diagnostic",
+        "//comp/logs-library/metrics",
         "//comp/logs/agent/config",
         "//pkg/logs/message",
         "//pkg/logs/sources",

--- a/comp/logs-library/processor/message_tap.go
+++ b/comp/logs-library/processor/message_tap.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package processor
+
+import (
+	"sync/atomic"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+// MessageTap receives messages after processing rules and rendering, but before
+// encoding. Decoder-side operations, including adaptive sampling, have already
+// happened by this point.
+//
+// A tap must be fast and non-blocking. It must not mutate the message or retain
+// the message after the callback returns.
+type MessageTap func(*message.Message)
+
+var messageTapHook atomic.Pointer[MessageTap]
+
+// SetMessageTap registers a single process-wide message tap. Passing nil
+// disables the tap.
+func SetMessageTap(tap MessageTap) {
+	if tap == nil {
+		messageTapHook.Store(nil)
+		return
+	}
+	tapPtr := new(MessageTap)
+	*tapPtr = tap
+	messageTapHook.Store(tapPtr)
+}
+
+func maybeTapMessage(msg *message.Message) {
+	tapPtr := messageTapHook.Load()
+	if tapPtr == nil {
+		return
+	}
+	(*tapPtr)(msg)
+}

--- a/comp/logs-library/processor/processor.go
+++ b/comp/logs-library/processor/processor.go
@@ -200,6 +200,7 @@ func (p *Processor) processMessage(msg *message.Message) {
 			return
 		}
 		msg.SetRendered(rendered)
+		maybeTapMessage(msg)
 
 		// report this message to diagnostic receivers (e.g. `stream-logs` command)
 		p.diagnosticMessageReceiver.HandleMessage(msg, rendered, "")

--- a/comp/logs-library/processor/processor_test.go
+++ b/comp/logs-library/processor/processor_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/mock"
+	"github.com/DataDog/datadog-agent/comp/logs-library/diagnostic"
+	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
@@ -24,6 +26,52 @@ type processorTestCase struct {
 	shouldProcess bool
 	matchCount    int64
 	ruleType      string
+}
+
+type encoderFunc func(*message.Message, string) error
+
+func (f encoderFunc) Encode(msg *message.Message, hostname string) error {
+	return f(msg, hostname)
+}
+
+func TestMessageTapRunsAfterProcessingAndBeforeEncoding(t *testing.T) {
+	t.Cleanup(func() { SetMessageTap(nil) })
+
+	tapCalls := 0
+	encodedAfterTap := false
+	SetMessageTap(func(msg *message.Message) {
+		tapCalls++
+		assert.Equal(t, message.StateRendered, msg.State)
+		assert.Equal(t, []byte("secret=[masked]"), msg.GetContent())
+	})
+
+	monitor := metrics.NewNoopPipelineMonitor("test")
+	p := New(
+		nil,
+		make(chan *message.Message, 1),
+		make(chan *message.Message, 2),
+		[]*config.ProcessingRule{newProcessingRule(maskSequenceRule, "[masked]", "password")},
+		encoderFunc(func(msg *message.Message, _ string) error {
+			encodedAfterTap = tapCalls == 1
+			msg.SetEncoded([]byte("encoded"))
+			return nil
+		}),
+		&diagnostic.NoopMessageReceiver{},
+		nil,
+		monitor,
+		"test",
+	)
+
+	msg := newMessage([]byte("secret=password"), sources.NewLogSource("", &config.LogsConfig{}), "info")
+	p.processMessage(msg)
+
+	assert.Equal(t, 1, tapCalls)
+	assert.True(t, encodedAfterTap)
+	assert.Equal(t, message.StateEncoded, msg.State)
+
+	SetMessageTap(nil)
+	p.processMessage(newMessage([]byte("another message"), sources.NewLogSource("", &config.LogsConfig{}), "info"))
+	assert.Equal(t, 1, tapCalls)
 }
 
 // exclusions tests


### PR DESCRIPTION
### What does this PR do?

When the Logs Agent is enabled, feed its processed messages into Observer before encoding instead of starting a standalone Observer log pipeline. Keep the standalone pipeline as a fallback when the Logs Agent is disabled.

### Motivation

POC to measure the overhead of running a second log collection pipeline. The tap is intentionally post-sampling, so this does not preserve adaptive sampling collaboration.

### Describe how you validated your changes

Added focused unit tests and ran the affected Go tests, Bazel tests, Go linter, and Agent build.