### PR TITLE
Add CODEOWNERS entries for workloadfilterlist and validatepodannotation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -253,6 +253,8 @@
 /cmd/agent/subcommands/streamep                     @DataDog/container-integrations
 /cmd/agent/subcommands/taggerlist                   @DataDog/container-platform
 /cmd/agent/subcommands/workloadlist                 @DataDog/container-platform
+/cmd/agent/subcommands/workloadfilterlist           @DataDog/container-platform
+/cmd/agent/subcommands/validatepodannotation        @DataDog/container-platform
 /cmd/agent/subcommands/run/                         @DataDog/agent-runtimes
 /cmd/agent/subcommands/run/internal/clcrunnerapi/   @DataDog/container-platform
 /cmd/agent/windows                                  @DataDog/windows-products


### PR DESCRIPTION
**what this does**
Assigns /cmd/agent/subcommands/workloadfilterlist and
/cmd/agent/subcommands/validatepodannotation to @DataDog/container-platform.
Neither directory had a CODEOWNERS entry. Both sit in the same domain as
the already-owned taggerlist/workloadlist: workloadfilterlist wraps
pkg/cli/subcommands/workloadfilter and comp/core/workloadfilter (both
container-platform), and validatepodannotation validates pod check
annotations for the admission controller, also a container-platform area.

@DataDog/fleet-remediation added as reviewer since these directories
previously had no explicit owner and fleet-remediation may have been
handling review for them informally.

**testing**

**next steps**