### PR TITLE
Carve out analysis_test subject-helper exception in label-literal rule

### DIFF
--- a/bazel/codereview_guideline.md
+++ b/bazel/codereview_guideline.md
@@ -73,8 +73,8 @@ Labels must be string literals and must never be split across lines. Automated t
 handle split or computed label values. Flag any `deps`, `srcs`, or other label lists that construct label strings via
 `+`, `%`, or line continuation.
 
-**Exception: `analysis_test` subject helpers.** A common idiom with `analysis_test` is to use a helper
-function that builds a test subjects (e.g. a `filegroup` or intermediate target) whose name is
+**Exception: `analysis_test` subject helpers.** A common idiom wraps `analysis_test` in a helper
+function that builds a test subject (e.g. a `filegroup` or intermediate target) whose name is
 derived from the test's own `name` parameter, so that multiple invocations of the helper don't
 clash on target names. Computing a subject label from `name + "_subject"` inside such a helper is
 expected and should not be flagged — the label is still a literal at the point the underlying rule

--- a/bazel/codereview_guideline.md
+++ b/bazel/codereview_guideline.md
@@ -73,6 +73,15 @@ Labels must be string literals and must never be split across lines. Automated t
 handle split or computed label values. Flag any `deps`, `srcs`, or other label lists that construct label strings via
 `+`, `%`, or line continuation.
 
+**Exception: `analysis_test` subject helpers.** A common idiom with `analysis_test` is to use a helper
+function that builds a test subjects (e.g. a `filegroup` or intermediate target) whose name is
+derived from the test's own `name` parameter, so that multiple invocations of the helper don't
+clash on target names. Computing a subject label from `name + "_subject"` inside such a helper is
+expected and should not be flagged — the label is still a literal at the point the underlying rule
+is instantiated, it's simply parameterized per call site. Do flag computed labels used to reference
+targets that already exist elsewhere in the tree (i.e. `deps`/`srcs` pointing at something outside
+the helper's own generated targets).
+
 ## Shell portability
 
 `genrule`, `sh_binary`, `sh_test`, and `ctx.actions.run_shell` require Bash and are non-portable:


### PR DESCRIPTION
## What does this change do

Adds an exception to the Bazel code-review guideline's "labels must be string literals" rule for `analysis_test` subject-helper idioms, where a helper computes a per-call-site subject label (e.g. `name + "_subject"`) to avoid target-name clashes across invocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)