### PR TITLE
[overhead] bound log pattern tag registry

### DIFF
--- a/comp/anomalydetection/observer/impl/log_pattern_extractor.go
+++ b/comp/anomalydetection/observer/impl/log_pattern_extractor.go
@@ -164,8 +164,7 @@ func (e *LogPatternExtractor) Name() string {
 }
 
 // Reset clears clustering state so reanalysis starts from the currently
-// observed logs. The registry is kept so that previously registered hashes
-// remain resolvable.
+// observed logs.
 func (e *LogPatternExtractor) Reset() {
 	e.taggedClusterer.Reset()
 	e.NextGarbageCollectionTime = 0

--- a/comp/anomalydetection/observer/impl/log_tagged_pattern_clusterer.go
+++ b/comp/anomalydetection/observer/impl/log_tagged_pattern_clusterer.go
@@ -60,8 +60,8 @@ func tagGroupByKeyHash(c TagGroupByKey) uint64 {
 	return h.Sum64()
 }
 
-// TagGroupByKeyRegistry is a bidirectional, append-only store between a uint64 hash
-// and a TagGroupByKey. It is NOT thread-safe; access must be confined to a single goroutine.
+// TagGroupByKeyRegistry stores active tag groups by their stable uint64 hash.
+// It is NOT thread-safe; access must be confined to a single goroutine.
 type TagGroupByKeyRegistry struct {
 	byHash map[uint64]TagGroupByKey
 }
@@ -75,16 +75,28 @@ func NewTagGroupByKeyRegistry() *TagGroupByKeyRegistry {
 // Calling Register twice with the same group returns the same hash.
 func (r *TagGroupByKeyRegistry) Register(group TagGroupByKey) uint64 {
 	hash := tagGroupByKeyHash(group)
+	r.register(hash, group)
+	return hash
+}
+
+func (r *TagGroupByKeyRegistry) register(hash uint64, group TagGroupByKey) {
 	if _, exists := r.byHash[hash]; !exists {
 		r.byHash[hash] = group
 	}
-	return hash
 }
 
 // Lookup returns the TagGroupByKey for the given hash, and whether it was found.
 func (r *TagGroupByKeyRegistry) Lookup(hash uint64) (TagGroupByKey, bool) {
 	group, ok := r.byHash[hash]
 	return group, ok
+}
+
+func (r *TagGroupByKeyRegistry) delete(hash uint64) {
+	delete(r.byHash, hash)
+}
+
+func (r *TagGroupByKeyRegistry) reset() {
+	r.byHash = make(map[uint64]TagGroupByKey)
 }
 
 // extractTagGroupByKey scans a flat "key:value" tag slice and extracts the
@@ -207,7 +219,7 @@ func NewTaggedPatternClustererWithFactory(registry *TagGroupByKeyRegistry, newPC
 // the next Process call to avoid silently dropping eviction context.
 func (tc *TaggedPatternClusterer) Process(tags []string, message string, unixSec int64) (uint64, *patterns.Cluster, bool) {
 	group := extractTagGroupByKey(tags)
-	groupHash := tc.registry.Register(group)
+	groupHash := tagGroupByKeyHash(group)
 
 	sub, exists := tc.subClusterers[groupHash]
 	if !exists {
@@ -231,6 +243,7 @@ func (tc *TaggedPatternClusterer) Process(tags []string, message string, unixSec
 		// eviction or LRU bookkeeping is needed.
 		return 0, nil, false
 	}
+	tc.registry.register(groupHash, group)
 
 	// Process accepted the message; only now do we commit the new
 	// sub-clusterer (and evict the LRU group if we've hit the cap).
@@ -266,8 +279,7 @@ func (tc *TaggedPatternClusterer) Process(tags []string, message string, unixSec
 // adding a new group would exceed MaxTagGroups. The about-to-be-added groupHash
 // is excluded from eviction. All clusters belonging to the evicted group are
 // surfaced via DrainLRUEvictions and the group is removed from
-// lastTouchByGroup. The group's hash remains in the registry (registry is
-// append-only by design).
+// lastTouchByGroup and the tag-group registry.
 //
 // Implementation: pops stale entries off touchHeap (entries whose touch no
 // longer matches lastTouchByGroup, or whose hash has already been deleted)
@@ -302,8 +314,7 @@ func (tc *TaggedPatternClusterer) evictLRUTagGroupIfOverCap(incoming uint64) {
 					tc.lruEvicted = append(tc.lruEvicted, EvictedCluster{GroupHash: top.hash, ClusterID: c.ID})
 				}
 			}
-			delete(tc.subClusterers, top.hash)
-			delete(tc.lastTouchByGroup, top.hash)
+			tc.removeTagGroup(top.hash)
 			return
 		}
 	}
@@ -333,8 +344,13 @@ func (tc *TaggedPatternClusterer) evictLRUTagGroupIfOverCap(incoming uint64) {
 			tc.lruEvicted = append(tc.lruEvicted, EvictedCluster{GroupHash: victim, ClusterID: c.ID})
 		}
 	}
-	delete(tc.subClusterers, victim)
-	delete(tc.lastTouchByGroup, victim)
+	tc.removeTagGroup(victim)
+}
+
+func (tc *TaggedPatternClusterer) removeTagGroup(groupHash uint64) {
+	delete(tc.subClusterers, groupHash)
+	delete(tc.lastTouchByGroup, groupHash)
+	tc.registry.delete(groupHash)
 }
 
 // heapCompactionThreshold sets when maybeCompactTouchHeap rebuilds touchHeap
@@ -407,11 +423,10 @@ func (tc *TaggedPatternClusterer) GetCluster(groupHash uint64, clusterID int64) 
 	return sub.GetCluster(clusterID)
 }
 
-// Reset drops all sub-clusterers. The registry is intentionally kept so that
-// previously registered hashes remain resolvable after a reset. LRU bookkeeping
-// (lastTouchByGroup, pending evictions) is also cleared.
+// Reset drops all sub-clusterers, registered groups, and LRU bookkeeping.
 func (tc *TaggedPatternClusterer) Reset() {
 	tc.subClusterers = make(map[uint64]*patterns.PatternClusterer)
+	tc.registry.reset()
 	tc.lastTouchByGroup = nil
 	tc.touchHeap = nil
 	tc.lruEvicted = nil
@@ -441,6 +456,11 @@ func (tc *TaggedPatternClusterer) GarbageCollectBefore(cutoff int64) []EvictedCl
 		}
 		if len(stale) > 0 {
 			_ = sub.RemoveClusters(stale)
+		}
+		if sub.NumClusters() == 0 {
+			// Keep the empty clusterer so a reappearing pattern receives a new
+			// cluster ID, but release the tag strings retained by the registry.
+			tc.registry.delete(groupHash)
 		}
 	}
 	return evicted

--- a/comp/anomalydetection/observer/impl/log_tagged_pattern_clusterer_test.go
+++ b/comp/anomalydetection/observer/impl/log_tagged_pattern_clusterer_test.go
@@ -6,6 +6,7 @@
 package observerimpl
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -166,10 +167,8 @@ func TestTaggedPatternClusterer_ResetDropsSubClusterers(t *testing.T) {
 	tc.Reset()
 	assert.Equal(t, 0, tc.NumSubClusterers())
 
-	// Registry must still resolve the hash after reset.
-	group, found := reg.Lookup(groupHash)
-	require.True(t, found)
-	assert.Equal(t, "api", group.Service)
+	_, found := reg.Lookup(groupHash)
+	assert.False(t, found, "reset must release registered tag groups")
 }
 
 func TestTaggedPatternClusterer_GlobalClusterHashIsStable(t *testing.T) {
@@ -218,7 +217,8 @@ func TestTaggedPatternClusterer_MaxClustersPerGroupPropagated(t *testing.T) {
 }
 
 func TestTaggedPatternClusterer_MaxTagGroupsEvictsLRUGroup(t *testing.T) {
-	tc := NewTaggedPatternClusterer(NewTagGroupByKeyRegistry())
+	registry := NewTagGroupByKeyRegistry()
+	tc := NewTaggedPatternClusterer(registry)
 	tc.MaxTagGroups = 2
 
 	tagsA := []string{"service:a"}
@@ -249,6 +249,12 @@ func TestTaggedPatternClusterer_MaxTagGroupsEvictsLRUGroup(t *testing.T) {
 	for _, ev := range evicted {
 		require.Equal(t, hashB, ev.GroupHash, "all evictions tagged with the evicted group's hash")
 	}
+	_, found := registry.Lookup(hashB)
+	assert.False(t, found, "LRU eviction must release the tag-group registry entry")
+	_, found = registry.Lookup(hashA)
+	assert.True(t, found)
+	_, found = registry.Lookup(hashC)
+	assert.True(t, found)
 }
 
 // TestTaggedPatternClusterer_EmptyMessageFromNewGroupDoesNotEvict regresses
@@ -265,7 +271,8 @@ func TestTaggedPatternClusterer_MaxTagGroupsEvictsLRUGroup(t *testing.T) {
 // ok. This test confirms an empty message from a new group at-cap is a
 // no-op for both the existing groups and the eviction queue.
 func TestTaggedPatternClusterer_EmptyMessageFromNewGroupDoesNotEvict(t *testing.T) {
-	tc := NewTaggedPatternClusterer(NewTagGroupByKeyRegistry())
+	registry := NewTagGroupByKeyRegistry()
+	tc := NewTaggedPatternClusterer(registry)
 	tc.MaxTagGroups = 2
 
 	tagsA := []string{"service:a"}
@@ -288,12 +295,63 @@ func TestTaggedPatternClusterer_EmptyMessageFromNewGroupDoesNotEvict(t *testing.
 		require.Empty(t, tc.DrainLRUEvictions(),
 			"empty msg from new group at-cap must NOT evict an existing group")
 	}
+	_, found := registry.Lookup(tagGroupByKeyHash(TagGroupByKey{Service: "c"}))
+	assert.False(t, found, "rejected logs must not leave registry entries behind")
 
 	// Both original groups must still be reachable after the empty stream.
 	gotA, _, _ := tc.Process(tagsA, "alpha", 1300)
 	require.Equal(t, hashA, gotA, "group A must survive a stream of empty new-group messages")
 	gotB, _, _ := tc.Process(tagsB, "beta", 1301)
 	require.Equal(t, hashB, gotB, "group B must survive a stream of empty new-group messages")
+}
+
+func TestTaggedPatternClusterer_GarbageCollectionReleasesRegistryEntries(t *testing.T) {
+	tc, registry := newTestTaggedClusterer()
+	tc.MaxTagGroups = 2
+
+	hashA, _, ok := tc.Process([]string{"service:a"}, "alpha", 1000)
+	require.True(t, ok)
+	hashB, _, ok := tc.Process([]string{"service:b"}, "beta", 1100)
+	require.True(t, ok)
+
+	evicted := tc.GarbageCollectBefore(1050)
+	require.Len(t, evicted, 1)
+	assert.Equal(t, hashA, evicted[0].GroupHash)
+	_, found := registry.Lookup(hashA)
+	assert.False(t, found, "GC must release a tag group after its final cluster expires")
+	_, found = registry.Lookup(hashB)
+	assert.True(t, found)
+
+	evicted = tc.GarbageCollectBefore(1200)
+	require.Len(t, evicted, 1)
+	assert.Equal(t, hashB, evicted[0].GroupHash)
+	assert.Empty(t, registry.byHash)
+
+	// Empty clusterers retain only bounded hash/counter bookkeeping so a
+	// reappearing pattern does not reuse an evicted metric name.
+	assert.Equal(t, 2, tc.NumSubClusterers())
+	reappearedHash, cluster, ok := tc.Process([]string{"service:a"}, "alpha", 1300)
+	require.True(t, ok)
+	assert.Equal(t, hashA, reappearedHash)
+	assert.Equal(t, int64(1), cluster.ID)
+	group, found := registry.Lookup(hashA)
+	require.True(t, found)
+	assert.Equal(t, "a", group.Service)
+}
+
+func TestTaggedPatternClusterer_RegistryRemainsBoundedByTagGroupCap(t *testing.T) {
+	registry := NewTagGroupByKeyRegistry()
+	tc := NewTaggedPatternClusterer(registry)
+	tc.MaxTagGroups = 2
+
+	for i := 0; i < 100; i++ {
+		_, _, ok := tc.Process([]string{fmt.Sprintf("service:%d", i)}, "message", int64(1000+i))
+		require.True(t, ok)
+		tc.DrainLRUEvictions()
+	}
+
+	assert.Equal(t, 2, tc.NumSubClusterers())
+	assert.Len(t, registry.byHash, 2)
 }
 
 func TestTaggedPatternClusterer_DrainLRUEvictionsIsOneShot(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Bounds the log-pattern tag-group registry to active pattern state. Rejected logs are registered only after acceptance, while LRU eviction, TTL expiration, and reset release retained tag values.

Empty clusterers remain bounded by `MaxTagGroups` to preserve cluster IDs and avoid reusing evicted metric names.

### Motivation

The registry was append-only, so historical `(source, service, env, host)` combinations accumulated for the Agent's lifetime despite the existing tag-group cap and pattern TTL.

### Describe how you validated your changes

Added coverage for rejected logs, LRU and TTL eviction, reset, cluster-ID preservation, and registry cardinality under tag-group churn.
