### PR TITLE
Add CODEOWNERS entry for cmd/agent/subcommands/coverage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -255,6 +255,7 @@
 /cmd/agent/subcommands/workloadlist                 @DataDog/container-platform
 /cmd/agent/subcommands/run/                         @DataDog/agent-runtimes
 /cmd/agent/subcommands/run/internal/clcrunnerapi/   @DataDog/container-platform
+/cmd/agent/subcommands/coverage                     @DataDog/agent-devx
 /cmd/agent/windows                                  @DataDog/windows-products
 /cmd/agent/windows_resources                        @DataDog/windows-products
 /cmd/agent/dist/conf.d/                             @DataDog/agent-integrations


### PR DESCRIPTION
**what this does**
Assigns /cmd/agent/subcommands/coverage to @DataDog/agent-devx. This
directory had no CODEOWNERS entry. It's a dev-tooling command (special
coverage-instrumented builds for testing), and its real feature commits
came from agent-devx/agent-supply-chain engineers rather than any
runtime-feature team.

@DataDog/fleet-remediation added as reviewer since this directory
previously had no explicit owner and fleet-remediation may have been
handling review for it informally.
