### PR TITLE
fix(privateactionrunner): attach TUF proof provider

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -170,6 +170,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 	if err != nil {
 		return Provides{}, err
 	}
+	taskverifier.SetProofProvider(reqs.KeysManager, runner.rcClient)
 	runner.keysManager = reqs.KeysManager
 	runner.ownsMetricsClient = true
 	reqs.Lifecycle.Append(compdef.Hook{
@@ -198,6 +199,7 @@ func NewExecutorComponent(reqs Requires) (Provides, error) {
 	if err != nil {
 		return Provides{}, err
 	}
+	taskverifier.SetProofProvider(reqs.KeysManager, runner.rcClient)
 	runner.keysManager = reqs.KeysManager
 	runner.ownsMetricsClient = true
 	runner.shutdowner = reqs.Shutdowner

--- a/pkg/privateactionrunner/task-verifier/keys_manager.go
+++ b/pkg/privateactionrunner/task-verifier/keys_manager.go
@@ -27,6 +27,7 @@ type UpdateCallback func(map[string]state.RawConfig, func(string, state.ApplySta
 
 type keysManager struct {
 	rcClient               rcclient.Client
+	proofProvider          rcclient.Client
 	stopChan               chan bool
 	keys                   map[string]storedKey
 	mu                     sync.RWMutex
@@ -44,8 +45,21 @@ func NewKeyManager(rcClient rcclient.Client) KeysManager {
 	manager, _ := NewKeyManagerWithCallback()
 	if manager, ok := manager.(*keysManager); ok {
 		manager.rcClient = rcClient
+		manager.proofProvider = rcClient
 	}
 	return manager
+}
+
+// SetProofProvider attaches the Remote Config proof provider to a key manager
+// whose update callback was registered eagerly through Fx. Keeping this
+// separate from rcClient avoids subscribing the manager a second time when it
+// starts.
+func SetProofProvider(manager KeysManager, provider rcclient.Client) {
+	if manager, ok := manager.(*keysManager); ok {
+		manager.mu.Lock()
+		manager.proofProvider = provider
+		manager.mu.Unlock()
+	}
 }
 
 // NewKeyManagerWithCallback returns a key manager and the callback to register
@@ -69,14 +83,15 @@ func (k *keysManager) Start(ctx context.Context) {
 func (k *keysManager) GetKey(keyId string) (types.DecodedKey, *types.DirectorKeyProof) {
 	k.mu.RLock()
 	entry, ok := k.keys[keyId]
+	proofProvider := k.proofProvider
 	k.mu.RUnlock()
 	if !ok {
 		return nil, nil
 	}
-	if k.rcClient == nil {
+	if proofProvider == nil {
 		return entry.key, nil
 	}
-	proof, ok := k.rcClient.GetConfigTUFProof(entry.targetPath)
+	proof, ok := proofProvider.GetConfigTUFProof(entry.targetPath)
 	if !ok {
 		return entry.key, nil
 	}

--- a/pkg/privateactionrunner/task-verifier/keys_manager_test.go
+++ b/pkg/privateactionrunner/task-verifier/keys_manager_test.go
@@ -71,3 +71,40 @@ func TestKeysManagerReturnsDirectorProofForKeyTarget(t *testing.T) {
 	assert.Equal(t, rcClient.proof.TargetPath, proof.TargetPath)
 	assert.Equal(t, rcClient.proof.TargetFile, proof.TargetFile)
 }
+
+func TestEagerKeysManagerReturnsDirectorProofAfterProviderAttached(t *testing.T) {
+	const targetPath = "datadog/42/AP_RUNNER_KEYS/key-1/config"
+	public, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKIXPublicKey(public)
+	require.NoError(t, err)
+	rawKey, err := json.Marshal(types.RawKey{
+		KeyType: types.KeyTypeED25519,
+		Key:     pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}),
+	})
+	require.NoError(t, err)
+
+	rcClient := &proofRCClient{proof: state.ConfigTUFProof{
+		Roots:      [][]byte{[]byte("root-2")},
+		Targets:    []byte("targets"),
+		TargetPath: targetPath,
+		TargetFile: rawKey,
+	}}
+	manager, callback := NewKeyManagerWithCallback()
+	callback(map[string]state.RawConfig{
+		targetPath: {
+			Config: rawKey,
+			Metadata: state.Metadata{
+				ID:      "key-1",
+				Product: state.ProductActionPlatformRunnerKeys,
+			},
+		},
+	}, func(string, state.ApplyStatus) {})
+
+	SetProofProvider(manager, rcClient)
+
+	key, proof := manager.GetKey("key-1")
+	require.NotNil(t, key)
+	require.NotNil(t, proof)
+	assert.Equal(t, rcClient.proof.TargetPath, proof.TargetPath)
+}


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Privileged rshell commands failed with `verified Director proof is required for privileged execution` even though the signing key existed. The eagerly registered key manager stored the key sent a nil Director proof, so it always failed.

This change attaches the TUF (the the update framework?) proof provider to the PAR key manager, allowing it to return both signing keys and their Director proofs. It preserves the existing Fx callback registration and avoids subscribing to Remote Config a second time.

### Motivation
Bugfix

### Describe how you validated your changes
Manually tested on VM

### Additional Notes
