### PR TITLE
docs: record how to typecheck code for another platform

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,9 +110,26 @@ Go tests run via `dda inv test --targets=<package>` (see the `dda inv` table abo
 - Full guide (scenarios, commands, stack lifecycle): `docs/public/how-to/test/manual-qa/index.md`
 
 ### Linting
+- Go: `dda inv linter.go` (see the `dda inv` table above)
 - Python: various linters via `dda inv linter.python`
 - YAML: yamllint
 - Shell: shellcheck
+
+#### Typechecking code for another platform
+Build-tagged files are invisible to the host test run, so `//go:build windows`
+code can be broken for a long time before CI says so. Prefix the linter with
+`GOOS`/`GOARCH` to typecheck it locally:
+
+```bash
+GOOS=windows GOARCH=amd64 dda inv linter.go --module=<module path>
+```
+
+Cross-linting for Windows needs mingw-w64 on `PATH` (`brew install mingw-w64` on
+macOS). `CGO_ENABLED=0` is not a substitute: core packages reach
+`pkg/util/winutil`, which requires real cgo. Note that
+`bazel build --platforms=@rules_go//go/toolchain:windows_amd64` builds libraries
+but cannot build `*_test` targets — Bazel requires exec platform == target
+platform for test rules — so the linter is the route for test files.
 
 ## Build System
 

--- a/codereview_guideline.md
+++ b/codereview_guideline.md
@@ -37,7 +37,9 @@ The agent ships on Linux, Windows, and macOS. Platform-specific code paths (via
 `runtime.GOOS`, build tags, OS-specific file paths) are a frequent source of
 bugs — typically the "other" platform is untested. The same applies to
 packaging: Windows MSI and Linux deb/rpm have independent logic that can
-silently diverge.
+silently diverge. Verifying the other platform is cheap — see "Typechecking code
+for another platform" in `AGENTS.md` — so ask for it rather than assuming CI
+will catch it.
 
 ### Concurrency and component lifecycle
 The agent runs many concurrent goroutines with explicit `Start()`/`Stop()`


### PR DESCRIPTION
### What does this PR do?

Documents how to typecheck build-tagged code for another platform from your dev machine:

- **`AGENTS.md`** — a new "Typechecking code for another platform" subsection under `### Linting`, giving the `GOOS`/`GOARCH`-prefixed linter invocation, its two non-obvious prerequisites, and one dead end worth signposting. Also adds the `- Go: dda inv linter.go` bullet that was missing from the linting list.
- **`codereview_guideline.md`** — the "Multi-platform divergence" item already names the failure mode ("typically the 'other' platform is untested") without saying what to do about it. It now points at the `AGENTS.md` section, so a reviewer can ask for the check instead of assuming CI will catch it.

### Motivation

Files behind `//go:build windows` are invisible to a host test run, so they can be broken for a long time before CI says so. The remedy is cheap, but three things about it are easy to get wrong and each one costs a debugging session:

1. Cross-linting for Windows needs `mingw-w64` on `PATH` (`brew install mingw-w64` on macOS).
2. `CGO_ENABLED=0` is **not** a way around that — core packages reach `pkg/util/winutil`, which requires real cgo.
3. `bazel build --platforms=@rules_go//go/toolchain:windows_amd64` builds libraries but cannot build `*_test` targets, because Bazel requires exec platform == target platform for test rules. So the linter is the route for test files.

Found while adding the Windows half of the ddprofiling unix-socket platform split in #55987, where the host test run compiles none of the code under review.

### Describe how you validated your changes

Documentation only — no code changes, no behaviour change.

Every command and claim in the new section was executed on this machine while writing it, against `comp/otelcol/ddprofilingextension/impl`:

- `GOOS=windows GOARCH=amd64 dda inv linter.go --module=comp/otelcol/ddprofilingextension/impl` → 0 issues, and it does compile the `//go:build windows` test file that the host run skips.
- The `mingw-w64` prerequisite and the `CGO_ENABLED=0` dead end were both established by hitting them: without the toolchain the run fails in `pkg/util/winutil/iphelper`, and `CGO_ENABLED=0` does not avoid it.
- The Bazel limitation was confirmed by attempting `bazel build --platforms=@rules_go//go/toolchain:windows_amd64` on `:impl_test` and reading the exec-platform error.

### Additional Notes

Split out of #55987 so the ddprofiling change carries only its own code. No dependency in either direction — this can merge whenever.

`changelog/no-changelog`: documentation only, nothing user-facing to release-note.
