### PR TITLE
Add CODEOWNERS entries for core agent CLI subcommands

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -255,6 +255,17 @@
 /cmd/agent/subcommands/workloadlist                 @DataDog/container-platform
 /cmd/agent/subcommands/run/                         @DataDog/agent-runtimes
 /cmd/agent/subcommands/run/internal/clcrunnerapi/   @DataDog/container-platform
+/cmd/agent/subcommands/configcheck                  @DataDog/fleet-automation
+/cmd/agent/subcommands/diagnose                     @DataDog/fleet-automation
+/cmd/agent/subcommands/experimental                 @DataDog/fleet-automation
+/cmd/agent/subcommands/flare                        @DataDog/fleet-automation
+/cmd/agent/subcommands/health                       @DataDog/fleet-automation
+/cmd/agent/subcommands/import                       @DataDog/fleet-automation
+/cmd/agent/subcommands/launchgui                    @DataDog/fleet-automation
+/cmd/agent/subcommands/secret                       @DataDog/fleet-automation
+/cmd/agent/subcommands/secrethelper                 @DataDog/fleet-automation
+/cmd/agent/subcommands/status                       @DataDog/fleet-automation
+/cmd/agent/subcommands/stop                         @DataDog/fleet-automation
 /cmd/agent/windows                                  @DataDog/windows-products
 /cmd/agent/windows_resources                        @DataDog/windows-products
 /cmd/agent/dist/conf.d/                             @DataDog/agent-integrations


### PR DESCRIPTION
**what this does**
Assigns configcheck, diagnose, experimental, flare, health, import,
launchgui, secret, secrethelper, status, and stop under
cmd/agent/subcommands/ to @DataDog/fleet-automation. None of these had
a CODEOWNERS entry. Every one of them is a thin CLI wrapper built
directly on comp/core/config, comp/core/secrets, and pkg/config/ —
all already owned by fleet-automation — and their real (non-mechanical)
recent feature commits (flare archive/local-file handling, diagnose
API-key validation, config Set/settings fixes) came from
fleet-automation engineers.

@DataDog/fleet-remediation added as reviewer since these directories
previously had no explicit owner and fleet-remediation may have been
handling review for them informally.

**testing**

**next steps**