### PR TITLE
[ACTP] e2e tests for PAR split mode via Helm

### DIFF
--- a/test/new-e2e/tests/privateactionrunner/provisioner.go
+++ b/test/new-e2e/tests/privateactionrunner/provisioner.go
@@ -26,10 +26,10 @@ import (
 )
 
 const (
-	// minHelmChartVersion is the earliest Datadog chart release that includes PAR sidecar support
-	// (helm-charts PR #2517). Drop this override once the e2e framework's global HelmVersion
+	// minHelmChartVersion is the earliest Datadog chart release that includes PAR split mode
+	// (helm-charts PR #2904). Drop this override once the e2e framework's global HelmVersion
 	// default is bumped to at least this value.
-	minHelmChartVersion = "3.197.2"
+	minHelmChartVersion = "3.243.0"
 
 	systemServiceOverlap        = "par-e2e.service"
 	systemServiceBackendOnly    = "par-e2e-backend-only.service"
@@ -41,7 +41,7 @@ const (
 // Fakeintake URL wiring (DD_DD_URL) is handled automatically by the e2e framework's
 // configureFakeintake when fakeintake is present. See SetupPARTaskSigning for the
 // signing identity dequeued tasks need to pass verification.
-// %s parameters: clusterName, runnerURN, privateKeyB64, systemServiceOperatorPolicy
+// Parameters: clusterName, splitEnabled, runnerURN, privateKeyB64, systemServiceOperatorPolicy
 const parHelmValuesTemplate = `
 datadog:
   kubelet:
@@ -49,6 +49,7 @@ datadog:
   clusterName: "%s"
   privateActionRunner:
     enabled: true
+    splitEnabled: %t
     selfEnroll: false
     urn: "%s"
     privateKey: "%s"
@@ -67,7 +68,7 @@ agents:
 // parK8sProvisioner provisions a Kind-on-EC2 cluster with:
 //   - fakeintake deployed as ECS Fargate (HTTP, no load balancer) — PAR polls its OPMS endpoints
 //   - Datadog Agent with PAR enabled (custom image via --agent-image CLI flag)
-func parK8sProvisioner(runnerURN, privateKeyB64 string) provisioners.Provisioner {
+func parK8sProvisioner(runnerURN, privateKeyB64 string, splitEnabled bool) provisioners.Provisioner {
 	p := provisioners.NewTypedPulumiProvisioner[environments.Kubernetes]("par-k8s",
 		func(ctx *pulumi.Context, env *environments.Kubernetes) error {
 			name := "kind"
@@ -142,6 +143,7 @@ func parK8sProvisioner(runnerURN, privateKeyB64 string) provisioners.Provisioner
 				kubernetesagentparams.WithHelmValues(fmt.Sprintf(
 					parHelmValuesTemplate,
 					ctx.Stack(),
+					splitEnabled,
 					runnerURN,
 					privateKeyB64,
 					systemServiceOperatorPolicy,

--- a/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
@@ -8,6 +8,7 @@ package privateactionrunner
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,14 +41,27 @@ const (
 
 type parK8sSuite struct {
 	e2e.BaseSuite[environments.Kubernetes]
-	runnerURN string
+	runnerURN    string
+	parPodName   string
+	splitEnabled bool
+}
+
+type parK8sSplitSuite struct {
+	parK8sSuite
 }
 
 func TestPARRshellK8sSuite(t *testing.T) {
 	t.Parallel()
 	urn, keyB64 := generateTestRunnerIdentity(t)
 	suite := &parK8sSuite{runnerURN: urn}
-	e2e.Run(t, suite, e2e.WithProvisioner(parK8sProvisioner(urn, keyB64)))
+	e2e.Run(t, suite, e2e.WithProvisioner(parK8sProvisioner(urn, keyB64, false)))
+}
+
+func TestPARSplitRshellK8sSuite(t *testing.T) {
+	t.Parallel()
+	urn, keyB64 := generateTestRunnerIdentity(t)
+	suite := &parK8sSplitSuite{parK8sSuite: parK8sSuite{runnerURN: urn, splitEnabled: true}}
+	e2e.Run(t, suite, e2e.WithProvisioner(parK8sProvisioner(urn, keyB64, true)))
 }
 
 // SetupSuite registers a signing identity with fakeintake, then waits for PAR to be
@@ -56,10 +70,10 @@ func (s *parK8sSuite) SetupSuite() {
 	s.BaseSuite.SetupSuite()
 	defer s.CleanupOnSetupFailure()
 	selector := s.Env().Agent.LinuxNodeAgent.LabelSelectors["app"]
-	keyPushed := false
+	setupComplete := false
 	defer func() {
-		if !keyPushed {
-			s.logPARContainerLogs(selector, "signing key push failure")
+		if !setupComplete {
+			s.logPARContainerLogs(selector, "setup failure")
 		}
 	}()
 
@@ -71,9 +85,11 @@ func (s *parK8sSuite) SetupSuite() {
 		}()
 		SetupPARTaskSigning(s.T(), s.Env().FakeIntake.Client(), testRunnerOrgID, testRunnerRunnerID)
 	}()
-	keyPushed = true
-
 	s.waitForPARReady()
+	if s.splitEnabled {
+		s.verifySplitExecutorStartup()
+	}
+	setupComplete = true
 }
 
 func (s *parK8sSuite) BeforeTest(suiteName, testName string) {
@@ -360,6 +376,7 @@ func (s *parK8sSuite) waitForPARReady() {
 		for _, pod := range pods.Items {
 			for _, cs := range pod.Status.ContainerStatuses {
 				if cs.Name == parContainerName && cs.Ready {
+					s.parPodName = pod.Name
 					return
 				}
 			}
@@ -368,8 +385,16 @@ func (s *parK8sSuite) waitForPARReady() {
 	}, 5*time.Minute, 10*time.Second, "PAR container should become ready")
 	s.T().Logf("PAR container became Ready after %s", time.Since(started))
 
-	// Confirm PAR is actively polling fakeintake by waiting for at least one dequeue call.
-	// The workflow loop starts only after KeysManager receives its first Remote Config update.
+	if s.splitEnabled {
+		_, stderr, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
+			agentNamespace, s.parPodName, parContainerName, []string{"/par-probe.sh"},
+		)
+		s.Require().NoError(err, stderr)
+		s.waitForPARProcessStates(parControlProcess, []string{"Running"}, 2*time.Minute)
+		s.waitForPARProcessStates(parExecutorProcess, []string{"Created", "Exited"}, 2*time.Minute)
+	}
+
+	// Confirm PAR is actively polling fakeintake by waiting for a dequeue call.
 	pollingObserved := false
 	dequeueStarted := time.Now()
 	defer func() {
@@ -384,6 +409,36 @@ func (s *parK8sSuite) waitForPARReady() {
 	}, 5*time.Minute, 3*time.Second, "PAR should start polling fakeintake")
 	pollingObserved = true
 	s.T().Logf("PAR started polling fakeintake %s after its container became Ready", time.Since(dequeueStarted))
+}
+
+func (s *parK8sSuite) verifySplitExecutorStartup() {
+	taskID := uuid.New().String()
+	s.Require().NoError(s.Env().FakeIntake.Client().EnqueuePARTask(taskID, runCommandAction, map[string]interface{}{
+		"command":         "echo par-split-k8s-e2e",
+		"allowedCommands": []string{"rshell:echo"},
+	}))
+	s.waitForPARProcessStates(parExecutorProcess, []string{"Running"}, 2*time.Minute)
+	result := s.pollResult(taskID, 2*time.Minute)
+	s.Require().True(result.Success, "split PAR action failed: %+v", result)
+	s.Require().Equal(0, rshellExitCode(s.T(), result), "unexpected rshell result: %+v", result)
+	s.Require().Contains(result.Outputs["stdout"], "par-split-k8s-e2e")
+}
+
+func (s *parK8sSuite) waitForPARProcessStates(process string, states []string, timeout time.Duration) {
+	s.T().Helper()
+	s.Require().EventuallyWithT(func(c *assert.CollectT) {
+		stdout, stderr, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
+			agentNamespace, s.parPodName, parContainerName, []string{procmgrCLI, "describe", process},
+		)
+		require.NoError(c, err, stderr)
+		stdout = strings.ReplaceAll(stdout, " ", "")
+		for _, state := range states {
+			if strings.Contains(stdout, "State:"+state) {
+				return
+			}
+		}
+		assert.Fail(c, "unexpected process state", "%s should be in one of %v:\n%s", process, states, stdout)
+	}, timeout, 200*time.Millisecond)
 }
 
 func (s *parK8sSuite) logPARContainerLogs(selector, reason string) {

--- a/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
@@ -386,6 +386,7 @@ func (s *parK8sSuite) waitForPARReady() {
 	s.T().Logf("PAR container became Ready after %s", time.Since(started))
 
 	if s.splitEnabled {
+		s.verifySplitPodSpec()
 		_, stderr, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
 			agentNamespace, s.parPodName, parContainerName, []string{"/par-probe.sh"},
 		)
@@ -409,6 +410,56 @@ func (s *parK8sSuite) waitForPARReady() {
 	}, 5*time.Minute, 3*time.Second, "PAR should start polling fakeintake")
 	pollingObserved = true
 	s.T().Logf("PAR started polling fakeintake %s after its container became Ready", time.Since(dequeueStarted))
+}
+
+func (s *parK8sSuite) verifySplitPodSpec() {
+	pod, err := s.Env().KubernetesCluster.Client().CoreV1().
+		Pods(agentNamespace).Get(context.Background(), s.parPodName, metav1.GetOptions{})
+	s.Require().NoError(err)
+	s.Require().NotNil(pod.Spec.TerminationGracePeriodSeconds)
+	s.Require().GreaterOrEqual(*pod.Spec.TerminationGracePeriodSeconds, int64(190))
+
+	var parContainer *corev1.Container
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == parContainerName {
+			parContainer = &pod.Spec.Containers[i]
+			break
+		}
+	}
+	s.Require().NotNil(parContainer)
+
+	env := make(map[string]string, len(parContainer.Env))
+	for _, variable := range parContainer.Env {
+		env[variable.Name] = variable.Value
+	}
+	s.Require().Equal("true", env["DD_PRIVATE_ACTION_RUNNER_SPLIT_ENABLED"])
+	s.Require().Equal("/etc/privateactionrunner/privateactionrunner.yaml", env["DD_PRIVATE_ACTION_RUNNER_EXTRA_CONFIG_PATH"])
+	s.Require().Equal("/opt/datadog-agent/run/dd-procmgrd.sock", env["DD_PM_SOCKET_PATH"])
+
+	var runVolumeName string
+	for _, mount := range parContainer.VolumeMounts {
+		if mount.MountPath == "/opt/datadog-agent/run" {
+			runVolumeName = mount.Name
+			s.Require().False(mount.ReadOnly)
+			break
+		}
+	}
+	s.Require().NotEmpty(runVolumeName)
+	for _, container := range pod.Spec.Containers {
+		if container.Name == parContainerName {
+			continue
+		}
+		for _, mount := range container.VolumeMounts {
+			s.Require().NotEqual(runVolumeName, mount.Name, "PAR run volume must not be shared with container %s", container.Name)
+		}
+	}
+	for _, volume := range pod.Spec.Volumes {
+		if volume.Name == runVolumeName {
+			s.Require().NotNil(volume.EmptyDir)
+			return
+		}
+	}
+	s.Require().Fail("PAR run volume is not defined", "volume %q", runVolumeName)
 }
 
 func (s *parK8sSuite) verifySplitExecutorStartup() {


### PR DESCRIPTION
### What does this PR do?

Adds Helm E2E coverage for PAR split mode using chart `3.243.0`. The test verifies the split pod spec, Process Manager startup, OPMS polling, on-demand executor startup, and task execution.

### Motivation

Validate that the Agent image and Helm chart deploy PAR split mode correctly end to end.

### Describe how you validated your changes

- `new-e2e-privateactionrunner` passes
- `dda inv linter.go --module=test/new-e2e --targets=./tests/privateactionrunner`

### Additional Notes

None.
