### PR TITLE
[CWS] Parse "trace id" pprof label

### DIFF
--- a/pkg/security/resolvers/golabelsctx/resolver.go
+++ b/pkg/security/resolvers/golabelsctx/resolver.go
@@ -41,8 +41,13 @@ const (
 	maxPairs   = 10
 
 	// keys published by dd-trace-go as goroutine pprof labels
-	spanIDKey  = "span id"
-	traceIDKey = "local root span id"
+	spanIDKey = "span id"
+	// legacyTraceIDKey is the low-64-bits-only decimal trace id label. Older
+	// dd-trace-go versions publish it.
+	legacyTraceIDKey = "local root span id"
+	// fullTraceIDKey is the full 128-bit trace id, encoded as a 32-character
+	// lowercase hex string.
+	fullTraceIDKey = "trace id"
 )
 
 // kernelLabelPair mirrors struct go_label_pair_t
@@ -79,7 +84,9 @@ func (r *Resolver) Resolve(ctxID uint32) (spanID uint64, traceID utils.TraceID, 
 		return 0, utils.TraceID{}, fmt.Errorf("%w: `%d` vs `%d`", ErrStaleID, ctxID, entry.ID)
 	}
 
-	for i := 0; i < maxPairs; i++ {
+	var legacyTraceIDVal, fullTraceIDVal string
+
+	for i := range entry.Pairs {
 		pair := &entry.Pairs[i]
 		if pair.KeyLen == 0 {
 			continue
@@ -88,9 +95,18 @@ func (r *Resolver) Resolve(ctxID uint32) (spanID uint64, traceID utils.TraceID, 
 		switch labelString(pair.Key[:], pair.KeyLen) {
 		case spanIDKey:
 			spanID = parseDecimal(labelString(pair.Val[:], pair.ValLen))
-		case traceIDKey:
-			traceID.Lo = parseDecimal(labelString(pair.Val[:], pair.ValLen))
+		case legacyTraceIDKey:
+			legacyTraceIDVal = labelString(pair.Val[:], pair.ValLen)
+		case fullTraceIDKey:
+			fullTraceIDVal = labelString(pair.Val[:], pair.ValLen)
 		}
+	}
+
+	// The full trace id wins
+	if hi, lo, ok := parseHexTraceID(fullTraceIDVal); ok {
+		traceID.Hi, traceID.Lo = hi, lo
+	} else {
+		traceID.Lo = parseDecimal(legacyTraceIDVal)
 	}
 
 	return spanID, traceID, nil
@@ -114,6 +130,34 @@ func parseDecimal(s string) uint64 {
 		return 0
 	}
 	return v
+}
+
+// parseHexTraceID parses the "trace id" label's 32-char lowercase hex value
+// (hi, lo).
+func parseHexTraceID(s string) (hi, lo uint64, ok bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, 0, false
+	}
+
+	split := max(len(s)-16, 0)
+
+	lo, err := strconv.ParseUint(s[split:], 16, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	if split == 0 {
+		// Less than 16 characters means we only have the low half.
+		return 0, lo, true
+	}
+
+	hi, err = strconv.ParseUint(s[:split], 16, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	return hi, lo, true
 }
 
 // Start the go labels context resolver


### PR DESCRIPTION
### What does this PR do?

Parses the "trace id" pprof label for the span context resolution.

### Motivation

This is the path to record a full 128 bits trace id.

### Describe how you validated your changes

The changes have been validated using system-tests and custom agent and dd-trace-go images to see
if a full 128 bits trace was correctly produced by the agent.

### Additional Notes

The Go side of the patch is not merged yet: https://github.com/DataDog/dd-trace-go/pull/5114
The DD Go Span tests may fail once the dd-trace-go release ships the above PR since it looks for the 'local root span id': We should keep an eye on it.
