### PR TITLE
fix(e2e): skip apt for pre-baked Kind dependencies

### DIFF
--- a/test/e2e-framework/components/kubernetes/kind.go
+++ b/test/e2e-framework/components/kubernetes/kind.go
@@ -60,7 +60,8 @@ func NewKindClusterWithConfig(env config.Env, vm *remote.Host, name, kubeVersion
 		runner := vm.OS.Runner()
 		commonEnvironment := env
 		packageManager := vm.OS.PackageManager()
-		curlCommand, err := packageManager.Ensure("curl", nil, "", os.WithPulumiResourceOptions(opts...))
+		// curl is pre-baked in AWS e2e AMIs, so skip APT when it is already present.
+		curlCommand, err := packageManager.Ensure("curl", nil, "curl", os.WithPulumiResourceOptions(opts...))
 		if err != nil {
 			return err
 		}

--- a/test/e2e-framework/components/os/BUILD.bazel
+++ b/test/e2e-framework/components/os/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "os",
@@ -39,4 +40,10 @@ go_library(
         "//test/e2e-framework/components/command",
         "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
     ],
+)
+
+dd_agent_go_test(
+    name = "os_test",
+    srcs = ["generic_packagemanager_test.go"],
+    embed = [":os"],
 )

--- a/test/e2e-framework/components/os/generic_packagemanager.go
+++ b/test/e2e-framework/components/os/generic_packagemanager.go
@@ -90,26 +90,21 @@ func (m *GenericPackageManager) Ensure(packageRef string, transform command.Tran
 	if err != nil {
 		return nil, err
 	}
+	if dedicatedPackageRef, exists := m.packageNameMapping[packageRef]; exists {
+		packageRef = dedicatedPackageRef
+	}
+
+	cmdStr, needsUpdate := m.ensureCommand(packageRef, checkBinary)
 
 	pulumiOpts := append(params.PulumiResourceOptions, m.opts...)
-	if m.updateCmd != "" {
+	// Checked binaries only refresh the package database when installation is needed.
+	if needsUpdate {
 		updateDB, err := m.updateDB(pulumiOpts)
 		if err != nil {
 			return nil, err
 		}
 
 		pulumiOpts = append(pulumiOpts, utils.PulumiDependsOn(updateDB))
-	}
-
-	if dedicatedPackageRef, exists := m.packageNameMapping[packageRef]; exists {
-		packageRef = dedicatedPackageRef
-	}
-
-	var cmdStr string
-	if checkBinary != "" {
-		cmdStr = fmt.Sprintf("bash -c 'command -v %s || %s %s'", checkBinary, m.installCmd, packageRef)
-	} else {
-		cmdStr = fmt.Sprintf("%s %s", m.installCmd, packageRef)
 	}
 
 	cmdName := m.namer.ResourceName("install-"+packageRef, utils.StrHash(cmdStr))
@@ -132,6 +127,18 @@ func (m *GenericPackageManager) Ensure(packageRef string, transform command.Tran
 	// Make sure the package manager isn't running in parallel
 	m.opts = append(m.opts, utils.PulumiDependsOn(cmd))
 	return cmd, nil
+}
+
+// ensureCommand returns the install command and whether it needs an unconditional package database refresh.
+func (m *GenericPackageManager) ensureCommand(packageRef, checkBinary string) (string, bool) {
+	install := fmt.Sprintf("%s %s", m.installCmd, packageRef)
+	if checkBinary == "" {
+		return install, m.updateCmd != ""
+	}
+	if m.updateCmd != "" {
+		install = fmt.Sprintf("(%s && %s)", m.updateCmd, install)
+	}
+	return fmt.Sprintf("bash -c 'command -v %s || %s'", checkBinary, install), false
 }
 
 func (m *GenericPackageManager) updateDB(opts []pulumi.ResourceOption) (command.Command, error) {

--- a/test/e2e-framework/components/os/generic_packagemanager_test.go
+++ b/test/e2e-framework/components/os/generic_packagemanager_test.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package os
+
+import "testing"
+
+func TestEnsureCommandWithCheckedBinaryDoesNotRequireAnUnconditionalUpdate(t *testing.T) {
+	manager := &GenericPackageManager{
+		installCmd: "apt-get install -y",
+		updateCmd:  "apt-get update -y",
+	}
+
+	got, needsUpdate := manager.ensureCommand("curl", "curl")
+	want := "bash -c 'command -v curl || (apt-get update -y && apt-get install -y curl)'"
+	if got != want {
+		t.Fatalf("command = %q, want %q", got, want)
+	}
+	if needsUpdate {
+		t.Fatal("a checked binary must not create an unconditional update resource")
+	}
+}
+
+func TestEnsureCommandWithoutBinaryCheckUpdatesBeforeInstalling(t *testing.T) {
+	manager := &GenericPackageManager{
+		installCmd: "apt-get install -y",
+		updateCmd:  "apt-get update -y",
+	}
+
+	got, needsUpdate := manager.ensureCommand("package-without-binary", "")
+	if got != "apt-get install -y package-without-binary" {
+		t.Fatalf("command = %q", got)
+	}
+	if !needsUpdate {
+		t.Fatal("an unchecked package must refresh the package database before installing")
+	}
+}


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/ACIX-2010
### What does this PR do?

Avoids calling APT when Kind’s pre-baked dependencies are already available. If a checked binary is missing, the package manager still refreshes metadata and installs it.

### Motivation

Kind no-internet environments fail when an unnecessary `apt-get update` runs.

### Describe how you validated your changes

Ran `dda inv test --targets=./test/e2e-framework/components/os`.