### PR TITLE
Document the ASH grant in the Oracle conf.yaml.example

### DIFF
--- a/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
@@ -176,6 +176,11 @@ instances:
       ## @param active_session_history - boolean - optional - default: false
       ## Collect activity samples from `v$active_session_history` instead of the Agent performing sampling.
       ## WARNING: Querying `v$active_session_history` requires optional Oracle licences and may result in additional costs if enabled.
+      ##
+      ## Note: Enabling this requires select access on v$active_session_history
+      ##   Self-hosted:  grant select on v_$active_session_history to datadog ;
+      ##   Amazon RDS:   exec rdsadmin.rdsadmin_util.grant_sys_object('V_$ACTIVE_SESSION_HISTORY','DATADOG','SELECT',p_grant_option => false);
+      ##   Autonomous:   grant select on v$active_session_history to datadog with grant option ;
       #
       # active_session_history: false
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Adds a note to the Oracle `conf.yaml.example` documenting the grant required to use `active_session_history`.

### Motivation

`v$active_session_history` is not in the grant list on any of the Oracle setup pages, so enabling the option fails with `ORA-00942` until the grant is added. 