### PR TITLE
[#incident-60343] Propagate mirror hardening to `TestPersistingIntegrations`/`TestUpgradeScript`

### DIFF
--- a/test/new-e2e/tests/agent-platform/tests/persisting_integrations_test.go
+++ b/test/new-e2e/tests/agent-platform/tests/persisting_integrations_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/install"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/install/installparams"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/platforms"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
 
 	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 
@@ -36,6 +37,15 @@ type persistingIntegrationsSuite struct {
 	srcVersion     string
 	osDesc         e2eos.Descriptor
 	testingKeysURL string
+}
+
+func (is *persistingIntegrationsSuite) SetupSuite() {
+	is.BaseSuite.SetupSuite()
+	defer is.CleanupOnSetupFailure()
+
+	h := host.New(is.T, is.Env().RemoteHost, is.osDesc, is.osDesc.Architecture)
+	h.ConfigureYumMirrors()
+	h.ConfigureAptMirrors()
 }
 
 func (is *persistingIntegrationsSuite) AfterTest(suiteName, testName string) {

--- a/test/new-e2e/tests/agent-platform/tests/upgrade_test.go
+++ b/test/new-e2e/tests/agent-platform/tests/upgrade_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/install"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/install/installparams"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/platforms"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
 
 	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
@@ -33,6 +34,15 @@ type upgradeSuite struct {
 	srcVersion     string
 	destVersion    string
 	testingKeysURL string
+}
+
+func (is *upgradeSuite) SetupSuite() {
+	is.BaseSuite.SetupSuite()
+	defer is.CleanupOnSetupFailure()
+
+	h := host.New(is.T, is.Env().RemoteHost, is.osDesc, is.osDesc.Architecture)
+	h.ConfigureYumMirrors()
+	h.ConfigureAptMirrors()
 }
 
 func TestUpgradeScript(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
Call `host.ConfigureAptMirrors` and `host.ConfigureYumMirrors` from `persistingIntegrationsSuite`'s and `upgradeSuite`'s `SetupSuite`, matching the existing pattern from `ddotInstallSuite` and `stepByStepSuite`.

### Motivation
Debian 11 (bullseye) went EOL on 2026-08-31 (#[incident-60343](https://dd.enterprise.slack.com/archives/C0BVDK23Y5T)): `security.debian.org`'s `bullseye-security` `InRelease` is now expired, so `apt-get update` fails on any e2e host that still talks to it.

#55976 already repointed the main archive to `archive.debian.org` for the 4 suites calling `ConfigureAptMirrors`, but
`host.ConfigureAptMirrors` and `host.upgradeSuite` never called it, so their `apt-get update` still hits the dead security repo.

This is failing on main right now ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/2026123023)):
```
E: Release file for
 http://security.debian.org/debian-security/dists/bullseye-security/InRelease
 is expired (invalid since 1d 5h 41min 34s).
Updates for this repository will not be applied.
```

### Describe how you validated your changes
The change mirrors the already-green pattern used in `ddot_install_test.go` and `step_by_step_test.go`.

### Additional Notes
#55986 addresses the same incident from a different angle, a prebaked Debian 11 e2e AMI, so this fix stands on its own.