### PR TITLE
Add gNMI health telemetry and stale sample suppression

### DIFF
--- a/pkg/collector/corechecks/network-devices/gnmi/client/cache.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/client/cache.go
@@ -65,6 +65,12 @@ func (c *cache) get(key CacheKey) (CacheEntry, bool) {
 	return cloneCacheEntry(entry), true
 }
 
+func (c *cache) count() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}
+
 func (c *cache) snapshot() []CachedValue {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/pkg/collector/corechecks/network-devices/gnmi/client/client.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/client/client.go
@@ -57,6 +57,18 @@ func WithReconnectDelays(minDelay, maxDelay time.Duration) Option {
 	}
 }
 
+// StreamState describes the current gNMI subscribe stream lifecycle.
+type StreamState int
+
+const (
+	// StreamStateNotReady means the client has not yet established a subscribe stream.
+	StreamStateNotReady StreamState = iota
+	// StreamStateConnected means the client is actively receiving updates.
+	StreamStateConnected
+	// StreamStateReconnecting means the client lost its stream and is reconnecting.
+	StreamStateReconnecting
+)
+
 // Client maintains a streaming gNMI subscription and a latest-value cache.
 type Client struct {
 	cfg Config
@@ -71,6 +83,8 @@ type Client struct {
 	cache *cache
 
 	reconnectAttempts int
+	streamState       StreamState
+	everConnected     bool
 }
 
 // New creates a client. Call Start to open the subscription loop.
@@ -183,8 +197,48 @@ func (c *Client) ReconnectAttempts() int {
 	return c.reconnectAttempts
 }
 
+// StreamState returns the current subscribe stream lifecycle state.
+func (c *Client) StreamState() StreamState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.streamState
+}
+
+// ReceivedSamples returns the number of cached samples.
+func (c *Client) ReceivedSamples() int {
+	return c.cache.count()
+}
+
+func (c *Client) setStreamState(state StreamState) {
+	c.mu.Lock()
+	c.streamState = state
+	c.mu.Unlock()
+}
+
+func (c *Client) setPreConnectStreamState() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.everConnected {
+		c.streamState = StreamStateReconnecting
+	} else {
+		c.streamState = StreamStateNotReady
+	}
+}
+
+func (c *Client) setPostDisconnectStreamState() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.everConnected {
+		c.streamState = StreamStateReconnecting
+	} else {
+		c.streamState = StreamStateNotReady
+	}
+}
+
 func (c *Client) run(ctx context.Context) {
 	defer close(c.done)
+
+	c.setStreamState(StreamStateNotReady)
 
 	policy := backoff.NewExpBackoffPolicy(
 		2,
@@ -201,12 +255,15 @@ func (c *Client) run(ctx context.Context) {
 			return
 		}
 
+		c.setPreConnectStreamState()
+
 		err := c.connectAndReceive(ctx)
 		if ctx.Err() != nil {
 			c.setCloseErr(ctx.Err())
 			return
 		}
 		if err != nil {
+			c.setPostDisconnectStreamState()
 			numErrors = policy.IncError(numErrors)
 			c.mu.Lock()
 			c.reconnectAttempts = numErrors
@@ -234,6 +291,8 @@ func (c *Client) connectAndReceive(ctx context.Context) error {
 	c.mu.Lock()
 	c.conn = conn
 	c.reconnectAttempts = 0
+	c.everConnected = true
+	c.streamState = StreamStateConnected
 	c.mu.Unlock()
 
 	defer func() {

--- a/pkg/collector/corechecks/network-devices/gnmi/gnmi.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/gnmi.go
@@ -113,9 +113,25 @@ func (c *Check) Run() error {
 		return errors.New("gNMI check is not configured")
 	}
 
+	now := time.Now()
 	snapshot := gnmiClient.Snapshot()
-	if err := report.ReportMetrics(s, checkConfig, snapshot); err != nil {
+	stalenessThreshold := report.DefaultStalenessThreshold(c.interval)
+	freshSnapshot := report.FilterStale(snapshot, stalenessThreshold, now)
+
+	healthStats := report.HealthStats{
+		StreamState:      gnmiClient.StreamState(),
+		ReconnectCount:   gnmiClient.ReconnectAttempts(),
+		ReceivedSamples:  gnmiClient.ReceivedSamples(),
+		SampleAgeSeconds: report.OldestSampleAgeSeconds(snapshot, now),
+	}
+	if err := report.ReportHealth(s, checkConfig, healthStats); err != nil {
 		return err
+	}
+
+	if len(freshSnapshot) > 0 {
+		if err := report.ReportMetrics(s, checkConfig, freshSnapshot); err != nil {
+			return err
+		}
 	}
 
 	s.Commit()

--- a/pkg/collector/corechecks/network-devices/gnmi/gnmi_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/gnmi_test.go
@@ -106,8 +106,80 @@ min_collection_interval: 15
 	}, 2*time.Second, 10*time.Millisecond)
 
 	assert.Equal(t, 1, server.ConnectionCount())
+	mockSender.AssertCalled(t, "Gauge", "datadog.gnmi.stream_state", mock.Anything, "", mock.Anything)
+	mockSender.AssertCalled(t, "Gauge", "datadog.gnmi.received_samples", mock.Anything, "", mock.Anything)
 	mockSender.AssertCalled(t, "MonotonicCount", "snmp.ifHCInOctets", float64(42), "", mock.Anything)
 	mockSender.AssertCalled(t, "MonotonicCount", "snmp.ifHCOutOctets", float64(84), "", mock.Anything)
+	mockSender.AssertCalled(t, "Commit")
+
+	checkInstance.Cancel()
+}
+
+func TestCheckRunEmitsHealthMetricsOnlyWhenCacheEmpty(t *testing.T) {
+	admission.ResetGateForTesting()
+	admission.SetPaceForTesting(10*time.Millisecond, 10)
+
+	mockConfig := configmock.New(t)
+	profilesRoot := t.TempDir()
+	mockConfig.SetInTest("confd_path", profilesRoot)
+
+	profileDir := filepath.Join(profilesRoot, "gnmi.d", "profiles")
+	require.NoError(t, os.MkdirAll(profileDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(profileDir, "basic-interfaces.yaml"), []byte(basicInterfacesProfile), 0o644))
+
+	server, err := fakeserver.New()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+	})
+	server.SetExpectedCredentials("user", "test-password")
+
+	host, port, err := hostPort(server.Addr())
+	require.NoError(t, err)
+
+	rawInstance := []byte(`
+address: ` + host + `
+port: ` + strconv.Itoa(port) + `
+username: user
+password: test-password
+profile: basic-interfaces
+min_collection_interval: 15
+`)
+
+	factoryOpt := gnmi.Factory()
+	checkFactory, ok := factoryOpt.Get()
+	require.True(t, ok)
+	checkInstance := checkFactory()
+
+	mockSender := mocksender.NewMockSender(t, "")
+	mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("Commit").Return()
+
+	err = checkInstance.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, rawInstance, []byte(""), "test", "test")
+	require.NoError(t, err)
+	mocksender.SetSender(mockSender, checkInstance.ID())
+
+	err = checkInstance.Run()
+	require.NoError(t, err)
+	waitSubscribeEvent(t, server)
+
+	require.Eventually(t, func() bool {
+		if err := checkInstance.Run(); err != nil {
+			return false
+		}
+		for _, call := range mockSender.Calls {
+			if call.Method == "Gauge" && call.Arguments[0] == "datadog.gnmi.received_samples" {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond)
+
+	mockSender.AssertCalled(t, "Gauge", "datadog.gnmi.stream_state", mock.Anything, "", mock.Anything)
+	mockSender.AssertCalled(t, "Gauge", "datadog.gnmi.reconnect_count", mock.Anything, "", mock.Anything)
+	mockSender.AssertCalled(t, "Gauge", "datadog.gnmi.received_samples", float64(0), "", mock.Anything)
+	mockSender.AssertCalled(t, "Gauge", "datadog.gnmi.sample_age_seconds", float64(0), "", mock.Anything)
+	mockSender.AssertNotCalled(t, "MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	mockSender.AssertCalled(t, "Commit")
 
 	checkInstance.Cancel()

--- a/pkg/collector/corechecks/network-devices/gnmi/report/BUILD.bazel
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/BUILD.bazel
@@ -3,7 +3,10 @@ load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "report",
-    srcs = ["metrics.go"],
+    srcs = [
+        "health.go",
+        "metrics.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/gnmi/report",
     visibility = ["//visibility:public"],
     deps = [
@@ -16,7 +19,10 @@ go_library(
 
 dd_agent_go_test(
     name = "report_test",
-    srcs = ["metrics_test.go"],
+    srcs = [
+        "health_test.go",
+        "metrics_test.go",
+    ],
     embed = [":report"],
     deps = [
         "//pkg/aggregator/mocksender",

--- a/pkg/collector/corechecks/network-devices/gnmi/report/health.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/health.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package report
+
+import (
+	"errors"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/gnmi/client"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/gnmi/config"
+)
+
+const (
+	metricStreamState      = "datadog.gnmi.stream_state"
+	metricReconnectCount   = "datadog.gnmi.reconnect_count"
+	metricReceivedSamples  = "datadog.gnmi.received_samples"
+	metricSampleAgeSeconds = "datadog.gnmi.sample_age_seconds"
+)
+
+const (
+	streamStateNotReady     = 0
+	streamStateConnected    = 1
+	streamStateReconnecting = 2
+)
+
+// HealthStats holds operational telemetry for a gNMI client snapshot.
+type HealthStats struct {
+	StreamState      client.StreamState
+	ReconnectCount   int
+	ReceivedSamples  int
+	SampleAgeSeconds float64
+}
+
+// DefaultStalenessThreshold returns the default maximum sample age before suppression.
+func DefaultStalenessThreshold(minCollectionInterval time.Duration) time.Duration {
+	return 2 * minCollectionInterval
+}
+
+// FilterStale removes cached values older than maxAge relative to now.
+func FilterStale(snapshot []client.CachedValue, maxAge time.Duration, now time.Time) []client.CachedValue {
+	if maxAge <= 0 || len(snapshot) == 0 {
+		return snapshot
+	}
+
+	filtered := make([]client.CachedValue, 0, len(snapshot))
+	for _, cached := range snapshot {
+		if cached.Entry.Timestamp.IsZero() {
+			continue
+		}
+		if now.Sub(cached.Entry.Timestamp) <= maxAge {
+			filtered = append(filtered, cached)
+		}
+	}
+	return filtered
+}
+
+// OldestSampleAgeSeconds returns the age in seconds of the oldest timestamp in snapshot.
+func OldestSampleAgeSeconds(snapshot []client.CachedValue, now time.Time) float64 {
+	var oldest time.Time
+	for _, cached := range snapshot {
+		if cached.Entry.Timestamp.IsZero() {
+			continue
+		}
+		if oldest.IsZero() || cached.Entry.Timestamp.Before(oldest) {
+			oldest = cached.Entry.Timestamp
+		}
+	}
+	if oldest.IsZero() {
+		return 0
+	}
+	return now.Sub(oldest).Seconds()
+}
+
+// ReportHealth submits datadog.gnmi.* operational metrics.
+func ReportHealth(s sender.Sender, cfg *config.CheckConfig, stats HealthStats) error {
+	if s == nil {
+		return errors.New("sender is nil")
+	}
+	if cfg == nil {
+		return errors.New("check config is nil")
+	}
+
+	tags := buildBaseTags(cfg)
+	s.Gauge(metricStreamState, streamStateValue(stats.StreamState), "", tags)
+	s.Gauge(metricReconnectCount, float64(stats.ReconnectCount), "", tags)
+	s.Gauge(metricReceivedSamples, float64(stats.ReceivedSamples), "", tags)
+	s.Gauge(metricSampleAgeSeconds, stats.SampleAgeSeconds, "", tags)
+	return nil
+}
+
+func streamStateValue(state client.StreamState) float64 {
+	switch state {
+	case client.StreamStateConnected:
+		return streamStateConnected
+	case client.StreamStateReconnecting:
+		return streamStateReconnecting
+	default:
+		return streamStateNotReady
+	}
+}

--- a/pkg/collector/corechecks/network-devices/gnmi/report/health_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/health_test.go
@@ -1,0 +1,201 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package report
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/gnmi/client"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/gnmi/config"
+)
+
+func TestDefaultStalenessThreshold(t *testing.T) {
+	assert.Equal(t, 30*time.Second, DefaultStalenessThreshold(15*time.Second))
+}
+
+func TestFilterStale(t *testing.T) {
+	now := time.Unix(100, 0)
+	threshold := 20 * time.Second
+
+	snapshot := []client.CachedValue{
+		{
+			Key: client.CacheKey{Path: "/fresh"},
+			Entry: client.CacheEntry{
+				Value:     int64(1),
+				Timestamp: now.Add(-10 * time.Second),
+			},
+		},
+		{
+			Key: client.CacheKey{Path: "/stale"},
+			Entry: client.CacheEntry{
+				Value:     int64(2),
+				Timestamp: now.Add(-30 * time.Second),
+			},
+		},
+		{
+			Key: client.CacheKey{Path: "/zero-timestamp"},
+			Entry: client.CacheEntry{
+				Value: int64(3),
+			},
+		},
+	}
+
+	filtered := FilterStale(snapshot, threshold, now)
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "/fresh", filtered[0].Key.Path)
+}
+
+func TestFilterStaleDisabled(t *testing.T) {
+	now := time.Unix(100, 0)
+	snapshot := []client.CachedValue{
+		{
+			Key: client.CacheKey{Path: "/stale"},
+			Entry: client.CacheEntry{
+				Value:     int64(1),
+				Timestamp: now.Add(-1 * time.Hour),
+			},
+		},
+	}
+
+	filtered := FilterStale(snapshot, 0, now)
+	assert.Equal(t, snapshot, filtered)
+}
+
+func TestOldestSampleAgeSeconds(t *testing.T) {
+	now := time.Unix(100, 0)
+	snapshot := []client.CachedValue{
+		{
+			Key: client.CacheKey{Path: "/newer"},
+			Entry: client.CacheEntry{
+				Timestamp: now.Add(-5 * time.Second),
+			},
+		},
+		{
+			Key: client.CacheKey{Path: "/older"},
+			Entry: client.CacheEntry{
+				Timestamp: now.Add(-25 * time.Second),
+			},
+		},
+	}
+
+	assert.Equal(t, 25.0, OldestSampleAgeSeconds(snapshot, now))
+	assert.Equal(t, 0.0, OldestSampleAgeSeconds(nil, now))
+}
+
+func TestReportHealth(t *testing.T) {
+	deviceAddress := "10.0.0.1"
+	baseTags := []string{
+		"device_ip:" + deviceAddress,
+		"device_id:default:" + deviceAddress,
+	}
+
+	cfg := &config.CheckConfig{
+		Instance: config.InstanceConfig{
+			Address: deviceAddress,
+		},
+	}
+
+	mockSender := mocksender.NewMockSender(t, checkid.ID("gnmi"))
+	mockSender.SetupAcceptAll()
+
+	stats := HealthStats{
+		StreamState:      client.StreamStateConnected,
+		ReconnectCount:   2,
+		ReceivedSamples:  4,
+		SampleAgeSeconds: 12.5,
+	}
+	require.NoError(t, ReportHealth(mockSender, cfg, stats))
+
+	mockSender.AssertMetric(t, "Gauge", metricStreamState, streamStateConnected, "", baseTags)
+	mockSender.AssertMetric(t, "Gauge", metricReconnectCount, 2, "", baseTags)
+	mockSender.AssertMetric(t, "Gauge", metricReceivedSamples, 4, "", baseTags)
+	mockSender.AssertMetric(t, "Gauge", metricSampleAgeSeconds, 12.5, "", baseTags)
+}
+
+func TestReportHealthValidation(t *testing.T) {
+	cfg := &config.CheckConfig{
+		Instance: config.InstanceConfig{Address: "10.0.0.1"},
+	}
+	stats := HealthStats{StreamState: client.StreamStateNotReady}
+
+	t.Run("nil sender", func(t *testing.T) {
+		err := ReportHealth(nil, cfg, stats)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sender is nil")
+	})
+
+	t.Run("nil config", func(t *testing.T) {
+		mockSender := mocksender.NewMockSender(t, checkid.ID("gnmi"))
+		err := ReportHealth(mockSender, nil, stats)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "check config is nil")
+	})
+}
+
+func TestReportMetricsSkipsStaleValues(t *testing.T) {
+	now := time.Unix(100, 0)
+	deviceAddress := "10.0.0.1"
+	baseTags := []string{
+		"device_ip:" + deviceAddress,
+		"device_id:default:" + deviceAddress,
+	}
+
+	cfg := &config.CheckConfig{
+		Instance: config.InstanceConfig{
+			Address:               deviceAddress,
+			MinCollectionInterval: 15,
+		},
+		Profile: config.ProfileDefinition{
+			Metrics: []config.MetricConfig{
+				{
+					Path:   "/interfaces/interface/state/counters/in-octets",
+					Metric: "snmp.ifHCInOctets",
+					Type:   config.MetricTypeMonotonicCount,
+					Tags: map[string]string{
+						"interface": "name",
+					},
+				},
+			},
+		},
+	}
+
+	snapshot := []client.CachedValue{
+		{
+			Key: client.CacheKey{
+				Path: "/interfaces/interface/state/counters/in-octets",
+				Keys: map[string]string{"name": "fresh"},
+			},
+			Entry: client.CacheEntry{
+				Value:     uint64(42),
+				Timestamp: now.Add(-10 * time.Second),
+			},
+		},
+		{
+			Key: client.CacheKey{
+				Path: "/interfaces/interface/state/counters/in-octets",
+				Keys: map[string]string{"name": "stale"},
+			},
+			Entry: client.CacheEntry{
+				Value:     uint64(99),
+				Timestamp: now.Add(-1 * time.Hour),
+			},
+		},
+	}
+
+	freshSnapshot := FilterStale(snapshot, DefaultStalenessThreshold(15*time.Second), now)
+	mockSender := mocksender.NewMockSender(t, checkid.ID("gnmi"))
+	mockSender.SetupAcceptAll()
+
+	require.NoError(t, ReportMetrics(mockSender, cfg, freshSnapshot))
+	mockSender.AssertMetric(t, "MonotonicCount", "snmp.ifHCInOctets", 42, "", append(baseTags, "interface:fresh"))
+	mockSender.AssertNumberOfCalls(t, "MonotonicCount", 1)
+}


### PR DESCRIPTION
Part of a stacked gNMI check implementation. Stacked on #56055.