### PR TITLE
Replace manual requires_ebpf based filtering with macro-generated tags

### DIFF
--- a/bazel/configs/go_tests.bazelrc
+++ b/bazel/configs/go_tests.bazelrc
@@ -1,9 +1,9 @@
-# BPF test-tag variants require a privileged environment or system tools.
-# Exclude those variants from the wildcard while still running the default and
-# other tag sets of the same packages. --test_tag_filters is last-wins rather
-# than additive, so any config or command line that sets it has to repeat these
-# exclusions.
-test --test_tag_filters=-tagset_bpf,-tagset_bpf_nvml,-tagset_bpf_functionaltests
+# BPF and NPM test-tag variants require privileged environment, system tools, or
+# platform drivers. Exclude those variants from the wildcard while still running
+# the default and other tag sets of the same packages. --test_tag_filters is
+# last-wins rather than additive, so any config or command line that sets it has
+# to repeat these exclusions.
+test --test_tag_filters=-tagset_bpf,-tagset_bpf_nvml,-tagset_bpf_functionaltests,-tagset_npm
 # To produce verbose test.xml files
 test --test_env=GO_TEST_WRAP_TESTV=1
 
@@ -15,7 +15,7 @@ test:gorace --test_env=GORACE=atexit_sleep_ms=50
 # one lane can build the repo while another runs the dd_agent_go_test targets.
 # Usage: bazel test --config=no-dd-agent-go-tests //...
 test:no-dd-agent-go-tests --test_tag_filters=-dd_agent_go_test
-test:dd-agent-go-tests-only --test_tag_filters=dd_agent_go_test,-tagset_bpf,-tagset_bpf_nvml,-tagset_bpf_functionaltests
+test:dd-agent-go-tests-only --test_tag_filters=dd_agent_go_test,-tagset_bpf,-tagset_bpf_nvml,-tagset_bpf_functionaltests,-tagset_npm
 
 # Go-only coverage: emit go cover profiles and merge Bazel baseline files.
 # Usage: bazel coverage --config=coverage:go //pkg/...

--- a/bazel/configs/go_tests.bazelrc
+++ b/bazel/configs/go_tests.bazelrc
@@ -1,9 +1,9 @@
-# bpf-tagged tests that require a privileged environment or system tools are tagged
-# "requires_ebpf". Exclude them from the wildcard while still running the other
-# tag sets of the same packages. --test_tag_filters is last-wins rather than
-# additive, so any config or command line that sets it has to repeat this
-# exclusion.
-test --test_tag_filters=-requires_ebpf
+# BPF test-tag variants require a privileged environment or system tools.
+# Exclude those variants from the wildcard while still running the default and
+# other tag sets of the same packages. --test_tag_filters is last-wins rather
+# than additive, so any config or command line that sets it has to repeat these
+# exclusions.
+test --test_tag_filters=-tagset_bpf,-tagset_bpf_nvml,-tagset_bpf_functionaltests
 # To produce verbose test.xml files
 test --test_env=GO_TEST_WRAP_TESTV=1
 
@@ -15,7 +15,7 @@ test:gorace --test_env=GORACE=atexit_sleep_ms=50
 # one lane can build the repo while another runs the dd_agent_go_test targets.
 # Usage: bazel test --config=no-dd-agent-go-tests //...
 test:no-dd-agent-go-tests --test_tag_filters=-dd_agent_go_test
-test:dd-agent-go-tests-only --test_tag_filters=dd_agent_go_test,-requires_ebpf
+test:dd-agent-go-tests-only --test_tag_filters=dd_agent_go_test,-tagset_bpf,-tagset_bpf_nvml,-tagset_bpf_functionaltests
 
 # Go-only coverage: emit go cover profiles and merge Bazel baseline files.
 # Usage: bazel coverage --config=coverage:go //pkg/...

--- a/pkg/ebpf/BUILD.bazel
+++ b/pkg/ebpf/BUILD.bazel
@@ -311,6 +311,7 @@ dd_agent_go_test(
 dd_agent_go_test(
     name = "ksyms_test",
     srcs = ["ksyms_test.go"],
+    data = glob(["testdata/kallsyms.*"]),
     embed = [":ebpf"],
     gotags_sets = [["bpf"]],
     tags = ["requires_ebpf"],


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

This is a partial revert for https://github.com/DataDog/datadog-agent/pull/54886, in that it goes back to relying on the bazel tags injected by our `dd_agent_go_test` macro instead of manual tagging of `requires_ebpf`.

The `requires_ebpf` tags will be removed in a separate cleanup PR in order to avoid pinging lots of people and in case we still need it later. They should have no impact.

### Motivation

#54886 seems to actually have introduced a regression, reducing the parity in coverage between the bazel-driven tests and the gotestsum (`dda inv test`) ones. This PR achieves a net reduction of 1,190 lines that are tested by the "legacy" test jobs and untested by the bazel-driven jobs (i.e. an improvement), based on the linux amd64 data.

### Describe how you validated your changes

CI passes and ran a local coverage analysis.

### Additional Notes

One of the previously skipped tests required adding `data` to work.

Tests relying on `npm` tag are also filtered out to match what the gotestsum-driven tests do for the unit test job.
