### PR TITLE
[CWS] Increase OTEL process context resolution queue size

### DIFF
--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -63,7 +63,7 @@ const (
 
 	// otelProcCtxQueueSize bounds the pids waiting for OTel process context
 	// resolution.
-	otelProcCtxQueueSize     = 100
+	otelProcCtxQueueSize     = 10000
 	tryReparentMaxForkDepth  = 3  // max ancestor fork levels to check in TryReparentFromProcfs (execs not counted)
 	tryReparentMaxIterations = 64 // hard cap on total loop iterations in tryReparentFromProcfs to prevent hangs on ancestor cycles or long exec chains
 )


### PR DESCRIPTION
### What does this PR do?

Increases the size of the queue allocated to resolve the OTel process context and OTel thread context record symbols.

### Motivation

When many processes are started at the same time, it creates a burst of prctl events and the queue can fill up quickly.