### PR TITLE
Add CODEOWNERS entry for cmd/agent/subcommands/jmx

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -242,6 +242,7 @@
 /cmd/agent/subcommands/otel                         @DataDog/opentelemetry-agent
 /cmd/agent/subcommands/check                        @DataDog/agent-runtimes @DataDog/agent-integrations
 /cmd/agent/subcommands/dogstatsd*                   @DataDog/agent-metric-pipelines
+/cmd/agent/subcommands/jmx                          @DataDog/agent-metric-pipelines
 /cmd/agent/subcommands/integrations                 @DataDog/agent-integrations @DataDog/agent-runtimes
 /cmd/agent/subcommands/hostname                     @DataDog/agent-runtimes
 /cmd/agent/subcommands/version                      @DataDog/agent-runtimes


### PR DESCRIPTION
**what this does**
Assigns /cmd/agent/subcommands/jmx to @DataDog/agent-metric-pipelines.
This directory had no CODEOWNERS entry. The team is the same one that
already owns comp/agent/jmxlogger and cmd/agent/subcommands/dogstatsd*,
which the jmx subcommand wires up directly — JMX metric collection is
the same domain as dogstatsd/metric-pipeline collection.

@DataDog/fleet-remediation added as reviewer since this directory
previously had no explicit owner and fleet-remediation may have been
handling review for it informally.

**testing**

**next steps**