### PR TITLE
Bump integrations-core to 7.84.0-rc.3

### DIFF
--- a/release.json
+++ b/release.json
@@ -2,7 +2,7 @@
     "base_branch": "7.84.x",
     "current_milestone": "7.84.0",
     "dependencies": {
-        "INTEGRATIONS_CORE_VERSION": "687712a0063b770cbaa527230c177f79b4c74275",
+        "INTEGRATIONS_CORE_VERSION": "d036745d00ff0c54ad3e7418b2e52d26df229a1e",
         "INTEGRATIONS_WHEELS_STORAGE": "stable",
         "JMXFETCH_HASH": "3eb735171a3e41518c4101a6aee06fee8b93092d015769c2e470eecadb4bd11b",
         "JMXFETCH_VERSION": "0.52.0",


### PR DESCRIPTION
Pins `INTEGRATIONS_CORE_VERSION` in `release.json` to `d036745d00ff0c54ad3e7418b2e52d26df229a1e`, the integrations-core commit tagged `7.84.0-rc.3` on `7.84.x`.