### PR TITLE
chore(devx): add Zed Go development configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,9 +256,10 @@ AUTO_JIRA.md
 .codex/*
 !.codex/config.toml
 
-# Zed config (commit the shared MCP config; ignore everything else)
+# Zed config (commit shared project config; ignore everything else)
 .zed/*
 !.zed/settings.json
+!.zed/tasks.json
 
 # Devcontainer
 .devcontainer/

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,4 +1,38 @@
 {
+  "languages": {
+    "Go": {
+      "format_on_save": "on",
+      "formatter": "language_server"
+    }
+  },
+  "lsp": {
+    "gopls": {
+      "initialization_options": {
+        "buildFlags": [
+          "-tags=anomalydetectiontestbench,cel,clusterchecks,consul,containerd,cri,crio,docker,ec2,etcd,fargateprocess,grpcnotrace,jetson,jmx,kubeapiserver,kubelet,ncm,netcgo,nvml,oracle,orchestrator,otlp,podman,python,retrynotrace,sharedlibrarycheck,systemd,systemprobechecks,test,trivy,trivy_no_javadb,zk,zlib,zstd",
+          "-buildvcs=false"
+        ],
+        "codelenses": {
+          "test": true
+        },
+        "directoryFilters": [
+          // The rtloader tests require native cgo headers. To work on them, remove this
+          // filter and set lsp.gopls.binary.env.CGO_CFLAGS to
+          // "-I<repo>/rtloader/include -I<repo>/rtloader/common -Wno-deprecated-declarations".
+          "-rtloader/test",
+          "-test/integration"
+        ],
+        "local": "github.com/DataDog/datadog-agent"
+      }
+    },
+    "ruff": {
+      "initialization_options": {
+        "settings": {
+          "configurationPreference": "filesystemFirst"
+        }
+      }
+    }
+  },
   "context_servers": {
     "dd-api": {
       "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=all"

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,19 @@
+[
+  {
+    "label": "dda inv test $ZED_SYMBOL",
+    "command": "dda",
+    "args": [
+      "inv",
+      "test",
+      "--targets",
+      "./$ZED_RELATIVE_DIR",
+      "--test-run-name",
+      "^$ZED_SYMBOL$",
+      "--rtloader-root",
+      "$ZED_WORKTREE_ROOT/rtloader"
+    ],
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "tags": ["go-test"],
+    "save": "current"
+  }
+]


### PR DESCRIPTION
### What does this PR do?

Configure Zed's Go support with the Agent's build tags and workspace filters. Add a `go-test` task that routes inline Go test runnables through `dda inv test`.

### Motivation

Zed otherwise reports false-positive diagnostics for tagged and generated code, while its default Go test action uses raw `go test` without the Agent-specific build and rtloader configuration.

### Describe how you validated your changes

https://github.com/user-attachments/assets/85c7901e-126f-48de-ad3c-c7a42989e0df
