### PR TITLE
Allow internet access for discovery LinuxTestSuite

### DIFF
--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -60,6 +60,14 @@ type linuxTestSuite struct {
 	e2e.BaseSuite[environments.Host]
 }
 
+// withInternetAccess opts the host into internet access, which the suite needs to
+// provision its test services: testdata/provision/provision.sh installs packages
+// from apt, pip, npm and gem. It must be passed to every provisioner call in the
+// suite, including UpdateEnv, since the awshost provisioner defaults to blocking
+// internet access and a call that omits it would put the host back behind the
+// no-internet security groups.
+var withInternetAccess = scenec2.WithEC2InstanceOptions(scenec2.WithInternetAccess())
+
 var services = []string{
 	"python-svc",
 	"python-instrumented",
@@ -75,7 +83,10 @@ func TestLinuxTestSuite(t *testing.T) {
 		agentparams.WithSystemProbeConfig(systemProbeConfigStr),
 	}
 	options := []e2e.SuiteOption{
-		e2e.WithProvisioner(awshost.Provisioner(awshost.WithRunOptions(scenec2.WithAgentOptions(agentParams...)))),
+		e2e.WithProvisioner(awshost.Provisioner(awshost.WithRunOptions(
+			scenec2.WithAgentOptions(agentParams...),
+			withInternetAccess,
+		))),
 	}
 	e2e.Run(t, &linuxTestSuite{}, options...)
 }
@@ -268,6 +279,7 @@ func (s *linuxTestSuite) testProcessCheckWithServiceDiscovery(agentConfigStr str
 		scenec2.WithAgentOptions(
 			agentparams.WithAgentConfig(agentConfigStr),
 			agentparams.WithSystemProbeConfig(systemProbeConfigStr)),
+		withInternetAccess,
 	)),
 	)
 	s.validateDiscoveryMode(mode)
@@ -417,6 +429,7 @@ func (s *linuxTestSuite) testProcessCheckWithServiceDiscoveryPrivilegedLogs(agen
 		scenec2.WithAgentOptions(
 			agentparams.WithAgentConfig(agentConfigStr),
 			agentparams.WithSystemProbeConfig(systemProbeConfigStr)),
+		withInternetAccess,
 	)),
 	)
 	client := s.Env().FakeIntake.Client()

--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -77,12 +77,7 @@ func TestLinuxTestSuite(t *testing.T) {
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.Provisioner(awshost.WithRunOptions(
 			scenec2.WithAgentOptions(agentParams...),
-			// The host needs internet access to provision the test services:
-			// testdata/provision/provision.sh installs packages from apt, pip,
-			// npm and gem. Every provisioner call in the suite must opt in,
-			// including UpdateEnv, since the awshost provisioner defaults to
-			// blocking internet access and a call that omits it would put the
-			// host back behind the no-internet security groups.
+			// provision.sh installs packages from apt, pip, npm and gem.
 			scenec2.WithEC2InstanceOptions(scenec2.WithInternetAccess()),
 		))),
 	}

--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -60,14 +60,6 @@ type linuxTestSuite struct {
 	e2e.BaseSuite[environments.Host]
 }
 
-// withInternetAccess opts the host into internet access, which the suite needs to
-// provision its test services: testdata/provision/provision.sh installs packages
-// from apt, pip, npm and gem. It must be passed to every provisioner call in the
-// suite, including UpdateEnv, since the awshost provisioner defaults to blocking
-// internet access and a call that omits it would put the host back behind the
-// no-internet security groups.
-var withInternetAccess = scenec2.WithEC2InstanceOptions(scenec2.WithInternetAccess())
-
 var services = []string{
 	"python-svc",
 	"python-instrumented",
@@ -85,7 +77,13 @@ func TestLinuxTestSuite(t *testing.T) {
 	options := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.Provisioner(awshost.WithRunOptions(
 			scenec2.WithAgentOptions(agentParams...),
-			withInternetAccess,
+			// The host needs internet access to provision the test services:
+			// testdata/provision/provision.sh installs packages from apt, pip,
+			// npm and gem. Every provisioner call in the suite must opt in,
+			// including UpdateEnv, since the awshost provisioner defaults to
+			// blocking internet access and a call that omits it would put the
+			// host back behind the no-internet security groups.
+			scenec2.WithEC2InstanceOptions(scenec2.WithInternetAccess()),
 		))),
 	}
 	e2e.Run(t, &linuxTestSuite{}, options...)
@@ -279,7 +277,7 @@ func (s *linuxTestSuite) testProcessCheckWithServiceDiscovery(agentConfigStr str
 		scenec2.WithAgentOptions(
 			agentparams.WithAgentConfig(agentConfigStr),
 			agentparams.WithSystemProbeConfig(systemProbeConfigStr)),
-		withInternetAccess,
+		scenec2.WithEC2InstanceOptions(scenec2.WithInternetAccess()),
 	)),
 	)
 	s.validateDiscoveryMode(mode)
@@ -429,7 +427,7 @@ func (s *linuxTestSuite) testProcessCheckWithServiceDiscoveryPrivilegedLogs(agen
 		scenec2.WithAgentOptions(
 			agentparams.WithAgentConfig(agentConfigStr),
 			agentparams.WithSystemProbeConfig(systemProbeConfigStr)),
-		withInternetAccess,
+		scenec2.WithEC2InstanceOptions(scenec2.WithInternetAccess()),
 	)),
 	)
 	client := s.Env().FakeIntake.Client()


### PR DESCRIPTION
<!-- dd-meta {"pullId":"830bffdd-5403-4b0e-a99d-b517403ba44b","source":"chat","resourceId":"563bdb96-4089-45cd-b04c-7781b836d94b","workflowId":"ef8c61d5-48f9-4de9-8e89-cfddb994350e","codeChangeId":"ef8c61d5-48f9-4de9-8e89-cfddb994350e","sourceType":"chat"} -->
### What does this PR do?

Passes `scenec2.WithEC2InstanceOptions(scenec2.WithInternetAccess())` to every `awshost.Provisioner` call made by the `discovery` package's `linuxTestSuite` (the suite run by `TestLinuxTestSuite`), so the provisioned EC2 host is not placed behind the no-internet security groups.

Changes in `test/new-e2e/tests/discovery/linux_test.go`:

- Pass the option in `TestLinuxTestSuite`'s initial provisioner.
- Pass it in the two `s.UpdateEnv(awshost.Provisioner(...))` calls, in `testProcessCheckWithServiceDiscovery` and `testProcessCheckWithServiceDiscoveryPrivilegedLogs`.

The option is written out at each call site, matching how `process_autodiscovery_test.go` in the same package already does it.

### Motivation

`awshost.Provisioner` prepends `ec2.WithoutInternetAccess()` as a default, so a host is created behind the account's no-internet security groups unless the caller explicitly opts in. `linuxTestSuite.SetupSuite` calls `provisionServer`, which runs `testdata/provision/provision.sh` on the host; that script installs the test services' dependencies from apt, pip, npm and gem, all of which require reaching external hosts. Without internet access the provision step fails and the suite calls `s.T().Skip("Unable to provision server")`, so the discovery assertions never run.

The option has to be repeated on the `UpdateEnv` provisioners as well: each provisioner call reconciles the stack from the options it is given, so a later call that omits it would move the already-provisioned host back behind the no-internet security groups mid-suite.

### Describe how you validated your changes

- `go vet ./tests/discovery/` in `test/new-e2e` passes.
- `gofmt -l tests/discovery/` reports no diff.
- The change is confined to provisioner options; no test logic or assertion was modified. Full validation is the `new-e2e-discovery` CI job, which provisions the host and runs the suite — it should now complete the provision step instead of skipping.

### Additional Notes

Only `linuxTestSuite` is changed. The other suites in the `discovery` package (`config_discovery_linux_test.go`, docker/k8s tests) keep the no-internet default and are out of scope here.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/563bdb96-4089-45cd-b04c-7781b836d94b)

Comment @datadog to request changes