### PR TITLE
Add fakeintake i/o timeout failure to the E2E-internal-error list

### DIFF
--- a/tasks/libs/common/junit_upload_core.py
+++ b/tasks/libs/common/junit_upload_core.py
@@ -17,6 +17,7 @@ from invoke.exceptions import Exit
 from tasks.flavor import AgentFlavor
 from tasks.libs.common.color import color_message
 from tasks.libs.common.utils import gitlab_section
+from tasks.libs.pipeline.data import FAKEINTAKE_TIMEOUT_PANIC, FAKEINTAKE_UNREACHABLE_RE
 from tasks.libs.pipeline.notifications import (
     DEFAULT_JIRA_PROJECT,
     DEFAULT_SLACK_CHANNEL,
@@ -284,11 +285,15 @@ def group_per_tags(team_dir: Path, additional_tags: list):
 
 def is_e2e_internal_failure(xml_path: Path):
     """
-    Check if the given JUnit XML file contains E2E INTERAL ERROR string.
+    Check whether the given JUnit XML file shows E2E test infrastructure flakiness rather
+    than a real product bug: an E2E INTERNAL ERROR from provisioning, or a network-level
+    failure reaching fakeintake.
     """
     with xml_path.open(encoding="utf8") as f:
         filecontent = f.read()
-    return E2E_INTERNAL_ERROR_STRING in filecontent
+    if E2E_INTERNAL_ERROR_STRING in filecontent or FAKEINTAKE_TIMEOUT_PANIC in filecontent:
+        return True
+    return bool(FAKEINTAKE_UNREACHABLE_RE.search(filecontent))
 
 
 def is_kitchen_version(tags):

--- a/tasks/libs/pipeline/data.py
+++ b/tasks/libs/pipeline/data.py
@@ -8,6 +8,41 @@ from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
 from tasks.libs.common.utils import Color, color_message
 from tasks.libs.types.types import FailedJobReason, FailedJobs, FailedJobType
 
+# fakeintake is test infrastructure, not the system under test: failing to reach it at the
+# network level (e.g. the VM being briefly unreachable, or fakeintake not listening yet) is
+# an infra flake, not a product bug. Shared with tasks.libs.common.junit_upload_core so the
+# job-log-level classifier here and the JUnit-XML-level classifier there never drift apart.
+#
+# Matches Go's *url.Error text for a fakeintake HTTP call that failed at the network level:
+#   Get "http://10.255.119.230:80/fakeintake/rc/stats": dial tcp 10.255.119.230:80: i/o timeout
+#   Get "http://10.255.98.252:80/fakeintake/payloads?endpoint=/api/v2/series": dial tcp ...: connect: connection refused
+#
+# Anchored on the route prefix rather than by excluding /api/... paths: the Agent's own
+# forwarder errors use /api/... on the same host and must not be swept in, but /api/... also
+# appears inside the ?endpoint= query of a legitimate fakeintake URL (second example above),
+# so only the path segment is a reliable discriminator. /debug/ covers GetLastAPIKey, the one
+# fakeintake client route not under /fakeintake/.
+#
+# The error-side alternation lists what real jobs have produced (i/o timeout, connection
+# refused -- both seen in the same retry loop, so which one surfaces is a timing coin-flip)
+# plus the neighbouring dial, transport and DNS failures of the same "cannot reach
+# fakeintake" class. It is still an enumeration, so a form not listed here is a false
+# negative; only the Go side could decide this on net.Error instead of on text.
+FAKEINTAKE_UNREACHABLE_RE = re.compile(
+    r'"https?://[^"\s]*/(?:fakeintake|debug)/[^"\s]*": [^"\n]*'
+    r'(?:i/o timeout'
+    r'|context deadline exceeded'
+    r'|TLS handshake timeout'
+    r'|connect: connection refused'
+    r'|connection reset by peer'
+    r'|no route to host'
+    r'|no such host)'
+)
+# Produced by test/fakeintake/client's c.get() panic on a read-side timeout. Complementary to
+# the regex above: c.get() is the only path that panics, every other client method returns the
+# bare *url.Error the regex matches.
+FAKEINTAKE_TIMEOUT_PANIC = 'fakeintake call timed out'
+
 
 def get_failed_jobs(pipeline: ProjectPipeline, repo_name: str) -> FailedJobs:
     """
@@ -109,6 +144,15 @@ infra_failure_logs = [
     # End to end tests internal infrastructure failures
     (
         re.compile(r'E2E INTERNAL ERROR'),
+        FailedJobReason.E2E_INFRA_FAILURE,
+    ),
+    # Network-level failure talking to fakeintake: test infra, not the system under test
+    (
+        FAKEINTAKE_UNREACHABLE_RE,
+        FailedJobReason.E2E_INFRA_FAILURE,
+    ),
+    (
+        re.compile(re.escape(FAKEINTAKE_TIMEOUT_PANIC)),
         FailedJobReason.E2E_INFRA_FAILURE,
     ),
 ]

--- a/tasks/unit_tests/junit_tests.py
+++ b/tasks/unit_tests/junit_tests.py
@@ -64,11 +64,36 @@ class TestGroupPerTag(unittest.TestCase):
         test_dir = Path("./tasks/unit_tests/testdata/to_group")
         grouped = junit.group_per_tags(test_dir, [])
         self.assertIn("default", grouped)
-        self.assertCountEqual([f"{str(test_dir)}/onepiece", f"{str(test_dir)}/dragonball"], grouped["default"])
+        self.assertCountEqual(
+            [f"{str(test_dir)}/onepiece", f"{str(test_dir)}/dragonball", f"{str(test_dir)}/gintama"],
+            grouped["default"],
+        )
         self.assertIn("e2e", grouped)
-        self.assertEqual([f"{str(test_dir)}/naruto"], grouped["e2e"])
+        self.assertCountEqual([f"{str(test_dir)}/naruto", f"{str(test_dir)}/bleach"], grouped["e2e"])
         self.assertNotIn("kitchen", grouped)
         self.assertNotIn("kitchen-e2e", grouped)
+
+
+class TestIsE2EInternalFailure(unittest.TestCase):
+    def test_e2e_internal_error_string(self):
+        xml_file = Path("./tasks/unit_tests/testdata/to_group/naruto")
+        self.assertTrue(junit.is_e2e_internal_failure(xml_file))
+
+    def test_fakeintake_timeout(self):
+        # Verbatim from the WINA-3079 job log: a fakeintake control endpoint that timed out
+        # at the network level, matched on its route prefix.
+        xml_file = Path("./tasks/unit_tests/testdata/to_group/bleach")
+        self.assertTrue(junit.is_e2e_internal_failure(xml_file))
+
+    def test_unrelated_timeout_is_not_flagged(self):
+        # Same dial timeout, but on a non-fakeintake route: it may be a genuine
+        # product/networking regression, so it must not be swept in as an infra flake.
+        xml_file = Path("./tasks/unit_tests/testdata/to_group/gintama")
+        self.assertFalse(junit.is_e2e_internal_failure(xml_file))
+
+    def test_no_failure(self):
+        xml_file = Path("./tasks/unit_tests/testdata/to_group/dragonball")
+        self.assertFalse(junit.is_e2e_internal_failure(xml_file))
 
 
 class TestSetTag(unittest.TestCase):

--- a/tasks/unit_tests/libs/data_tests.py
+++ b/tasks/unit_tests/libs/data_tests.py
@@ -34,6 +34,66 @@ class TestGetInfraFailuresJob(unittest.TestCase):
             get_infra_failure_info('something E2E INTERNAL ERROR something'), FailedJobReason.E2E_INFRA_FAILURE
         )
 
+    def test_fakeintake_timeout_infra_failure(self):
+        # Verbatim from the WINA-3079 job log.
+        self.assertEqual(
+            get_infra_failure_info(
+                'Get "http://10.255.119.230:80/fakeintake/rc/stats": dial tcp 10.255.119.230:80: i/o timeout'
+            ),
+            FailedJobReason.E2E_INFRA_FAILURE,
+        )
+        self.assertEqual(
+            get_infra_failure_info(
+                'Post "http://10.255.119.230:80/fakeintake/rc/config": dial tcp 10.255.119.230:80: i/o timeout'
+            ),
+            FailedJobReason.E2E_INFRA_FAILURE,
+        )
+
+    def test_fakeintake_connection_refused_infra_failure(self):
+        # Verbatim from the pipeline-3070 job log: fakeintake not listening, rather than the
+        # host being unreachable. Same root cause class, and that job's retry loop also
+        # produced two i/o timeouts, so which form ends up reported is a timing coin-flip.
+        self.assertEqual(
+            get_infra_failure_info(
+                'Get "http://10.255.98.252:80/fakeintake/payloads?endpoint=/api/intake/metrics/v3/series": '
+                'dial tcp 10.255.98.252:80: connect: connection refused'
+            ),
+            FailedJobReason.E2E_INFRA_FAILURE,
+        )
+
+    def test_fakeintake_url_with_api_endpoint_query_is_infra_failure(self):
+        # The ?endpoint= query holds an /api/... path, so the classifier must key off the
+        # /fakeintake/ path segment rather than treating any /api/ URL as product traffic.
+        self.assertEqual(
+            get_infra_failure_info(
+                'Get "http://10.255.98.252:80/fakeintake/payloads?endpoint=/api/v2/series": '
+                'dial tcp 10.255.98.252:80: i/o timeout'
+            ),
+            FailedJobReason.E2E_INFRA_FAILURE,
+        )
+
+    def test_fakeintake_timeout_panic_infra_failure(self):
+        # client.go's c.get() panics with this marker instead of returning the *url.Error.
+        self.assertEqual(
+            get_infra_failure_info('panic: fakeintake call timed out: dial tcp 10.0.0.1:80: i/o timeout'),
+            FailedJobReason.E2E_INFRA_FAILURE,
+        )
+
+    def test_non_fakeintake_network_error_is_not_infra_failure(self):
+        # Same dial errors on a route the fakeintake client never calls: those may be a real
+        # product or networking regression, so widening the error side must not sweep them in.
+        self.assertIsNone(
+            get_infra_failure_info(
+                'Get "http://10.255.119.230:80/api/v2/series": dial tcp 10.255.119.230:80: i/o timeout'
+            )
+        )
+        self.assertIsNone(
+            get_infra_failure_info(
+                'Get "http://10.255.119.230:80/api/v2/series": '
+                'dial tcp 10.255.119.230:80: connect: connection refused'
+            )
+        )
+
     def test_no_match(self):
         self.assertIsNone(get_infra_failure_info('something no match something'))
 

--- a/tasks/unit_tests/testdata/to_group/bleach
+++ b/tasks/unit_tests/testdata/to_group/bleach
@@ -1,0 +1,1 @@
+Post "http://10.255.119.230:80/fakeintake/rc/config": dial tcp 10.255.119.230:80: i/o timeout

--- a/tasks/unit_tests/testdata/to_group/gintama
+++ b/tasks/unit_tests/testdata/to_group/gintama
@@ -1,0 +1,1 @@
+Get "http://10.255.119.230:80/some/agent/endpoint": dial tcp 10.255.119.230:80: i/o timeout


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
The goal of this PR is to classify network-level timeouts talking to fakeintake (dial tcp  i/o timeout on a /fakeintake/ or /debug/ route) as E2E test infrastructure flakiness rather than a product bug, in both the job-log-level classifier  (tasks/libs/pipeline/data.py) and the JUnit-XML-level classifier (tasks/libs/common/junit_upload_core.py).

### Motivation
https://datadoghq.atlassian.net/browse/ACIX-1970

[WINA-3070](https://datadoghq.atlassian.net/browse/WINA-3070), [WINA-3079](https://datadoghq.atlassian.net/browse/WINA-3079)

### Describe how you validated your changes
Verify with stress tests and ensure CI pipeline pass.

### Additional Notes


[WINA-3070]: https://datadoghq.atlassian.net/browse/WINA-3070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WINA-3079]: https://datadoghq.atlassian.net/browse/WINA-3079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ