### PR TITLE
fix(apm): obfuscate client stats tags

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -758,7 +758,7 @@ func (a *Agent) ProcessV1(p *api.PayloadV1) {
 			if a.SpanModifierV1 != nil {
 				a.SpanModifierV1.ModifySpanV1(chunk, span)
 			}
-			a.obfuscateSpanInternal(span)
+			a.obfuscateSpanInternal(span, true)
 			a.TruncateV1(span)
 			if p.ClientComputedTopLevel {
 				traceutil.UpdateTracerTopLevelV1(span)

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -1025,9 +1025,7 @@ func (a *Agent) processStats(in *pb.ClientStatsPayload, lang, tracerVersion, con
 			if !a.Blacklister.AllowsStat(b) {
 				continue
 			}
-			if shouldObfuscate {
-				a.obfuscateStatsGroup(b)
-			}
+			a.obfuscateStatsGroup(b, shouldObfuscate)
 			b.Resource, _ = a.TruncateResource(b.Resource)
 			a.Replacer.ReplaceStatsGroup(b)
 			group.Stats[n] = b

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -3671,19 +3671,20 @@ func TestConvertStats(t *testing.T) {
 }
 
 func TestProcessStatsObfuscatesTagsRegardlessOfTracerObfuscationVersion(t *testing.T) {
-	const query = "SELECT 1 FROM users"
+	const command = "SET key value"
 
 	for _, tt := range []struct {
 		name               string
 		obfuscationVersion string
 		expectedResource   string
 	}{
-		{name: "missing-obfuscation-version", expectedResource: "SELECT ? FROM users"},
-		{name: "current-obfuscation-version", obfuscationVersion: strconv.Itoa(obfuscate.Version), expectedResource: query},
+		{name: "missing-obfuscation-version", expectedResource: "SET"},
+		{name: "current-obfuscation-version", obfuscationVersion: strconv.Itoa(obfuscate.Version), expectedResource: command},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := config.New()
 			cfg.MaxResourceLen = 5000
+			cfg.Obfuscation.Redis.Enabled = true
 			o := cfg.Obfuscation.Export(cfg)
 			agnt := &Agent{
 				Blacklister:    filters.NewBlacklister(nil),
@@ -3696,10 +3697,10 @@ func TestProcessStatsObfuscatesTagsRegardlessOfTracerObfuscationVersion(t *testi
 					Stats: []*pb.ClientGroupedStats{{
 						Service:                "service",
 						Name:                   "operation",
-						Type:                   "sql",
-						Resource:               query,
-						SpanDerivedPrimaryTags: []string{"sql.query:" + query},
-						AdditionalMetricTags:   []string{"sql.query:" + query},
+						Type:                   "redis",
+						Resource:               command,
+						SpanDerivedPrimaryTags: []string{"redis.raw_command:" + command},
+						AdditionalMetricTags:   []string{"redis.raw_command:" + command},
 					}},
 				}},
 			}
@@ -3709,8 +3710,8 @@ func TestProcessStatsObfuscatesTagsRegardlessOfTracerObfuscationVersion(t *testi
 			require.Len(t, out.Stats, 1)
 			require.Len(t, out.Stats[0].Stats, 1)
 			assert.Equal(t, tt.expectedResource, out.Stats[0].Stats[0].Resource)
-			assert.Equal(t, []string{"sql.query:SELECT ? FROM users"}, out.Stats[0].Stats[0].SpanDerivedPrimaryTags)
-			assert.Equal(t, []string{"sql.query:SELECT ? FROM users"}, out.Stats[0].Stats[0].AdditionalMetricTags)
+			assert.Equal(t, []string{"redis.raw_command:SET key ?"}, out.Stats[0].Stats[0].SpanDerivedPrimaryTags)
+			assert.Equal(t, []string{"redis.raw_command:SET key ?"}, out.Stats[0].Stats[0].AdditionalMetricTags)
 		})
 	}
 }

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -3670,6 +3670,51 @@ func TestConvertStats(t *testing.T) {
 	}
 }
 
+func TestProcessStatsObfuscatesTagsRegardlessOfTracerObfuscationVersion(t *testing.T) {
+	const query = "SELECT 1 FROM users"
+
+	for _, tt := range []struct {
+		name               string
+		obfuscationVersion string
+		expectedResource   string
+	}{
+		{name: "missing-obfuscation-version", expectedResource: "SELECT ? FROM users"},
+		{name: "current-obfuscation-version", obfuscationVersion: strconv.Itoa(obfuscate.Version), expectedResource: query},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.New()
+			cfg.MaxResourceLen = 5000
+			o := cfg.Obfuscation.Export(cfg)
+			agnt := &Agent{
+				Blacklister:    filters.NewBlacklister(nil),
+				obfuscatorConf: &o,
+				Replacer:       filters.NewReplacer(nil),
+				conf:           cfg,
+			}
+			in := &pb.ClientStatsPayload{
+				Stats: []*pb.ClientStatsBucket{{
+					Stats: []*pb.ClientGroupedStats{{
+						Service:                "service",
+						Name:                   "operation",
+						Type:                   "sql",
+						Resource:               query,
+						SpanDerivedPrimaryTags: []string{"sql.query:" + query},
+						AdditionalMetricTags:   []string{"sql.query:" + query},
+					}},
+				}},
+			}
+
+			out := agnt.processStats(in, "go", "v1", "", tt.obfuscationVersion)
+
+			require.Len(t, out.Stats, 1)
+			require.Len(t, out.Stats[0].Stats, 1)
+			assert.Equal(t, tt.expectedResource, out.Stats[0].Stats[0].Resource)
+			assert.Equal(t, []string{"sql.query:SELECT ? FROM users"}, out.Stats[0].Stats[0].SpanDerivedPrimaryTags)
+			assert.Equal(t, []string{"sql.query:SELECT ? FROM users"}, out.Stats[0].Stats[0].AdditionalMetricTags)
+		})
+	}
+}
+
 func TestProcessStatsLongSQLResource(t *testing.T) {
 	// A valid SQL resource longer than MaxResourceLen (5000). Using backtick-quoted
 	// identifiers ensures the obfuscator must see the full string to tokenize it

--- a/pkg/trace/agent/obfuscate.go
+++ b/pkg/trace/agent/obfuscate.go
@@ -205,7 +205,7 @@ func obfuscateValkeySpan(o *obfuscate.Obfuscator, span obfuscateSpan, removeAllA
 	span.SetStringAttribute(tagValkeyRawCommand, o.ObfuscateRedisString(v))
 }
 
-func (a *Agent) obfuscateSpanInternal(span obfuscateSpan) {
+func (a *Agent) obfuscateSpanInternal(span obfuscateSpan, obfuscateResource bool) {
 	o := a.lazyInitObfuscator()
 	if a.conf.Obfuscation != nil && a.conf.Obfuscation.CreditCards.Enabled {
 		span.MapFilteredAttributes(o.ShouldObfuscateCCKey, func(k, v string) string {
@@ -220,7 +220,7 @@ func (a *Agent) obfuscateSpanInternal(span obfuscateSpan) {
 
 	switch span.Type() {
 	case "sql", "cassandra":
-		if span.Resource() == "" {
+		if !obfuscateResource || span.Resource() == "" {
 			return
 		}
 		oq, err := obfuscateSQLSpan(o, span)
@@ -234,9 +234,11 @@ func (a *Agent) obfuscateSpanInternal(span obfuscateSpan) {
 			return
 		}
 	case "redis", "valkey":
-		// if a span is redis/valkey type, it should be quantized regardless of obfuscation setting.
-		// valkey is a folk of redis, so we can use the same logic for both.
-		span.SetResource(o.QuantizeRedisString(span.Resource()))
+		// Redis/Valkey resources are quantized independently of their tag obfuscation settings.
+		// Valkey is a fork of Redis, so we can use the same logic for both.
+		if obfuscateResource {
+			span.SetResource(o.QuantizeRedisString(span.Resource()))
+		}
 		if span.Type() == "redis" && a.conf.Obfuscation.Redis.Enabled {
 			obfuscateRedisSpan(o, span, a.conf.Obfuscation.Redis.RemoveAllArgs)
 		}
@@ -289,7 +291,7 @@ func (a *Agent) ObfuscateSpan(span *pb.Span) {
 	for _, spanEvent := range span.SpanEvents {
 		a.obfuscateSpanEvent(spanEvent)
 	}
-	a.obfuscateSpanInternal(&obfuscateSpanV0{span: span})
+	a.obfuscateSpanInternal(&obfuscateSpanV0{span: span}, true)
 }
 
 // obfuscateSpanEvent uses the pre-configured agent obfuscator to do limited obfuscation of span events
@@ -350,8 +352,11 @@ func (a *Agent) ccObfuscateAttributeArray(v *pb.AttributeAnyValue) {
 }
 
 func (a *Agent) obfuscateStatsGroup(b *pb.ClientGroupedStats, obfuscateResource bool) {
+	if !obfuscateResource && len(b.SpanDerivedPrimaryTags) == 0 && len(b.AdditionalMetricTags) == 0 {
+		return
+	}
 	span := &obfuscateSpanStatsGroup{group: b, resource: b.Resource}
-	a.obfuscateSpanInternal(span)
+	a.obfuscateSpanInternal(span, obfuscateResource)
 	if obfuscateResource {
 		b.Resource = span.resource
 	}

--- a/pkg/trace/agent/obfuscate.go
+++ b/pkg/trace/agent/obfuscate.go
@@ -7,6 +7,7 @@ package agent
 
 import (
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
@@ -85,6 +86,64 @@ func (o *obfuscateSpanV0) MapFilteredAttributes(shouldMap func(k string) bool, m
 			o.span.Meta[k] = newV
 		}
 	}
+}
+
+type obfuscateSpanStatsGroup struct {
+	group    *pb.ClientGroupedStats
+	resource string
+}
+
+func (o *obfuscateSpanStatsGroup) GetAttributeAsString(key string) (string, bool) {
+	if key == tagDBMS && o.group.DBType != "" {
+		return o.group.DBType, true
+	}
+	for _, tags := range [][]string{o.group.AdditionalMetricTags, o.group.SpanDerivedPrimaryTags} {
+		for _, tag := range tags {
+			k, value, found := strings.Cut(tag, ":")
+			if found && k == key {
+				return value, true
+			}
+		}
+	}
+	return "", false
+}
+
+func (o *obfuscateSpanStatsGroup) SetStringAttribute(key string, value string) {
+	o.MapFilteredAttributes(func(k string) bool { return k == key }, func(_, _ string) string { return value })
+}
+
+func (o *obfuscateSpanStatsGroup) Type() string {
+	return o.group.Type
+}
+
+func (o *obfuscateSpanStatsGroup) Resource() string {
+	return o.resource
+}
+
+func (o *obfuscateSpanStatsGroup) SetResource(resource string) {
+	o.resource = resource
+}
+
+func (o *obfuscateSpanStatsGroup) Service() string {
+	return o.group.Service
+}
+
+func (o *obfuscateSpanStatsGroup) MapFilteredAttributes(shouldMap func(k string) bool, mapper func(k, v string) string) {
+	mapTags := func(tags []string) {
+		for i, tag := range tags {
+			key, value, found := strings.Cut(tag, ":")
+			if !found || key == "" || !shouldMap(key) {
+				continue
+			}
+			newValue := mapper(key, value)
+			if newValue != value {
+				tags[i] = key + ":" + newValue
+			}
+		}
+	}
+
+	mapTags(o.group.SpanDerivedPrimaryTags)
+	mapTags(o.group.AdditionalMetricTags)
 }
 
 // ObfuscateSQLSpan obfuscates a SQL span
@@ -290,20 +349,11 @@ func (a *Agent) ccObfuscateAttributeArray(v *pb.AttributeAnyValue) {
 	}
 }
 
-func (a *Agent) obfuscateStatsGroup(b *pb.ClientGroupedStats) {
-	o := a.lazyInitObfuscator()
-
-	switch b.Type {
-	case "sql", "cassandra":
-		oq, err := o.ObfuscateSQLStringForDBMS(b.Resource, b.DBType)
-		if err != nil {
-			log.Errorf("Error obfuscating stats group resource %q: %v", b.Resource, err)
-			b.Resource = textNonParsable
-		} else {
-			b.Resource = oq.Query
-		}
-	case "redis", "valkey":
-		b.Resource = o.QuantizeRedisString(b.Resource)
+func (a *Agent) obfuscateStatsGroup(b *pb.ClientGroupedStats, obfuscateResource bool) {
+	span := &obfuscateSpanStatsGroup{group: b, resource: b.Resource}
+	a.obfuscateSpanInternal(span)
+	if obfuscateResource {
+		b.Resource = span.resource
 	}
 }
 

--- a/pkg/trace/agent/obfuscate_test.go
+++ b/pkg/trace/agent/obfuscate_test.go
@@ -58,6 +58,81 @@ func TestObfuscateStatsGroup(t *testing.T) {
 	}
 }
 
+func TestObfuscateStatsGroupSkipsResourceObfuscation(t *testing.T) {
+	for _, typ := range []string{"sql", "cassandra", "redis", "valkey"} {
+		t.Run(typ, func(t *testing.T) {
+			cfg := config.New()
+			o := cfg.Obfuscation.Export(cfg)
+			agnt := &Agent{conf: cfg, obfuscatorConf: &o}
+			group := &pb.ClientGroupedStats{Type: typ, Resource: "unobfuscated resource"}
+
+			agnt.obfuscateStatsGroup(group, false)
+
+			assert.Equal(t, "unobfuscated resource", group.Resource)
+			assert.Nil(t, agnt.obfuscator)
+		})
+	}
+}
+
+type resourceTrackingSpan struct {
+	obfuscateSpan
+	reads  int
+	writes int
+}
+
+func (s *resourceTrackingSpan) Resource() string {
+	s.reads++
+	return s.obfuscateSpan.Resource()
+}
+
+func (s *resourceTrackingSpan) SetResource(resource string) {
+	s.writes++
+	s.obfuscateSpan.SetResource(resource)
+}
+
+func TestObfuscateSpanInternalSkipsResourceProcessing(t *testing.T) {
+	for _, tt := range []struct {
+		typ    string
+		tagKey string
+	}{
+		{typ: "sql"},
+		{typ: "cassandra"},
+		{typ: "redis", tagKey: tagRedisRawCommand},
+		{typ: "valkey", tagKey: tagValkeyRawCommand},
+	} {
+		t.Run(tt.typ, func(t *testing.T) {
+			cfg := config.New()
+			switch tt.typ {
+			case "redis":
+				cfg.Obfuscation.Redis.Enabled = true
+			case "valkey":
+				cfg.Obfuscation.Valkey.Enabled = true
+			}
+			o := cfg.Obfuscation.Export(cfg)
+			agnt := &Agent{conf: cfg, obfuscatorConf: &o}
+
+			tag := "custom:value"
+			if tt.tagKey != "" {
+				tag = tt.tagKey + ":SET key value"
+			}
+			group := &pb.ClientGroupedStats{
+				Type:                 tt.typ,
+				Resource:             "SET key value",
+				AdditionalMetricTags: []string{tag},
+			}
+			span := &resourceTrackingSpan{obfuscateSpan: &obfuscateSpanStatsGroup{group: group, resource: group.Resource}}
+
+			agnt.obfuscateSpanInternal(span, false)
+
+			assert.Zero(t, span.reads)
+			assert.Zero(t, span.writes)
+			if tt.tagKey != "" {
+				assert.Equal(t, []string{tt.tagKey + ":SET key ?"}, group.AdditionalMetricTags)
+			}
+		})
+	}
+}
+
 func TestObfuscateStatsGroupTags(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
@@ -65,7 +140,6 @@ func TestObfuscateStatsGroupTags(t *testing.T) {
 		key      string
 		value    string
 		resource string
-		dbType   string
 		config   *config.ObfuscationConfig
 	}{
 		{
@@ -74,15 +148,6 @@ func TestObfuscateStatsGroupTags(t *testing.T) {
 			key:    "customer.card",
 			value:  "4111111111111111",
 			config: &config.ObfuscationConfig{CreditCards: obfuscate.CreditCardsConfig{Enabled: true}},
-		},
-		{
-			name:     "sql",
-			typ:      "sql",
-			key:      "sql.query",
-			value:    "SELECT 1 FROM users",
-			resource: "SELECT 1 FROM users",
-			dbType:   "postgresql",
-			config:   &config.ObfuscationConfig{},
 		},
 		{
 			name:     "redis",
@@ -142,15 +207,11 @@ func TestObfuscateStatsGroupTags(t *testing.T) {
 			o := cfg.Obfuscation.Export(cfg)
 			agnt := &Agent{conf: cfg, obfuscatorConf: &o}
 			meta := map[string]string{tt.key: tt.value}
-			if tt.dbType != "" {
-				meta[tagDBMS] = tt.dbType
-			}
 			span := &pb.Span{Type: tt.typ, Service: "service", Resource: tt.resource, Meta: meta}
 			group := &pb.ClientGroupedStats{
 				Service:                "service",
 				Type:                   tt.typ,
 				Resource:               tt.resource,
-				DBType:                 tt.dbType,
 				SpanDerivedPrimaryTags: []string{tt.key + ":" + tt.value},
 				AdditionalMetricTags:   []string{tt.key + ":" + tt.value},
 			}

--- a/pkg/trace/agent/obfuscate_test.go
+++ b/pkg/trace/agent/obfuscate_test.go
@@ -53,9 +53,169 @@ func TestObfuscateStatsGroup(t *testing.T) {
 		{statsGroup("valkey", "ADD 1, 2"), "ADD"},
 		{statsGroup("other", "ADD 1, 2"), "ADD 1, 2"},
 	} {
-		agnt.obfuscateStatsGroup(tt.in)
+		agnt.obfuscateStatsGroup(tt.in, true)
 		assert.Equal(t, tt.in.Resource, tt.out)
 	}
+}
+
+func TestObfuscateStatsGroupTags(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		typ      string
+		key      string
+		value    string
+		resource string
+		dbType   string
+		config   *config.ObfuscationConfig
+	}{
+		{
+			name:   "credit-card",
+			typ:    "custom",
+			key:    "customer.card",
+			value:  "4111111111111111",
+			config: &config.ObfuscationConfig{CreditCards: obfuscate.CreditCardsConfig{Enabled: true}},
+		},
+		{
+			name:     "sql",
+			typ:      "sql",
+			key:      "sql.query",
+			value:    "SELECT 1 FROM users",
+			resource: "SELECT 1 FROM users",
+			dbType:   "postgresql",
+			config:   &config.ObfuscationConfig{},
+		},
+		{
+			name:     "redis",
+			typ:      "redis",
+			key:      "redis.raw_command",
+			value:    "SET key value",
+			resource: "SET key value",
+			config:   &config.ObfuscationConfig{Redis: obfuscate.RedisConfig{Enabled: true}},
+		},
+		{
+			name:     "valkey",
+			typ:      "valkey",
+			key:      "valkey.raw_command",
+			value:    "SET key value",
+			resource: "SET key value",
+			config:   &config.ObfuscationConfig{Valkey: obfuscate.ValkeyConfig{Enabled: true}},
+		},
+		{
+			name:   "memcached",
+			typ:    "memcached",
+			key:    "memcached.command",
+			value:  "set key 0 0 0\r\nvalue",
+			config: &config.ObfuscationConfig{Memcached: obfuscate.MemcachedConfig{Enabled: true}},
+		},
+		{
+			name:   "http",
+			typ:    "web",
+			key:    "http.url",
+			value:  "http://example.com/1/2?secret=value",
+			config: &config.ObfuscationConfig{HTTP: obfuscate.HTTPConfig{RemovePathDigits: true, RemoveQueryString: true}},
+		},
+		{
+			name:   "mongodb",
+			typ:    "mongodb",
+			key:    "mongodb.query",
+			value:  `{"find":"users","filter":{"email":"test@example.com"}}`,
+			config: &config.ObfuscationConfig{Mongo: obfuscate.JSONConfig{Enabled: true}},
+		},
+		{
+			name:   "elasticsearch",
+			typ:    "elasticsearch",
+			key:    "elasticsearch.body",
+			value:  `{"query":{"match":{"user":"alice"}}}`,
+			config: &config.ObfuscationConfig{ES: obfuscate.JSONConfig{Enabled: true}},
+		},
+		{
+			name:   "opensearch",
+			typ:    "opensearch",
+			key:    "opensearch.body",
+			value:  `{"query":{"match":{"user":"alice"}}}`,
+			config: &config.ObfuscationConfig{OpenSearch: obfuscate.JSONConfig{Enabled: true}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.New()
+			cfg.Obfuscation = tt.config
+			o := cfg.Obfuscation.Export(cfg)
+			agnt := &Agent{conf: cfg, obfuscatorConf: &o}
+			meta := map[string]string{tt.key: tt.value}
+			if tt.dbType != "" {
+				meta[tagDBMS] = tt.dbType
+			}
+			span := &pb.Span{Type: tt.typ, Service: "service", Resource: tt.resource, Meta: meta}
+			group := &pb.ClientGroupedStats{
+				Service:                "service",
+				Type:                   tt.typ,
+				Resource:               tt.resource,
+				DBType:                 tt.dbType,
+				SpanDerivedPrimaryTags: []string{tt.key + ":" + tt.value},
+				AdditionalMetricTags:   []string{tt.key + ":" + tt.value},
+			}
+
+			agnt.ObfuscateSpan(span)
+			agnt.obfuscateStatsGroup(group, true)
+
+			expectedTag := tt.key + ":" + span.Meta[tt.key]
+			assert.NotEqual(t, tt.value, span.Meta[tt.key], "test input must exercise obfuscation")
+			assert.Equal(t, span.Resource, group.Resource)
+			assert.Equal(t, []string{expectedTag}, group.SpanDerivedPrimaryTags)
+			assert.Equal(t, []string{expectedTag}, group.AdditionalMetricTags)
+		})
+	}
+}
+
+func TestObfuscateStatsGroupTagEdgeCases(t *testing.T) {
+	const cardNumber = "4111111111111111"
+	t.Run("duplicates-safe-keys-and-malformed-tags", func(t *testing.T) {
+		cfg := config.New()
+		cfg.Obfuscation.CreditCards.Enabled = true
+		cfg.Obfuscation.CreditCards.KeepValues = []string{"keep.card"}
+		o := cfg.Obfuscation.Export(cfg)
+		agnt := &Agent{conf: cfg, obfuscatorConf: &o}
+		group := &pb.ClientGroupedStats{
+			Type: "custom",
+			SpanDerivedPrimaryTags: []string{
+				"customer.card:" + cardNumber,
+				"customer.card:" + cardNumber,
+				"account_id:" + cardNumber,
+				"keep.card:" + cardNumber,
+				"missing-value-separator",
+				":" + cardNumber,
+			},
+		}
+
+		agnt.obfuscateStatsGroup(group, false)
+
+		assert.Equal(t, []string{
+			"customer.card:?",
+			"customer.card:?",
+			"account_id:" + cardNumber,
+			"keep.card:" + cardNumber,
+			"missing-value-separator",
+			":" + cardNumber,
+		}, group.SpanDerivedPrimaryTags)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		cfg := config.New()
+		o := cfg.Obfuscation.Export(cfg)
+		agnt := &Agent{conf: cfg, obfuscatorConf: &o}
+		tags := []string{
+			"customer.card:" + cardNumber,
+			"http.url:http://example.com/1/2?secret=value",
+		}
+		group := &pb.ClientGroupedStats{
+			Type:                 "web",
+			AdditionalMetricTags: append([]string(nil), tags...),
+		}
+
+		agnt.obfuscateStatsGroup(group, false)
+
+		assert.Equal(t, tags, group.AdditionalMetricTags)
+	})
 }
 
 // TestObfuscateDefaults ensures that running the obfuscator with no config continues to obfuscate/quantize

--- a/releasenotes/notes/apm-obfuscate-client-stats-tags-fb06325200d7c5dc.yaml
+++ b/releasenotes/notes/apm-obfuscate-client-stats-tags-fb06325200d7c5dc.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    APM : Apply configured trace tag obfuscation to span-derived primary tags
+    received with client-computed stats.


### PR DESCRIPTION
### What does this PR do?

Apply the Agent configured span metadata obfuscation to span-derived primary tags in client-computed stats. This covers both `additional_metric_tags` and the legacy `span_derived_primary_tags` fields while preserving the existing tracer-version gate for stats resource obfuscation.

### Motivation

Client-computed stats could forward sensitive values in derived primary tags even though the same tags were obfuscated on received traces.

### Describe how you validated your changes

- Added parity coverage for every metadata branch in `obfuscateSpanInternal`
- Ran `dda inv test --targets=./pkg/trace/agent`
- Ran `dda inv linter.go --targets=./pkg/trace/agent`
- Ran `reno lint`


[Generated using codex]