### PR TITLE
Validate client stats ddsketch index mappings

### DIFF
--- a/pkg/trace/stats/BUILD.bazel
+++ b/pkg/trace/stats/BUILD.bazel
@@ -54,6 +54,7 @@ dd_agent_go_test(
         "//pkg/trace/traceutil",
         "@com_github_datadog_datadog_go_v5//statsd",
         "@com_github_datadog_sketches_go//ddsketch",
+        "@com_github_datadog_sketches_go//ddsketch/mapping",
         "@com_github_datadog_sketches_go//ddsketch/pb/sketchpb",
         "@com_github_google_gofuzz//:gofuzz",
         "@com_github_stretchr_testify//assert",

--- a/pkg/trace/stats/client_stats_aggregator.go
+++ b/pkg/trace/stats/client_stats_aggregator.go
@@ -6,6 +6,10 @@
 package stats
 
 import (
+	"errors"
+	"fmt"
+	"math"
+	"runtime"
 	"sync"
 	"time"
 
@@ -29,10 +33,13 @@ const (
 	bucketDuration       = 2 * time.Second
 	clientBucketDuration = 10 * time.Second
 	oldestBucketStart    = 20 * time.Second
+
+	maxRelativeAccuracy = 0.5 // a mapping above this bound is treated as malformed
 )
 
 var (
 	ddsketchMapping, _ = mapping.NewLogarithmicMapping(relativeAccuracy)
+	logger             = log.NewThrottled(5, 10*time.Second) // no more than 5 messages every 10 seconds
 )
 
 // ClientStatsAggregator aggregates client stats payloads on buckets of bucketDuration
@@ -171,6 +178,13 @@ func (a *ClientStatsAggregator) getAggregationBucketTime(now, bs time.Time) time
 
 // add takes a new ClientStatsPayload and aggregates its stats in the internal buckets.
 func (a *ClientStatsAggregator) add(now time.Time, p *pb.ClientStatsPayload) {
+	// A malformed payload must not take down the trace-agent.
+	defer func() {
+		if r := recover(); r != nil {
+			a.onAggregationPanic(r)
+		}
+	}()
+
 	// populate container tags data on the payload
 	a.setVersionDataFromContainerTags(p)
 	p.ProcessTagsHash = processTagsHash(p.ProcessTags)
@@ -196,6 +210,14 @@ func (a *ClientStatsAggregator) add(now time.Time, p *pb.ClientStatsPayload) {
 		b.processTags[p.ProcessTagsHash] = p.ProcessTags
 		b.aggregateStatsBucket(clientBucket, payloadAggKey)
 	}
+}
+
+// onAggregationPanic reports a panic recovered while aggregating a payload. It
+// records what watchdog.LogOnPanic would have, without re-raising.
+func (a *ClientStatsAggregator) onAggregationPanic(r any) {
+	buf := make([]byte, 4096)
+	length := runtime.Stack(buf, false)
+	logger.Error("Recovered from panic aggregating client stats, dropping payload: %v\n%s", r, buf[:length])
 }
 
 func (a *ClientStatsAggregator) flushPayloads(p []*pb.ClientStatsPayload) {
@@ -291,21 +313,11 @@ func (b *bucket) aggregateStatsBucket(sb *pb.ClientStatsBucket, payloadAggKey Pa
 
 		// Decode, if needed, the raw ddsketches from the first payload that reached the bucket
 		if len(agg.okDistributionRaw) > 0 {
-			sketch, err := decodeSketch(agg.okDistributionRaw)
-			if err != nil {
-				log.Errorf("Unable to decode OK distribution ddsketch: %v", err)
-			} else {
-				agg.okDistribution = normalizeSketch(sketch)
-			}
+			agg.okDistribution = decodeAndNormalize(agg.okDistributionRaw, "OK")
 			agg.okDistributionRaw = nil
 		}
 		if len(agg.errDistributionRaw) > 0 {
-			sketch, err := decodeSketch(agg.errDistributionRaw)
-			if err != nil {
-				log.Errorf("Unable to decode Error distribution ddsketch: %v", err)
-			} else {
-				agg.errDistribution = normalizeSketch(sketch)
-			}
+			agg.errDistribution = decodeAndNormalize(agg.errDistributionRaw, "Error")
 			agg.errDistributionRaw = nil
 		}
 
@@ -313,13 +325,13 @@ func (b *bucket) aggregateStatsBucket(sb *pb.ClientStatsBucket, payloadAggKey Pa
 		if sketch, err := mergeSketch(agg.okDistribution, gs.OkSummary); err == nil {
 			agg.okDistribution = sketch
 		} else {
-			log.Errorf("Unable to merge OK distribution ddsketch: %v", err)
+			logger.Error("Unable to merge OK distribution ddsketch: %v", err)
 		}
 
 		if sketch, err := mergeSketch(agg.errDistribution, gs.ErrorSummary); err == nil {
 			agg.errDistribution = sketch
 		} else {
-			log.Errorf("Unable to merge Error distribution ddsketch: %v", err)
+			logger.Error("Unable to merge Error distribution ddsketch: %v", err)
 		}
 	}
 }
@@ -342,7 +354,8 @@ func (b *bucket) aggregationToPayloads() []*pb.ClientStatsPayload {
 				Start:    uint64(b.ts.UnixNano()),
 				Duration: uint64(clientBucketDuration.Nanoseconds()),
 				Stats:    groupedStats,
-			}}
+			},
+		}
 		res = append(res, &pb.ClientStatsPayload{
 			Hostname:        payloadKey.Hostname,
 			Env:             payloadKey.Env,
@@ -469,7 +482,15 @@ func mergeSketch(s1 *ddsketch.DDSketch, raw []byte) (*ddsketch.DDSketch, error) 
 	if err != nil {
 		return s1, err
 	}
-	s2 = normalizeSketch(s2)
+	s2, err = normalizeSketch(s2)
+	if err != nil {
+		return s1, err
+	}
+	// A rejected sketch leaves nothing to merge. MergeWith dereferences its
+	// argument's index mapping, so it must never be reached with a nil sketch.
+	if s2 == nil {
+		return s1, nil
+	}
 
 	if s1 == nil {
 		return s2, nil
@@ -481,16 +502,57 @@ func mergeSketch(s1 *ddsketch.DDSketch, raw []byte) (*ddsketch.DDSketch, error) 
 	return s1, nil
 }
 
-func normalizeSketch(s *ddsketch.DDSketch) *ddsketch.DDSketch {
+// validMapping reports whether m is well formed.
+func validMapping(m mapping.IndexMapping) bool {
+	if m == nil {
+		return false
+	}
+	minValue, maxValue := m.MinIndexableValue(), m.MaxIndexableValue()
+	if math.IsNaN(minValue) || math.IsNaN(maxValue) {
+		return false
+	}
+	if minValue <= 0 || maxValue <= minValue || math.IsInf(maxValue, 0) {
+		return false
+	}
+	accuracy := m.RelativeAccuracy()
+	return !math.IsNaN(accuracy) && accuracy > 0 && accuracy < maxRelativeAccuracy
+}
+
+// normalizeSketch re-maps s onto the agent's canonical mapping.
+func normalizeSketch(s *ddsketch.DDSketch) (*ddsketch.DDSketch, error) {
 	if s == nil {
-		return nil
+		return nil, nil
+	}
+	if s.IndexMapping == nil {
+		return nil, errors.New("sketch has no index mapping")
 	}
 	if s.IndexMapping.Equals(ddsketchMapping) {
 		// already normalized
-		return s
+		return s, nil
+	}
+	if !validMapping(s.IndexMapping) {
+		return nil, fmt.Errorf("refusing to normalize sketch with degenerate index mapping (relative accuracy %g, indexable range [%g, %g])",
+			s.IndexMapping.RelativeAccuracy(), s.IndexMapping.MinIndexableValue(), s.IndexMapping.MaxIndexableValue())
 	}
 
-	return s.ChangeMapping(ddsketchMapping, store.NewCollapsingLowestDenseStore(maxNumBins), store.NewCollapsingLowestDenseStore(maxNumBins), 1)
+	return s.ChangeMapping(ddsketchMapping, store.NewCollapsingLowestDenseStore(maxNumBins), store.NewCollapsingLowestDenseStore(maxNumBins), 1), nil
+}
+
+// decodeAndNormalize decodes a raw client sketch and re-maps it onto the agent's
+// canonical mapping, returning nil if either step fails. kind names the
+// distribution for logging.
+func decodeAndNormalize(raw []byte, kind string) *ddsketch.DDSketch {
+	sketch, err := decodeSketch(raw)
+	if err != nil {
+		logger.Error("Unable to decode %s distribution ddsketch: %v", kind, err)
+		return nil
+	}
+	sketch, err = normalizeSketch(sketch)
+	if err != nil {
+		logger.Error("Unable to normalize %s distribution ddsketch: %v", kind, err)
+		return nil
+	}
+	return sketch
 }
 
 func decodeSketch(data []byte) (*ddsketch.DDSketch, error) {

--- a/pkg/trace/stats/client_stats_aggregator.go
+++ b/pkg/trace/stats/client_stats_aggregator.go
@@ -536,11 +536,13 @@ func normalizeSketch(s *ddsketch.DDSketch) (*ddsketch.DDSketch, error) {
 // canonical mapping, returning nil if either step fails.
 func decodeAndNormalize(raw []byte) *ddsketch.DDSketch {
 	sketch, err := decodeSketch(raw)
-	if err == nil {
-		sketch, err = normalizeSketch(sketch)
-	}
 	if err != nil {
 		logger.Error("Unable to decode distribution ddsketch: %v", err)
+		return nil
+	}
+	sketch, err = normalizeSketch(sketch)
+	if err != nil {
+		logger.Error("Unable to normalize distribution ddsketch: %v", err)
 		return nil
 	}
 	return sketch

--- a/pkg/trace/stats/client_stats_aggregator.go
+++ b/pkg/trace/stats/client_stats_aggregator.go
@@ -307,11 +307,11 @@ func (b *bucket) aggregateStatsBucket(sb *pb.ClientStatsBucket, payloadAggKey Pa
 
 		// Decode, if needed, the raw ddsketches from the first payload that reached the bucket
 		if len(agg.okDistributionRaw) > 0 {
-			agg.okDistribution = decodeAndNormalize(agg.okDistributionRaw, "OK")
+			agg.okDistribution = decodeAndNormalize(agg.okDistributionRaw)
 			agg.okDistributionRaw = nil
 		}
 		if len(agg.errDistributionRaw) > 0 {
-			agg.errDistribution = decodeAndNormalize(agg.errDistributionRaw, "Error")
+			agg.errDistribution = decodeAndNormalize(agg.errDistributionRaw)
 			agg.errDistributionRaw = nil
 		}
 
@@ -533,17 +533,14 @@ func normalizeSketch(s *ddsketch.DDSketch) (*ddsketch.DDSketch, error) {
 }
 
 // decodeAndNormalize decodes a raw client sketch and re-maps it onto the agent's
-// canonical mapping, returning nil if either step fails. kind names the
-// distribution for logging.
-func decodeAndNormalize(raw []byte, kind string) *ddsketch.DDSketch {
+// canonical mapping, returning nil if either step fails.
+func decodeAndNormalize(raw []byte) *ddsketch.DDSketch {
 	sketch, err := decodeSketch(raw)
-	if err != nil {
-		logger.Error("Unable to decode %s distribution ddsketch: %v", kind, err)
-		return nil
+	if err == nil {
+		sketch, err = normalizeSketch(sketch)
 	}
-	sketch, err = normalizeSketch(sketch)
 	if err != nil {
-		logger.Error("Unable to normalize %s distribution ddsketch: %v", kind, err)
+		logger.Error("Unable to decode distribution ddsketch: %v", err)
 		return nil
 	}
 	return sketch

--- a/pkg/trace/stats/client_stats_aggregator.go
+++ b/pkg/trace/stats/client_stats_aggregator.go
@@ -181,7 +181,9 @@ func (a *ClientStatsAggregator) add(now time.Time, p *pb.ClientStatsPayload) {
 	// A malformed payload must not take down the trace-agent.
 	defer func() {
 		if r := recover(); r != nil {
-			a.onAggregationPanic(r)
+			buf := make([]byte, 4096)
+			length := runtime.Stack(buf, false)
+			logger.Error("Recovered from panic aggregating client stats, dropping payload: %v\n%s", r, buf[:length])
 		}
 	}()
 
@@ -210,14 +212,6 @@ func (a *ClientStatsAggregator) add(now time.Time, p *pb.ClientStatsPayload) {
 		b.processTags[p.ProcessTagsHash] = p.ProcessTags
 		b.aggregateStatsBucket(clientBucket, payloadAggKey)
 	}
-}
-
-// onAggregationPanic reports a panic recovered while aggregating a payload. It
-// records what watchdog.LogOnPanic would have, without re-raising.
-func (a *ClientStatsAggregator) onAggregationPanic(r any) {
-	buf := make([]byte, 4096)
-	length := runtime.Stack(buf, false)
-	logger.Error("Recovered from panic aggregating client stats, dropping payload: %v\n%s", r, buf[:length])
 }
 
 func (a *ClientStatsAggregator) flushPayloads(p []*pb.ClientStatsPayload) {

--- a/pkg/trace/stats/client_stats_aggregator_test.go
+++ b/pkg/trace/stats/client_stats_aggregator_test.go
@@ -6,6 +6,7 @@
 package stats
 
 import (
+	"math"
 	"math/rand"
 	"sync"
 	"testing"
@@ -18,6 +19,8 @@ import (
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/sketches-go/ddsketch"
+	"github.com/DataDog/sketches-go/ddsketch/mapping"
+	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"google.golang.org/protobuf/proto"
@@ -137,7 +140,9 @@ func generateTestSketch(t *testing.T) *ddsketch.DDSketch {
 		v := rand.NormFloat64()
 		sketch.Add(v)
 	}
-	return normalizeSketch(sketch)
+	normalized, err := normalizeSketch(sketch)
+	assert.NoError(t, err)
+	return normalized
 }
 
 func encodeTestSketch(t *testing.T, s *ddsketch.DDSketch) []byte {
@@ -195,7 +200,7 @@ func duplicateStats(insertionTime time.Time, p *pb.ClientStatsPayload, times uin
 				copy(okSumBytes, stat.OkSummary)
 
 				okSummary, _ := decodeSketch(stat.OkSummary)
-				okSummary = normalizeSketch(okSummary)
+				okSummary, _ = normalizeSketch(okSummary)
 
 				mergeSketch(okSummary, okSumBytes)
 				stat.OkSummary, _ = proto.Marshal(okSummary.ToProto())
@@ -205,7 +210,7 @@ func duplicateStats(insertionTime time.Time, p *pb.ClientStatsPayload, times uin
 				copy(errSumBytes, stat.ErrorSummary)
 
 				errSummary, _ := decodeSketch(stat.ErrorSummary)
-				errSummary = normalizeSketch(errSummary)
+				errSummary, _ = normalizeSketch(errSummary)
 
 				mergeSketch(errSummary, errSumBytes)
 
@@ -1111,4 +1116,163 @@ func deepCopyGroupedStats(s []*pb.ClientGroupedStats) []*pb.ClientGroupedStats {
 		}
 	}
 	return stats
+}
+
+// degenerateSketchBytes returns an encoded sketch whose index mapping has a
+// gamma large enough that its bucket lower bounds overflow to +Inf. sketches-go
+// only rejects gamma <= 1, so this decodes successfully; re-mapping it onto the
+// agent's mapping used to index out of the bounds of a collapsing store and
+// panic. Two bin counts are required: a single-bin sketch is re-mapped through a
+// path that does not compute a lower bound.
+func degenerateSketchBytes(t *testing.T) []byte {
+	t.Helper()
+	msg := &sketchpb.DDSketch{
+		Mapping: &sketchpb.IndexMapping{
+			Gamma:         math.MaxFloat64,
+			Interpolation: sketchpb.IndexMapping_NONE,
+		},
+		PositiveValues: &sketchpb.Store{BinCounts: map[int32]float64{1: 1, 2: 1}},
+		NegativeValues: &sketchpb.Store{},
+	}
+	data, err := proto.Marshal(msg)
+	require.NoError(t, err)
+	return data
+}
+
+func TestValidMapping(t *testing.T) {
+	canonical, err := mapping.NewLogarithmicMapping(relativeAccuracy)
+	require.NoError(t, err)
+	finer, err := mapping.NewLogarithmicMapping(0.005)
+	require.NoError(t, err)
+	// Passes the gamma > 1 check in sketches-go but is degenerate: both
+	// indexable bounds come out finite (4 and 0) yet inverted, and the relative
+	// accuracy is 1.
+	overflowing, err := mapping.NewLogarithmicMappingWithGamma(math.MaxFloat64, 0)
+	require.NoError(t, err)
+	coarse, err := mapping.NewLogarithmicMapping(0.9)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name  string
+		m     mapping.IndexMapping
+		valid bool
+	}{
+		{"nil", nil, false},
+		{"canonical", canonical, true},
+		{"finer", finer, true},
+		{"overflowing gamma", overflowing, false},
+		{"too coarse", coarse, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.valid, validMapping(tc.m))
+		})
+	}
+}
+
+func TestNormalizeSketch(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		s, err := normalizeSketch(nil)
+		assert.NoError(t, err)
+		assert.Nil(t, s)
+	})
+
+	t.Run("canonical mapping is returned as is", func(t *testing.T) {
+		in, err := ddsketch.LogCollapsingLowestDenseDDSketch(relativeAccuracy, maxNumBins)
+		require.NoError(t, err)
+		require.NoError(t, in.Add(1))
+		out, err := normalizeSketch(in)
+		assert.NoError(t, err)
+		assert.Same(t, in, out)
+	})
+
+	t.Run("finer mapping is normalized", func(t *testing.T) {
+		in, err := ddsketch.LogCollapsingLowestDenseDDSketch(0.005, maxNumBins)
+		require.NoError(t, err)
+		require.NoError(t, in.Add(1))
+		require.NoError(t, in.Add(1000))
+		out, err := normalizeSketch(in)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		assert.True(t, out.IndexMapping.Equals(ddsketchMapping))
+		assert.Equal(t, 2.0, out.GetCount())
+	})
+
+	t.Run("degenerate mapping is rejected", func(t *testing.T) {
+		in, err := decodeSketch(degenerateSketchBytes(t))
+		require.NoError(t, err)
+		require.NotNil(t, in)
+		out, err := normalizeSketch(in)
+		assert.Error(t, err)
+		assert.Nil(t, out)
+	})
+}
+
+func TestMergeSketchDegenerate(t *testing.T) {
+	raw := degenerateSketchBytes(t)
+
+	t.Run("no existing sketch", func(t *testing.T) {
+		out, err := mergeSketch(nil, raw)
+		assert.Error(t, err)
+		assert.Nil(t, out)
+	})
+
+	t.Run("existing sketch is preserved", func(t *testing.T) {
+		s1 := generateTestSketch(t)
+		count := s1.GetCount()
+		out, err := mergeSketch(s1, raw)
+		assert.Error(t, err)
+		assert.Same(t, s1, out)
+		assert.Equal(t, count, out.GetCount())
+	})
+}
+
+// TestAggregatorDegenerateSketch covers the full aggregation path: a client
+// sends the same degenerate sketch twice, so the second payload forces the
+// aggregator to decode and re-map the first one. The counts must survive and
+// only the distributions are dropped.
+func TestAggregatorDegenerateSketch(t *testing.T) {
+	a := newTestAggregator()
+	msw := &mockStatsWriter{}
+	a.writer = msw
+	testTime := time.Unix(time.Now().Unix(), 0)
+	raw := degenerateSketchBytes(t)
+	k := BucketsAggregationKey{Service: "s", Name: "n", Resource: "r"}
+
+	for i := 0; i < 2; i++ {
+		p := payloadWithCounts(testTime, k, "", "test-version", "", "", "", 11, 7, 100)
+		p.Stats[0].Stats[0].OkSummary = raw
+		p.Stats[0].Stats[0].ErrorSummary = raw
+		a.add(testTime, p)
+	}
+
+	a.flushOnTime(testTime.Add(oldestBucketStart + time.Nanosecond))
+	require.Len(t, msw.payloads, 1)
+	stats := msw.payloads[0].Stats[0].Stats[0].Stats
+	require.Len(t, stats, 1)
+	assert.Equal(t, uint64(22), stats[0].Hits)
+	assert.Equal(t, uint64(14), stats[0].Errors)
+	assert.Equal(t, uint64(200), stats[0].Duration)
+	assert.Nil(t, stats[0].OkSummary)
+	assert.Nil(t, stats[0].ErrorSummary)
+	assert.Len(t, a.buckets, 0)
+}
+
+// TestAggregatorAddRecovers checks that a panic while aggregating one payload
+// drops that payload instead of taking down the trace-agent, and that the
+// aggregator's lock is released so later payloads still go through.
+func TestAggregatorAddRecovers(t *testing.T) {
+	a := newTestAggregator()
+	msw := &mockStatsWriter{}
+	a.writer = msw
+	testTime := time.Unix(time.Now().Unix(), 0)
+
+	assert.NotPanics(t, func() { a.add(testTime, nil) })
+
+	k := BucketsAggregationKey{Service: "s"}
+	a.add(testTime, payloadWithCounts(testTime, k, "", "test-version", "", "", "", 11, 7, 100))
+	a.flushOnTime(testTime.Add(oldestBucketStart + time.Nanosecond))
+	require.Len(t, msw.payloads, 1)
+	stats := msw.payloads[0].Stats[0].Stats[0].Stats
+	require.Len(t, stats, 1)
+	assert.Equal(t, uint64(11), stats[0].Hits)
 }

--- a/releasenotes/notes/client-stats-sketch-validation-3d9a1c4f8b2e5607.yaml
+++ b/releasenotes/notes/client-stats-sketch-validation-3d9a1c4f8b2e5607.yaml
@@ -1,0 +1,8 @@
+---
+security:
+  - |
+    APM: The trace-agent now validates the index mapping of the DDSketch
+    distributions it receives on the client stats intake, and rejects mappings
+    whose bucket bounds cannot be re-mapped safely. A crafted payload could
+    previously corrupt or crash the aggregation of client stats. Affected
+    distributions are dropped while the request counts are kept.


### PR DESCRIPTION
### What does this PR do?

Fixes a potential memory-safety crash when the client stats intake receives a malformed ddsketch. 

### Motivation

The sketch index mapping is now validated before being re-mapped onto the agent's canonical mapping; if it cannot be, the distribution is dropped and the request counts are kept. Aggregation also recovers from a panic on a single payload rather than taking down the trace-agent.


### Describe how you validated your changes

Added unit tests

### Additional Notes