### PR TITLE
ci(e2e): decouple go_e2e_test_binaries build parallelism from CPU request

### DIFF
--- a/.gitlab/test/e2e/e2e_devx.yml
+++ b/.gitlab/test/e2e/e2e_devx.yml
@@ -16,13 +16,15 @@ go_e2e_test_binaries:
     KUBERNETES_CPU_LIMIT: 4
     KUBERNETES_MEMORY_REQUEST: 72Gi
     KUBERNETES_MEMORY_LIMIT: 72Gi
+    # Special value to prevent OOMkill on go_e2e_binaries, pending bazel optimisation
+    BUILD_BINARIES_PARALLELISM: 3
   before_script:
     - !reference [.retrieve_linux_go_e2e_deps]
   script:
     - pushd test/new-e2e
     - go install github.com/DataDog/orchestrion
     - popd
-    - dda inv -- -e new-e2e-tests.build-binaries --output-dir test-binaries -p $KUBERNETES_CPU_REQUEST --manifest-file-path manifest.json
+    - dda inv -- -e new-e2e-tests.build-binaries --output-dir test-binaries -p $BUILD_BINARIES_PARALLELISM --manifest-file-path manifest.json
     - dda inv -- -e new-e2e-tests.upload-binaries --output-dir test-binaries --manifest-file-path manifest.json --s3-base-uri $S3_PERMANENT_ARTIFACTS_URI/e2e-pre-build/$CI_PIPELINE_ID
   rules:
     - !reference [.except_mergequeue]


### PR DESCRIPTION
#incident-60431
### What does this PR do?

Adds a `BUILD_BINARIES_PARALLELISM: 3` variable for the `go_e2e_test_binaries` job and uses it for `-p`, instead of reusing `KUBERNETES_CPU_REQUEST` (4). `KUBERNETES_CPU_REQUEST`/`KUBERNETES_CPU_LIMIT` stay at 4.

### Motivation

`go_e2e_test_binaries` keeps OOM-killing (incident-60368, #55992) because each of its 4 concurrent workers spawns its own orchestrion-instrumented `go test -c`, and running 4 of those at once needs more memory than even the current 72Gi ceiling. #55974 already fixed the unbounded-`GOMAXPROCS` bug by capping `KUBERNETES_CPU_LIMIT`, but that wasn't enough on its own. Dropping to 3 concurrent builds cuts peak memory without touching the memory ceiling again, and costs less build time than dropping further (e.g. `-p 2` or `GOMAXPROCS=1`, which past attempts showed roughly doubles the runtime).

This is a stopgap alongside the planned Bazel rewrite that removes orchestrion's memory cost directly (per #55992).

### Describe how you validated your changes

Not yet validated on a real pipeline — opening as draft to watch a run before marking ready.