### PR TITLE
Add in-process gNMI fakeserver for integration tests

### DIFF
--- a/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/BUILD.bazel
+++ b/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+
+go_library(
+    name = "fakeserver",
+    srcs = [
+        "auth.go",
+        "server.go",
+        "values.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_openconfig_gnmi//proto/gnmi",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//credentials/insecure",
+        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//stats",
+        "@org_golang_google_grpc//status",
+    ],
+)
+
+dd_agent_go_test(
+    name = "fakeserver_test",
+    srcs = ["server_test.go"],
+    deps = [
+        ":fakeserver",
+        "@com_github_openconfig_gnmi//proto/gnmi",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//credentials/insecure",
+        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//status",
+    ],
+)

--- a/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/auth.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/auth.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package fakeserver
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+
+	"google.golang.org/grpc/metadata"
+)
+
+func credentialsFromContext(ctx context.Context) (username, password string) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", ""
+	}
+
+	if values := md.Get("username"); len(values) > 0 {
+		username = values[0]
+	}
+	if values := md.Get("password"); len(values) > 0 {
+		password = values[0]
+	}
+
+	if username != "" && password != "" {
+		return username, password
+	}
+
+	for _, value := range md.Get("authorization") {
+		if !strings.HasPrefix(value, "Basic ") {
+			continue
+		}
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(value, "Basic "))
+		if err != nil {
+			continue
+		}
+		parts := strings.SplitN(string(decoded), ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		return parts[0], parts[1]
+	}
+
+	return username, password
+}

--- a/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/server.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/server.go
@@ -36,30 +36,21 @@ type streamState struct {
 	delaySync      bool
 	sendMu         sync.Mutex
 	stopPublishing bool
-	subscribeOnce  sync.Once
-	subscribeCh    chan struct{}
 	closeOnce      sync.Once
 	closeCh        chan struct{}
 }
 
 func newStreamState(stream grpc.BidiStreamingServer[gnmipb.SubscribeRequest, gnmipb.SubscribeResponse], delaySync bool) *streamState {
 	return &streamState{
-		stream:      stream,
-		delaySync:   delaySync,
-		subscribeCh: make(chan struct{}),
-		closeCh:     make(chan struct{}),
+		stream:    stream,
+		delaySync: delaySync,
+		closeCh:   make(chan struct{}),
 	}
 }
 
 func (s *streamState) close() {
 	s.closeOnce.Do(func() {
 		close(s.closeCh)
-	})
-}
-
-func (s *streamState) signalSubscribe() {
-	s.subscribeOnce.Do(func() {
-		close(s.subscribeCh)
 	})
 }
 
@@ -247,35 +238,13 @@ func (s *Server) CloseStream(streamID int) error {
 	return nil
 }
 
-// CloseConnections stops the gRPC server and closes all connections.
-func (s *Server) CloseConnections() {
-	s.Close()
-}
-
 // Close stops the server and releases resources.
 func (s *Server) Close() error {
 	s.closeOnce.Do(s.grpcServer.Stop)
 	return nil
 }
 
-// AwaitSubscribe waits until the stream receives its first Subscribe message or the context is done.
-func (s *Server) AwaitSubscribe(ctx context.Context, streamID int) error {
-	s.mu.RLock()
-	stream, ok := s.streams[streamID]
-	s.mu.RUnlock()
-	if !ok {
-		return fmt.Errorf("stream %d not found", streamID)
-	}
-
-	select {
-	case <-stream.subscribeCh:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
-
-func (s *Server) registerStream(stream grpc.BidiStreamingServer[gnmipb.SubscribeRequest, gnmipb.SubscribeResponse], delaySync bool) int {
+func (s *Server) registerStream(stream grpc.BidiStreamingServer[gnmipb.SubscribeRequest, gnmipb.SubscribeResponse], delaySync bool) (int, *streamState) {
 	id := int(s.nextStreamID.Add(1))
 	state := newStreamState(stream, delaySync)
 
@@ -284,7 +253,7 @@ func (s *Server) registerStream(stream grpc.BidiStreamingServer[gnmipb.Subscribe
 	s.mu.Unlock()
 
 	s.activeStreams.Add(1)
-	return id
+	return id, state
 }
 
 func (s *Server) unregisterStream(id int) {
@@ -336,6 +305,11 @@ type gnmiService struct {
 	server *Server
 }
 
+type recvResult struct {
+	request *gnmipb.SubscribeRequest
+	err     error
+}
+
 func (g *gnmiService) Subscribe(stream grpc.BidiStreamingServer[gnmipb.SubscribeRequest, gnmipb.SubscribeResponse]) error {
 	username, password := credentialsFromContext(stream.Context())
 	if !g.server.credentialsAllowed(username, password) {
@@ -346,31 +320,19 @@ func (g *gnmiService) Subscribe(stream grpc.BidiStreamingServer[gnmipb.Subscribe
 	delaySync := g.server.delaySyncDefault
 	g.server.mu.RUnlock()
 
-	streamID := g.server.registerStream(stream, delaySync)
+	streamID, state := g.server.registerStream(stream, delaySync)
 	defer g.server.unregisterStream(streamID)
 
-	g.server.mu.RLock()
-	state := g.server.streams[streamID]
-	g.server.mu.RUnlock()
-	if state == nil {
-		return status.Error(codes.Internal, "stream state missing")
-	}
-
-	reqCh := make(chan *gnmipb.SubscribeRequest)
-	errCh := make(chan error, 1)
+	recvCh := make(chan recvResult)
 	go func() {
 		for {
 			req, err := stream.Recv()
-			if err != nil {
-				select {
-				case errCh <- err:
-				case <-stream.Context().Done():
-				}
+			select {
+			case recvCh <- recvResult{request: req, err: err}:
+			case <-stream.Context().Done():
 				return
 			}
-			select {
-			case reqCh <- req:
-			case <-stream.Context().Done():
+			if err != nil {
 				return
 			}
 		}
@@ -382,10 +344,11 @@ func (g *gnmiService) Subscribe(stream grpc.BidiStreamingServer[gnmipb.Subscribe
 			return status.Error(codes.Canceled, "stream closed by server")
 		case <-stream.Context().Done():
 			return stream.Context().Err()
-		case err := <-errCh:
-			return err
-		case req := <-reqCh:
-			if err := g.handleSubscribeRequest(streamID, state, username, password, req); err != nil {
+		case result := <-recvCh:
+			if result.err != nil {
+				return result.err
+			}
+			if err := g.handleSubscribeRequest(streamID, state, username, password, result.request); err != nil {
 				return err
 			}
 		}
@@ -396,7 +359,6 @@ func (g *gnmiService) handleSubscribeRequest(streamID int, state *streamState, u
 	switch req.GetRequest().(type) {
 	case *gnmipb.SubscribeRequest_Subscribe:
 		g.server.subscriptionCount.Add(1)
-		state.signalSubscribe()
 
 		event := SubscribeEvent{
 			StreamID: streamID,

--- a/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/server.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/server.go
@@ -1,0 +1,442 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package fakeserver provides a controllable in-process gNMI server for tests.
+package fakeserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/status"
+)
+
+// SubscribeEvent captures a Subscribe RPC request and the credentials presented on the stream.
+type SubscribeEvent struct {
+	StreamID int
+	Request  *gnmipb.SubscribeRequest
+	Username string
+	Password string
+}
+
+type streamState struct {
+	id             int
+	stream         grpc.BidiStreamingServer[gnmipb.SubscribeRequest, gnmipb.SubscribeResponse]
+	delaySync      bool
+	stopPublishing bool
+	subscribed     bool
+	subscribeOnce  sync.Once
+	subscribeCh    chan struct{}
+	closeOnce      sync.Once
+	closeCh        chan struct{}
+}
+
+func newStreamState(id int, stream grpc.BidiStreamingServer[gnmipb.SubscribeRequest, gnmipb.SubscribeResponse], delaySync bool) *streamState {
+	return &streamState{
+		id:          id,
+		stream:      stream,
+		delaySync:   delaySync,
+		subscribeCh: make(chan struct{}),
+		closeCh:     make(chan struct{}),
+	}
+}
+
+func (s *streamState) close() {
+	s.closeOnce.Do(func() {
+		close(s.closeCh)
+	})
+}
+
+func (s *streamState) signalSubscribe() {
+	s.subscribed = true
+	s.subscribeOnce.Do(func() {
+		close(s.subscribeCh)
+	})
+}
+
+type connStatsHandler struct {
+	activeConns atomic.Int32
+}
+
+func (h *connStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+func (h *connStatsHandler) HandleRPC(_ context.Context, _ stats.RPCStats) {}
+
+func (h *connStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (h *connStatsHandler) HandleConn(_ context.Context, s stats.ConnStats) {
+	switch s.(type) {
+	case *stats.ConnBegin:
+		h.activeConns.Add(1)
+	case *stats.ConnEnd:
+		h.activeConns.Add(-1)
+	}
+}
+
+// Server is a loopback gNMI server with deterministic controls for Subscribe testing.
+type Server struct {
+	grpcServer *grpc.Server
+	listener   net.Listener
+	addr       string
+
+	mu           sync.RWMutex
+	streams      map[int]*streamState
+	nextStreamID atomic.Int32
+
+	subscribeRequests chan SubscribeEvent
+
+	expectedUsername  string
+	expectedPassword  string
+	rejectCredentials bool
+	delaySyncDefault  bool
+
+	subscriptionCount atomic.Int32
+	activeStreams     atomic.Int32
+	connStats         connStatsHandler
+
+	closed chan struct{}
+}
+
+// New starts a gNMI server on a random loopback TCP port.
+func New() (*Server, error) {
+	return NewOn("127.0.0.1:0")
+}
+
+// NewOn starts a gNMI server bound to the given TCP address.
+func NewOn(listenAddr string) (*Server, error) {
+	listener, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		return nil, fmt.Errorf("listen: %w", err)
+	}
+
+	s := &Server{
+		listener:          listener,
+		addr:              listener.Addr().String(),
+		streams:           make(map[int]*streamState),
+		subscribeRequests: make(chan SubscribeEvent, 16),
+		closed:            make(chan struct{}),
+	}
+
+	grpcServer := grpc.NewServer(
+		grpc.Creds(insecure.NewCredentials()),
+		grpc.StatsHandler(&s.connStats),
+	)
+	gnmipb.RegisterGNMIServer(grpcServer, &gnmiService{server: s})
+	s.grpcServer = grpcServer
+
+	go func() {
+		if err := grpcServer.Serve(listener); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			panic(fmt.Sprintf("fakeserver: serve failed: %v", err))
+		}
+	}()
+
+	return s, nil
+}
+
+// Addr returns the loopback address (host:port) of the running server.
+func (s *Server) Addr() string {
+	return s.addr
+}
+
+// SubscribeRequests returns a channel of Subscribe RPC events for inspection in tests.
+func (s *Server) SubscribeRequests() <-chan SubscribeEvent {
+	return s.subscribeRequests
+}
+
+// ConnectionCount returns the number of active gRPC connections.
+func (s *Server) ConnectionCount() int {
+	return int(s.connStats.activeConns.Load())
+}
+
+// SubscriptionCount returns the number of Subscribe messages received.
+func (s *Server) SubscriptionCount() int {
+	return int(s.subscriptionCount.Load())
+}
+
+// ActiveStreamCount returns the number of open Subscribe streams.
+func (s *Server) ActiveStreamCount() int {
+	return int(s.activeStreams.Load())
+}
+
+// SetExpectedCredentials configures credentials that must match unless rejection is enabled.
+func (s *Server) SetExpectedCredentials(username, password string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.expectedUsername = username
+	s.expectedPassword = password
+}
+
+// SetRejectCredentials configures whether all credentials are rejected regardless of value.
+func (s *Server) SetRejectCredentials(reject bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rejectCredentials = reject
+}
+
+// SetDelaySync configures whether new streams wait for SendSyncResponse before auto-syncing.
+func (s *Server) SetDelaySync(delay bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.delaySyncDefault = delay
+}
+
+// DelaySync prevents automatic sync_response for an existing stream until SendSyncResponse is called.
+func (s *Server) DelaySync(streamID int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	stream, ok := s.streams[streamID]
+	if !ok {
+		return fmt.Errorf("stream %d not found", streamID)
+	}
+	stream.delaySync = true
+	return nil
+}
+
+// StopPublishing prevents further updates from being sent on the stream.
+func (s *Server) StopPublishing(streamID int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	stream, ok := s.streams[streamID]
+	if !ok {
+		return fmt.Errorf("stream %d not found", streamID)
+	}
+	stream.stopPublishing = true
+	return nil
+}
+
+// SendSyncResponse sends a sync_response on the given stream.
+func (s *Server) SendSyncResponse(streamID int) error {
+	return s.sendResponse(streamID, &gnmipb.SubscribeResponse{
+		Response: &gnmipb.SubscribeResponse_SyncResponse{
+			SyncResponse: true,
+		},
+	})
+}
+
+// SendUpdate sends a single-path update notification on the stream.
+func (s *Server) SendUpdate(streamID int, update *gnmipb.Update) error {
+	return s.sendNotification(streamID, &gnmipb.Notification{
+		Timestamp: time.Now().UnixNano(),
+		Update:    []*gnmipb.Update{update},
+	})
+}
+
+// SendReplace sends a full notification (replace semantics) on the stream.
+func (s *Server) SendReplace(streamID int, notification *gnmipb.Notification) error {
+	return s.sendNotification(streamID, notification)
+}
+
+// SendDelete sends a delete notification on the stream.
+func (s *Server) SendDelete(streamID int, path *gnmipb.Path) error {
+	return s.sendNotification(streamID, &gnmipb.Notification{
+		Timestamp: time.Now().UnixNano(),
+		Delete:    []*gnmipb.Path{path},
+	})
+}
+
+// CloseStream closes the server side of a Subscribe stream.
+func (s *Server) CloseStream(streamID int) error {
+	s.mu.RLock()
+	stream, ok := s.streams[streamID]
+	s.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("stream %d not found", streamID)
+	}
+	stream.close()
+	return nil
+}
+
+// CloseConnections stops the gRPC server and closes all connections.
+func (s *Server) CloseConnections() {
+	s.Close()
+}
+
+// Close stops the server and releases resources.
+func (s *Server) Close() error {
+	select {
+	case <-s.closed:
+		return nil
+	default:
+		close(s.closed)
+	}
+
+	s.grpcServer.GracefulStop()
+	if err := s.listener.Close(); err != nil {
+		if errors.Is(err, net.ErrClosed) {
+			return nil
+		}
+		if opErr, ok := err.(*net.OpError); ok && opErr.Err != nil && errors.Is(opErr.Err, net.ErrClosed) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// AwaitSubscribe waits until the stream receives its first Subscribe message or the context is done.
+func (s *Server) AwaitSubscribe(ctx context.Context, streamID int) error {
+	s.mu.RLock()
+	stream, ok := s.streams[streamID]
+	s.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("stream %d not found", streamID)
+	}
+
+	select {
+	case <-stream.subscribeCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *Server) registerStream(stream grpc.BidiStreamingServer[gnmipb.SubscribeRequest, gnmipb.SubscribeResponse], delaySync bool) int {
+	id := int(s.nextStreamID.Add(1))
+	state := newStreamState(id, stream, delaySync)
+
+	s.mu.Lock()
+	s.streams[id] = state
+	s.mu.Unlock()
+
+	s.activeStreams.Add(1)
+	return id
+}
+
+func (s *Server) unregisterStream(id int) {
+	s.mu.Lock()
+	delete(s.streams, id)
+	s.mu.Unlock()
+	s.activeStreams.Add(-1)
+}
+
+func (s *Server) credentialsAllowed(username, password string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.rejectCredentials {
+		return false
+	}
+	if s.expectedUsername == "" && s.expectedPassword == "" {
+		return true
+	}
+	return username == s.expectedUsername && password == s.expectedPassword
+}
+
+func (s *Server) sendResponse(streamID int, response *gnmipb.SubscribeResponse) error {
+	s.mu.RLock()
+	stream, ok := s.streams[streamID]
+	s.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("stream %d not found", streamID)
+	}
+	if stream.stopPublishing {
+		return fmt.Errorf("stream %d is not publishing", streamID)
+	}
+	return stream.stream.Send(response)
+}
+
+func (s *Server) sendNotification(streamID int, notification *gnmipb.Notification) error {
+	return s.sendResponse(streamID, &gnmipb.SubscribeResponse{
+		Response: &gnmipb.SubscribeResponse_Update{
+			Update: notification,
+		},
+	})
+}
+
+type gnmiService struct {
+	gnmipb.UnimplementedGNMIServer
+	server *Server
+}
+
+func (g *gnmiService) Subscribe(stream grpc.BidiStreamingServer[gnmipb.SubscribeRequest, gnmipb.SubscribeResponse]) error {
+	username, password := credentialsFromContext(stream.Context())
+	if !g.server.credentialsAllowed(username, password) {
+		return status.Error(codes.Unauthenticated, "invalid credentials")
+	}
+
+	g.server.mu.RLock()
+	delaySync := g.server.delaySyncDefault
+	g.server.mu.RUnlock()
+
+	streamID := g.server.registerStream(stream, delaySync)
+	defer g.server.unregisterStream(streamID)
+
+	g.server.mu.RLock()
+	state := g.server.streams[streamID]
+	g.server.mu.RUnlock()
+	if state == nil {
+		return status.Error(codes.Internal, "stream state missing")
+	}
+
+	reqCh := make(chan *gnmipb.SubscribeRequest)
+	errCh := make(chan error, 1)
+	go func() {
+		for {
+			req, err := stream.Recv()
+			if err != nil {
+				errCh <- err
+				return
+			}
+			reqCh <- req
+		}
+	}()
+
+	for {
+		select {
+		case <-state.closeCh:
+			return status.Error(codes.Canceled, "stream closed by server")
+		case err := <-errCh:
+			return err
+		case req := <-reqCh:
+			if err := g.handleSubscribeRequest(streamID, state, username, password, req); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (g *gnmiService) handleSubscribeRequest(streamID int, state *streamState, username, password string, req *gnmipb.SubscribeRequest) error {
+	switch req.GetRequest().(type) {
+	case *gnmipb.SubscribeRequest_Subscribe:
+		g.server.subscriptionCount.Add(1)
+		state.signalSubscribe()
+
+		event := SubscribeEvent{
+			StreamID: streamID,
+			Request:  req,
+			Username: username,
+			Password: password,
+		}
+		select {
+		case g.server.subscribeRequests <- event:
+		default:
+		}
+
+		if !state.delaySync {
+			if err := g.server.SendSyncResponse(streamID); err != nil {
+				return err
+			}
+		}
+	case *gnmipb.SubscribeRequest_Poll:
+		// Poll requests are accepted; tests drive responses explicitly.
+	default:
+		return status.Error(codes.InvalidArgument, "unsupported subscribe request type")
+	}
+	return nil
+}

--- a/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/server.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/server.go
@@ -32,20 +32,18 @@ type SubscribeEvent struct {
 }
 
 type streamState struct {
-	id             int
 	stream         grpc.BidiStreamingServer[gnmipb.SubscribeRequest, gnmipb.SubscribeResponse]
 	delaySync      bool
+	sendMu         sync.Mutex
 	stopPublishing bool
-	subscribed     bool
 	subscribeOnce  sync.Once
 	subscribeCh    chan struct{}
 	closeOnce      sync.Once
 	closeCh        chan struct{}
 }
 
-func newStreamState(id int, stream grpc.BidiStreamingServer[gnmipb.SubscribeRequest, gnmipb.SubscribeResponse], delaySync bool) *streamState {
+func newStreamState(stream grpc.BidiStreamingServer[gnmipb.SubscribeRequest, gnmipb.SubscribeResponse], delaySync bool) *streamState {
 	return &streamState{
-		id:          id,
 		stream:      stream,
 		delaySync:   delaySync,
 		subscribeCh: make(chan struct{}),
@@ -60,7 +58,6 @@ func (s *streamState) close() {
 }
 
 func (s *streamState) signalSubscribe() {
-	s.subscribed = true
 	s.subscribeOnce.Do(func() {
 		close(s.subscribeCh)
 	})
@@ -92,7 +89,6 @@ func (h *connStatsHandler) HandleConn(_ context.Context, s stats.ConnStats) {
 // Server is a loopback gNMI server with deterministic controls for Subscribe testing.
 type Server struct {
 	grpcServer *grpc.Server
-	listener   net.Listener
 	addr       string
 
 	mu           sync.RWMutex
@@ -110,7 +106,7 @@ type Server struct {
 	activeStreams     atomic.Int32
 	connStats         connStatsHandler
 
-	closed chan struct{}
+	closeOnce sync.Once
 }
 
 // New starts a gNMI server on a random loopback TCP port.
@@ -126,11 +122,9 @@ func NewOn(listenAddr string) (*Server, error) {
 	}
 
 	s := &Server{
-		listener:          listener,
 		addr:              listener.Addr().String(),
 		streams:           make(map[int]*streamState),
 		subscribeRequests: make(chan SubscribeEvent, 16),
-		closed:            make(chan struct{}),
 	}
 
 	grpcServer := grpc.NewServer(
@@ -196,26 +190,17 @@ func (s *Server) SetDelaySync(delay bool) {
 	s.delaySyncDefault = delay
 }
 
-// DelaySync prevents automatic sync_response for an existing stream until SendSyncResponse is called.
-func (s *Server) DelaySync(streamID int) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	stream, ok := s.streams[streamID]
-	if !ok {
-		return fmt.Errorf("stream %d not found", streamID)
-	}
-	stream.delaySync = true
-	return nil
-}
-
 // StopPublishing prevents further updates from being sent on the stream.
 func (s *Server) StopPublishing(streamID int) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
 	stream, ok := s.streams[streamID]
+	s.mu.RUnlock()
 	if !ok {
 		return fmt.Errorf("stream %d not found", streamID)
 	}
+
+	stream.sendMu.Lock()
+	defer stream.sendMu.Unlock()
 	stream.stopPublishing = true
 	return nil
 }
@@ -269,23 +254,7 @@ func (s *Server) CloseConnections() {
 
 // Close stops the server and releases resources.
 func (s *Server) Close() error {
-	select {
-	case <-s.closed:
-		return nil
-	default:
-		close(s.closed)
-	}
-
-	s.grpcServer.GracefulStop()
-	if err := s.listener.Close(); err != nil {
-		if errors.Is(err, net.ErrClosed) {
-			return nil
-		}
-		if opErr, ok := err.(*net.OpError); ok && opErr.Err != nil && errors.Is(opErr.Err, net.ErrClosed) {
-			return nil
-		}
-		return err
-	}
+	s.closeOnce.Do(s.grpcServer.Stop)
 	return nil
 }
 
@@ -308,7 +277,7 @@ func (s *Server) AwaitSubscribe(ctx context.Context, streamID int) error {
 
 func (s *Server) registerStream(stream grpc.BidiStreamingServer[gnmipb.SubscribeRequest, gnmipb.SubscribeResponse], delaySync bool) int {
 	id := int(s.nextStreamID.Add(1))
-	state := newStreamState(id, stream, delaySync)
+	state := newStreamState(stream, delaySync)
 
 	s.mu.Lock()
 	s.streams[id] = state
@@ -345,6 +314,9 @@ func (s *Server) sendResponse(streamID int, response *gnmipb.SubscribeResponse) 
 	if !ok {
 		return fmt.Errorf("stream %d not found", streamID)
 	}
+
+	stream.sendMu.Lock()
+	defer stream.sendMu.Unlock()
 	if stream.stopPublishing {
 		return fmt.Errorf("stream %d is not publishing", streamID)
 	}
@@ -390,10 +362,17 @@ func (g *gnmiService) Subscribe(stream grpc.BidiStreamingServer[gnmipb.Subscribe
 		for {
 			req, err := stream.Recv()
 			if err != nil {
-				errCh <- err
+				select {
+				case errCh <- err:
+				case <-stream.Context().Done():
+				}
 				return
 			}
-			reqCh <- req
+			select {
+			case reqCh <- req:
+			case <-stream.Context().Done():
+				return
+			}
 		}
 	}()
 
@@ -401,6 +380,8 @@ func (g *gnmiService) Subscribe(stream grpc.BidiStreamingServer[gnmipb.Subscribe
 		select {
 		case <-state.closeCh:
 			return status.Error(codes.Canceled, "stream closed by server")
+		case <-stream.Context().Done():
+			return stream.Context().Err()
 		case err := <-errCh:
 			return err
 		case req := <-reqCh:
@@ -423,15 +404,15 @@ func (g *gnmiService) handleSubscribeRequest(streamID int, state *streamState, u
 			Username: username,
 			Password: password,
 		}
-		select {
-		case g.server.subscribeRequests <- event:
-		default:
-		}
-
 		if !state.delaySync {
 			if err := g.server.SendSyncResponse(streamID); err != nil {
 				return err
 			}
+		}
+
+		select {
+		case g.server.subscribeRequests <- event:
+		default:
 		}
 	case *gnmipb.SubscribeRequest_Poll:
 		// Poll requests are accepted; tests drive responses explicitly.

--- a/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/server_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/server_test.go
@@ -7,6 +7,7 @@ package fakeserver_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -240,6 +241,84 @@ func TestCloseStreamAndCounts(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	require.Equal(t, 0, server.ActiveStreamCount())
+}
+
+func TestConcurrentCloseStopsActiveStream(t *testing.T) {
+	server := startServer(t)
+
+	client := dialGNMI(t, server.Addr(), "user", "pass")
+	stream := openSubscribeStream(t, client, "user", "pass")
+	require.NoError(t, stream.Send(subscribeRequest()))
+	waitSubscribeEvent(t, server)
+	_, err := stream.Recv()
+	require.NoError(t, err)
+
+	const closeCount = 8
+	closeErrors := make(chan error, closeCount)
+	var wg sync.WaitGroup
+	for range closeCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			closeErrors <- server.Close()
+		}()
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out closing server with an active stream")
+	}
+	close(closeErrors)
+	for err := range closeErrors {
+		require.NoError(t, err)
+	}
+
+	_, err = stream.Recv()
+	require.Error(t, err)
+	require.Eventually(t, func() bool {
+		return server.ActiveStreamCount() == 0
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestConcurrentSendUpdate(t *testing.T) {
+	server := startServer(t)
+	server.SetDelaySync(true)
+
+	client := dialGNMI(t, server.Addr(), "user", "pass")
+	stream := openSubscribeStream(t, client, "user", "pass")
+	require.NoError(t, stream.Send(subscribeRequest()))
+	event := waitSubscribeEvent(t, server)
+
+	const updateCount = 16
+	sendErrors := make(chan error, updateCount)
+	var wg sync.WaitGroup
+	for value := range updateCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sendErrors <- server.SendUpdate(event.StreamID, fakeserver.InterfaceInOctetsUpdate("eth0", uint64(value)))
+		}()
+	}
+	wg.Wait()
+	close(sendErrors)
+	for err := range sendErrors {
+		require.NoError(t, err)
+	}
+
+	values := make(map[uint64]struct{}, updateCount)
+	for range updateCount {
+		resp, err := stream.Recv()
+		require.NoError(t, err)
+		require.Len(t, resp.GetUpdate().GetUpdate(), 1)
+		values[resp.GetUpdate().GetUpdate()[0].GetVal().GetUintVal()] = struct{}{}
+	}
+	require.Len(t, values, updateCount)
 }
 
 func TestValueHelpers(t *testing.T) {

--- a/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/server_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/server_test.go
@@ -1,0 +1,277 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package fakeserver_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver"
+)
+
+func startServer(t *testing.T) *fakeserver.Server {
+	server, err := fakeserver.New()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+	})
+	return server
+}
+
+func dialGNMI(t *testing.T, addr string, _ string, _ string) gnmipb.GNMIClient {
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+	return gnmipb.NewGNMIClient(conn)
+}
+
+func subscribeRequest() *gnmipb.SubscribeRequest {
+	return &gnmipb.SubscribeRequest{
+		Request: &gnmipb.SubscribeRequest_Subscribe{
+			Subscribe: &gnmipb.SubscriptionList{
+				Mode:     gnmipb.SubscriptionList_STREAM,
+				Encoding: gnmipb.Encoding_PROTO,
+				Subscription: []*gnmipb.Subscription{
+					{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{
+								{Name: "interfaces"},
+								{Name: "interface", Key: map[string]string{"name": "*"}},
+								{Name: "state"},
+								{Name: "counters"},
+								{Name: "in-octets"},
+							},
+						},
+						Mode: gnmipb.SubscriptionMode_SAMPLE,
+					},
+				},
+			},
+		},
+	}
+}
+
+func openSubscribeStream(t *testing.T, client gnmipb.GNMIClient, username, password string) grpc.BidiStreamingClient[gnmipb.SubscribeRequest, gnmipb.SubscribeResponse] {
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(
+		"username", username,
+		"password", password,
+	))
+	stream, err := client.Subscribe(ctx)
+	require.NoError(t, err)
+	return stream
+}
+
+func waitForActiveStreams(t *testing.T, server *fakeserver.Server, count int) {
+	require.Eventually(t, func() bool {
+		return server.ActiveStreamCount() == count
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestSubscribeSyncAndUpdate(t *testing.T) {
+	server := startServer(t)
+	server.SetExpectedCredentials("user", "pass")
+
+	client := dialGNMI(t, server.Addr(), "user", "pass")
+	stream := openSubscribeStream(t, client, "user", "pass")
+
+	require.NoError(t, stream.Send(subscribeRequest()))
+
+	event := waitSubscribeEvent(t, server)
+	require.Equal(t, "user", event.Username)
+	require.Equal(t, "pass", event.Password)
+	require.NotNil(t, event.Request.GetSubscribe())
+	require.Equal(t, gnmipb.Encoding_PROTO, event.Request.GetSubscribe().GetEncoding())
+
+	syncResp, err := stream.Recv()
+	require.NoError(t, err)
+	require.True(t, syncResp.GetSyncResponse())
+
+	update := fakeserver.InterfaceInOctetsUpdate("eth0", 42)
+	require.NoError(t, server.SendUpdate(event.StreamID, update))
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	notification := resp.GetUpdate()
+	require.NotNil(t, notification)
+	require.Len(t, notification.GetUpdate(), 1)
+	require.Equal(t, uint64(42), notification.GetUpdate()[0].GetVal().GetUintVal())
+}
+
+func TestRejectCredentials(t *testing.T) {
+	server := startServer(t)
+	server.SetExpectedCredentials("user", "pass")
+	server.SetRejectCredentials(true)
+
+	client := dialGNMI(t, server.Addr(), "user", "pass")
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(
+		"username", "user",
+		"password", "pass",
+	))
+	stream, err := client.Subscribe(ctx)
+	if err != nil {
+		require.Equal(t, codes.Unauthenticated, status.Code(err))
+		return
+	}
+
+	_, err = stream.Recv()
+	require.Error(t, err)
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestDelaySync(t *testing.T) {
+	server := startServer(t)
+	server.SetDelaySync(true)
+
+	client := dialGNMI(t, server.Addr(), "user", "pass")
+	stream := openSubscribeStream(t, client, "user", "pass")
+	require.NoError(t, stream.Send(subscribeRequest()))
+
+	event := waitSubscribeEvent(t, server)
+
+	// Recv is called from a single goroutine so that, once the receive is
+	// pending, no other goroutine touches the stream concurrently: gRPC does
+	// not allow concurrent RecvMsg calls on the same stream.
+	pending := recvAsync(stream)
+	select {
+	case <-pending:
+		t.Fatal("expected sync response to be delayed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	require.NoError(t, server.SendSyncResponse(event.StreamID))
+
+	select {
+	case res := <-pending:
+		require.NoError(t, res.err)
+		require.True(t, res.resp.GetSyncResponse())
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for sync response")
+	}
+}
+
+func TestStopPublishing(t *testing.T) {
+	server := startServer(t)
+
+	client := dialGNMI(t, server.Addr(), "user", "pass")
+	stream := openSubscribeStream(t, client, "user", "pass")
+	require.NoError(t, stream.Send(subscribeRequest()))
+
+	event := waitSubscribeEvent(t, server)
+	_, err := stream.Recv()
+	require.NoError(t, err)
+
+	require.NoError(t, server.StopPublishing(event.StreamID))
+	err = server.SendUpdate(event.StreamID, fakeserver.InterfaceInOctetsUpdate("eth0", 1))
+	require.Error(t, err)
+}
+
+func TestSendReplaceAndDelete(t *testing.T) {
+	server := startServer(t)
+
+	client := dialGNMI(t, server.Addr(), "user", "pass")
+	stream := openSubscribeStream(t, client, "user", "pass")
+	require.NoError(t, stream.Send(subscribeRequest()))
+
+	event := waitSubscribeEvent(t, server)
+	_, err := stream.Recv()
+	require.NoError(t, err)
+
+	replace := &gnmipb.Notification{
+		Timestamp: time.Now().UnixNano(),
+		Update: []*gnmipb.Update{
+			fakeserver.InterfaceInOctetsUpdate("eth1", 100),
+			fakeserver.InterfaceOutOctetsUpdate("eth1", 200),
+		},
+	}
+	require.NoError(t, server.SendReplace(event.StreamID, replace))
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.GetUpdate().GetUpdate(), 2)
+
+	deletePath := &gnmipb.Path{
+		Elem: []*gnmipb.PathElem{
+			{Name: "interfaces"},
+			{Name: "interface", Key: map[string]string{"name": "eth1"}},
+		},
+	}
+	require.NoError(t, server.SendDelete(event.StreamID, deletePath))
+
+	resp, err = stream.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.GetUpdate().GetDelete(), 1)
+}
+
+func TestCloseStreamAndCounts(t *testing.T) {
+	server := startServer(t)
+
+	client := dialGNMI(t, server.Addr(), "user", "pass")
+	stream := openSubscribeStream(t, client, "user", "pass")
+	waitForActiveStreams(t, server, 1)
+	require.GreaterOrEqual(t, server.ConnectionCount(), 1)
+
+	require.NoError(t, stream.Send(subscribeRequest()))
+	event := waitSubscribeEvent(t, server)
+	require.Equal(t, 1, server.SubscriptionCount())
+
+	_, err := stream.Recv()
+	require.NoError(t, err)
+
+	require.NoError(t, server.CloseStream(event.StreamID))
+
+	_, err = stream.Recv()
+	require.Error(t, err)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for server.ActiveStreamCount() > 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.Equal(t, 0, server.ActiveStreamCount())
+}
+
+func TestValueHelpers(t *testing.T) {
+	require.Equal(t, uint64(7), fakeserver.ScalarUint64(7).GetUintVal())
+	require.Equal(t, int64(-3), fakeserver.ScalarInt64(-3).GetIntVal())
+	require.Equal(t, "open", fakeserver.ScalarString("open").GetStringVal())
+
+	update := fakeserver.InterfaceInOctetsUpdate("ge-0/0/0", 999)
+	require.Equal(t, "ge-0/0/0", update.GetPath().GetElem()[1].GetKey()["name"])
+	require.Equal(t, uint64(999), update.GetVal().GetUintVal())
+}
+
+func waitSubscribeEvent(t *testing.T, server *fakeserver.Server) fakeserver.SubscribeEvent {
+	select {
+	case event := <-server.SubscribeRequests():
+		return event
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for subscribe event")
+		return fakeserver.SubscribeEvent{}
+	}
+}
+
+type recvResult struct {
+	resp *gnmipb.SubscribeResponse
+	err  error
+}
+
+func recvAsync(stream grpc.BidiStreamingClient[gnmipb.SubscribeRequest, gnmipb.SubscribeResponse]) <-chan recvResult {
+	ch := make(chan recvResult, 1)
+	go func() {
+		resp, err := stream.Recv()
+		ch <- recvResult{resp: resp, err: err}
+	}()
+	return ch
+}

--- a/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/server_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/server_test.go
@@ -257,11 +257,9 @@ func TestConcurrentCloseStopsActiveStream(t *testing.T) {
 	closeErrors := make(chan error, closeCount)
 	var wg sync.WaitGroup
 	for range closeCount {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			closeErrors <- server.Close()
-		}()
+		})
 	}
 
 	closed := make(chan struct{})
@@ -288,7 +286,6 @@ func TestConcurrentCloseStopsActiveStream(t *testing.T) {
 
 func TestConcurrentSendUpdate(t *testing.T) {
 	server := startServer(t)
-	server.SetDelaySync(true)
 
 	client := dialGNMI(t, server.Addr(), "user", "pass")
 	stream := openSubscribeStream(t, client, "user", "pass")
@@ -299,17 +296,14 @@ func TestConcurrentSendUpdate(t *testing.T) {
 	sendErrors := make(chan error, updateCount)
 	var wg sync.WaitGroup
 	for value := range updateCount {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			sendErrors <- server.SendUpdate(event.StreamID, fakeserver.InterfaceInOctetsUpdate("eth0", uint64(value)))
-		}()
+		})
 	}
-	wg.Wait()
-	close(sendErrors)
-	for err := range sendErrors {
-		require.NoError(t, err)
-	}
+
+	syncResp, err := stream.Recv()
+	require.NoError(t, err)
+	require.True(t, syncResp.GetSyncResponse())
 
 	values := make(map[uint64]struct{}, updateCount)
 	for range updateCount {
@@ -319,6 +313,12 @@ func TestConcurrentSendUpdate(t *testing.T) {
 		values[resp.GetUpdate().GetUpdate()[0].GetVal().GetUintVal()] = struct{}{}
 	}
 	require.Len(t, values, updateCount)
+
+	wg.Wait()
+	close(sendErrors)
+	for err := range sendErrors {
+		require.NoError(t, err)
+	}
 }
 
 func TestValueHelpers(t *testing.T) {

--- a/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/values.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/internal/fakeserver/values.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package fakeserver
+
+import (
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+)
+
+// ScalarUint64 returns a protobuf TypedValue for an unsigned integer scalar.
+func ScalarUint64(value uint64) *gnmipb.TypedValue {
+	return &gnmipb.TypedValue{
+		Value: &gnmipb.TypedValue_UintVal{
+			UintVal: value,
+		},
+	}
+}
+
+// ScalarInt64 returns a protobuf TypedValue for a signed integer scalar.
+func ScalarInt64(value int64) *gnmipb.TypedValue {
+	return &gnmipb.TypedValue{
+		Value: &gnmipb.TypedValue_IntVal{
+			IntVal: value,
+		},
+	}
+}
+
+// ScalarString returns a protobuf TypedValue for a string scalar.
+func ScalarString(value string) *gnmipb.TypedValue {
+	return &gnmipb.TypedValue{
+		Value: &gnmipb.TypedValue_StringVal{
+			StringVal: value,
+		},
+	}
+}
+
+// InterfaceInOctetsUpdate returns an Update for a keyed interface counter path using TypedValue.
+func InterfaceInOctetsUpdate(interfaceName string, octets uint64) *gnmipb.Update {
+	return &gnmipb.Update{
+		Path: &gnmipb.Path{
+			Elem: []*gnmipb.PathElem{
+				{Name: "interfaces"},
+				{Name: "interface", Key: map[string]string{"name": interfaceName}},
+				{Name: "state"},
+				{Name: "counters"},
+				{Name: "in-octets"},
+			},
+		},
+		Val: ScalarUint64(octets),
+	}
+}
+
+// InterfaceOutOctetsUpdate returns an Update for outbound octets on a keyed interface path.
+func InterfaceOutOctetsUpdate(interfaceName string, octets uint64) *gnmipb.Update {
+	return &gnmipb.Update{
+		Path: &gnmipb.Path{
+			Elem: []*gnmipb.PathElem{
+				{Name: "interfaces"},
+				{Name: "interface", Key: map[string]string{"name": interfaceName}},
+				{Name: "state"},
+				{Name: "counters"},
+				{Name: "out-octets"},
+			},
+		},
+		Val: ScalarUint64(octets),
+	}
+}


### PR DESCRIPTION
Part of a stacked gNMI check implementation. Stacked on #56049.