### PR TITLE
Replace deprecated golang.org/x/net/http2 usage with net/http stdlib

### DIFF
--- a/comp/api/api/apiimpl/BUILD.bazel
+++ b/comp/api/api/apiimpl/BUILD.bazel
@@ -51,7 +51,6 @@ dd_agent_go_test(
         "@com_github_prometheus_client_model//go",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_net//http2",
         "@org_uber_go_fx//:fx",
     ],
 )

--- a/comp/api/api/apiimpl/api_test.go
+++ b/comp/api/api/apiimpl/api_test.go
@@ -15,8 +15,6 @@ import (
 	"strconv"
 	"testing"
 
-	"golang.org/x/net/http2"
-
 	"github.com/DataDog/datadog-agent/comp/api/api/apiimpl/observability"
 	api "github.com/DataDog/datadog-agent/comp/api/api/def"
 	grpc "github.com/DataDog/datadog-agent/comp/api/grpcserver/def"
@@ -245,11 +243,14 @@ func TestStartServerWithGrpcServer(t *testing.T) {
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/grpc")
 
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetHTTP2(true)
 	transport := &http.Transport{
 		TLSClientConfig: deps.IPC.GetTLSClientConfig(),
+		Protocols:       protocols,
 	}
 
-	http2.ConfigureTransport(transport)
 	http2Client := &http.Client{
 		Transport: transport,
 	}
@@ -290,11 +291,14 @@ func TestStartServerWithoutGrpcServer(t *testing.T) {
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/grpc")
 
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetHTTP2(true)
 	transport := &http.Transport{
 		TLSClientConfig: deps.IPC.GetTLSClientConfig(),
+		Protocols:       protocols,
 	}
 
-	http2.ConfigureTransport(transport)
 	http2Client := &http.Client{
 		Transport: transport,
 	}

--- a/comp/logs-library/client/http/BUILD.bazel
+++ b/comp/logs-library/client/http/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//pkg/util/http",
         "//pkg/util/log",
         "//pkg/version",
-        "@org_golang_x_net//http2",
     ],
 )
 

--- a/comp/logs-library/client/http/test_utils.go
+++ b/comp/logs-library/client/http/test_utils.go
@@ -19,8 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-
-	"golang.org/x/net/http2"
 )
 
 // StatusCodeContainer is a lock around the status code to return
@@ -105,15 +103,8 @@ func NewTestHTTPSServer(forceHTTP1 bool) *httptest.Server {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	// Configure the server to support HTTP/2
-	if !forceHTTP1 {
-		err := http2.ConfigureServer(testServer.Config, &http2.Server{})
-		if err != nil {
-			panic(err)
-		}
-		testServer.TLS = testServer.Config.TLSConfig
-	}
-	// Start the server with TLS
+	// Enable HTTP/2 support unless HTTP/1 is forced
+	testServer.EnableHTTP2 = !forceHTTP1
 	testServer.StartTLS()
 
 	return testServer

--- a/pkg/privateactionrunner/adapters/httpclient/BUILD.bazel
+++ b/pkg/privateactionrunner/adapters/httpclient/BUILD.bazel
@@ -5,8 +5,5 @@ go_library(
     srcs = ["adapter.go"],
     importpath = "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/httpclient",
     visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/privateactionrunner/adapters/logging",
-        "@org_golang_x_net//http2",
-    ],
+    deps = ["//pkg/privateactionrunner/adapters/logging"],
 )

--- a/pkg/privateactionrunner/adapters/httpclient/adapter.go
+++ b/pkg/privateactionrunner/adapters/httpclient/adapter.go
@@ -6,8 +6,6 @@
 package httpclient
 
 import (
-	"context"
-	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -15,7 +13,6 @@ import (
 	"time"
 
 	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
-	"golang.org/x/net/http2"
 )
 
 // Authorizer describes security authorization gates for HTTP clients.
@@ -68,18 +65,10 @@ func WrapClient(client *http.Client, az Authorizer) *http.Client {
 
 	// Decorate the transport with the safe dialer
 	switch tr := transport.(type) {
-	case *http2.Transport:
-		tr.DialTLSContext = func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
-			tlsDialer := &tls.Dialer{
-				NetDialer: dialer,
-				Config:    cfg,
-			}
-			return tlsDialer.DialContext(ctx, network, addr)
-		}
 	case *http.Transport:
 		tr.DialContext = dialer.DialContext
 	default:
-		log.Errorf("client.Transport is of type %T, not of type *http.Transport or *http2.Transport, replacing with the default transporter", client.Transport)
+		log.Errorf("client.Transport is of type %T, not of type *http.Transport, replacing with the default transporter", client.Transport)
 		transport = defaultTransport
 		transport.(*http.Transport).DialContext = dialer.DialContext
 	}

--- a/pkg/util/http/BUILD.bazel
+++ b/pkg/util/http/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/config/model",
         "//pkg/util/log",
         "@org_golang_x_net//http/httpproxy",
-        "@org_golang_x_net//http2",
     ],
 )
 

--- a/pkg/util/http/transport.go
+++ b/pkg/util/http/transport.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"golang.org/x/net/http/httpproxy"
-	"golang.org/x/net/http2"
 
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -225,10 +224,9 @@ func GetProxyTransportFunc(p *pkgconfigmodel.Proxy, cfg pkgconfigmodel.Reader) f
 // WithHTTP2 returns a http2 as a transport option
 func WithHTTP2() func(*http.Transport) {
 	return func(transport *http.Transport) {
-		err := http2.ConfigureTransport(transport)
-		if err != nil {
-			log.Warnf("Failed to configure HTTP/2 transport: %v. Resolving to best available protocol", err)
-		}
+		transport.Protocols = new(http.Protocols)
+		transport.Protocols.SetHTTP1(true)
+		transport.Protocols.SetHTTP2(true)
 	}
 }
 

--- a/pkg/util/http/transport_test.go
+++ b/pkg/util/http/transport_test.go
@@ -207,19 +207,9 @@ func TestCreateHTTP2Transport(t *testing.T) {
 	transport := CreateHTTPTransport(c, WithHTTP2())
 	require.NotNil(t, transport)
 
-	// x/net/http2 v0.56.0+ compiles different code on Go 1.27+
-	// (transport_wrap.go, //go:build go1.27 && !http2legacy): it registers HTTP/2
-	// via the new transport.Protocols API rather than the old TLSNextProto map.
-	// Check whichever mechanism is active so the test works on all Go versions.
-	if transport.Protocols != nil {
-		assert.True(t, transport.Protocols.HTTP2(), "Protocols should indicate HTTP/2 support")
-		assert.True(t, transport.Protocols.HTTP1(), "Protocols should allow HTTP/1.1 fallback")
-	} else {
-		assert.NotNil(t, transport.TLSNextProto)
-		assert.Contains(t, transport.TLSNextProto, "h2", "TLSNextProto should indicate HTTP/2 support")
-		assert.Contains(t, transport.TLSClientConfig.NextProtos, "h2", "NextProtos should prefer HTTP/2")
-		assert.Contains(t, transport.TLSClientConfig.NextProtos, "http/1.1", "NextProtos should allow fallback to HTTP/1.1")
-	}
+	require.NotNil(t, transport.Protocols)
+	assert.True(t, transport.Protocols.HTTP2(), "Protocols should indicate HTTP/2 support")
+	assert.True(t, transport.Protocols.HTTP1(), "Protocols should allow HTTP/1.1 fallback")
 }
 
 func TestNoProxyWarningMap(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Replaces deprecated `golang.org/x/net/http2` usages with stdlib `net/http` equivalents:
- `http2.ConfigureTransport` → `http.Transport.Protocols` (`SetHTTP1` + `SetHTTP2`)
- `http2.ConfigureServer` (test helper) → `httptest.Server.EnableHTTP2`
- drops the `*http2.Transport` case in the private action runner client wrapper (no caller uses it; unknown transports already fall back to the safe default)

### Motivation

x/net v0.59.0 deprecates these symbols, failing lint (SA1019) in the dependency bump PR #56107.

### Describe how you validated your changes

CI

### Additional Notes

No behavior change: HTTP/2 stays opt-in with HTTP/1.1 fallback.