### PR TITLE
Add process-wide gNMI connection admission gate

### DIFF
--- a/pkg/collector/corechecks/network-devices/gnmi/admission/BUILD.bazel
+++ b/pkg/collector/corechecks/network-devices/gnmi/admission/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+
+go_library(
+    name = "admission",
+    srcs = [
+        "gate.go",
+        "testing.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/gnmi/admission",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/util/procfilestats"],
+)
+
+dd_agent_go_test(
+    name = "admission_test",
+    srcs = ["gate_test.go"],
+    embed = [":admission"],
+    deps = [
+        "//pkg/util/procfilestats",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/collector/corechecks/network-devices/gnmi/admission/gate.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/admission/gate.go
@@ -1,0 +1,205 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package admission limits concurrent gNMI connection dials across check instances.
+package admission
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/procfilestats"
+)
+
+const (
+	maxConfiguredDevices = 1000
+	fdHoldThreshold      = 0.7
+
+	defaultPaceInterval    = 100 * time.Millisecond
+	defaultPaceBurst       = 10
+	defaultFDRetryInterval = 1 * time.Second
+)
+
+// ErrDeviceCapExceeded is returned when the process-wide device admission cap is reached.
+var ErrDeviceCapExceeded = errors.New("gNMI device admission cap exceeded")
+
+// AdmissionGate limits concurrent gNMI connection dials across all check instances.
+type AdmissionGate struct {
+	mu   sync.Mutex
+	cond *sync.Cond
+
+	configured int
+
+	paceInterval time.Duration
+	paceBurst    int
+	tokens       int
+	lastRefill   time.Time
+
+	fdRetryInterval time.Duration
+
+	getFileStats func() (*procfilestats.ProcessFileStats, error)
+}
+
+var (
+	gateInstance *AdmissionGate
+	gateOnce     sync.Once
+)
+
+// Gate returns the process-wide admission gate singleton.
+func Gate() *AdmissionGate {
+	gateOnce.Do(func() {
+		gateInstance = newGate()
+	})
+	return gateInstance
+}
+
+func newGate() *AdmissionGate {
+	g := &AdmissionGate{
+		paceInterval:    defaultPaceInterval,
+		paceBurst:       defaultPaceBurst,
+		tokens:          defaultPaceBurst,
+		fdRetryInterval: defaultFDRetryInterval,
+		getFileStats:    procfilestats.GetProcessFileStats,
+	}
+	g.cond = sync.NewCond(&g.mu)
+	return g
+}
+
+// Admit blocks until a new connection dial may proceed, the context is cancelled,
+// or the configured device cap is reached.
+func (g *AdmissionGate) Admit(ctx context.Context) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		wait, err := g.tryAdmitLocked()
+		if err != nil {
+			return err
+		}
+		if wait == 0 {
+			return nil
+		}
+
+		g.waitForRetry(ctx, wait)
+	}
+}
+
+func (g *AdmissionGate) tryAdmitLocked() (time.Duration, error) {
+	if g.configured >= maxConfiguredDevices {
+		return 0, ErrDeviceCapExceeded
+	}
+
+	stats, statsErr := g.getFileStats()
+	if statsErr != nil && !errors.Is(statsErr, procfilestats.ErrNotImplemented) {
+		return 0, fmt.Errorf("process file stats: %w", statsErr)
+	}
+	if stats != nil && fileDescriptorRatio(stats) > fdHoldThreshold {
+		return g.fdRetryInterval, nil
+	}
+
+	g.refillTokens()
+	if g.tokens <= 0 {
+		return g.timeUntilNextPaceToken(), nil
+	}
+
+	g.tokens--
+	g.configured++
+	return 0, nil
+}
+
+func (g *AdmissionGate) waitForRetry(ctx context.Context, wait time.Duration) {
+	if wait <= 0 {
+		return
+	}
+
+	timer := time.AfterFunc(wait, func() {
+		g.cond.Broadcast()
+	})
+	defer timer.Stop()
+
+	ctxDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			g.cond.Broadcast()
+		case <-ctxDone:
+		}
+	}()
+	defer close(ctxDone)
+
+	g.cond.Wait()
+}
+
+// Release decrements the configured device count when a connection closes.
+func (g *AdmissionGate) Release() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.configured > 0 {
+		g.configured--
+	}
+}
+
+// ConfiguredCount returns the number of devices currently holding admission slots.
+func (g *AdmissionGate) ConfiguredCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.configured
+}
+
+func (g *AdmissionGate) refillTokens() {
+	if g.paceInterval <= 0 {
+		g.tokens = g.paceBurst
+		return
+	}
+
+	now := time.Now()
+	if g.lastRefill.IsZero() {
+		g.lastRefill = now
+		if g.tokens == 0 {
+			g.tokens = g.paceBurst
+		}
+		return
+	}
+
+	elapsed := now.Sub(g.lastRefill)
+	ticks := int(elapsed / g.paceInterval)
+	if ticks <= 0 {
+		return
+	}
+
+	g.tokens += ticks * g.paceBurst
+	if g.tokens > g.paceBurst {
+		g.tokens = g.paceBurst
+	}
+	g.lastRefill = now
+}
+
+func (g *AdmissionGate) timeUntilNextPaceToken() time.Duration {
+	if g.paceInterval <= 0 {
+		return 0
+	}
+	if g.lastRefill.IsZero() {
+		return g.paceInterval
+	}
+	elapsed := time.Since(g.lastRefill)
+	if elapsed >= g.paceInterval {
+		return 0
+	}
+	return g.paceInterval - elapsed
+}
+
+func fileDescriptorRatio(stats *procfilestats.ProcessFileStats) float64 {
+	if stats.OsFileLimit == 0 {
+		return 0
+	}
+	return float64(stats.AgentOpenFiles) / float64(stats.OsFileLimit)
+}

--- a/pkg/collector/corechecks/network-devices/gnmi/admission/gate_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/admission/gate_test.go
@@ -1,0 +1,154 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package admission
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/procfilestats"
+)
+
+func resetGate(t *testing.T) {
+	t.Helper()
+	ResetGateForTesting()
+	SetPaceForTesting(0, maxConfiguredDevices)
+	SetFileStatsFuncForTesting(func() (*procfilestats.ProcessFileStats, error) {
+		return &procfilestats.ProcessFileStats{
+			AgentOpenFiles: 1,
+			OsFileLimit:    1000,
+		}, nil
+	})
+}
+
+func TestDeviceCapExceeded(t *testing.T) {
+	resetGate(t)
+
+	g := Gate()
+	for i := 0; i < maxConfiguredDevices; i++ {
+		require.NoError(t, g.Admit(context.Background()))
+	}
+
+	err := g.Admit(context.Background())
+	require.ErrorIs(t, err, ErrDeviceCapExceeded)
+	require.Equal(t, maxConfiguredDevices, g.ConfiguredCount())
+}
+
+func TestReleaseDecrementsConfiguredCount(t *testing.T) {
+	resetGate(t)
+
+	g := Gate()
+	require.NoError(t, g.Admit(context.Background()))
+	require.Equal(t, 1, g.ConfiguredCount())
+
+	g.Release()
+	require.Equal(t, 0, g.ConfiguredCount())
+}
+
+func TestStartupPacingBlocksUntilTokensAvailable(t *testing.T) {
+	resetGate(t)
+	SetPaceForTesting(time.Hour, 1)
+
+	g := Gate()
+	ctx := context.Background()
+	require.NoError(t, g.Admit(ctx))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- g.Admit(ctx)
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("second admit should block, got %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	AddPacingTokensForTesting(1)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for paced admit")
+	}
+}
+
+func TestFDGuardBlocksUntilUtilizationDrops(t *testing.T) {
+	resetGate(t)
+	SetFDRetryIntervalForTesting(20 * time.Millisecond)
+
+	stats := &procfilestats.ProcessFileStats{
+		AgentOpenFiles: 900,
+		OsFileLimit:    1000,
+	}
+	SetFileStatsFuncForTesting(func() (*procfilestats.ProcessFileStats, error) {
+		return stats, nil
+	})
+
+	g := Gate()
+	done := make(chan error, 1)
+	go func() {
+		done <- g.Admit(context.Background())
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("admit should block on high FD utilization, got %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	stats.AgentOpenFiles = 100
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for FD guard to clear")
+	}
+}
+
+func TestFDGuardSkipsOnErrNotImplemented(t *testing.T) {
+	resetGate(t)
+	SetFileStatsFuncForTesting(func() (*procfilestats.ProcessFileStats, error) {
+		return nil, procfilestats.ErrNotImplemented
+	})
+
+	g := Gate()
+	require.NoError(t, g.Admit(context.Background()))
+}
+
+func TestAdmitRespectsContextCancellation(t *testing.T) {
+	resetGate(t)
+	SetPaceForTesting(time.Hour, 0)
+	SetFileStatsFuncForTesting(func() (*procfilestats.ProcessFileStats, error) {
+		return &procfilestats.ProcessFileStats{
+			AgentOpenFiles: 900,
+			OsFileLimit:    1000,
+		}, nil
+	})
+
+	g := Gate()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	errCh := make(chan error, 1)
+	go func() {
+		defer wg.Done()
+		errCh <- g.Admit(ctx)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	wg.Wait()
+
+	require.ErrorIs(t, <-errCh, context.Canceled)
+}

--- a/pkg/collector/corechecks/network-devices/gnmi/admission/gate_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/admission/gate_test.go
@@ -8,6 +8,7 @@ package admission
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -85,12 +86,13 @@ func TestFDGuardBlocksUntilUtilizationDrops(t *testing.T) {
 	resetGate(t)
 	SetFDRetryIntervalForTesting(20 * time.Millisecond)
 
-	stats := &procfilestats.ProcessFileStats{
-		AgentOpenFiles: 900,
-		OsFileLimit:    1000,
-	}
+	var agentOpenFiles atomic.Uint64
+	agentOpenFiles.Store(900)
 	SetFileStatsFuncForTesting(func() (*procfilestats.ProcessFileStats, error) {
-		return stats, nil
+		return &procfilestats.ProcessFileStats{
+			AgentOpenFiles: agentOpenFiles.Load(),
+			OsFileLimit:    1000,
+		}, nil
 	})
 
 	g := Gate()
@@ -105,7 +107,7 @@ func TestFDGuardBlocksUntilUtilizationDrops(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 	}
 
-	stats.AgentOpenFiles = 100
+	agentOpenFiles.Store(100)
 
 	select {
 	case err := <-done:

--- a/pkg/collector/corechecks/network-devices/gnmi/admission/testing.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/admission/testing.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package admission
+
+import (
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/procfilestats"
+)
+
+// ResetGateForTesting destroys the singleton gate. Only use in tests.
+func ResetGateForTesting() {
+	gateOnce = sync.Once{}
+	gateInstance = nil
+}
+
+// SetPaceForTesting overrides pacing parameters on the singleton gate.
+func SetPaceForTesting(interval time.Duration, burst int) {
+	g := Gate()
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.paceInterval = interval
+	g.paceBurst = burst
+	g.tokens = burst
+	g.lastRefill = time.Time{}
+}
+
+// SetFDRetryIntervalForTesting overrides the FD guard retry interval.
+func SetFDRetryIntervalForTesting(interval time.Duration) {
+	g := Gate()
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.fdRetryInterval = interval
+}
+
+// SetFileStatsFuncForTesting overrides process file stats retrieval.
+func SetFileStatsFuncForTesting(fn func() (*procfilestats.ProcessFileStats, error)) {
+	g := Gate()
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.getFileStats = fn
+}
+
+// AddPacingTokensForTesting adds pacing tokens for tests waiting on startup pacing.
+func AddPacingTokensForTesting(tokens int) {
+	g := Gate()
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.tokens += tokens
+	if g.tokens > g.paceBurst {
+		g.tokens = g.paceBurst
+	}
+	g.cond.Broadcast()
+}

--- a/pkg/collector/corechecks/network-devices/gnmi/client/BUILD.bazel
+++ b/pkg/collector/corechecks/network-devices/gnmi/client/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/collector/corechecks/network-devices/gnmi",
+        "//pkg/collector/corechecks/network-devices/gnmi/admission",
         "//pkg/collector/corechecks/network-devices/gnmi/config",
         "//pkg/util/backoff",
         "@com_github_benbjohnson_clock//:clock",

--- a/pkg/collector/corechecks/network-devices/gnmi/client/client.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/client/client.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	parentgnmi "github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/gnmi"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/gnmi/admission"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/gnmi/config"
 	"github.com/DataDog/datadog-agent/pkg/util/backoff"
 )
@@ -257,6 +258,7 @@ func (c *Client) connectAndReceive(ctx context.Context) (bool, error) {
 		c.mu.Lock()
 		c.conn = nil
 		c.mu.Unlock()
+		admission.Gate().Release()
 		_ = conn.Close()
 	}()
 
@@ -309,10 +311,15 @@ func (c *Client) connectAndReceive(ctx context.Context) (bool, error) {
 }
 
 func (c *Client) dial(ctx context.Context) (*grpc.ClientConn, error) {
+	if err := admission.Gate().Admit(ctx); err != nil {
+		return nil, fmt.Errorf("admission gate: %w", err)
+	}
+
 	target := net.JoinHostPort(c.cfg.Address, strconv.Itoa(c.cfg.Port))
 	// MVP uses insecure transport credentials; production TLS support is follow-up work.
 	conn, err := c.opt.dial(ctx, target, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
+		admission.Gate().Release()
 		return nil, fmt.Errorf("dial %s: %w", target, err)
 	}
 	return conn, nil


### PR DESCRIPTION
Part of a stacked gNMI check implementation. Stacked on #56052.