### PR TITLE
Randomize GCP E2E zones

### DIFF
--- a/test/e2e-framework/resources/gcp/environment.go
+++ b/test/e2e-framework/resources/gcp/environment.go
@@ -31,13 +31,7 @@ const (
 	MaxResourceLabelValueLen = 63
 )
 
-var availableZones = []string{
-	"us-central1-a",
-	"us-central1-b",
-	"us-central1-c",
-}
-
-func randomZone() string {
+func randomZone(availableZones []string) string {
 	return availableZones[rand.Intn(len(availableZones))]
 }
 
@@ -98,7 +92,7 @@ func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 	}
 	env.CommonEnvironment = &commonEnv
 	env.envDefault = getEnvironmentDefault(config.FindEnvironmentName(commonEnv.InfraEnvironmentNames(), gcpNamerNamespace))
-	env.envDefault.gcp.zone = randomZone()
+	env.envDefault.gcp.zone = randomZone(env.envDefault.ddInfra.defaultZones)
 
 	if scenario := pulumiConfig.Get(ctx, "scenario"); strings.Contains(scenario, "openshift") {
 		env.envDefault.ddInfra.openshift.nestedVirtualization = true

--- a/test/e2e-framework/resources/gcp/environment.go
+++ b/test/e2e-framework/resources/gcp/environment.go
@@ -7,6 +7,7 @@ package gcp
 
 import (
 	"fmt"
+	"hash/fnv"
 	"os"
 	"os/exec"
 	"strings"
@@ -22,6 +23,7 @@ import (
 const (
 	gcpConfigNamespace = "gcp"
 	gcpNamerNamespace  = "gcp"
+	gcpZoneCount       = 3
 
 	// MaxResourceLabelValueLen is the maximum length allowed by GCP for a
 	// resource label value (in bytes). Values longer than this are rejected
@@ -29,6 +31,15 @@ const (
 	// See https://cloud.google.com/resource-manager/docs/labels-overview.
 	MaxResourceLabelValueLen = 63
 )
+
+// zoneForStack distributes stacks across zones a, b, and c while keeping the
+// selected zone stable when Pulumi evaluates the same stack more than once.
+func zoneForStack(region, stack string) string {
+	hasher := fnv.New64a()
+	_, _ = hasher.Write([]byte(stack))
+	zoneSuffix := byte('a' + hasher.Sum64()%gcpZoneCount)
+	return fmt.Sprintf("%s-%c", region, zoneSuffix)
+}
 
 // TruncateLabelValue truncates v to at most MaxResourceLabelValueLen bytes
 // without splitting a multi-byte UTF-8 rune. GCP rejects label values longer
@@ -87,6 +98,7 @@ func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 	}
 	env.CommonEnvironment = &commonEnv
 	env.envDefault = getEnvironmentDefault(config.FindEnvironmentName(commonEnv.InfraEnvironmentNames(), gcpNamerNamespace))
+	env.envDefault.gcp.zone = zoneForStack(env.envDefault.gcp.region, ctx.Stack())
 
 	if scenario := pulumiConfig.Get(ctx, "scenario"); strings.Contains(scenario, "openshift") {
 		env.envDefault.ddInfra.openshift.nestedVirtualization = true
@@ -106,7 +118,7 @@ func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 	gcpProvider, err := gcp.NewProvider(ctx, string(config.ProviderGCP), &gcp.ProviderArgs{
 		Project:       pulumi.StringPtr(env.envDefault.gcp.project),
 		Region:        pulumi.StringPtr(env.envDefault.gcp.region),
-		Zone:          pulumi.StringPtr(env.envDefault.gcp.zone),
+		Zone:          pulumi.StringPtr(env.Zone()),
 		DefaultLabels: defaultLabels,
 	})
 	if err != nil {

--- a/test/e2e-framework/resources/gcp/environment.go
+++ b/test/e2e-framework/resources/gcp/environment.go
@@ -7,7 +7,6 @@ package gcp
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
 	"os/exec"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/namer"
 	"github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp"
+	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumiConfig "github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
@@ -30,10 +30,6 @@ const (
 	// See https://cloud.google.com/resource-manager/docs/labels-overview.
 	MaxResourceLabelValueLen = 63
 )
-
-func randomZone(availableZones []string) string {
-	return availableZones[rand.Intn(len(availableZones))]
-}
 
 // TruncateLabelValue truncates v to at most MaxResourceLabelValueLen bytes
 // without splitting a multi-byte UTF-8 rune. GCP rejects label values longer
@@ -77,6 +73,7 @@ type Environment struct {
 	Namer namer.Namer
 
 	envDefault environmentDefault
+	randomZone pulumi.StringOutput
 }
 
 var _ config.Env = (*Environment)(nil)
@@ -92,11 +89,19 @@ func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 	}
 	env.CommonEnvironment = &commonEnv
 	env.envDefault = getEnvironmentDefault(config.FindEnvironmentName(commonEnv.InfraEnvironmentNames(), gcpNamerNamespace))
-	env.envDefault.gcp.zone = randomZone(env.envDefault.ddInfra.defaultZones)
 
 	if scenario := pulumiConfig.Get(ctx, "scenario"); strings.Contains(scenario, "openshift") {
 		env.envDefault.ddInfra.openshift.nestedVirtualization = true
 	}
+
+	shuffle, err := random.NewRandomShuffle(env.Ctx(), env.Namer.ResourceName("rnd-zone"), &random.RandomShuffleArgs{
+		Inputs:      pulumi.ToStringArray(env.DefaultZones()),
+		ResultCount: pulumi.IntPtr(1),
+	}, env.WithProviders(config.ProviderRandom))
+	if err != nil {
+		return Environment{}, err
+	}
+	env.randomZone = shuffle.Results.Index(pulumi.Int(0))
 
 	// TODO: Remove this when we find a better way to automatically log in
 	logIn(ctx)
@@ -110,9 +115,11 @@ func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 	}).(pulumi.StringMapOutput)
 
 	gcpProvider, err := gcp.NewProvider(ctx, string(config.ProviderGCP), &gcp.ProviderArgs{
-		Project:       pulumi.StringPtr(env.envDefault.gcp.project),
-		Region:        pulumi.StringPtr(env.envDefault.gcp.region),
-		Zone:          pulumi.StringPtr(env.Zone()),
+		Project: pulumi.StringPtr(env.envDefault.gcp.project),
+		Region:  pulumi.StringPtr(env.envDefault.gcp.region),
+		Zone: env.RandomZone().ApplyT(func(zone string) *string {
+			return &zone
+		}).(pulumi.StringPtrOutput),
 		DefaultLabels: defaultLabels,
 	})
 	if err != nil {
@@ -228,9 +235,18 @@ func (e *Environment) Region() string {
 	return e.GetStringWithDefault(e.InfraConfig, DDInfraDefaultRegionNameParamName, e.envDefault.gcp.region)
 }
 
-// Zone returns the default zone for the GCP environment
-func (e *Environment) Zone() string {
-	return e.GetStringWithDefault(e.InfraConfig, DDInfraDefaultZoneNameParamName, e.envDefault.gcp.zone)
+// DefaultZones returns the zones available to the GCP environment. An explicit
+// defaultZone configuration restricts selection to that zone.
+func (e *Environment) DefaultZones() []string {
+	if zone := e.GetStringWithDefault(e.InfraConfig, DDInfraDefaultZoneNameParamName, ""); zone != "" {
+		return []string{zone}
+	}
+	return e.envDefault.ddInfra.defaultZones
+}
+
+// RandomZone returns the zone selected for the GCP environment.
+func (e *Environment) RandomZone() pulumi.StringOutput {
+	return e.randomZone
 }
 
 // OpenShiftPullSecretPath returns the path to the OpenShift pull secret file

--- a/test/e2e-framework/resources/gcp/environment.go
+++ b/test/e2e-framework/resources/gcp/environment.go
@@ -7,7 +7,7 @@ package gcp
 
 import (
 	"fmt"
-	"hash/fnv"
+	"math/rand"
 	"os"
 	"os/exec"
 	"strings"
@@ -23,7 +23,6 @@ import (
 const (
 	gcpConfigNamespace = "gcp"
 	gcpNamerNamespace  = "gcp"
-	gcpZoneCount       = 3
 
 	// MaxResourceLabelValueLen is the maximum length allowed by GCP for a
 	// resource label value (in bytes). Values longer than this are rejected
@@ -32,13 +31,14 @@ const (
 	MaxResourceLabelValueLen = 63
 )
 
-// zoneForStack distributes stacks across zones a, b, and c while keeping the
-// selected zone stable when Pulumi evaluates the same stack more than once.
-func zoneForStack(region, stack string) string {
-	hasher := fnv.New64a()
-	_, _ = hasher.Write([]byte(stack))
-	zoneSuffix := byte('a' + hasher.Sum64()%gcpZoneCount)
-	return fmt.Sprintf("%s-%c", region, zoneSuffix)
+var availableZones = []string{
+	"us-central1-a",
+	"us-central1-b",
+	"us-central1-c",
+}
+
+func randomZone() string {
+	return availableZones[rand.Intn(len(availableZones))]
 }
 
 // TruncateLabelValue truncates v to at most MaxResourceLabelValueLen bytes
@@ -98,7 +98,7 @@ func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 	}
 	env.CommonEnvironment = &commonEnv
 	env.envDefault = getEnvironmentDefault(config.FindEnvironmentName(commonEnv.InfraEnvironmentNames(), gcpNamerNamespace))
-	env.envDefault.gcp.zone = zoneForStack(env.envDefault.gcp.region, ctx.Stack())
+	env.envDefault.gcp.zone = randomZone()
 
 	if scenario := pulumiConfig.Get(ctx, "scenario"); strings.Contains(scenario, "openshift") {
 		env.envDefault.ddInfra.openshift.nestedVirtualization = true

--- a/test/e2e-framework/resources/gcp/environmentDefaults.go
+++ b/test/e2e-framework/resources/gcp/environmentDefaults.go
@@ -18,7 +18,6 @@ type environmentDefault struct {
 type gcpProvider struct {
 	project string
 	region  string
-	zone    string
 }
 
 type ddInfra struct {
@@ -56,7 +55,6 @@ func agentSandboxDefault() environmentDefault {
 		gcp: gcpProvider{
 			project: "datadog-agent-sandbox",
 			region:  "us-central1",
-			zone:    "us-central1-a",
 		},
 		ddInfra: ddInfra{
 			defaultInstanceType:     "e2-standard-2",
@@ -76,7 +74,6 @@ func agentQaDefault() environmentDefault {
 		gcp: gcpProvider{
 			project: "datadog-agent-qa",
 			region:  "us-central1",
-			zone:    "us-central1-a",
 		},
 		ddInfra: ddInfra{
 			defaultInstanceType:     "e2-standard-2",

--- a/test/e2e-framework/resources/gcp/environmentDefaults.go
+++ b/test/e2e-framework/resources/gcp/environmentDefaults.go
@@ -26,6 +26,7 @@ type ddInfra struct {
 	defaultGKENodeCount     int
 	defaultNetworkName      string
 	defaultSubnetName       string
+	defaultZones            []string
 	defaultVMServiceAccount string
 	gke                     ddInfraGKE
 	openshift               ddInfraOpenShift
@@ -62,6 +63,7 @@ func agentSandboxDefault() environmentDefault {
 			defaultGKENodeCount:     1,
 			defaultNetworkName:      "datadog-agent-sandbox-us-central1",
 			defaultSubnetName:       "datadog-agent-sandbox-us-central1-private",
+			defaultZones:            []string{"us-central1-a", "us-central1-b", "us-central1-c"},
 			defaultVMServiceAccount: "vmserviceaccount@datadog-agent-sandbox.iam.gserviceaccount.com",
 			gke:                     ddInfraGKE{autopilot: false},
 			openshift:               ddInfraOpenShift{nestedVirtualization: false},
@@ -81,6 +83,7 @@ func agentQaDefault() environmentDefault {
 			defaultGKENodeCount:     1,
 			defaultNetworkName:      "datadog-agent-qa-us-central1",
 			defaultSubnetName:       "datadog-agent-qa-us-central1-private",
+			defaultZones:            []string{"us-central1-a", "us-central1-b", "us-central1-c"},
 			defaultVMServiceAccount: "vmserviceaccount@datadog-agent-qa.iam.gserviceaccount.com",
 			gke:                     ddInfraGKE{autopilot: false},
 			openshift:               ddInfraOpenShift{nestedVirtualization: false},

--- a/test/e2e-framework/resources/gcp/environment_test.go
+++ b/test/e2e-framework/resources/gcp/environment_test.go
@@ -12,16 +12,6 @@ import (
 	"unicode/utf8"
 )
 
-func TestRandomZone(t *testing.T) {
-	availableZones := []string{"zone-a", "zone-b", "zone-c"}
-	for range 100 {
-		zone := randomZone(availableZones)
-		if !slices.Contains(availableZones, zone) {
-			t.Fatalf("randomZone() = %q, want one of %v", zone, availableZones)
-		}
-	}
-}
-
 func TestEnvironmentDefaultZones(t *testing.T) {
 	wantZones := []string{"us-central1-a", "us-central1-b", "us-central1-c"}
 	for _, envName := range []string{agentSandboxEnv, agentQaEnv} {

--- a/test/e2e-framework/resources/gcp/environment_test.go
+++ b/test/e2e-framework/resources/gcp/environment_test.go
@@ -6,10 +6,32 @@
 package gcp
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"unicode/utf8"
 )
+
+func TestZoneForStack(t *testing.T) {
+	const region = "us-central1"
+	seen := make(map[string]bool, gcpZoneCount)
+
+	for i := 0; i < 100; i++ {
+		stack := fmt.Sprintf("stack-%d", i)
+		zone := zoneForStack(region, stack)
+		if zone != region+"-a" && zone != region+"-b" && zone != region+"-c" {
+			t.Fatalf("zoneForStack(%q, %q) = %q, want a zone in %s-{a,b,c}", region, stack, zone, region)
+		}
+		if got := zoneForStack(region, stack); got != zone {
+			t.Fatalf("zoneForStack(%q, %q) returned %q then %q", region, stack, zone, got)
+		}
+		seen[zone] = true
+	}
+
+	if len(seen) != gcpZoneCount {
+		t.Fatalf("zoneForStack used %d zones, want %d", len(seen), gcpZoneCount)
+	}
+}
 
 func TestTruncateLabelValue(t *testing.T) {
 	tests := []struct {

--- a/test/e2e-framework/resources/gcp/environment_test.go
+++ b/test/e2e-framework/resources/gcp/environment_test.go
@@ -6,30 +6,23 @@
 package gcp
 
 import (
-	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"unicode/utf8"
 )
 
-func TestZoneForStack(t *testing.T) {
-	const region = "us-central1"
-	seen := make(map[string]bool, gcpZoneCount)
-
-	for i := 0; i < 100; i++ {
-		stack := fmt.Sprintf("stack-%d", i)
-		zone := zoneForStack(region, stack)
-		if zone != region+"-a" && zone != region+"-b" && zone != region+"-c" {
-			t.Fatalf("zoneForStack(%q, %q) = %q, want a zone in %s-{a,b,c}", region, stack, zone, region)
-		}
-		if got := zoneForStack(region, stack); got != zone {
-			t.Fatalf("zoneForStack(%q, %q) returned %q then %q", region, stack, zone, got)
-		}
-		seen[zone] = true
+func TestRandomZone(t *testing.T) {
+	wantZones := []string{"us-central1-a", "us-central1-b", "us-central1-c"}
+	if !slices.Equal(availableZones, wantZones) {
+		t.Fatalf("availableZones = %v, want %v", availableZones, wantZones)
 	}
 
-	if len(seen) != gcpZoneCount {
-		t.Fatalf("zoneForStack used %d zones, want %d", len(seen), gcpZoneCount)
+	for range 100 {
+		zone := randomZone()
+		if !slices.Contains(availableZones, zone) {
+			t.Fatalf("randomZone() = %q, want one of %v", zone, availableZones)
+		}
 	}
 }
 

--- a/test/e2e-framework/resources/gcp/environment_test.go
+++ b/test/e2e-framework/resources/gcp/environment_test.go
@@ -13,15 +13,20 @@ import (
 )
 
 func TestRandomZone(t *testing.T) {
-	wantZones := []string{"us-central1-a", "us-central1-b", "us-central1-c"}
-	if !slices.Equal(availableZones, wantZones) {
-		t.Fatalf("availableZones = %v, want %v", availableZones, wantZones)
-	}
-
+	availableZones := []string{"zone-a", "zone-b", "zone-c"}
 	for range 100 {
-		zone := randomZone()
+		zone := randomZone(availableZones)
 		if !slices.Contains(availableZones, zone) {
 			t.Fatalf("randomZone() = %q, want one of %v", zone, availableZones)
+		}
+	}
+}
+
+func TestEnvironmentDefaultZones(t *testing.T) {
+	wantZones := []string{"us-central1-a", "us-central1-b", "us-central1-c"}
+	for _, envName := range []string{agentSandboxEnv, agentQaEnv} {
+		if got := getEnvironmentDefault(envName).ddInfra.defaultZones; !slices.Equal(got, wantZones) {
+			t.Errorf("getEnvironmentDefault(%q).ddInfra.defaultZones = %v, want %v", envName, got, wantZones)
 		}
 	}
 }

--- a/test/e2e-framework/resources/gcp/gke/cluster.go
+++ b/test/e2e-framework/resources/gcp/gke/cluster.go
@@ -70,7 +70,7 @@ func NewCluster(e gcp.Environment, name string, autopilot bool, opts ...pulumi.R
 	if !autopilot {
 		clusterArgs.InitialNodeCount = pulumi.Int(e.DefaultGKENodeCount())
 		clusterArgs.NodeVersion = pulumi.String(e.KubernetesVersion())
-		clusterArgs.NodeLocations = pulumi.StringArray{pulumi.String(e.Zone())}
+		clusterArgs.NodeLocations = pulumi.StringArray{e.RandomZone()}
 		clusterArgs.NodeConfig = &container.ClusterNodeConfigArgs{
 			MachineType: pulumi.String(e.DefaultInstanceType()),
 			OauthScopes: pulumi.StringArray{


### PR DESCRIPTION
<!-- dd-meta {"pullId":"33d579ce-b6bc-4b4a-88c0-c1a9766b0e05","source":"chat","resourceId":"e5c1126f-09d0-4623-a349-a124b7c2525f","workflowId":"844d2e37-1672-44e2-8bd8-0c037d8c87ee","codeChangeId":"844d2e37-1672-44e2-8bd8-0c037d8c87ee","sourceType":"chat"} -->
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

- Defines the available GCP E2E zones per account as `us-central1-a`, `us-central1-b`, and `us-central1-c`.
- Uses a Pulumi `RandomShuffle` resource to select one zone and retain it in stack state across previews and updates.
- Uses the same selected zone for the GCP provider and GKE node locations.
- Preserves the explicit `gcp/defaultZone` override by treating it as the only selection candidate.
- Adds unit coverage for the per-account zone configuration.

### Motivation

GCP E2E infrastructure currently defaults to `us-central1-a`, concentrating all test resources in one availability zone. The selection must be randomized across supported zones without rerolling on every Pulumi evaluation and replacing existing infrastructure.

### Describe how you validated your changes

- Formatted the changed Go files with Go 1.26.3 `gofmt`.
- `git diff --check` passes.
- Attempted `GOENV_VERSION=1.26.3 dda inv test --targets=./test/e2e-framework/resources/gcp`; the repository task could not compile the tests because the sandbox failed to download Bazel 9.2.0 (`Bad Gateway`).

### Additional Notes

The stateful selection follows the same Pulumi `RandomShuffle` pattern used for AWS subnet selection.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/e5c1126f-09d0-4623-a349-a124b7c2525f)

Comment @datadog to request changes