### PR TITLE
Align gNMI device and interface identity with SNMP, fixing interface inventory pollution

### DIFF
--- a/cmd/agent/dist/conf.d/gnmi.d/profiles/_openconfig-metadata.yaml
+++ b/cmd/agent/dist/conf.d/gnmi.d/profiles/_openconfig-metadata.yaml
@@ -24,3 +24,10 @@ metadata:
     mac_address: /openconfig/interfaces/interface/ethernet/state/hw-mac-address
     ifindex: /openconfig/interfaces/interface/state/ifindex
     type: /openconfig/interfaces/interface/state/type
+  ip_address:
+    keys:
+      interface: name
+      subinterface: index
+      address: ip
+    ip: /openconfig/interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/state/ip
+    prefix_length: /openconfig/interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/state/prefix-length

--- a/pkg/collector/corechecks/network-devices/gnmi/config/metadata.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/config/metadata.go
@@ -40,10 +40,18 @@ type InterfaceMetadataConfig struct {
 	Type        string            `yaml:"type"`
 }
 
+// IPAddressMetadataConfig maps logical interface IP metadata fields to gNMI paths.
+type IPAddressMetadataConfig struct {
+	Keys         map[string]string `yaml:"keys"`
+	IP           string            `yaml:"ip"`
+	PrefixLength string            `yaml:"prefix_length"`
+}
+
 // MetadataConfig defines gNMI paths used for NDM device and interface metadata.
 type MetadataConfig struct {
 	Device    DeviceMetadataConfig    `yaml:"device"`
 	Interface InterfaceMetadataConfig `yaml:"interface"`
+	IPAddress IPAddressMetadataConfig `yaml:"ip_address"`
 }
 
 // DefaultOpenConfigMetadata returns the standard OpenConfig metadata path mappings.
@@ -72,6 +80,15 @@ func DefaultOpenConfigMetadata() MetadataConfig {
 			IfIndex:     "/openconfig/interfaces/interface/state/ifindex",
 			Type:        "/openconfig/interfaces/interface/state/type",
 		},
+		IPAddress: IPAddressMetadataConfig{
+			Keys: map[string]string{
+				"interface":    "name",
+				"subinterface": "index",
+				"address":      "ip",
+			},
+			IP:           "/openconfig/interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/state/ip",
+			PrefixLength: "/openconfig/interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/state/prefix-length",
+		},
 	}
 }
 
@@ -93,7 +110,10 @@ func (m MetadataConfig) IsZero() bool {
 		m.Interface.MACAddress == "" &&
 		m.Interface.IfIndex == "" &&
 		m.Interface.Type == "" &&
-		len(m.Interface.Keys) == 0
+		len(m.Interface.Keys) == 0 &&
+		m.IPAddress.IP == "" &&
+		m.IPAddress.PrefixLength == "" &&
+		len(m.IPAddress.Keys) == 0
 }
 
 func deviceMetadataConfigIsZero(device DeviceMetadataConfig) bool {
@@ -146,6 +166,9 @@ func (m MetadataConfig) SubscriptionPaths() []PathSubscriptionConfig {
 	add(resolved.Interface.IfIndex)
 	add(resolved.Interface.Type)
 
+	add(resolved.IPAddress.IP)
+	add(resolved.IPAddress.PrefixLength)
+
 	return out
 }
 
@@ -197,8 +220,32 @@ func (m MetadataConfig) InterfaceKeyValues(interfaceName string) map[string]stri
 	return keys
 }
 
+// DeviceKeyValues builds cache lookup keys for a named device component.
+func (m MetadataConfig) DeviceKeyValues(componentName string) map[string]string {
+	resolved := m.Resolved()
+	if componentName == "" || len(resolved.Device.Keys) == 0 {
+		return nil
+	}
+
+	keys := make(map[string]string, len(resolved.Device.Keys))
+	for _, keyName := range resolved.Device.Keys {
+		if keyName == "" {
+			continue
+		}
+		keys[keyName] = componentName
+	}
+	if len(keys) == 0 {
+		return map[string]string{"name": componentName}
+	}
+	return keys
+}
+
 func metadataSubscriptionKeys(resolved MetadataConfig, path string) map[string]string {
+	normalized := normalizeMetadataPath(path)
 	switch {
+	case normalized == normalizeMetadataPath(resolved.IPAddress.IP),
+		normalized == normalizeMetadataPath(resolved.IPAddress.PrefixLength):
+		return copyStringMap(resolved.IPAddress.Keys)
 	case strings.Contains(path, "/interfaces/interface/"):
 		return copyStringMap(resolved.Interface.Keys)
 	case strings.Contains(path, "/components/component/"):
@@ -236,6 +283,8 @@ func validateMetadataConfig(metadata MetadataConfig) error {
 		"interface.mac_address": resolved.Interface.MACAddress,
 		"interface.ifindex":       resolved.Interface.IfIndex,
 		"interface.type":          resolved.Interface.Type,
+		"ip_address.ip":           resolved.IPAddress.IP,
+		"ip_address.prefix_length": resolved.IPAddress.PrefixLength,
 	} {
 		if strings.TrimSpace(path) == "" {
 			continue
@@ -257,6 +306,14 @@ func validateMetadataConfig(metadata MetadataConfig) error {
 		}
 		if strings.TrimSpace(keyName) == "" {
 			return fmt.Errorf("metadata.interface.keys[%q] must not be empty", segment)
+		}
+	}
+	for segment, keyName := range resolved.IPAddress.Keys {
+		if strings.TrimSpace(segment) == "" {
+			return fmt.Errorf("metadata.ip_address.keys contains an empty segment name")
+		}
+		if strings.TrimSpace(keyName) == "" {
+			return fmt.Errorf("metadata.ip_address.keys[%q] must not be empty", segment)
 		}
 	}
 	return nil

--- a/pkg/collector/corechecks/network-devices/gnmi/config/metadata_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/config/metadata_test.go
@@ -37,6 +37,9 @@ func TestMetadataConfigSubscriptionPaths(t *testing.T) {
 	assert.Equal(t, map[string]string(nil), seen["/openconfig/system/state/hostname"].Tags)
 	assert.Equal(t, map[string]string{"component": "name"}, seen["/openconfig/components/component/state/mfg-name"].Tags)
 	assert.Equal(t, map[string]string{"interface": "name"}, seen["/openconfig/interfaces/interface/state/ifindex"].Tags)
+	ipPath := "/openconfig/interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/state/ip"
+	assert.Contains(t, seen, ipPath)
+	assert.Equal(t, map[string]string{"interface": "name", "subinterface": "index", "address": "ip"}, seen[ipPath].Tags)
 }
 
 func TestInterfaceKeyValues(t *testing.T) {

--- a/pkg/collector/corechecks/network-devices/gnmi/config/profile.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/config/profile.go
@@ -183,6 +183,7 @@ func mergeMetadataConfig(base, override MetadataConfig) MetadataConfig {
 	merged := base
 	merged.Device = mergeDeviceMetadataConfig(base.Device, override.Device)
 	merged.Interface = mergeInterfaceMetadataConfig(base.Interface, override.Interface)
+	merged.IPAddress = mergeIPAddressMetadataConfig(base.IPAddress, override.IPAddress)
 	return merged
 }
 
@@ -235,6 +236,19 @@ func mergeInterfaceMetadataConfig(base, override InterfaceMetadataConfig) Interf
 	}
 	if override.Type != "" {
 		base.Type = override.Type
+	}
+	return base
+}
+
+func mergeIPAddressMetadataConfig(base, override IPAddressMetadataConfig) IPAddressMetadataConfig {
+	if len(override.Keys) > 0 {
+		base.Keys = copyStringMap(override.Keys)
+	}
+	if override.IP != "" {
+		base.IP = override.IP
+	}
+	if override.PrefixLength != "" {
+		base.PrefixLength = override.PrefixLength
 	}
 	return base
 }

--- a/pkg/collector/corechecks/network-devices/gnmi/config/profile_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/config/profile_test.go
@@ -209,6 +209,10 @@ metadata:
     keys:
       interface: name
     ifindex: /openconfig/interfaces/interface/state/ifindex
+  ip_address:
+    keys:
+      interface: name
+    ip: /openconfig/interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/state/ip
 `))
 	require.NoError(t, writeTestProfile(profileDir, "with-metadata.yaml", `
 extends:
@@ -223,6 +227,7 @@ metrics:
 	require.NoError(t, err)
 	assert.Equal(t, "/openconfig/system/state/hostname", profile.Metadata.Device.Hostname)
 	assert.Equal(t, "/openconfig/interfaces/interface/state/ifindex", profile.Metadata.Interface.IfIndex)
+	assert.Equal(t, "/openconfig/interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/state/ip", profile.Metadata.IPAddress.IP)
 }
 
 func TestLoadProfileWithTopologyExtend(t *testing.T) {

--- a/pkg/collector/corechecks/network-devices/gnmi/gnmi.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/gnmi.go
@@ -149,7 +149,7 @@ func (c *Check) Run() error {
 		ReceivedSamples:  gnmiClient.ReceivedSamples(),
 		SampleAgeSeconds: report.OldestSampleAgeSeconds(snapshot, now),
 	}
-	if err := report.ReportHealth(s, checkConfig, healthStats); err != nil {
+	if err := report.ReportHealth(s, checkConfig, snapshot, healthStats); err != nil {
 		return err
 	}
 
@@ -236,15 +236,9 @@ func (c *Check) IsHASupported() bool {
 	return true
 }
 
-// String returns a redacted representation safe for logs.
+// String returns the check name, matching other core checks.
 func (c *Check) String() string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.config == nil {
-		return CheckName
-	}
-	return c.config.String()
+	return CheckName
 }
 
 func (c *Check) ensureClientStarted() error {
@@ -328,16 +322,7 @@ func formatSubscriptionPaths(specs []client.SubscriptionSpec) []string {
 }
 
 func deviceHostname(snapshot []client.CachedValue, metadata config.MetadataConfig) string {
-	hostnamePath := metadata.Resolved().Device.Hostname
-	for _, item := range snapshot {
-		if item.Key.Path != hostnamePath {
-			continue
-		}
-		if value, ok := item.Entry.Value.(string); ok && value != "" {
-			return value
-		}
-	}
-	return ""
+	return report.ResolveDeviceHostname(snapshot, metadata)
 }
 
 func countProfileMetricValues(profile config.ProfileDefinition, snapshot []client.CachedValue) int {

--- a/pkg/collector/corechecks/network-devices/gnmi/gnmi_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/gnmi_test.go
@@ -79,13 +79,14 @@ min_collection_interval: 15
 	mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockSender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockSender.On("Rate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
 	mockSender.On("Commit").Return()
 
 	err = checkInstance.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, rawInstance, []byte(""), "test", "test")
 	require.NoError(t, err)
 	mocksender.SetSender(mockSender, checkInstance.ID())
 
-	assert.NotContains(t, checkInstance.String(), "test-password")
+	assert.Equal(t, gnmi.CheckName, checkInstance.String())
 
 	err = checkInstance.Run()
 	require.NoError(t, err)

--- a/pkg/collector/corechecks/network-devices/gnmi/report/BUILD.bazel
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/BUILD.bazel
@@ -35,6 +35,7 @@ dd_agent_go_test(
         "health_test.go",
         "metadata_test.go",
         "metrics_test.go",
+        "snapshot_test.go",
         "topology_test.go",
     ],
     embed = [":report"],

--- a/pkg/collector/corechecks/network-devices/gnmi/report/derived_metrics.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/derived_metrics.go
@@ -7,7 +7,6 @@ package report
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/gnmi/client"
@@ -43,13 +42,13 @@ func ReportDerivedMetrics(s sender.Sender, cfg *config.CheckConfig, snapshot []c
 		return errors.New("bandwidth state is nil")
 	}
 
-	baseTags := buildBaseTags(cfg)
-	deviceID := buildDeviceID(cfg.Instance.Address)
-	interfaceInventory := interfaceInventoryByName(deviceID, cfg.Profile.Metadata, snapshot)
+	baseTags := buildBaseTags(cfg, snapshot)
+	deviceID := buildDeviceID(cfg)
+	interfaceInventory := interfaceInventoryByName(deviceID, cfg.Profile, snapshot)
 	speedValueMap := portSpeedValueMap(cfg.Profile)
 
 	reportInterfaceBandwidthUsage(s, baseTags, deviceID, snapshot, interfaceInventory, speedValueMap, bandwidthState)
-	reportMemoryUsage(s, snapshot, baseTags)
+	reportMemoryUsage(s, cfg.Profile, snapshot, baseTags)
 
 	return nil
 }
@@ -105,36 +104,58 @@ func collectInterfaceBandwidthData(
 	inventory map[string]devicemetadata.InterfaceMetadata,
 	speedValueMap map[string]int,
 ) map[string]*interfaceBandwidthData {
+	byPath := indexSnapshotByPath(snapshot)
 	interfaces := make(map[string]*interfaceBandwidthData)
 
-	for _, cached := range snapshot {
+	for _, cached := range byPath[pathInOctets] {
+		keysID := cacheKeysID(cached.Key.Keys)
+		if keysID == "" {
+			continue
+		}
+		value, ok := decodeNumericValue(cached.Entry.Value)
+		if !ok {
+			continue
+		}
+
 		interfaceName := cached.Key.Keys["name"]
 		if interfaceName == "" {
 			continue
 		}
 
-		entry := interfaces[interfaceName]
+		entry := interfaces[keysID]
 		if entry == nil {
 			entry = &interfaceBandwidthData{name: interfaceName, inOctets: -1, outOctets: -1}
-			interfaces[interfaceName] = entry
+			interfaces[keysID] = entry
 		}
+		entry.inOctets = value
+		entry.inTags = interfaceBandwidthTags(baseTags, deviceID, interfaceName, inventory)
+	}
 
-		switch cached.Key.Path {
-		case pathInOctets:
-			if value, ok := decodeNumericValue(cached.Entry.Value); ok {
-				entry.inOctets = value
-				entry.inTags = interfaceBandwidthTags(baseTags, deviceID, interfaceName, inventory)
-			}
-		case pathOutOctets:
-			if value, ok := decodeNumericValue(cached.Entry.Value); ok {
-				entry.outOctets = value
-				entry.outTags = interfaceBandwidthTags(baseTags, deviceID, interfaceName, inventory)
-			}
-		case pathPortSpeed:
-			if value, ok := decodeMetricValue(cached.Entry.Value, speedValueMap); ok && value > 0 {
-				entry.speed = uint64(value)
-			}
+	for _, cached := range byPath[pathOutOctets] {
+		keysID := cacheKeysID(cached.Key.Keys)
+		entry := interfaces[keysID]
+		if entry == nil {
+			continue
 		}
+		value, ok := decodeNumericValue(cached.Entry.Value)
+		if !ok {
+			continue
+		}
+		entry.outOctets = value
+		entry.outTags = interfaceBandwidthTags(baseTags, deviceID, entry.name, inventory)
+	}
+
+	for _, cached := range byPath[pathPortSpeed] {
+		keysID := cacheKeysID(cached.Key.Keys)
+		entry := interfaces[keysID]
+		if entry == nil {
+			continue
+		}
+		value, ok := decodeMetricValue(cached.Entry.Value, speedValueMap)
+		if !ok || value <= 0 {
+			continue
+		}
+		entry.speed = uint64(value)
 	}
 
 	return interfaces
@@ -143,15 +164,14 @@ func collectInterfaceBandwidthData(
 func interfaceBandwidthTags(baseTags []string, deviceID string, interfaceName string, inventory map[string]devicemetadata.InterfaceMetadata) []string {
 	tags := append(ndmutils.CopyStrings(baseTags), "interface:"+interfaceName)
 	iface, ok := inventory[interfaceName]
-	if !ok || iface.Index <= 0 {
+	if !ok || iface.Name == "" {
 		return tags
 	}
 
-	tags = append(tags, "interface_index:"+fmt.Sprintf("%d", iface.Index))
 	if iface.Description != "" {
 		tags = append(tags, "interface_alias:"+iface.Description)
 	}
-	return append(tags, internalInterfaceResourceTag(deviceID, iface.Index))
+	return append(tags, internalInterfaceResourceTag(deviceID, iface.Name))
 }
 
 func emitBandwidthUsageRate(
@@ -180,53 +200,67 @@ func emitBandwidthUsageRate(
 	s.Gauge(metricName, rate, "", tags)
 }
 
-type memoryComponentData struct {
-	used  float64
-	free  float64
-	tags  []string
-	hasOK bool
+func reportMemoryUsage(s sender.Sender, profile config.ProfileDefinition, snapshot []client.CachedValue, baseTags []string) {
+	usedMetric, freeMetric, ok := memoryMetricsFromProfile(profile)
+	if !ok {
+		return
+	}
+
+	usedPath := normalizeProfilePath(usedMetric.Path)
+	freePath := normalizeProfilePath(freeMetric.Path)
+	if _, ok := pathsShareParent(usedPath, freePath); !ok {
+		log.Tracef("skip memory usage metric: %s and %s do not share the same parent path", usedPath, freePath)
+		return
+	}
+
+	byPath := indexSnapshotByPath(snapshot)
+	freeByKeys := indexCachedValuesByKeys(byPath[freePath])
+
+	for _, usedCached := range sortCachedValues(byPath[usedPath]) {
+		keys := usedCached.Key.Keys
+		if len(keys) == 0 {
+			continue
+		}
+
+		freeCached, ok := freeByKeys[cacheKeysID(keys)]
+		if !ok {
+			continue
+		}
+
+		used, ok := decodeNumericValue(usedCached.Entry.Value)
+		if !ok {
+			continue
+		}
+		free, ok := decodeNumericValue(freeCached.Entry.Value)
+		if !ok {
+			continue
+		}
+
+		usage, err := evaluateMemoryUsage(used, used+free)
+		if err != nil {
+			log.Tracef("skip memory usage metric for %s: %s", cacheKeysID(keys), err)
+			continue
+		}
+
+		tags := buildMetricTags(baseTags, usedMetric, keys)
+		s.Gauge(metricMemoryUsage, usage, "", tags)
+	}
 }
 
-func reportMemoryUsage(s sender.Sender, snapshot []client.CachedValue, baseTags []string) {
-	components := make(map[string]*memoryComponentData)
-
-	for _, cached := range snapshot {
-		componentName := cached.Key.Keys["name"]
-		if componentName == "" {
-			continue
-		}
-
-		entry := components[componentName]
-		if entry == nil {
-			entry = &memoryComponentData{tags: append(baseTags, "memory:"+componentName)}
-			components[componentName] = entry
-		}
-
-		switch cached.Key.Path {
-		case pathMemoryUsed:
-			if value, ok := decodeNumericValue(cached.Entry.Value); ok {
-				entry.used = value
-				entry.hasOK = true
-			}
-		case pathMemoryAvail:
-			if value, ok := decodeNumericValue(cached.Entry.Value); ok {
-				entry.free = value
-				entry.hasOK = true
-			}
+func memoryMetricsFromProfile(profile config.ProfileDefinition) (used config.MetricConfig, free config.MetricConfig, ok bool) {
+	var foundUsed bool
+	var foundFree bool
+	for _, metric := range profile.Metrics {
+		switch metric.Metric {
+		case "snmp.memory.used":
+			used = metric
+			foundUsed = true
+		case "snmp.memory.free":
+			free = metric
+			foundFree = true
 		}
 	}
-
-	for componentName, entry := range components {
-		if !entry.hasOK {
-			continue
-		}
-		usage, err := evaluateMemoryUsage(entry.used, entry.used+entry.free)
-		if err != nil {
-			log.Tracef("skip memory usage metric for %s: %s", componentName, err)
-			continue
-		}
-		s.Gauge(metricMemoryUsage, usage, "", entry.tags)
-	}
+	return used, free, foundUsed && foundFree
 }
 
 func evaluateMemoryUsage(memoryUsed float64, memoryTotal float64) (float64, error) {

--- a/pkg/collector/corechecks/network-devices/gnmi/report/derived_metrics_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/derived_metrics_test.go
@@ -20,13 +20,35 @@ import (
 
 func TestReportDerivedMetricsMemoryUsage(t *testing.T) {
 	deviceAddress := "10.0.0.5"
+	deviceID := buildDeviceIDFromConfigAddress(deviceAddress)
 	baseTags := []string{
+		deviceNamespaceTag,
 		"device_ip:" + deviceAddress,
-		"device_id:default:" + deviceAddress,
+		"device_id:" + deviceID,
+		"snmp_device:" + deviceAddress,
+		integrationSourceGNMITag,
+		internalDeviceResourceTag(deviceID),
 	}
 	cfg := &config.CheckConfig{
 		Instance: config.InstanceConfig{Address: deviceAddress},
-		Profile:  config.ProfileDefinition{},
+		Profile: config.ProfileDefinition{
+			Metrics: []config.MetricConfig{
+				{
+					Path: pathMemoryUsed,
+					Metric: "snmp.memory.used",
+					Type:   config.MetricTypeGauge,
+					Keys:   map[string]string{"component": "name"},
+					Tags:   map[string]string{"memory": "name"},
+				},
+				{
+					Path: pathMemoryAvail,
+					Metric: "snmp.memory.free",
+					Type:   config.MetricTypeGauge,
+					Keys:   map[string]string{"component": "name"},
+					Tags:   map[string]string{"memory": "name"},
+				},
+			},
+		},
 	}
 	snapshot := []client.CachedValue{
 		{
@@ -54,15 +76,125 @@ func TestReportDerivedMetricsMemoryUsage(t *testing.T) {
 	mockSender.AssertMetric(t, "Gauge", metricMemoryUsage, 25.0, "", append(baseTags, "memory:Chassis"))
 }
 
+func TestReportDerivedMetricsMemoryUsageRequiresBothPaths(t *testing.T) {
+	deviceAddress := "10.0.0.5"
+	cfg := &config.CheckConfig{
+		Instance: config.InstanceConfig{Address: deviceAddress},
+		Profile: config.ProfileDefinition{
+			Metrics: []config.MetricConfig{
+				{
+					Path: pathMemoryUsed,
+					Metric: "snmp.memory.used",
+					Type:   config.MetricTypeGauge,
+					Keys:   map[string]string{"component": "name"},
+					Tags:   map[string]string{"memory": "name"},
+				},
+				{
+					Path: pathMemoryAvail,
+					Metric: "snmp.memory.free",
+					Type:   config.MetricTypeGauge,
+					Keys:   map[string]string{"component": "name"},
+					Tags:   map[string]string{"memory": "name"},
+				},
+			},
+		},
+	}
+	snapshot := []client.CachedValue{
+		{
+			Key: client.CacheKey{
+				Path: pathMemoryUsed,
+				Keys: map[string]string{"name": "FanTray3"},
+			},
+			Entry: client.CacheEntry{Value: int64(10)},
+		},
+		{
+			Key: client.CacheKey{
+				Path: pathMemoryAvail,
+				Keys: map[string]string{"name": "ControlA"},
+			},
+			Entry: client.CacheEntry{Value: int64(90)},
+		},
+	}
+
+	mockSender := mocksender.NewMockSender(t, checkid.ID("gnmi"))
+	mockSender.SetupAcceptAll()
+
+	err := ReportDerivedMetrics(mockSender, cfg, snapshot, NewBandwidthState())
+	require.NoError(t, err)
+
+	mockSender.AssertNotCalled(t, "Gauge", metricMemoryUsage)
+}
+
+func TestReportDerivedMetricsMemoryUsageMatchesProfileComponentTags(t *testing.T) {
+	deviceAddress := "10.0.0.5"
+	deviceID := buildDeviceIDFromConfigAddress(deviceAddress)
+	controlTags := []string{
+		deviceNamespaceTag,
+		"device_ip:" + deviceAddress,
+		"device_id:" + deviceID,
+		"snmp_device:" + deviceAddress,
+		"integration_source:gnmi",
+		"memory:ControlA",
+	}
+	cfg := &config.CheckConfig{
+		Instance: config.InstanceConfig{Address: deviceAddress},
+		Profile: config.ProfileDefinition{
+			Metrics: []config.MetricConfig{
+				{
+					Path:   pathMemoryUsed,
+					Metric: "snmp.memory.used",
+					Type:   config.MetricTypeGauge,
+					Keys:   map[string]string{"component": "name"},
+					Tags:   map[string]string{"memory": "name"},
+				},
+				{
+					Path:   pathMemoryAvail,
+					Metric: "snmp.memory.free",
+					Type:   config.MetricTypeGauge,
+					Keys:   map[string]string{"component": "name"},
+					Tags:   map[string]string{"memory": "name"},
+				},
+			},
+		},
+	}
+	snapshot := []client.CachedValue{
+		{
+			Key: client.CacheKey{
+				Path: pathMemoryUsed,
+				Keys: map[string]string{"name": "ControlA"},
+			},
+			Entry: client.CacheEntry{Value: int64(25)},
+		},
+		{
+			Key: client.CacheKey{
+				Path: pathMemoryAvail,
+				Keys: map[string]string{"name": "ControlA"},
+			},
+			Entry: client.CacheEntry{Value: int64(75)},
+		},
+	}
+
+	mockSender := mocksender.NewMockSender(t, checkid.ID("gnmi"))
+	mockSender.SetupAcceptAll()
+
+	err := ReportDerivedMetrics(mockSender, cfg, snapshot, NewBandwidthState())
+	require.NoError(t, err)
+
+	mockSender.AssertMetric(t, "Gauge", metricMemoryUsage, 25.0, "", controlTags)
+}
+
 func TestReportDerivedMetricsInterfaceBandwidthUsage(t *testing.T) {
 	deviceAddress := "10.0.0.5"
+	deviceID := buildDeviceIDFromConfigAddress(deviceAddress)
 	ifSpeed := uint64(1_000_000_000)
 	interfaceTags := []string{
+		deviceNamespaceTag,
 		"device_ip:" + deviceAddress,
-		"device_id:default:" + deviceAddress,
+		"device_id:" + deviceID,
+		"snmp_device:" + deviceAddress,
+		"integration_source:gnmi",
 		"interface:eth0",
-		"interface_index:42",
-		"dd.internal.resource:ndm_interface:default:" + deviceAddress + ":42",
+		"dd.internal.resource:ndm_interface:" + deviceID + ":eth0",
 	}
 	cfg := &config.CheckConfig{
 		Instance: config.InstanceConfig{Address: deviceAddress},
@@ -155,6 +287,7 @@ func TestReportDerivedMetricsInterfaceBandwidthUsage(t *testing.T) {
 
 func TestReportMetricsEmitsThroughputRates(t *testing.T) {
 	deviceAddress := "10.0.0.1"
+	deviceID := buildDeviceIDFromConfigAddress(deviceAddress)
 	cfg := &config.CheckConfig{
 		Instance: config.InstanceConfig{Address: deviceAddress},
 		Profile: config.ProfileDefinition{
@@ -187,13 +320,19 @@ func TestReportMetricsEmitsThroughputRates(t *testing.T) {
 	require.NoError(t, err)
 
 	mockSender.AssertMetric(t, "MonotonicCount", "snmp.ifHCInOctets", 2_000_000, "", []string{
+		deviceNamespaceTag,
 		"device_ip:" + deviceAddress,
-		"device_id:default:" + deviceAddress,
+		"device_id:" + deviceID,
+		"snmp_device:" + deviceAddress,
+		"integration_source:gnmi",
 		"interface:eth0",
 	})
 	mockSender.AssertMetric(t, "Rate", "snmp.ifHCInOctets.rate", 2_000_000, "", []string{
+		deviceNamespaceTag,
 		"device_ip:" + deviceAddress,
-		"device_id:default:" + deviceAddress,
+		"device_id:" + deviceID,
+		"snmp_device:" + deviceAddress,
+		"integration_source:gnmi",
 		"interface:eth0",
 	})
 }

--- a/pkg/collector/corechecks/network-devices/gnmi/report/health.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/health.go
@@ -76,7 +76,7 @@ func OldestSampleAgeSeconds(snapshot []client.CachedValue, now time.Time) float6
 }
 
 // ReportHealth submits datadog.gnmi.* operational metrics.
-func ReportHealth(s sender.Sender, cfg *config.CheckConfig, stats HealthStats) error {
+func ReportHealth(s sender.Sender, cfg *config.CheckConfig, snapshot []client.CachedValue, stats HealthStats) error {
 	if s == nil {
 		return errors.New("sender is nil")
 	}
@@ -84,7 +84,7 @@ func ReportHealth(s sender.Sender, cfg *config.CheckConfig, stats HealthStats) e
 		return errors.New("check config is nil")
 	}
 
-	tags := buildBaseTags(cfg)
+	tags := buildBaseTags(cfg, snapshot)
 	s.Gauge(metricStreamState, streamStateValue(stats.StreamState), "", tags)
 	s.Gauge(metricReconnectCount, float64(stats.ReconnectCount), "", tags)
 	s.Gauge(metricReceivedSamples, float64(stats.ReceivedSamples), "", tags)

--- a/pkg/collector/corechecks/network-devices/gnmi/report/health_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/health_test.go
@@ -93,9 +93,14 @@ func TestOldestSampleAgeSeconds(t *testing.T) {
 
 func TestReportHealth(t *testing.T) {
 	deviceAddress := "10.0.0.1"
+	deviceID := buildDeviceIDFromConfigAddress(deviceAddress)
 	baseTags := []string{
+		deviceNamespaceTag,
 		"device_ip:" + deviceAddress,
-		"device_id:default:" + deviceAddress,
+		"device_id:" + deviceID,
+		"snmp_device:" + deviceAddress,
+		integrationSourceGNMITag,
+		internalDeviceResourceTag(deviceID),
 	}
 
 	cfg := &config.CheckConfig{
@@ -113,7 +118,7 @@ func TestReportHealth(t *testing.T) {
 		ReceivedSamples:  4,
 		SampleAgeSeconds: 12.5,
 	}
-	require.NoError(t, ReportHealth(mockSender, cfg, stats))
+	require.NoError(t, ReportHealth(mockSender, cfg, nil, stats))
 
 	mockSender.AssertMetric(t, "Gauge", metricStreamState, streamStateConnected, "", baseTags)
 	mockSender.AssertMetric(t, "Gauge", metricReconnectCount, 2, "", baseTags)
@@ -128,14 +133,14 @@ func TestReportHealthValidation(t *testing.T) {
 	stats := HealthStats{StreamState: client.StreamStateNotReady}
 
 	t.Run("nil sender", func(t *testing.T) {
-		err := ReportHealth(nil, cfg, stats)
+		err := ReportHealth(nil, cfg, nil, stats)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "sender is nil")
 	})
 
 	t.Run("nil config", func(t *testing.T) {
 		mockSender := mocksender.NewMockSender(t, checkid.ID("gnmi"))
-		err := ReportHealth(mockSender, nil, stats)
+		err := ReportHealth(mockSender, nil, nil, stats)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "check config is nil")
 	})
@@ -144,9 +149,14 @@ func TestReportHealthValidation(t *testing.T) {
 func TestReportMetricsSkipsStaleValues(t *testing.T) {
 	now := time.Unix(100, 0)
 	deviceAddress := "10.0.0.1"
+	deviceID := buildDeviceIDFromConfigAddress(deviceAddress)
 	baseTags := []string{
+		deviceNamespaceTag,
 		"device_ip:" + deviceAddress,
-		"device_id:default:" + deviceAddress,
+		"device_id:" + deviceID,
+		"snmp_device:" + deviceAddress,
+		integrationSourceGNMITag,
+		internalDeviceResourceTag(deviceID),
 	}
 
 	cfg := &config.CheckConfig{

--- a/pkg/collector/corechecks/network-devices/gnmi/report/metadata.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/metadata.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -29,6 +28,11 @@ const (
 	DefaultMetadataCollectionInterval = 10 * time.Minute
 
 	interfaceStatusMetric = "snmp.interface.status"
+
+	// gnmiInterfaceRawIDType identifies the RawID scheme (deviceID:interfaceName) used for
+	// gNMI interfaces, matching the naming convention used by other integrations
+	// (e.g. "versa_interface").
+	gnmiInterfaceRawIDType = "gnmi_interface"
 )
 
 // ShouldReportMetadata reports whether metadata should be submitted based on the last report time.
@@ -50,9 +54,8 @@ func MetadataCollectionInterval(cfg *config.CheckConfig) time.Duration {
 	return time.Duration(cfg.Instance.MetadataCollectionInterval) * time.Second
 }
 
-// InterfaceSnapshotComplete reports whether every discovered interface has a stable ifindex.
+// InterfaceSnapshotComplete reports whether every discovered interface has a name in the snapshot.
 func InterfaceSnapshotComplete(snapshot []client.CachedValue, metadata config.MetadataConfig) bool {
-	resolved := metadata.Resolved()
 	index := indexSnapshot(snapshot)
 	names := interfaceNames(index, metadata, nil)
 	if len(names) == 0 {
@@ -60,9 +63,7 @@ func InterfaceSnapshotComplete(snapshot []client.CachedValue, metadata config.Me
 	}
 
 	for _, name := range names {
-		keys := metadata.InterfaceKeyValues(name)
-		ifIndex, ok := firstInt32Value(index, resolved.Interface.IfIndex, keys)
-		if !ok || ifIndex <= 0 {
+		if strings.TrimSpace(name) == "" {
 			return false
 		}
 	}
@@ -79,11 +80,12 @@ func ReportMetadata(s sender.Sender, cfg *config.CheckConfig, snapshot []client.
 		return false, errors.New("check config is nil")
 	}
 
-	deviceID := buildDeviceID(cfg.Instance.Address)
-	tags := sortutil.UniqInPlace(ndmutils.CopyStrings(buildBaseTags(cfg)))
+	deviceID := buildDeviceID(cfg)
+	tags := sortutil.UniqInPlace(ndmutils.CopyStrings(buildBaseTags(cfg, snapshot)))
 
 	device := buildDeviceMetadata(deviceID, cfg, snapshot, tags)
-	interfaces := buildInterfaceMetadata(deviceID, cfg.Profile.Metadata, snapshot)
+	interfaces := buildInterfaceMetadata(deviceID, cfg.Profile.Metadata, snapshot, interfaceMetricPathsFromProfile(cfg.Profile))
+	ipAddresses := buildIPAddressMetadata(deviceID, cfg.Profile.Metadata, interfaces, snapshot)
 
 	var topologyLinks []devicemetadata.TopologyLinkMetadata
 	if cfg.Instance.CollectTopology {
@@ -103,7 +105,7 @@ func ReportMetadata(s sender.Sender, cfg *config.CheckConfig, snapshot []client.
 		devicemetadata.PayloadMetadataBatchSize,
 		[]devicemetadata.DeviceMetadata{device},
 		interfaces,
-		nil,
+		ipAddresses,
 		topologyLinks,
 		nil,
 		nil,
@@ -130,20 +132,19 @@ func ReportInterfaceStatus(s sender.Sender, cfg *config.CheckConfig, snapshot []
 		return errors.New("check config is nil")
 	}
 
-	deviceID := buildDeviceID(cfg.Instance.Address)
-	interfaces := buildInterfaceMetadata(deviceID, cfg.Profile.Metadata, snapshot)
+	deviceID := buildDeviceID(cfg)
+	interfaces := buildInterfaceMetadata(deviceID, cfg.Profile.Metadata, snapshot, interfaceMetricPathsFromProfile(cfg.Profile))
 	if len(interfaces) == 0 {
 		return nil
 	}
 
-	baseTags := buildBaseTags(cfg)
+	baseTags := buildBaseTags(cfg, snapshot)
 	for _, iface := range interfaces {
 		status := string(computeInterfaceStatus(iface.AdminStatus, iface.OperStatus))
 		tags := []string{
 			"status:" + status,
 			"admin_status:" + iface.AdminStatus.AsString(),
 			"oper_status:" + iface.OperStatus.AsString(),
-			"interface_index:" + strconv.Itoa(int(iface.Index)),
 		}
 		if iface.Name != "" {
 			tags = append(tags, "interface:"+iface.Name)
@@ -152,7 +153,9 @@ func ReportInterfaceStatus(s sender.Sender, cfg *config.CheckConfig, snapshot []
 			tags = append(tags, "interface_alias:"+iface.Description)
 		}
 		tags = append(tags, baseTags...)
-		tags = append(tags, internalInterfaceResourceTag(deviceID, iface.Index))
+		if iface.Name != "" {
+			tags = append(tags, internalInterfaceResourceTag(deviceID, iface.Name))
+		}
 
 		s.Gauge(interfaceStatusMetric, 1, "", tags)
 	}
@@ -192,7 +195,7 @@ func isEmptyMetadata(device devicemetadata.DeviceMetadata, interfaces []deviceme
 	if len(interfaces) > 0 || len(links) > 0 {
 		return false
 	}
-	return device.Name == "" &&
+	return device.OsHostname == "" &&
 		device.Vendor == "" &&
 		device.SerialNumber == "" &&
 		device.ProductName == "" &&
@@ -204,22 +207,31 @@ func buildDeviceMetadata(deviceID string, cfg *config.CheckConfig, snapshot []cl
 	index := indexSnapshot(snapshot)
 	metadata := cfg.Profile.Metadata.Resolved()
 
-	hostname := firstStringValue(index, metadata.Device.Hostname, nil)
-	vendor := firstStringValue(index, metadata.Device.VendorName, nil)
-	serialNumber := firstStringValue(index, metadata.Device.SerialNumber, nil)
-	platform := firstStringValue(index, metadata.Device.Platform, nil)
+	hostname := resolveDeviceHostname(index, metadata)
+	componentName := resolveDeviceComponentName(index, metadata)
+	deviceKeys := metadata.DeviceKeyValues(componentName)
+
+	vendor := firstStringValue(index, metadata.Device.VendorName, deviceKeys)
+	serialNumber := firstStringValue(index, metadata.Device.SerialNumber, deviceKeys)
+	platform := firstStringValue(index, metadata.Device.Platform, deviceKeys)
 	softwareVersion := firstStringValue(index, metadata.Device.SoftwareVersion, nil)
-	hardwareVersion := firstStringValue(index, metadata.Device.HardwareVersion, nil)
+	hardwareVersion := firstStringValue(index, metadata.Device.HardwareVersion, deviceKeys)
 
 	productName := platform
 	if productName == "" {
 		productName = hardwareVersion
 	}
 
+	deviceName := hostname
+	if deviceName == "" {
+		deviceName = cfg.Instance.Address
+	}
+
 	return devicemetadata.DeviceMetadata{
 		ID:           deviceID,
-		IDTags:       []string{"device_ip:" + cfg.Instance.Address},
-		Name:         hostname,
+		IDTags:       buildDeviceIDTags(cfg),
+		Name:         deviceName,
+		OsHostname:   hostname,
 		IPAddress:    cfg.Instance.Address,
 		Profile:      cfg.Profile.Name,
 		Vendor:       vendor,
@@ -233,10 +245,10 @@ func buildDeviceMetadata(deviceID string, cfg *config.CheckConfig, snapshot []cl
 	}
 }
 
-func buildInterfaceMetadata(deviceID string, metadata config.MetadataConfig, snapshot []client.CachedValue) []devicemetadata.InterfaceMetadata {
+func buildInterfaceMetadata(deviceID string, metadata config.MetadataConfig, snapshot []client.CachedValue, metricPaths []string) []devicemetadata.InterfaceMetadata {
 	resolved := metadata.Resolved()
 	index := indexSnapshot(snapshot)
-	names := interfaceNames(index, metadata, nil)
+	names := interfaceNames(index, metadata, metricPaths)
 	if len(names) == 0 {
 		return nil
 	}
@@ -246,11 +258,16 @@ func buildInterfaceMetadata(deviceID string, metadata config.MetadataConfig, sna
 	for _, name := range names {
 		keys := metadata.InterfaceKeyValues(name)
 
-		ifIndex, ok := firstInt32Value(index, resolved.Interface.IfIndex, keys)
-		if !ok || ifIndex <= 0 {
-			log.Debugf("skipping interface %q metadata for %s: missing ifindex at %s", name, deviceID, resolved.Interface.IfIndex)
+		interfaceName := firstStringValue(index, resolved.Interface.Name, keys)
+		if interfaceName == "" {
+			interfaceName = name
+		}
+		if interfaceName == "" {
+			log.Debugf("skipping interface metadata for %s: missing interface name", deviceID)
 			continue
 		}
+
+		ifIndex, _ := firstInt32Value(index, resolved.Interface.IfIndex, keys)
 
 		ifType, _ := firstInt32Value(index, resolved.Interface.Type, keys)
 		if ifType == 0 {
@@ -262,16 +279,13 @@ func buildInterfaceMetadata(deviceID string, metadata config.MetadataConfig, sna
 		adminStatus := parseAdminStatus(firstStringValue(index, resolved.Interface.AdminStatus, keys))
 		operStatus := parseOperStatus(firstStringValue(index, resolved.Interface.OperStatus, keys))
 
-		interfaceName := firstStringValue(index, resolved.Interface.Name, keys)
-		if interfaceName == "" {
-			interfaceName = name
-		}
-
 		interfaces = append(interfaces, devicemetadata.InterfaceMetadata{
-			DeviceID: deviceID,
-			IDTags:   []string{"interface:" + interfaceName},
-			Index:    ifIndex,
-			Name:     interfaceName,
+			DeviceID:    deviceID,
+			IDTags:      []string{"interface:" + interfaceName},
+			Index:       ifIndex,
+			RawID:       buildInterfaceID(deviceID, interfaceName),
+			RawIDType:   gnmiInterfaceRawIDType,
+			Name:        interfaceName,
 			Description: firstStringValue(index, resolved.Interface.Description, keys),
 			MacAddress:  firstStringValue(index, resolved.Interface.MACAddress, keys),
 			AdminStatus: adminStatus,
@@ -282,6 +296,125 @@ func buildInterfaceMetadata(deviceID string, metadata config.MetadataConfig, sna
 	}
 
 	return interfaces
+}
+
+func buildIPAddressMetadata(
+	deviceID string,
+	metadata config.MetadataConfig,
+	interfaces []devicemetadata.InterfaceMetadata,
+	snapshot []client.CachedValue,
+) []devicemetadata.IPAddressMetadata {
+	resolved := metadata.Resolved()
+	ipPath := normalizeProfilePath(resolved.IPAddress.IP)
+	if ipPath == "" {
+		return nil
+	}
+	prefixPath := normalizeProfilePath(resolved.IPAddress.PrefixLength)
+	interfaceKey := interfaceNameKeyFromMetadataKeys(resolved.IPAddress.Keys)
+
+	type addressData struct {
+		ip        string
+		prefixLen int32
+		hasPrefix bool
+	}
+
+	addresses := make(map[string]*addressData)
+	addressKey := func(keys map[string]string) string {
+		interfaceName := keys[interfaceKey]
+		if interfaceName == "" {
+			return ""
+		}
+		parts := []string{interfaceName}
+		if subinterfaceIndex := keys["index"]; subinterfaceIndex != "" {
+			parts = append(parts, subinterfaceIndex)
+		}
+		if ip := keys["ip"]; ip != "" {
+			parts = append(parts, ip)
+		}
+		return strings.Join(parts, "\x00")
+	}
+
+	for _, cached := range snapshot {
+		key := addressKey(cached.Key.Keys)
+		if key == "" {
+			continue
+		}
+		entry := addresses[key]
+		if entry == nil {
+			entry = &addressData{}
+			addresses[key] = entry
+		}
+
+		switch cached.Key.Path {
+		case ipPath:
+			if value, ok := stringValue(cached.Entry.Value); ok {
+				entry.ip = value
+			}
+			if entry.ip == "" {
+				entry.ip = cached.Key.Keys["ip"]
+			}
+		case prefixPath:
+			if value, ok := int64Value(cached.Entry.Value); ok {
+				entry.prefixLen = int32(value)
+				entry.hasPrefix = true
+			}
+		}
+	}
+
+	interfaceByName := make(map[string]devicemetadata.InterfaceMetadata, len(interfaces))
+	for _, iface := range interfaces {
+		if iface.Name == "" {
+			continue
+		}
+		interfaceByName[iface.Name] = iface
+	}
+
+	ipAddresses := make([]devicemetadata.IPAddressMetadata, 0, len(addresses))
+	for key, entry := range addresses {
+		if entry.ip == "" {
+			continue
+		}
+		interfaceName := strings.Split(key, "\x00")[0]
+		iface, ok := interfaceByName[interfaceName]
+		if !ok || iface.Name == "" {
+			log.Debugf("skipping interface IP %s for %s: missing interface metadata for %q", entry.ip, deviceID, interfaceName)
+			continue
+		}
+		if iface.Index == 0 {
+			log.Debugf("skipping interface IP %s for %s: interface %q has no ifIndex", entry.ip, deviceID, interfaceName)
+			continue
+		}
+
+		ipMetadata := devicemetadata.IPAddressMetadata{
+			InterfaceID: buildInterfaceIDFromIndex(deviceID, iface.Index),
+			IPAddress:   entry.ip,
+		}
+		if entry.hasPrefix {
+			ipMetadata.Prefixlen = entry.prefixLen
+		}
+		ipAddresses = append(ipAddresses, ipMetadata)
+	}
+
+	sort.Slice(ipAddresses, func(i, j int) bool {
+		if ipAddresses[i].InterfaceID == ipAddresses[j].InterfaceID {
+			return ipAddresses[i].IPAddress < ipAddresses[j].IPAddress
+		}
+		return ipAddresses[i].InterfaceID < ipAddresses[j].InterfaceID
+	})
+
+	return ipAddresses
+}
+
+func interfaceNameKeyFromMetadataKeys(keys map[string]string) string {
+	if keyName, ok := keys["interface"]; ok && keyName != "" {
+		return keyName
+	}
+	for _, keyName := range keys {
+		if keyName != "" {
+			return keyName
+		}
+	}
+	return "name"
 }
 
 func parseAdminStatus(value string) devicemetadata.IfAdminStatus {

--- a/pkg/collector/corechecks/network-devices/gnmi/report/metadata_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/metadata_test.go
@@ -38,20 +38,169 @@ func TestBuildDeviceMetadata(t *testing.T) {
 	}
 	snapshot := []client.CachedValue{
 		{Key: client.CacheKey{Path: defaultMetadata.Device.Hostname}, Entry: client.CacheEntry{Value: "router-1"}},
-		{Key: client.CacheKey{Path: defaultMetadata.Device.VendorName}, Entry: client.CacheEntry{Value: "Cisco"}},
-		{Key: client.CacheKey{Path: defaultMetadata.Device.SerialNumber}, Entry: client.CacheEntry{Value: "ABC123"}},
-		{Key: client.CacheKey{Path: defaultMetadata.Device.Platform}, Entry: client.CacheEntry{Value: "ASR9000"}},
+		{
+			Key:   client.CacheKey{Path: defaultMetadata.Device.VendorName, Keys: map[string]string{"name": "Chassis"}},
+			Entry: client.CacheEntry{Value: "Cisco"},
+		},
+		{
+			Key:   client.CacheKey{Path: defaultMetadata.Device.VendorName, Keys: map[string]string{"name": "FanTray3"}},
+			Entry: client.CacheEntry{Value: "Nokia"},
+		},
+		{
+			Key:   client.CacheKey{Path: defaultMetadata.Device.SerialNumber, Keys: map[string]string{"name": "Chassis"}},
+			Entry: client.CacheEntry{Value: "ABC123"},
+		},
+		{
+			Key:   client.CacheKey{Path: defaultMetadata.Device.Platform, Keys: map[string]string{"name": "Chassis"}},
+			Entry: client.CacheEntry{Value: "ASR9000"},
+		},
+		{
+			Key:   client.CacheKey{Path: defaultMetadata.Device.Platform, Keys: map[string]string{"name": "FanTray3"}},
+			Entry: client.CacheEntry{Value: "imm48-25g-sfp28"},
+		},
 		{Key: client.CacheKey{Path: defaultMetadata.Device.SoftwareVersion}, Entry: client.CacheEntry{Value: "7.3.2"}},
+		{
+			Key:   client.CacheKey{Path: defaultMetadata.Device.HardwareVersion, Keys: map[string]string{"name": "Chassis"}},
+			Entry: client.CacheEntry{Value: "Sim Part No."},
+		},
+		{
+			Key:   client.CacheKey{Path: defaultMetadata.Device.HardwareVersion, Keys: map[string]string{"name": "FanTray3"}},
+			Entry: client.CacheEntry{Value: "Unknown"},
+		},
 	}
 
 	device := buildDeviceMetadata("default:10.0.0.5", cfg, snapshot, []string{"device_ip:10.0.0.5"})
 	assert.Equal(t, "default:10.0.0.5", device.ID)
+	assert.Equal(t, []string{"device_namespace:default", "snmp_device:10.0.0.5"}, device.IDTags)
 	assert.Equal(t, "router-1", device.Name)
+	assert.Equal(t, "router-1", device.OsHostname)
 	assert.Equal(t, "Cisco", device.Vendor)
 	assert.Equal(t, "ABC123", device.SerialNumber)
 	assert.Equal(t, "ASR9000", device.ProductName)
+	assert.Equal(t, "Sim Part No.", device.Version)
 	assert.Equal(t, "7.3.2", device.OsVersion)
 	assert.Equal(t, "gnmi", device.Integration)
+}
+
+func TestBuildDeviceMetadataUsesIPAddressWhenHostnameMissing(t *testing.T) {
+	cfg := &config.CheckConfig{
+		Instance: config.InstanceConfig{Address: "10.0.0.9"},
+		Profile:  config.ProfileDefinition{Name: "interface-stats"},
+	}
+
+	device := buildDeviceMetadata("default:10.0.0.9", cfg, nil, nil)
+	assert.Equal(t, "10.0.0.9", device.Name)
+	assert.Empty(t, device.OsHostname)
+}
+
+func TestBuildBaseTagsIncludesSNMPHost(t *testing.T) {
+	cfg := &config.CheckConfig{
+		Instance: config.InstanceConfig{Address: "10.0.0.5"},
+		Profile:  config.ProfileDefinition{Name: "interface-stats"},
+	}
+	snapshot := []client.CachedValue{
+		{
+			Key:   client.CacheKey{Path: "/openconfig/system/state/hostname"},
+			Entry: client.CacheEntry{Value: "router-1"},
+		},
+	}
+
+	tags := buildBaseTags(cfg, snapshot)
+	assert.Contains(t, tags, "snmp_host:router-1")
+	assert.Contains(t, tags, "snmp_profile:interface-stats")
+	assert.Contains(t, tags, "snmp_device:10.0.0.5")
+	assert.Contains(t, tags, deviceNamespaceTag)
+	assert.Contains(t, tags, integrationSourceGNMITag)
+	assert.Contains(t, tags, internalDeviceResourceTag("default:10.0.0.5"))
+}
+
+func TestBuildDeviceIDTags(t *testing.T) {
+	cfg := &config.CheckConfig{
+		Instance: config.InstanceConfig{Address: "10.0.0.5"},
+	}
+	assert.Equal(t, []string{"device_namespace:default", "snmp_device:10.0.0.5"}, buildDeviceIDTags(cfg))
+}
+
+func TestReportMetadataUsesConfigAddressForDeviceID(t *testing.T) {
+	cfg := &config.CheckConfig{
+		Instance: config.InstanceConfig{Address: "srl1"},
+		Profile:  config.ProfileDefinition{Name: "interface-stats"},
+	}
+	snapshot := []client.CachedValue{
+		{Key: client.CacheKey{Path: config.DefaultOpenConfigMetadata().Device.Hostname}, Entry: client.CacheEntry{Value: "router-1"}},
+		{
+			Key:   client.CacheKey{Path: "/openconfig/interfaces/interface/state/name", Keys: map[string]string{"name": "Ethernet1"}},
+			Entry: client.CacheEntry{Value: "Ethernet1"},
+		},
+	}
+
+	mockSender := mocksender.NewMockSender(t, checkid.ID("gnmi"))
+	mockSender.SetupAcceptAll()
+
+	sent, err := ReportMetadata(mockSender, cfg, snapshot, time.Unix(123, 0))
+	require.NoError(t, err)
+	require.True(t, sent)
+
+	var rawEvent []byte
+	for _, call := range mockSender.Calls {
+		if call.Method == "EventPlatformEvent" {
+			rawEvent = call.Arguments[0].([]byte)
+			break
+		}
+	}
+	require.NotEmpty(t, rawEvent)
+
+	var metadata devicemetadata.NetworkDevicesMetadata
+	require.NoError(t, json.Unmarshal(rawEvent, &metadata))
+	require.Len(t, metadata.Devices, 1)
+	assert.Equal(t, "default:srl1", metadata.Devices[0].ID)
+	assert.Equal(t, "srl1", metadata.Devices[0].IPAddress)
+	assert.Equal(t, "router-1", metadata.Devices[0].Name)
+}
+
+func TestReportMetadataUsesConfigAddressForLoopbackDeviceID(t *testing.T) {
+	cfg := &config.CheckConfig{
+		Instance: config.InstanceConfig{Address: "127.0.0.1"},
+		Profile:  config.ProfileDefinition{Name: "interface-stats"},
+	}
+	snapshot := []client.CachedValue{
+		{Key: client.CacheKey{Path: config.DefaultOpenConfigMetadata().Device.Hostname}, Entry: client.CacheEntry{Value: "srl2"}},
+	}
+
+	mockSender := mocksender.NewMockSender(t, checkid.ID("gnmi"))
+	mockSender.SetupAcceptAll()
+
+	sent, err := ReportMetadata(mockSender, cfg, snapshot, time.Unix(123, 0))
+	require.NoError(t, err)
+	require.True(t, sent)
+
+	var rawEvent []byte
+	for _, call := range mockSender.Calls {
+		if call.Method == "EventPlatformEvent" {
+			rawEvent = call.Arguments[0].([]byte)
+			break
+		}
+	}
+	require.NotEmpty(t, rawEvent)
+
+	var metadata devicemetadata.NetworkDevicesMetadata
+	require.NoError(t, json.Unmarshal(rawEvent, &metadata))
+	require.Len(t, metadata.Devices, 1)
+	assert.Equal(t, "default:127.0.0.1", metadata.Devices[0].ID)
+	assert.Equal(t, "127.0.0.1", metadata.Devices[0].IPAddress)
+	assert.Equal(t, "srl2", metadata.Devices[0].Name)
+}
+
+func TestResolveDeviceHostnameFallback(t *testing.T) {
+	snapshot := []client.CachedValue{
+		{
+			Key:   client.CacheKey{Path: "/openconfig/system/config/hostname"},
+			Entry: client.CacheEntry{Value: "srl2"},
+		},
+	}
+
+	hostname := ResolveDeviceHostname(snapshot, config.MetadataConfig{})
+	assert.Equal(t, "srl2", hostname)
 }
 
 func TestBuildInterfaceMetadata(t *testing.T) {
@@ -82,7 +231,7 @@ func TestBuildInterfaceMetadata(t *testing.T) {
 		},
 	}
 
-	interfaces := buildInterfaceMetadata("default:10.0.0.5", config.DefaultOpenConfigMetadata(), snapshot)
+	interfaces := buildInterfaceMetadata("default:10.0.0.5", config.DefaultOpenConfigMetadata(), snapshot, nil)
 	require.Len(t, interfaces, 1)
 	assert.Equal(t, int32(42), interfaces[0].Index)
 	assert.Equal(t, "eth0", interfaces[0].Name)
@@ -91,9 +240,11 @@ func TestBuildInterfaceMetadata(t *testing.T) {
 	assert.Equal(t, devicemetadata.OperStatusUp, interfaces[0].OperStatus)
 	require.NotNil(t, interfaces[0].IsPhysical)
 	assert.True(t, *interfaces[0].IsPhysical)
+	assert.Equal(t, "default:10.0.0.5:eth0", interfaces[0].RawID)
+	assert.Equal(t, "gnmi_interface", interfaces[0].RawIDType)
 }
 
-func TestBuildInterfaceMetadataSkipsMissingIfIndex(t *testing.T) {
+func TestBuildInterfaceMetadataIncludesInterfacesWithoutIfIndex(t *testing.T) {
 	snapshot := []client.CachedValue{
 		{
 			Key:   client.CacheKey{Path: "/openconfig/interfaces/interface/state/name", Keys: map[string]string{"name": "eth0"}},
@@ -109,30 +260,26 @@ func TestBuildInterfaceMetadataSkipsMissingIfIndex(t *testing.T) {
 		},
 	}
 
-	interfaces := buildInterfaceMetadata("default:10.0.0.5", config.DefaultOpenConfigMetadata(), snapshot)
-	require.Len(t, interfaces, 1)
-	assert.Equal(t, "eth1", interfaces[0].Name)
-	assert.Equal(t, int32(7), interfaces[0].Index)
-	assert.Equal(t, []string{"interface:eth1"}, interfaces[0].IDTags)
+	interfaces := buildInterfaceMetadata("default:10.0.0.5", config.DefaultOpenConfigMetadata(), snapshot, nil)
+	require.Len(t, interfaces, 2)
+	assert.Equal(t, "eth0", interfaces[0].Name)
+	assert.Equal(t, int32(0), interfaces[0].Index)
+	assert.Equal(t, []string{"interface:eth0"}, interfaces[0].IDTags)
+	assert.Equal(t, "eth1", interfaces[1].Name)
+	assert.Equal(t, int32(7), interfaces[1].Index)
+	assert.Equal(t, []string{"interface:eth1"}, interfaces[1].IDTags)
 }
 
 func TestInterfaceSnapshotComplete(t *testing.T) {
 	metadata := config.DefaultOpenConfigMetadata()
 	assert.True(t, InterfaceSnapshotComplete(nil, metadata))
 
-	incomplete := []client.CachedValue{
+	assert.True(t, InterfaceSnapshotComplete([]client.CachedValue{
 		{
 			Key:   client.CacheKey{Path: "/openconfig/interfaces/interface/state/name", Keys: map[string]string{"name": "eth0"}},
 			Entry: client.CacheEntry{Value: "eth0"},
 		},
-	}
-	assert.False(t, InterfaceSnapshotComplete(incomplete, metadata))
-
-	complete := append(incomplete, client.CachedValue{
-		Key:   client.CacheKey{Path: "/openconfig/interfaces/interface/state/ifindex", Keys: map[string]string{"name": "eth0"}},
-		Entry: client.CacheEntry{Value: int32(42)},
-	})
-	assert.True(t, InterfaceSnapshotComplete(complete, metadata))
+	}, metadata))
 }
 
 func TestReportInterfaceStatus(t *testing.T) {
@@ -171,12 +318,14 @@ func TestReportInterfaceStatus(t *testing.T) {
 		"status:up",
 		"admin_status:up",
 		"oper_status:up",
-		"interface_index:42",
 		"interface:Ethernet1",
 		"interface_alias:uplink",
+		deviceNamespaceTag,
 		"device_ip:10.0.0.5",
 		"device_id:default:10.0.0.5",
-		"dd.internal.resource:ndm_interface:default:10.0.0.5:42",
+		"snmp_device:10.0.0.5",
+		"integration_source:gnmi",
+		"dd.internal.resource:ndm_interface:default:10.0.0.5:Ethernet1",
 	})
 }
 
@@ -246,6 +395,96 @@ func TestReportMetadataSubmitsEvent(t *testing.T) {
 	assert.Equal(t, "uplink", metadata.Interfaces[0].Description)
 	assert.Equal(t, devicemetadata.AdminStatusUp, metadata.Interfaces[0].AdminStatus)
 	assert.Equal(t, devicemetadata.OperStatusUp, metadata.Interfaces[0].OperStatus)
+}
+
+func TestBuildIPAddressMetadata(t *testing.T) {
+	metadata := config.DefaultOpenConfigMetadata()
+	deviceID := "default:router-1"
+	snapshot := []client.CachedValue{
+		{
+			Key: client.CacheKey{
+				Path: metadata.Interface.IfIndex,
+				Keys: map[string]string{"name": "Ethernet1"},
+			},
+			Entry: client.CacheEntry{Value: int32(42)},
+		},
+		{
+			Key: client.CacheKey{
+				Path: metadata.IPAddress.IP,
+				Keys: map[string]string{"name": "Ethernet1", "index": "0", "ip": "10.1.1.1"},
+			},
+			Entry: client.CacheEntry{Value: "10.1.1.1"},
+		},
+		{
+			Key: client.CacheKey{
+				Path: metadata.IPAddress.PrefixLength,
+				Keys: map[string]string{"name": "Ethernet1", "index": "0", "ip": "10.1.1.1"},
+			},
+			Entry: client.CacheEntry{Value: int32(24)},
+		},
+	}
+	interfaces := buildInterfaceMetadata(deviceID, metadata, snapshot, nil)
+
+	ipAddresses := buildIPAddressMetadata(deviceID, metadata, interfaces, snapshot)
+	require.Len(t, ipAddresses, 1)
+	assert.Equal(t, "default:router-1:42", ipAddresses[0].InterfaceID)
+	assert.Equal(t, "10.1.1.1", ipAddresses[0].IPAddress)
+	assert.Equal(t, int32(24), ipAddresses[0].Prefixlen)
+}
+
+func TestReportMetadataIncludesIPAddresses(t *testing.T) {
+	cfg := &config.CheckConfig{
+		Instance: config.InstanceConfig{Address: "10.0.0.5"},
+		Profile:  config.ProfileDefinition{Name: "interface-stats"},
+	}
+	metadata := config.DefaultOpenConfigMetadata()
+	snapshot := []client.CachedValue{
+		{Key: client.CacheKey{Path: metadata.Device.Hostname}, Entry: client.CacheEntry{Value: "router-1"}},
+		{
+			Key:   client.CacheKey{Path: metadata.Interface.Name, Keys: map[string]string{"name": "Ethernet1"}},
+			Entry: client.CacheEntry{Value: "Ethernet1"},
+		},
+		{
+			Key:   client.CacheKey{Path: metadata.Interface.IfIndex, Keys: map[string]string{"name": "Ethernet1"}},
+			Entry: client.CacheEntry{Value: int32(42)},
+		},
+		{
+			Key: client.CacheKey{
+				Path: metadata.IPAddress.IP,
+				Keys: map[string]string{"name": "Ethernet1", "index": "0", "ip": "10.1.1.1"},
+			},
+			Entry: client.CacheEntry{Value: "10.1.1.1"},
+		},
+		{
+			Key: client.CacheKey{
+				Path: metadata.IPAddress.PrefixLength,
+				Keys: map[string]string{"name": "Ethernet1", "index": "0", "ip": "10.1.1.1"},
+			},
+			Entry: client.CacheEntry{Value: int32(24)},
+		},
+	}
+
+	mockSender := mocksender.NewMockSender(t, checkid.ID("gnmi"))
+	mockSender.SetupAcceptAll()
+
+	sent, err := ReportMetadata(mockSender, cfg, snapshot, time.Unix(123, 0))
+	require.NoError(t, err)
+	require.True(t, sent)
+
+	var rawEvent []byte
+	for _, call := range mockSender.Calls {
+		if call.Method == "EventPlatformEvent" {
+			rawEvent = call.Arguments[0].([]byte)
+		}
+	}
+	require.NotEmpty(t, rawEvent)
+
+	var payload devicemetadata.NetworkDevicesMetadata
+	require.NoError(t, json.Unmarshal(rawEvent, &payload))
+	require.Len(t, payload.IPAddresses, 1)
+	assert.Equal(t, "default:10.0.0.5:42", payload.IPAddresses[0].InterfaceID)
+	assert.Equal(t, "10.1.1.1", payload.IPAddresses[0].IPAddress)
+	assert.Equal(t, int32(24), payload.IPAddresses[0].Prefixlen)
 }
 
 func TestReportMetadataSkipsEmptyPayload(t *testing.T) {

--- a/pkg/collector/corechecks/network-devices/gnmi/report/metrics.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/metrics.go
@@ -8,6 +8,7 @@ package report
 
 import (
 	"errors"
+	"sort"
 	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -18,6 +19,8 @@ import (
 )
 
 const defaultDeviceNamespace = "default"
+const integrationSourceGNMITag = "integration_source:gnmi"
+const deviceNamespaceTag = "device_namespace:" + defaultDeviceNamespace
 
 // ReportMetrics submits snmp.* metrics from a client snapshot using profile mappings.
 // metricSnapshot contains the values to emit; inventorySnapshot supplies interface metadata
@@ -33,9 +36,9 @@ func ReportMetrics(s sender.Sender, cfg *config.CheckConfig, metricSnapshot []cl
 		inventorySnapshot = metricSnapshot
 	}
 
-	baseTags := buildBaseTags(cfg)
-	deviceID := buildDeviceID(cfg.Instance.Address)
-	interfaceInventory := interfaceInventoryByName(deviceID, cfg.Profile.Metadata, inventorySnapshot)
+	baseTags := buildBaseTags(cfg, inventorySnapshot)
+	deviceID := buildDeviceID(cfg)
+	interfaceInventory := interfaceInventoryByName(deviceID, cfg.Profile, inventorySnapshot)
 	byPath := indexSnapshotByPath(metricSnapshot)
 
 	for _, metric := range cfg.Profile.Metrics {
@@ -73,18 +76,61 @@ func normalizeProfilePath(path string) string {
 	return trimmed
 }
 
-func buildBaseTags(cfg *config.CheckConfig) []string {
+func buildBaseTags(cfg *config.CheckConfig, snapshot []client.CachedValue) []string {
 	address := cfg.Instance.Address
-	deviceID := buildDeviceID(address)
+	deviceID := buildDeviceID(cfg)
+	hostname := ResolveDeviceHostname(snapshot, cfg.Profile.Metadata)
 	tags := []string{
+		deviceNamespaceTag,
 		"device_ip:" + address,
 		"device_id:" + deviceID,
+		"snmp_device:" + address,
+		integrationSourceGNMITag,
+		internalDeviceResourceTag(deviceID),
+	}
+	if cfg.Profile.Name != "" {
+		tags = append(tags, "snmp_profile:"+cfg.Profile.Name)
+	}
+	if hostname != "" {
+		tags = append(tags, "snmp_host:"+hostname)
 	}
 	return append(tags, ndmutils.CopyStrings(cfg.Instance.Tags)...)
 }
 
-func buildDeviceID(address string) string {
+func buildDeviceIDTags(cfg *config.CheckConfig) []string {
+	if cfg == nil {
+		return nil
+	}
+	tags := []string{
+		deviceNamespaceTag,
+		"snmp_device:" + cfg.Instance.Address,
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+// buildDeviceID returns the NDM device identifier used for metadata and metric tags.
+// It always uses the configured address verbatim (hostname or IP).
+func buildDeviceID(cfg *config.CheckConfig) string {
+	if cfg == nil {
+		return defaultDeviceNamespace + ":"
+	}
+	return buildDeviceIDFromConfigAddress(cfg.Instance.Address)
+}
+
+func buildDeviceIDFromConfigAddress(address string) string {
 	return defaultDeviceNamespace + ":" + address
+}
+
+func buildInterfaceID(deviceID string, interfaceName string) string {
+	return deviceID + ":" + interfaceName
+}
+
+// buildInterfaceIDFromIndex builds the canonical interface_id used to join IPAddressMetadata
+// to InterfaceMetadata, matching the deviceID:ifIndex convention used by the other NDM
+// integrations (SNMP, Cisco SD-WAN).
+func buildInterfaceIDFromIndex(deviceID string, ifIndex int32) string {
+	return deviceID + ":" + strconv.Itoa(int(ifIndex))
 }
 
 func buildMetricTags(baseTags []string, metric config.MetricConfig, keys map[string]string) []string {
@@ -102,8 +148,20 @@ func buildMetricTags(baseTags []string, metric config.MetricConfig, keys map[str
 	return tags
 }
 
-func interfaceInventoryByName(deviceID string, metadata config.MetadataConfig, snapshot []client.CachedValue) map[string]devicemetadata.InterfaceMetadata {
-	interfaces := buildInterfaceMetadata(deviceID, metadata, snapshot)
+func interfaceMetricPathsFromProfile(profile config.ProfileDefinition) []string {
+	paths := make([]string, 0, len(profile.Metrics))
+	for _, metric := range profile.Metrics {
+		keyName, ok := metric.Tags["interface"]
+		if !ok || keyName == "" {
+			continue
+		}
+		paths = append(paths, normalizeProfilePath(metric.Path))
+	}
+	return paths
+}
+
+func interfaceInventoryByName(deviceID string, profile config.ProfileDefinition, snapshot []client.CachedValue) map[string]devicemetadata.InterfaceMetadata {
+	interfaces := buildInterfaceMetadata(deviceID, profile.Metadata, snapshot, interfaceMetricPathsFromProfile(profile))
 	inventory := make(map[string]devicemetadata.InterfaceMetadata, len(interfaces))
 	for _, iface := range interfaces {
 		if iface.Name == "" {
@@ -127,15 +185,14 @@ func enrichInterfaceMetricTags(
 	}
 
 	iface, ok := inventory[interfaceName]
-	if !ok || iface.Index <= 0 {
+	if !ok || iface.Name == "" {
 		return tags
 	}
 
-	tags = append(tags, "interface_index:"+strconv.Itoa(int(iface.Index)))
 	if iface.Description != "" {
 		tags = append(tags, "interface_alias:"+iface.Description)
 	}
-	return append(tags, internalInterfaceResourceTag(deviceID, iface.Index))
+	return append(tags, internalInterfaceResourceTag(deviceID, iface.Name))
 }
 
 func interfaceNameFromMetricTags(metric config.MetricConfig, keys map[string]string) string {
@@ -146,8 +203,12 @@ func interfaceNameFromMetricTags(metric config.MetricConfig, keys map[string]str
 	return keys[keyName]
 }
 
-func internalInterfaceResourceTag(deviceID string, ifIndex int32) string {
-	return "dd.internal.resource:ndm_interface:" + deviceID + ":" + strconv.FormatInt(int64(ifIndex), 10)
+func internalInterfaceResourceTag(deviceID string, interfaceName string) string {
+	return "dd.internal.resource:ndm_interface:" + buildInterfaceID(deviceID, interfaceName)
+}
+
+func internalDeviceResourceTag(deviceID string) string {
+	return "dd.internal.resource:ndm_device:" + deviceID
 }
 
 func decodeMetricValue(value any, valueMap map[string]int) (float64, bool) {

--- a/pkg/collector/corechecks/network-devices/gnmi/report/metrics_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/metrics_test.go
@@ -20,9 +20,14 @@ import (
 
 func TestReportMetrics(t *testing.T) {
 	deviceAddress := "10.0.0.1"
+	deviceID := buildDeviceIDFromConfigAddress(deviceAddress)
 	baseTags := []string{
+		deviceNamespaceTag,
 		"device_ip:" + deviceAddress,
-		"device_id:default:" + deviceAddress,
+		"device_id:" + deviceID,
+		"snmp_device:" + deviceAddress,
+		integrationSourceGNMITag,
+		internalDeviceResourceTag(deviceID),
 	}
 
 	tests := []struct {
@@ -112,12 +117,15 @@ func TestReportMetrics(t *testing.T) {
 					name:   "snmp.ifHCInOctets",
 					value:  2_000_000,
 					tags: []string{
+						deviceNamespaceTag,
 						"device_ip:" + deviceAddress,
-						"device_id:default:" + deviceAddress,
+						"device_id:" + deviceID,
+						"snmp_device:" + deviceAddress,
+						integrationSourceGNMITag,
+						internalDeviceResourceTag(deviceID),
 						"interface:eth0",
-						"interface_index:42",
 						"interface_alias:uplink",
-						"dd.internal.resource:ndm_interface:default:" + deviceAddress + ":42",
+						"dd.internal.resource:ndm_interface:" + deviceID + ":eth0",
 					},
 				},
 				{
@@ -125,12 +133,15 @@ func TestReportMetrics(t *testing.T) {
 					name:   "snmp.ifHCInOctets.rate",
 					value:  2_000_000,
 					tags: []string{
+						deviceNamespaceTag,
 						"device_ip:" + deviceAddress,
-						"device_id:default:" + deviceAddress,
+						"device_id:" + deviceID,
+						"snmp_device:" + deviceAddress,
+						integrationSourceGNMITag,
+						internalDeviceResourceTag(deviceID),
 						"interface:eth0",
-						"interface_index:42",
 						"interface_alias:uplink",
-						"dd.internal.resource:ndm_interface:default:" + deviceAddress + ":42",
+						"dd.internal.resource:ndm_interface:" + deviceID + ":eth0",
 					},
 				},
 			},
@@ -327,6 +338,68 @@ func TestReportMetrics(t *testing.T) {
 			mockSender.AssertNumberOfCalls(t, "Rate", rateCalls)
 		})
 	}
+}
+
+func TestBuildDeviceID(t *testing.T) {
+	cfg := &config.CheckConfig{
+		Instance: config.InstanceConfig{Address: "127.0.0.1", Port: 57401},
+		Profile:  config.ProfileDefinition{},
+	}
+
+	assert.Equal(t, "default:127.0.0.1", buildDeviceID(cfg))
+
+	cfg.Instance.Address = "srl1"
+	assert.Equal(t, "default:srl1", buildDeviceID(cfg))
+}
+
+func TestBuildDeviceIDIgnoresTelemetryHostname(t *testing.T) {
+	cfg := &config.CheckConfig{
+		Instance: config.InstanceConfig{Address: "127.0.0.1"},
+		Profile:  config.ProfileDefinition{},
+	}
+	snapshot := []client.CachedValue{
+		{
+			Key:   client.CacheKey{Path: "/openconfig/system/state/hostname"},
+			Entry: client.CacheEntry{Value: "srl2"},
+		},
+	}
+
+	assert.Equal(t, "default:127.0.0.1", buildDeviceID(cfg))
+
+	tags := buildBaseTags(cfg, snapshot)
+	assert.Contains(t, tags, "device_id:default:127.0.0.1")
+	assert.Contains(t, tags, internalDeviceResourceTag("default:127.0.0.1"))
+	assert.Contains(t, tags, "snmp_device:127.0.0.1")
+	assert.Contains(t, tags, "device_ip:127.0.0.1")
+	assert.Contains(t, tags, "snmp_host:srl2")
+}
+
+func TestBuildBaseTagsIncludesDeviceResourceTag(t *testing.T) {
+	cfg := &config.CheckConfig{
+		Instance: config.InstanceConfig{Address: "10.0.0.1"},
+	}
+
+	tags := buildBaseTags(cfg, nil)
+	assert.Contains(t, tags, "device_id:default:10.0.0.1")
+	assert.Contains(t, tags, internalDeviceResourceTag("default:10.0.0.1"))
+	assert.NotContains(t, tags, "dd.internal.resource:ndm_interface:")
+}
+
+func TestBuildInterfaceMetadataIncludesMetricPaths(t *testing.T) {
+	snapshot := []client.CachedValue{
+		{
+			Key: client.CacheKey{
+				Path: "/openconfig/interfaces/interface/ethernet/state/port-speed",
+				Keys: map[string]string{"name": "ethernet-1/9"},
+			},
+			Entry: client.CacheEntry{Value: "SPEED_1GB"},
+		},
+	}
+	metricPaths := []string{"/openconfig/interfaces/interface/ethernet/state/port-speed"}
+
+	interfaces := buildInterfaceMetadata("default:srl2", config.DefaultOpenConfigMetadata(), snapshot, metricPaths)
+	require.Len(t, interfaces, 1)
+	assert.Equal(t, "ethernet-1/9", interfaces[0].Name)
 }
 
 func TestReportMetricsValidation(t *testing.T) {

--- a/pkg/collector/corechecks/network-devices/gnmi/report/snapshot.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/snapshot.go
@@ -8,6 +8,7 @@ package report
 import (
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -26,10 +27,19 @@ func indexSnapshot(snapshot []client.CachedValue) snapshotIndex {
 }
 
 func firstStringValue(index snapshotIndex, path string, keys map[string]string) string {
-	for _, cached := range index[path] {
-		if !keysMatch(cached.Key.Keys, keys) {
-			continue
+	if len(keys) > 0 {
+		cached, ok := lookupCachedValue(index, path, keys)
+		if !ok {
+			return ""
 		}
+		value, ok := stringValue(cached.Entry.Value)
+		if !ok {
+			return ""
+		}
+		return value
+	}
+
+	for _, cached := range sortCachedValues(index[path]) {
 		if value, ok := stringValue(cached.Entry.Value); ok {
 			return value
 		}
@@ -37,16 +47,181 @@ func firstStringValue(index snapshotIndex, path string, keys map[string]string) 
 	return ""
 }
 
-func firstInt32Value(index snapshotIndex, path string, keys map[string]string) (int32, bool) {
-	for _, cached := range index[path] {
-		if !keysMatch(cached.Key.Keys, keys) {
+// ResolveDeviceHostname returns the device hostname from the gNMI snapshot.
+func ResolveDeviceHostname(snapshot []client.CachedValue, metadata config.MetadataConfig) string {
+	return resolveDeviceHostname(indexSnapshot(snapshot), metadata)
+}
+
+func resolveDeviceHostname(index snapshotIndex, metadata config.MetadataConfig) string {
+	resolved := metadata.Resolved()
+	if hostname := firstStringValue(index, resolved.Device.Hostname, nil); hostname != "" {
+		return hostname
+	}
+
+	for path, values := range index {
+		if !strings.HasSuffix(path, "/hostname") {
 			continue
 		}
+		for _, cached := range values {
+			if value, ok := stringValue(cached.Entry.Value); ok {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func firstInt32Value(index snapshotIndex, path string, keys map[string]string) (int32, bool) {
+	if len(keys) > 0 {
+		cached, ok := lookupCachedValue(index, path, keys)
+		if !ok {
+			return 0, false
+		}
+		value, ok := int64Value(cached.Entry.Value)
+		if !ok {
+			return 0, false
+		}
+		return int32(value), true
+	}
+
+	for _, cached := range sortCachedValues(index[path]) {
 		if value, ok := int64Value(cached.Entry.Value); ok {
 			return int32(value), true
 		}
 	}
 	return 0, false
+}
+
+func lookupCachedValue(index snapshotIndex, path string, keys map[string]string) (client.CachedValue, bool) {
+	for _, cached := range index[path] {
+		if keysEqual(cached.Key.Keys, keys) {
+			return cached, true
+		}
+	}
+	return client.CachedValue{}, false
+}
+
+func lookupNumericValue(index snapshotIndex, path string, keys map[string]string) (float64, bool) {
+	cached, ok := lookupCachedValue(index, path, keys)
+	if !ok {
+		return 0, false
+	}
+	return decodeNumericValue(cached.Entry.Value)
+}
+
+func indexCachedValuesByKeys(entries []client.CachedValue) map[string]client.CachedValue {
+	indexed := make(map[string]client.CachedValue, len(entries))
+	for _, cached := range entries {
+		indexed[cacheKeysID(cached.Key.Keys)] = cached
+	}
+	return indexed
+}
+
+func cacheKeysID(keys map[string]string) string {
+	if len(keys) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(keys))
+	for name := range keys {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		parts = append(parts, name+"="+keys[name])
+	}
+	return strings.Join(parts, ",")
+}
+
+func pathsShareParent(pathA, pathB string) (string, bool) {
+	parentA, okA := pathParent(pathA)
+	parentB, okB := pathParent(pathB)
+	if !okA || !okB {
+		return "", false
+	}
+	if parentA != parentB {
+		return "", false
+	}
+	return parentA, true
+}
+
+func pathParent(path string) (string, bool) {
+	trimmed := strings.TrimSuffix(path, "/")
+	idx := strings.LastIndex(trimmed, "/")
+	if idx <= 0 {
+		return "", false
+	}
+	return trimmed[:idx], true
+}
+
+func keysEqual(actual, expected map[string]string) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	for key, value := range expected {
+		if actual[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func sortCachedValues(entries []client.CachedValue) []client.CachedValue {
+	if len(entries) <= 1 {
+		return entries
+	}
+	sorted := append([]client.CachedValue(nil), entries...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Key.String() < sorted[j].Key.String()
+	})
+	return sorted
+}
+
+const componentPathSegment = "/components/component/"
+
+func componentNameKey(metadata config.MetadataConfig) string {
+	for _, keyName := range metadata.Resolved().Device.Keys {
+		if keyName != "" {
+			return keyName
+		}
+	}
+	return "name"
+}
+
+func componentNames(index snapshotIndex, metadata config.MetadataConfig) []string {
+	nameKey := componentNameKey(metadata)
+	names := make(map[string]struct{})
+	for path, values := range index {
+		if !strings.Contains(path, componentPathSegment) {
+			continue
+		}
+		for _, cached := range values {
+			if name := cached.Key.Keys[nameKey]; name != "" {
+				names[name] = struct{}{}
+			}
+		}
+	}
+
+	out := make([]string, 0, len(names))
+	for name := range names {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func resolveDeviceComponentName(index snapshotIndex, metadata config.MetadataConfig) string {
+	names := componentNames(index, metadata)
+	if len(names) == 0 {
+		return ""
+	}
+	for _, name := range names {
+		if strings.EqualFold(name, "Chassis") {
+			return name
+		}
+	}
+	return names[0]
 }
 
 func keysMatch(actual, expected map[string]string) bool {

--- a/pkg/collector/corechecks/network-devices/gnmi/report/snapshot_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/snapshot_test.go
@@ -1,0 +1,177 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package report
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/gnmi/client"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/gnmi/config"
+)
+
+func TestFirstStringValueIsDeterministic(t *testing.T) {
+	path := "/openconfig/components/component/state/model-name"
+	index := indexSnapshot([]client.CachedValue{
+		{
+			Key:   client.CacheKey{Path: path, Keys: map[string]string{"name": "FanTray3"}},
+			Entry: client.CacheEntry{Value: "fan-model"},
+		},
+		{
+			Key:   client.CacheKey{Path: path, Keys: map[string]string{"name": "Chassis"}},
+			Entry: client.CacheEntry{Value: "chassis-model"},
+		},
+	})
+
+	assert.Equal(t, "chassis-model", firstStringValue(index, path, map[string]string{"name": "Chassis"}))
+}
+
+func TestPathsShareParent(t *testing.T) {
+	parent, ok := pathsShareParent(
+		"/openconfig/components/component/state/memory/utilized",
+		"/openconfig/components/component/state/memory/available",
+	)
+	assert.True(t, ok)
+	assert.Equal(t, "/openconfig/components/component/state/memory", parent)
+
+	_, ok = pathsShareParent(
+		"/openconfig/components/component/state/memory/utilized",
+		"/openconfig/components/component/state/cpu/utilized",
+	)
+	assert.False(t, ok)
+}
+
+func TestLookupCachedValueRequiresExactKeys(t *testing.T) {
+	path := "/openconfig/components/component/state/memory/utilized"
+	index := indexSnapshot([]client.CachedValue{
+		{
+			Key:   client.CacheKey{Path: path, Keys: map[string]string{"name": "ControlA"}},
+			Entry: client.CacheEntry{Value: int64(25)},
+		},
+		{
+			Key:   client.CacheKey{Path: path, Keys: map[string]string{"name": "FanTray3"}},
+			Entry: client.CacheEntry{Value: int64(10)},
+		},
+	})
+
+	cached, ok := lookupCachedValue(index, path, map[string]string{"name": "ControlA"})
+	require.True(t, ok)
+	value, ok := int64Value(cached.Entry.Value)
+	require.True(t, ok)
+	assert.Equal(t, int64(25), value)
+
+	_, ok = lookupCachedValue(index, path, map[string]string{"name": "FanTray6"})
+	assert.False(t, ok)
+}
+
+func TestResolveDeviceComponentNamePrefersChassis(t *testing.T) {
+	metadata := config.DefaultOpenConfigMetadata()
+	index := indexSnapshot([]client.CachedValue{
+		{
+			Key:   client.CacheKey{Path: metadata.Device.Platform, Keys: map[string]string{"name": "FanTray3"}},
+			Entry: client.CacheEntry{Value: "fan-model"},
+		},
+		{
+			Key:   client.CacheKey{Path: metadata.Device.Platform, Keys: map[string]string{"name": "Chassis"}},
+			Entry: client.CacheEntry{Value: "chassis-model"},
+		},
+	})
+
+	assert.Equal(t, "Chassis", resolveDeviceComponentName(index, metadata))
+}
+
+func TestInterfaceNamesIgnoresComponentMetricPaths(t *testing.T) {
+	metadata := config.DefaultOpenConfigMetadata()
+	index := indexSnapshot([]client.CachedValue{
+		{
+			Key: client.CacheKey{
+				Path: "/openconfig/interfaces/interface/ethernet/state/port-speed",
+				Keys: map[string]string{"name": "ethernet-1/1"},
+			},
+			Entry: client.CacheEntry{Value: "SPEED_1GB"},
+		},
+		{
+			Key: client.CacheKey{
+				Path: "/openconfig/components/component/cpu/utilization/state/instant",
+				Keys: map[string]string{"name": "ControlA"},
+			},
+			Entry: client.CacheEntry{Value: 12.5},
+		},
+		{
+			Key: client.CacheKey{
+				Path: "/openconfig/components/component/state/memory/utilized",
+				Keys: map[string]string{"name": "CPU-ControlA"},
+			},
+			Entry: client.CacheEntry{Value: int64(100)},
+		},
+	})
+
+	profile := config.ProfileDefinition{
+		Metrics: []config.MetricConfig{
+			{
+				Path: "/openconfig/interfaces/interface/ethernet/state/port-speed",
+				Tags: map[string]string{"interface": "name"},
+			},
+			{
+				Path: "/openconfig/components/component/cpu/utilization/state/instant",
+				Keys:   map[string]string{"component": "name"},
+				Tags:   map[string]string{"cpu": "name"},
+			},
+			{
+				Path: "/openconfig/components/component/state/memory/utilized",
+				Keys:   map[string]string{"component": "name"},
+				Tags:   map[string]string{"memory": "name"},
+			},
+		},
+	}
+
+	names := interfaceNames(index, metadata, interfaceMetricPathsFromProfile(profile))
+	assert.Equal(t, []string{"ethernet-1/1"}, names)
+
+	snapshot := []client.CachedValue{
+		{
+			Key: client.CacheKey{
+				Path: "/openconfig/interfaces/interface/ethernet/state/port-speed",
+				Keys: map[string]string{"name": "ethernet-1/1"},
+			},
+			Entry: client.CacheEntry{Value: "SPEED_1GB"},
+		},
+		{
+			Key: client.CacheKey{
+				Path: "/openconfig/components/component/cpu/utilization/state/instant",
+				Keys: map[string]string{"name": "ControlA"},
+			},
+			Entry: client.CacheEntry{Value: 12.5},
+		},
+	}
+	interfaces := buildInterfaceMetadata("default:srl2", metadata, snapshot, interfaceMetricPathsFromProfile(profile))
+	require.Len(t, interfaces, 1)
+	assert.Equal(t, "ethernet-1/1", interfaces[0].Name)
+}
+
+func TestComponentNamesIgnoresInterfacePaths(t *testing.T) {
+	metadata := config.DefaultOpenConfigMetadata()
+	index := indexSnapshot([]client.CachedValue{
+		{
+			Key: client.CacheKey{
+				Path: metadata.Device.Platform,
+				Keys: map[string]string{"name": "Chassis"},
+			},
+			Entry: client.CacheEntry{Value: "7220 IXR"},
+		},
+		{
+			Key: client.CacheKey{
+				Path: "/openconfig/interfaces/interface/state/name",
+				Keys: map[string]string{"name": "ethernet-1/1"},
+			},
+			Entry: client.CacheEntry{Value: "ethernet-1/1"},
+		},
+	})
+
+	assert.Equal(t, []string{"Chassis"}, componentNames(index, metadata))
+}

--- a/pkg/collector/corechecks/network-devices/gnmi/report/topology.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/topology.go
@@ -6,8 +6,8 @@
 package report
 
 import (
+	"net"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/gnmi/client"
@@ -38,12 +38,11 @@ func buildTopologyLinks(deviceID string, topology config.TopologyConfig, snapsho
 		return left < right
 	})
 
-	interfaceIndexByIDType := buildInterfaceIndexByIDType(interfaces)
 	links := make([]devicemetadata.TopologyLinkMetadata, 0, len(neighborKeys))
 
 	for _, keys := range neighborKeys {
 		interfaceName := keys[topology.NeighborInterfaceKey()]
-		neighborID := keys[topology.NeighborIDKey()]
+		neighborKey := keys[topology.NeighborIDKey()]
 
 		remoteChassisIDType := normalizeLLDPIDType(firstStringValue(index, topology.LLDP.ChassisIDType, keys))
 		remoteChassisID := formatLLDPID(remoteChassisIDType, firstStringValue(index, topology.LLDP.ChassisID, keys))
@@ -51,21 +50,27 @@ func buildTopologyLinks(deviceID string, topology config.TopologyConfig, snapsho
 		remotePortIDType := normalizeLLDPIDType(firstStringValue(index, topology.LLDP.PortIDType, keys))
 		remotePortID := formatLLDPID(remotePortIDType, firstStringValue(index, topology.LLDP.PortID, keys))
 
-		localInterfaceID := resolveLocalInterface(deviceID, interfaceIndexByIDType, devicemetadata.IDTypeInterfaceName, interfaceName)
+		remoteName := firstStringValue(index, topology.LLDP.SystemName, keys)
+		remoteMgmtAddress := firstStringValue(index, topology.LLDP.ManagementAddress, keys)
+		remoteMgmtIP := canonicalManagementIPAddress(remoteMgmtAddress)
+		remoteDevice := &devicemetadata.TopologyLinkDevice{
+			Name:        remoteName,
+			Description: firstStringValue(index, topology.LLDP.SystemDescription, keys),
+			ID:          remoteChassisID,
+			IDType:      remoteChassisIDType,
+			IPAddress:   remoteTopologyIPAddress(remoteMgmtIP, remoteMgmtAddress),
+		}
+		if remoteMgmtIP != "" {
+			remoteDevice.DDID = buildDeviceIDFromConfigAddress(remoteMgmtIP)
+		}
 
-		linkID := deviceID + ":" + interfaceName + "." + neighborID
+		linkID := buildTopologyLinkID(deviceID, interfaceName, remoteChassisIDType, remoteChassisID, neighborKey)
 		links = append(links, devicemetadata.TopologyLinkMetadata{
 			ID:          linkID,
 			SourceType:  topologyLinkSourceTypeLLDP,
 			Integration: string(integrations.Gnmi),
 			Remote: &devicemetadata.TopologyLinkSide{
-				Device: &devicemetadata.TopologyLinkDevice{
-					Name:        firstStringValue(index, topology.LLDP.SystemName, keys),
-					Description: firstStringValue(index, topology.LLDP.SystemDescription, keys),
-					ID:          remoteChassisID,
-					IDType:      remoteChassisIDType,
-					IPAddress:   firstStringValue(index, topology.LLDP.ManagementAddress, keys),
-				},
+				Device: remoteDevice,
 				Interface: &devicemetadata.TopologyLinkInterface{
 					ID:          remotePortID,
 					IDType:      remotePortIDType,
@@ -74,7 +79,7 @@ func buildTopologyLinks(deviceID string, topology config.TopologyConfig, snapsho
 			},
 			Local: &devicemetadata.TopologyLinkSide{
 				Interface: &devicemetadata.TopologyLinkInterface{
-					DDID:   localInterfaceID,
+					DDID:   buildInterfaceID(deviceID, interfaceName),
 					ID:     interfaceName,
 					IDType: devicemetadata.IDTypeInterfaceName,
 				},
@@ -86,6 +91,43 @@ func buildTopologyLinks(deviceID string, topology config.TopologyConfig, snapsho
 	}
 
 	return links
+}
+
+// buildTopologyLinkID builds a stable link identifier from the local interface and
+// normalized remote chassis ID. The neighbor list key is only used as a fallback
+// when chassis-id telemetry is missing, and is normalized with the same rules.
+func buildTopologyLinkID(deviceID, interfaceName, remoteChassisIDType, remoteChassisID, neighborKey string) string {
+	neighborToken := remoteChassisID
+	if neighborToken == "" {
+		neighborToken = formatLLDPID(remoteChassisIDType, neighborKey)
+	}
+	return deviceID + ":" + interfaceName + "." + neighborToken
+}
+
+// canonicalManagementIPAddress returns a normalized IP address when the LLDP management
+// address is a parseable IP. Hostnames and other non-IP values return empty string.
+// This matches the SNMP check, which only extracts IPv4 management addresses from the
+// LLDP MIB and never sets remote dd_id from hostnames.
+func canonicalManagementIPAddress(address string) string {
+	trimmed := strings.TrimSpace(address)
+	if trimmed == "" {
+		return ""
+	}
+	ip := net.ParseIP(trimmed)
+	if ip == nil {
+		return ""
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return v4.String()
+	}
+	return ip.String()
+}
+
+func remoteTopologyIPAddress(canonicalIP, rawAddress string) string {
+	if canonicalIP != "" {
+		return canonicalIP
+	}
+	return strings.TrimSpace(rawAddress)
 }
 
 func normalizeLLDPIDType(value string) string {
@@ -113,97 +155,4 @@ func formatLLDPID(idType, idValue string) string {
 		return strings.ToLower(idValue)
 	}
 	return idValue
-}
-
-type interfaceCandidate struct {
-	ifIndex    int32
-	isPhysical bool
-	macAddress string
-}
-
-func resolveLocalInterface(deviceID string, interfaceIndexByIDType map[string]map[string][]interfaceCandidate, localInterfaceIDType string, localInterfaceID string) string {
-	if localInterfaceID == "" {
-		return ""
-	}
-
-	typesToTry := []string{localInterfaceIDType}
-	if localInterfaceIDType == "" {
-		typesToTry = []string{"mac_address", "interface_name", "interface_alias", "interface_index"}
-	}
-
-	matchedCandidates := make(map[int32]interfaceCandidate)
-	for _, idType := range typesToTry {
-		interfaceIndexByIDValue, ok := interfaceIndexByIDType[idType]
-		if !ok {
-			continue
-		}
-		for _, candidate := range interfaceIndexByIDValue[localInterfaceID] {
-			matchedCandidates[candidate.ifIndex] = candidate
-		}
-	}
-
-	if len(matchedCandidates) == 1 {
-		for ifIndex := range matchedCandidates {
-			return deviceID + ":" + formatInt32(ifIndex)
-		}
-	}
-
-	if len(matchedCandidates) > 1 {
-		if physical, ok := singlePhysicalCandidateSharingMAC(matchedCandidates); ok {
-			return deviceID + ":" + formatInt32(physical.ifIndex)
-		}
-	}
-
-	return ""
-}
-
-func singlePhysicalCandidateSharingMAC(candidates map[int32]interfaceCandidate) (interfaceCandidate, bool) {
-	var found interfaceCandidate
-	var physicalCount int
-	var sharedMAC string
-	for _, candidate := range candidates {
-		if candidate.macAddress == "" {
-			return interfaceCandidate{}, false
-		}
-		if sharedMAC == "" {
-			sharedMAC = candidate.macAddress
-		} else if candidate.macAddress != sharedMAC {
-			return interfaceCandidate{}, false
-		}
-		if candidate.isPhysical {
-			found = candidate
-			physicalCount++
-			if physicalCount > 1 {
-				return interfaceCandidate{}, false
-			}
-		}
-	}
-	return found, physicalCount == 1
-}
-
-func buildInterfaceIndexByIDType(interfaces []devicemetadata.InterfaceMetadata) map[string]map[string][]interfaceCandidate {
-	interfaceIndexByIDType := make(map[string]map[string][]interfaceCandidate)
-	for _, idType := range []string{"mac_address", "interface_name", "interface_alias", "interface_index"} {
-		interfaceIndexByIDType[idType] = make(map[string][]interfaceCandidate)
-	}
-
-	for _, devInterface := range interfaces {
-		isPhysical := devInterface.IsPhysical != nil && *devInterface.IsPhysical
-		candidate := interfaceCandidate{
-			ifIndex:    devInterface.Index,
-			isPhysical: isPhysical,
-			macAddress: devInterface.MacAddress,
-		}
-
-		interfaceIndexByIDType["mac_address"][devInterface.MacAddress] = append(interfaceIndexByIDType["mac_address"][devInterface.MacAddress], candidate)
-		interfaceIndexByIDType["interface_name"][devInterface.Name] = append(interfaceIndexByIDType["interface_name"][devInterface.Name], candidate)
-		interfaceIndexByIDType["interface_alias"][devInterface.Alias] = append(interfaceIndexByIDType["interface_alias"][devInterface.Alias], candidate)
-		interfaceIndexByIDType["interface_index"][formatInt32(devInterface.Index)] = append(interfaceIndexByIDType["interface_index"][formatInt32(devInterface.Index)], candidate)
-	}
-
-	return interfaceIndexByIDType
-}
-
-func formatInt32(value int32) string {
-	return strconv.FormatInt(int64(value), 10)
 }

--- a/pkg/collector/corechecks/network-devices/gnmi/report/topology_test.go
+++ b/pkg/collector/corechecks/network-devices/gnmi/report/topology_test.go
@@ -6,6 +6,7 @@
 package report
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,9 +40,11 @@ func TestBuildTopologyLinks(t *testing.T) {
 
 	links := buildTopologyLinks(deviceID, topology, snapshot, interfaces)
 	require.Len(t, links, 1)
+	assert.Equal(t, deviceID+":eth0.00:aa:bb:cc:dd:ee", links[0].ID)
 	assert.Equal(t, topologyLinkSourceTypeLLDP, links[0].SourceType)
 	assert.Equal(t, "gnmi", links[0].Integration)
 	require.NotNil(t, links[0].Remote)
+	assert.Equal(t, "default:10.0.0.9", links[0].Remote.Device.DDID)
 	assert.Equal(t, "remote-switch", links[0].Remote.Device.Name)
 	assert.Equal(t, "mac_address", links[0].Remote.Device.IDType)
 	assert.Equal(t, "00:aa:bb:cc:dd:ee", links[0].Remote.Device.ID)
@@ -49,8 +52,117 @@ func TestBuildTopologyLinks(t *testing.T) {
 	assert.Equal(t, "interface_name", links[0].Remote.Interface.IDType)
 	assert.Equal(t, "Gi0/1", links[0].Remote.Interface.ID)
 	require.NotNil(t, links[0].Local)
-	assert.Equal(t, deviceID+":1", links[0].Local.Interface.DDID)
+	assert.Equal(t, deviceID+":eth0", links[0].Local.Interface.DDID)
 	assert.Equal(t, "eth0", links[0].Local.Interface.ID)
+}
+
+func TestBuildTopologyLinksSRLinuxStyle(t *testing.T) {
+	topology := config.DefaultOpenConfigLLDP()
+	deviceID := "default:srl2"
+	keys := map[string]string{"id": "1A:E1:02:FF:00:00", "name": "ethernet-1/1"}
+	snapshot := []client.CachedValue{
+		{Key: client.CacheKey{Path: topology.LLDP.ChassisIDType, Keys: keys}, Entry: client.CacheEntry{Value: "MAC_ADDRESS"}},
+		{Key: client.CacheKey{Path: topology.LLDP.ChassisID, Keys: keys}, Entry: client.CacheEntry{Value: "1A:E1:02:FF:00:00"}},
+		{Key: client.CacheKey{Path: topology.LLDP.PortIDType, Keys: keys}, Entry: client.CacheEntry{Value: "INTERFACE_NAME"}},
+		{Key: client.CacheKey{Path: topology.LLDP.PortID, Keys: keys}, Entry: client.CacheEntry{Value: "ethernet-1/1"}},
+		{Key: client.CacheKey{Path: topology.LLDP.SystemName, Keys: keys}, Entry: client.CacheEntry{Value: "srl1"}},
+		{Key: client.CacheKey{Path: topology.LLDP.SystemDescription, Keys: keys}, Entry: client.CacheEntry{Value: "SRLinux srl1"}},
+	}
+
+	interfaces := []devicemetadata.InterfaceMetadata{
+		{
+			DeviceID: deviceID,
+			Index:    9,
+			Name:     "ethernet-1/1",
+		},
+	}
+
+	links := buildTopologyLinks(deviceID, topology, snapshot, interfaces)
+	require.Len(t, links, 1)
+	assert.Equal(t, deviceID+":ethernet-1/1.1a:e1:02:ff:00:00", links[0].ID)
+	require.NotNil(t, links[0].Remote)
+	assert.Empty(t, links[0].Remote.Device.DDID)
+	assert.Equal(t, "srl1", links[0].Remote.Device.Name)
+	assert.Equal(t, "1a:e1:02:ff:00:00", links[0].Remote.Device.ID)
+	assert.Equal(t, links[0].Remote.Device.ID, strings.TrimPrefix(links[0].ID, deviceID+":ethernet-1/1."))
+	require.NotNil(t, links[0].Local)
+	assert.Equal(t, deviceID+":ethernet-1/1", links[0].Local.Interface.DDID)
+	assert.Equal(t, "ethernet-1/1", links[0].Local.Interface.ID)
+}
+
+func TestBuildTopologyLinksRemoteDDIDMatchesDeviceIDForManagementIP(t *testing.T) {
+	topology := config.DefaultOpenConfigLLDP()
+	localDeviceID := "default:127.0.0.1"
+	remoteConfigAddress := "10.0.0.9"
+	remoteDeviceID := buildDeviceIDFromConfigAddress(remoteConfigAddress)
+	keys := map[string]string{"name": "ethernet-1/1", "id": "1"}
+	snapshot := []client.CachedValue{
+		{Key: client.CacheKey{Path: topology.LLDP.ChassisIDType, Keys: keys}, Entry: client.CacheEntry{Value: "MAC_ADDRESS"}},
+		{Key: client.CacheKey{Path: topology.LLDP.ChassisID, Keys: keys}, Entry: client.CacheEntry{Value: "00:11:22:33:44:55"}},
+		{Key: client.CacheKey{Path: topology.LLDP.PortIDType, Keys: keys}, Entry: client.CacheEntry{Value: "INTERFACE_NAME"}},
+		{Key: client.CacheKey{Path: topology.LLDP.PortID, Keys: keys}, Entry: client.CacheEntry{Value: "ethernet-1/1"}},
+		{Key: client.CacheKey{Path: topology.LLDP.SystemName, Keys: keys}, Entry: client.CacheEntry{Value: "srl1"}},
+		{Key: client.CacheKey{Path: topology.LLDP.ManagementAddress, Keys: keys}, Entry: client.CacheEntry{Value: "10.0.0.9"}},
+	}
+
+	links := buildTopologyLinks(localDeviceID, topology, snapshot, nil)
+	require.Len(t, links, 1)
+	require.NotNil(t, links[0].Remote)
+
+	assert.Equal(t, remoteDeviceID, links[0].Remote.Device.DDID)
+	assert.Equal(t, remoteDeviceID, buildDeviceID(&config.CheckConfig{
+		Instance: config.InstanceConfig{Address: remoteConfigAddress},
+	}))
+	assert.Equal(t, "10.0.0.9", links[0].Remote.Device.IPAddress)
+}
+
+func TestBuildTopologyLinksRemoteDDIDEmptyForHostnameManagementAddress(t *testing.T) {
+	topology := config.DefaultOpenConfigLLDP()
+	keys := map[string]string{"name": "ethernet-1/1", "id": "1"}
+	snapshot := []client.CachedValue{
+		{Key: client.CacheKey{Path: topology.LLDP.ChassisIDType, Keys: keys}, Entry: client.CacheEntry{Value: "MAC_ADDRESS"}},
+		{Key: client.CacheKey{Path: topology.LLDP.ChassisID, Keys: keys}, Entry: client.CacheEntry{Value: "00:11:22:33:44:55"}},
+		{Key: client.CacheKey{Path: topology.LLDP.ManagementAddress, Keys: keys}, Entry: client.CacheEntry{Value: "srl1"}},
+	}
+
+	links := buildTopologyLinks("default:127.0.0.1", topology, snapshot, nil)
+	require.Len(t, links, 1)
+	require.NotNil(t, links[0].Remote)
+
+	assert.Empty(t, links[0].Remote.Device.DDID)
+	assert.Equal(t, "srl1", links[0].Remote.Device.IPAddress)
+	assert.NotEqual(t, buildDeviceID(&config.CheckConfig{
+		Instance: config.InstanceConfig{Address: "127.0.0.1"},
+	}), links[0].Remote.Device.DDID)
+}
+
+func TestCanonicalManagementIPAddress(t *testing.T) {
+	assert.Equal(t, "10.0.0.9", canonicalManagementIPAddress("10.0.0.9"))
+	assert.Equal(t, "10.0.0.9", canonicalManagementIPAddress(" 10.0.0.9 "))
+	assert.Empty(t, canonicalManagementIPAddress("srl1"))
+	assert.Empty(t, canonicalManagementIPAddress(""))
+}
+
+func TestBuildTopologyLinkIDUsesNormalizedChassisID(t *testing.T) {
+	linkID := buildTopologyLinkID(
+		"default:127.0.0.1",
+		"ethernet-1/1",
+		"mac_address",
+		"1a:e1:02:ff:00:00",
+		"1A:E1:02:FF:00:00",
+	)
+	assert.Equal(t, "default:127.0.0.1:ethernet-1/1.1a:e1:02:ff:00:00", linkID)
+}
+
+func TestBuildTopologyLinkIDFallsBackToNormalizedNeighborKey(t *testing.T) {
+	linkID := buildTopologyLinkID(
+		"default:10.0.0.5",
+		"eth0",
+		"mac_address",
+		"",
+		"00:AA:BB:CC:DD:EE",
+	)
+	assert.Equal(t, "default:10.0.0.5:eth0.00:aa:bb:cc:dd:ee", linkID)
 }
 
 func TestBuildTopologyLinksEmptyWhenNoNeighbors(t *testing.T) {


### PR DESCRIPTION
Part of a stacked gNMI check implementation. Stacked on #56065.