### PR TITLE
[NDM] Fix SNMP autodiscovery listener data race and lock contention

### DIFF
--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -67,6 +67,24 @@ type SNMPListener struct {
 	deviceDeduper  devicededuper.DeviceDeduper
 	sessionFactory snmpSessionFactory
 	workerFunc     snmpWorkerFunc
+
+	// Service transitions are queued here and published by a single goroutine. Autodiscovery
+	// reads additions and deletions from two independent channels and selects between them, so
+	// it can observe them in either order: publishing from the discovery workers directly would
+	// let a device's re-addition overtake its pending deletion, leaving it in l.services but
+	// unscheduled, and never re-registered because registerDevice skips known entities.
+	// Enqueuing happens under the listener lock so the queue order matches the order in which
+	// l.services was mutated, while the blocking channel sends stay off the lock.
+	eventsMu      sync.Mutex
+	eventsCond    *sync.Cond
+	pendingEvents []serviceEvent
+	publisherOnce sync.Once
+}
+
+// serviceEvent is a queued service transition awaiting publication to autodiscovery.
+type serviceEvent struct {
+	svc     *SNMPService
+	removed bool
 }
 
 // SNMPService implements and store results from the Service interface for the SNMP listener
@@ -128,12 +146,81 @@ func NewSNMPListener(ServiceListernerDeps) (ServiceListener, error) {
 	}, nil
 }
 
+// startPublisher brings up the publication goroutine, at most once. It is called both from
+// Listen and from the first enqueue, so that callers wiring the service channels up directly
+// do not have to know about it.
+func (l *SNMPListener) startPublisher() {
+	l.publisherOnce.Do(func() {
+		l.eventsMu.Lock()
+		l.eventsCond = sync.NewCond(&l.eventsMu)
+		l.eventsMu.Unlock()
+		go l.publishServices()
+	})
+}
+
+// stopped reports whether Stop has been called.
+func (l *SNMPListener) stopped() bool {
+	select {
+	case <-l.stop:
+		return true
+	default:
+		return false
+	}
+}
+
+// enqueueService queues a service transition for publication. It never blocks, so it is safe to
+// call with the listener lock held, which is how the queue stays ordered consistently with the
+// mutations of l.services.
+func (l *SNMPListener) enqueueService(svc *SNMPService, removed bool) {
+	if svc == nil {
+		return
+	}
+
+	l.startPublisher()
+
+	l.eventsMu.Lock()
+	l.pendingEvents = append(l.pendingEvents, serviceEvent{svc: svc, removed: removed})
+	l.eventsCond.Signal()
+	l.eventsMu.Unlock()
+}
+
+// publishServices drains the queue in order, one event at a time. It runs on its own goroutine
+// and holds no listener lock while sending, so a slow autodiscovery consumer cannot stall
+// device discovery.
+func (l *SNMPListener) publishServices() {
+	for {
+		l.eventsMu.Lock()
+		for len(l.pendingEvents) == 0 {
+			if l.stopped() {
+				l.eventsMu.Unlock()
+				return
+			}
+			l.eventsCond.Wait()
+		}
+		event := l.pendingEvents[0]
+		l.pendingEvents = l.pendingEvents[1:]
+		l.eventsMu.Unlock()
+
+		ch := l.newService
+		if event.removed {
+			ch = l.delService
+		}
+
+		select {
+		case ch <- event.svc:
+		case <-l.stop:
+			return
+		}
+	}
+}
+
 // Listen periodically refreshes devices
 func (l *SNMPListener) Listen(newSvc chan<- Service, delSvc chan<- Service) {
 	// setup the I/O channels
 	l.newService = newSvc
 	l.delService = delSvc
 
+	l.startPublisher()
 	go l.checkDevices()
 }
 
@@ -513,34 +600,17 @@ func (l *SNMPListener) createService(
 	deviceFailures int,
 	addedFromCache bool,
 ) {
-	// The AD service channels are unbuffered and drained by a single goroutine shared by every
-	// listener, so the send must happen outside of the listener lock: blocking on it while
-	// holding the lock stalls every other listener goroutine.
-	l.announceService(l.registerDevice(entityID, subnet, deviceIP, deviceInfo, authIndex, deviceFailures, addedFromCache))
-}
-
-// registerDevice records a newly discovered device and returns the service to announce, or nil
-// if there is nothing to announce yet (the device is still pending deduplication).
-func (l *SNMPListener) registerDevice(
-	entityID string,
-	subnet *snmpSubnet,
-	deviceIP string,
-	deviceInfo devicededuper.DeviceInfo,
-	authIndex int,
-	deviceFailures int,
-	addedFromCache bool,
-) *SNMPService {
 	l.Lock()
 	defer l.Unlock()
 
 	if _, present := l.services[entityID]; present {
-		return nil
+		return
 	}
 
 	config := subnet.config
 	if authIndex < 0 || authIndex >= len(config.Authentications) {
 		log.Errorf("Invalid authentication index %d for device %s (max: %d)", authIndex, deviceIP, len(config.Authentications)-1)
-		return nil
+		return
 	}
 	authentication := config.Authentications[authIndex]
 	config.Version = authentication.Version
@@ -575,29 +645,15 @@ func (l *SNMPListener) registerDevice(
 	}
 
 	if deviceInfo == (devicededuper.DeviceInfo{}) {
-		return l.registerServiceLocked(pendingDevice)
+		l.registerServiceLocked(pendingDevice)
+		return
 	}
 
-	var toAnnounce *SNMPService
 	if addedFromCache {
-		toAnnounce = l.registerServiceLocked(pendingDevice)
+		l.registerServiceLocked(pendingDevice)
 	}
 
 	l.deviceDeduper.AddPendingDevice(pendingDevice)
-
-	return toAnnounce
-}
-
-// announceService publishes a newly registered service to autodiscovery. The listener lock must
-// NOT be held: the channel is unbuffered and the send can block for as long as the consumer takes.
-func (l *SNMPListener) announceService(svc *SNMPService) {
-	if svc == nil {
-		return
-	}
-	select {
-	case l.newService <- svc:
-	case <-l.stop:
-	}
 }
 
 func (l *SNMPListener) registerDedupedDevices() {
@@ -606,32 +662,29 @@ func (l *SNMPListener) registerDedupedDevices() {
 	}
 
 	l.Lock()
-	var toAnnounce []*SNMPService
-	for _, pendingSvc := range l.deviceDeduper.GetDedupedDevices() {
-		if svc := l.registerServiceLocked(pendingSvc); svc != nil {
-			toAnnounce = append(toAnnounce, svc)
-		}
-	}
-	l.Unlock()
+	defer l.Unlock()
 
-	for _, svc := range toAnnounce {
-		l.announceService(svc)
+	for _, pendingSvc := range l.deviceDeduper.GetDedupedDevices() {
+		l.registerServiceLocked(pendingSvc)
 	}
 }
 
-// registerServiceLocked marks a pending service as registered. The listener lock must be held.
-// It returns the service to announce, which the caller must publish only after releasing the
-// lock, or nil when there is nothing to announce.
-func (l *SNMPListener) registerServiceLocked(pendingDevice devicededuper.PendingDevice) *SNMPService {
+// registerServiceLocked marks a pending service as registered and queues its publication.
+// The listener lock must be held, so that the queued event is ordered against the other
+// transitions of l.services.
+func (l *SNMPListener) registerServiceLocked(pendingDevice devicededuper.PendingDevice) {
 	entityID := pendingDevice.Config.Digest(pendingDevice.IP)
 
 	svc, ok := l.services[entityID]
 	if !ok {
-		return nil
+		return
 	}
 	svc.pending = false
 
-	// Lock order is always listener -> subnet.
+	// Lock order is always listener -> subnet. The cache write stays here, under both locks:
+	// snapshotting and writing must be atomic, or a slower goroutine holding an older snapshot
+	// could overwrite the file after a newer one and drop a device from the cache. This path
+	// only runs the first time a device is seen, so it is not the hot one.
 	svc.subnet.devicesMu.Lock()
 	svc.subnet.devices[svc.entityID] = deviceCache{
 		IP:        net.ParseIP(svc.deviceIP),
@@ -643,7 +696,7 @@ func (l *SNMPListener) registerServiceLocked(pendingDevice devicededuper.Pending
 	}
 	svc.subnet.devicesMu.Unlock()
 
-	return svc
+	l.enqueueService(svc, false)
 }
 
 func (l *SNMPListener) deleteService(entityID string, subnet *snmpSubnet) {
@@ -678,25 +731,23 @@ func (l *SNMPListener) deleteService(entityID string, subnet *snmpSubnet) {
 	}
 
 	l.Lock()
-	svc, stillPresent := l.services[entityID]
-	if stillPresent {
+	if svc, stillPresent := l.services[entityID]; stillPresent {
 		delete(l.services, entityID)
+		l.enqueueService(svc, true)
 	}
 	l.Unlock()
-
-	if !stillPresent {
-		return
-	}
-
-	select {
-	case l.delService <- svc:
-	case <-l.stop:
-	}
 }
 
 // Stop queues a shutdown of SNMPListener
 func (l *SNMPListener) Stop() {
 	close(l.stop)
+
+	// Wake the publisher so it observes the stop instead of blocking on an empty queue.
+	l.eventsMu.Lock()
+	if l.eventsCond != nil {
+		l.eventsCond.Broadcast()
+	}
+	l.eventsMu.Unlock()
 }
 
 // Equal returns whether the two SNMPService are equal

--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -50,6 +50,10 @@ const (
 	defaultAllowedFailures   = 3
 	defaultDiscoveryInterval = 3600
 	tagSeparator             = ","
+	// warnWorkersThreshold is the worker count above which we warn. It is not a hard cap: very
+	// large pools multiply concurrent SNMP sessions and in-flight cache writes, which degrades
+	// the whole listener when the scanned devices are slow or unreachable.
+	warnWorkersThreshold = 100
 )
 
 // SNMPListener implements SNMP discovery
@@ -78,12 +82,18 @@ type SNMPService struct {
 // Make sure SNMPService implements the Service interface
 var _ Service = &SNMPService{}
 
+// snmpSubnet holds the discovery state of a single configured network. It is always shared
+// between the discovery workers through a pointer and must never be copied: `devicesMu` and
+// `devicesScannedCounter` are only meaningful when every worker refers to the same instance.
 type snmpSubnet struct {
-	adIdentifier          string
-	config                snmp.Config
-	startingIP            net.IP
-	network               net.IPNet
-	cacheKey              string
+	adIdentifier string
+	config       snmp.Config
+	startingIP   net.IP
+	network      net.IPNet
+	cacheKey     string
+	// devicesMu guards `devices` and the persistent cache entry stored at `cacheKey`.
+	// When both are needed, the listener lock is always taken before devicesMu.
+	devicesMu             sync.Mutex
 	devices               map[string]deviceCache
 	devicesScannedCounter atomic.Uint32
 	index                 int
@@ -184,8 +194,9 @@ func (l *SNMPListener) loadCache(subnet *snmpSubnet) {
 	}
 }
 
-func (l *SNMPListener) writeCache(subnet *snmpSubnet) {
-	// We don't lock the subnet for now, because the listener ought to be already locked
+// writeCacheLocked persists the subnet's known devices. The caller must hold subnet.devicesMu:
+// this function iterates `devices`, so any concurrent write to that map is a fatal runtime error.
+func (l *SNMPListener) writeCacheLocked(subnet *snmpSubnet) {
 	devices := make([]deviceCache, 0, len(subnet.devices))
 	for _, device := range subnet.devices {
 		devices = append(devices, device)
@@ -230,13 +241,15 @@ func (l *SNMPListener) checkDevice(job snmpJob) {
 
 		l.deviceDeduper.MarkIPAsProcessed(deviceIP)
 
+		job.subnet.devicesMu.Lock()
 		device, exists := job.subnet.devices[entityID]
 		if exists && device.Failures != 0 {
 			device.Failures = 0
 			job.subnet.devices[entityID] = device
 
-			l.writeCache(job.subnet)
+			l.writeCacheLocked(job.subnet)
 		}
+		job.subnet.devicesMu.Unlock()
 
 		deviceInfo := l.checkDeviceInfo(authentication, job.subnet.config.Port, deviceIP)
 		l.createService(entityID, job.subnet, deviceIP, deviceInfo, authIndex, 0, false)
@@ -250,7 +263,7 @@ func (l *SNMPListener) checkDevice(job snmpJob) {
 		l.deleteService(entityID, job.subnet)
 	}
 
-	autodiscoveryStatus := AutodiscoveryStatus{DevicesFoundList: l.getDevicesFoundInSubnet(*job.subnet), CurrentDevice: job.currentIP.String(), DevicesScannedCount: int(job.subnet.devicesScannedCounter.Inc())}
+	autodiscoveryStatus := AutodiscoveryStatus{DevicesFoundList: l.getDevicesFoundInSubnet(job.subnet.cacheKey), CurrentDevice: job.currentIP.String(), DevicesScannedCount: int(job.subnet.devicesScannedCounter.Inc())}
 	autodiscoveryStatusBySubnetVar.Set(GetSubnetVarKey(job.subnet.config.Network, job.subnet.index), &autodiscoveryStatus)
 }
 
@@ -340,21 +353,21 @@ func (l *SNMPListener) checkDeviceInfo(authentication snmp.Authentication, port 
 	return devicededuper.DeviceInfo{Name: sysName, Description: sysDescr, BootTimeMs: bootTimestamp, SysObjectID: sysObjectID}
 }
 
-func (l *SNMPListener) getDevicesFoundInSubnet(subnet snmpSubnet) []string {
-	l.Lock()
-	defer l.Unlock()
+func (l *SNMPListener) getDevicesFoundInSubnet(cacheKey string) []string {
+	l.RLock()
+	defer l.RUnlock()
 
 	ipsFound := []string{}
 	for _, svc := range l.services {
-		if svc.subnet.cacheKey == subnet.cacheKey && !svc.pending {
+		if svc.subnet.cacheKey == cacheKey && !svc.pending {
 			ipsFound = append(ipsFound, svc.deviceIP)
 		}
 	}
 	return ipsFound
 }
 
-func (l *SNMPListener) initializeSubnets() []snmpSubnet {
-	subnets := []snmpSubnet{}
+func (l *SNMPListener) initializeSubnets() []*snmpSubnet {
+	subnets := []*snmpSubnet{}
 	for index, config := range l.config.Configs {
 		ipAddr, ipNet, err := net.ParseCIDR(config.Network)
 		if err != nil {
@@ -371,7 +384,7 @@ func (l *SNMPListener) initializeSubnets() []snmpSubnet {
 			adIdentifier = "snmp"
 		}
 
-		subnet := snmpSubnet{
+		subnet := &snmpSubnet{
 			adIdentifier: adIdentifier,
 			config:       config,
 			startingIP:   startingIP,
@@ -382,7 +395,7 @@ func (l *SNMPListener) initializeSubnets() []snmpSubnet {
 		}
 		subnets = append(subnets, subnet)
 
-		l.loadCache(&subnet)
+		l.loadCache(subnet)
 	}
 
 	return subnets
@@ -413,8 +426,16 @@ func migrateCache(config snmp.Config) string {
 }
 
 func (l *SNMPListener) checkDevices() {
-	if l.config.Workers == 0 {
+	switch {
+	case l.config.Workers == 0:
 		l.config.Workers = defaultWorkers
+	case l.config.Workers < 0:
+		log.Errorf("Invalid network_devices.autodiscovery.workers value %d, falling back to %d", l.config.Workers, defaultWorkers)
+		l.config.Workers = defaultWorkers
+	case l.config.Workers > warnWorkersThreshold:
+		log.Warnf("network_devices.autodiscovery.workers is set to %d, which is far above the recommended maximum of %d. "+
+			"Very large worker pools open that many concurrent SNMP sessions and can make device discovery unresponsive, "+
+			"especially over high-latency links. Consider lowering it.", l.config.Workers, warnWorkersThreshold)
 	}
 
 	if l.config.AllowedFailures == 0 {
@@ -449,10 +470,7 @@ func (l *SNMPListener) checkDevices() {
 			autodiscoveryStatusBySubnetVar.Set(GetSubnetVarKey(subnet.config.Network, subnet.index), &expvar.String{})
 		}
 
-		var subnet *snmpSubnet
-		for i := range subnets {
-			// Use `&subnets[i]` to pass the correct pointer address to snmpJob{}
-			subnet = &subnets[i]
+		for _, subnet := range subnets {
 			subnet.devicesScannedCounter.Store(uint32(len(subnet.config.IgnoredIPAddresses)))
 			startingIP := make(net.IP, len(subnet.startingIP))
 			copy(startingIP, subnet.startingIP)
@@ -495,17 +513,34 @@ func (l *SNMPListener) createService(
 	deviceFailures int,
 	addedFromCache bool,
 ) {
+	// The AD service channels are unbuffered and drained by a single goroutine shared by every
+	// listener, so the send must happen outside of the listener lock: blocking on it while
+	// holding the lock stalls every other listener goroutine.
+	l.announceService(l.registerDevice(entityID, subnet, deviceIP, deviceInfo, authIndex, deviceFailures, addedFromCache))
+}
+
+// registerDevice records a newly discovered device and returns the service to announce, or nil
+// if there is nothing to announce yet (the device is still pending deduplication).
+func (l *SNMPListener) registerDevice(
+	entityID string,
+	subnet *snmpSubnet,
+	deviceIP string,
+	deviceInfo devicededuper.DeviceInfo,
+	authIndex int,
+	deviceFailures int,
+	addedFromCache bool,
+) *SNMPService {
 	l.Lock()
 	defer l.Unlock()
 
 	if _, present := l.services[entityID]; present {
-		return
+		return nil
 	}
 
 	config := subnet.config
 	if authIndex < 0 || authIndex >= len(config.Authentications) {
 		log.Errorf("Invalid authentication index %d for device %s (max: %d)", authIndex, deviceIP, len(config.Authentications)-1)
-		return
+		return nil
 	}
 	authentication := config.Authentications[authIndex]
 	config.Version = authentication.Version
@@ -540,70 +575,123 @@ func (l *SNMPListener) createService(
 	}
 
 	if deviceInfo == (devicededuper.DeviceInfo{}) {
-		l.registerService(pendingDevice)
-		return
+		return l.registerServiceLocked(pendingDevice)
 	}
 
+	var toAnnounce *SNMPService
 	if addedFromCache {
-		l.registerService(pendingDevice)
+		toAnnounce = l.registerServiceLocked(pendingDevice)
 	}
 
 	l.deviceDeduper.AddPendingDevice(pendingDevice)
+
+	return toAnnounce
+}
+
+// announceService publishes a newly registered service to autodiscovery. The listener lock must
+// NOT be held: the channel is unbuffered and the send can block for as long as the consumer takes.
+func (l *SNMPListener) announceService(svc *SNMPService) {
+	if svc == nil {
+		return
+	}
+	select {
+	case l.newService <- svc:
+	case <-l.stop:
+	}
 }
 
 func (l *SNMPListener) registerDedupedDevices() {
 	if !l.config.Deduplicate {
 		return
 	}
+
+	l.Lock()
+	var toAnnounce []*SNMPService
 	for _, pendingSvc := range l.deviceDeduper.GetDedupedDevices() {
-		l.registerService(pendingSvc)
+		if svc := l.registerServiceLocked(pendingSvc); svc != nil {
+			toAnnounce = append(toAnnounce, svc)
+		}
+	}
+	l.Unlock()
+
+	for _, svc := range toAnnounce {
+		l.announceService(svc)
 	}
 }
 
-func (l *SNMPListener) registerService(pendingDevice devicededuper.PendingDevice) {
+// registerServiceLocked marks a pending service as registered. The listener lock must be held.
+// It returns the service to announce, which the caller must publish only after releasing the
+// lock, or nil when there is nothing to announce.
+func (l *SNMPListener) registerServiceLocked(pendingDevice devicededuper.PendingDevice) *SNMPService {
 	entityID := pendingDevice.Config.Digest(pendingDevice.IP)
 
 	svc, ok := l.services[entityID]
 	if !ok {
-		return
+		return nil
 	}
 	svc.pending = false
 
+	// Lock order is always listener -> subnet.
+	svc.subnet.devicesMu.Lock()
 	svc.subnet.devices[svc.entityID] = deviceCache{
 		IP:        net.ParseIP(svc.deviceIP),
 		AuthIndex: pendingDevice.AuthIndex,
 		Failures:  pendingDevice.Failures,
 	}
 	if !pendingDevice.AddedFromCache {
-		l.writeCache(svc.subnet)
+		l.writeCacheLocked(svc.subnet)
 	}
-	l.newService <- svc
+	svc.subnet.devicesMu.Unlock()
+
+	return svc
 }
 
 func (l *SNMPListener) deleteService(entityID string, subnet *snmpSubnet) {
-	l.Lock()
-	defer l.Unlock()
-
-	svc, exists := l.services[entityID]
-	if !exists {
+	l.RLock()
+	_, known := l.services[entityID]
+	l.RUnlock()
+	if !known {
 		return
 	}
 
+	// Account the failure under the subnet lock only. The cache write is disk I/O and must not
+	// run while the listener lock is held, or every worker serialises behind it.
+	subnet.devicesMu.Lock()
 	device, exists := subnet.devices[entityID]
 	if !exists {
+		subnet.devicesMu.Unlock()
 		return
 	}
 
 	device.Failures++
-	subnet.devices[entityID] = device
-
-	if l.config.AllowedFailures != -1 && device.Failures >= l.config.AllowedFailures {
-		l.delService <- svc
-		delete(l.services, entityID)
+	evict := l.config.AllowedFailures != -1 && device.Failures >= l.config.AllowedFailures
+	if evict {
 		delete(subnet.devices, entityID)
+	} else {
+		subnet.devices[entityID] = device
+	}
+	l.writeCacheLocked(subnet)
+	subnet.devicesMu.Unlock()
+
+	if !evict {
+		return
 	}
 
-	l.writeCache(subnet)
+	l.Lock()
+	svc, stillPresent := l.services[entityID]
+	if stillPresent {
+		delete(l.services, entityID)
+	}
+	l.Unlock()
+
+	if !stillPresent {
+		return
+	}
+
+	select {
+	case l.delService <- svc:
+	case <-l.stop:
+	}
 }
 
 // Stop queues a shutdown of SNMPListener

--- a/comp/core/autodiscovery/listeners/snmp_test.go
+++ b/comp/core/autodiscovery/listeners/snmp_test.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -595,8 +594,9 @@ func TestCreateServiceFromCacheRegistersImmediately(t *testing.T) {
 	entityID1 := subnet.config.Digest("192.168.0.1")
 	l.createService(entityID1, subnet, "192.168.0.1", deviceInfo, 0, 0, true)
 
-	assert.Equal(t, 1, len(newSvc))
-	svc := (<-newSvc).(*SNMPService)
+	// Services are published asynchronously, so wait for the event rather than sampling the
+	// channel length.
+	svc := collectServices(t, newSvc, 1, 2*time.Second)[0]
 	assert.Equal(t, "192.168.0.1", svc.deviceIP)
 	assert.False(t, svc.pending)
 
@@ -604,7 +604,7 @@ func TestCreateServiceFromCacheRegistersImmediately(t *testing.T) {
 	entityID2 := subnet.config.Digest("192.168.0.2")
 	l.createService(entityID2, subnet, "192.168.0.2", deviceInfo, 0, 0, false)
 
-	assert.Equal(t, 0, len(newSvc), "second IP for same device should not be registered")
+	noMoreServices(t, newSvc, 500*time.Millisecond)
 }
 
 func TestBuildCacheKey(t *testing.T) {
@@ -1243,18 +1243,21 @@ func TestCheckDeviceConcurrentSubnetAccess(t *testing.T) {
 	assert.NotZero(t, found, "expected the concurrent scan to discover at least one device")
 }
 
-// TestCreateServiceDoesNotHoldLockWhileAnnouncing is a regression test for the lock contention
-// half of AGENT-16950: createService used to send on the unbuffered newService channel while
-// holding the listener lock, so a slow autodiscovery consumer stalled every other listener
-// goroutine (the crash dump showed 421 goroutines blocked on Lock()).
-func TestCreateServiceDoesNotHoldLockWhileAnnouncing(t *testing.T) {
+// TestCreateServiceDoesNotBlockOnAutodiscovery is a regression test for the lock contention half
+// of AGENT-16950: createService used to send on the unbuffered newService channel while holding
+// the listener lock, so a slow autodiscovery consumer stalled every other listener goroutine
+// (the crash dump showed 421 goroutines blocked on Lock()). Discovery must now make progress
+// regardless of how slow the consumer is, so createService returns without anyone reading.
+func TestCreateServiceDoesNotBlockOnAutodiscovery(t *testing.T) {
 	l, _ := setupTestListener(t, []interface{}{
 		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
 	}, nil)
 
+	// Deliberately unbuffered and never read from, standing in for a stalled consumer.
 	newSvc := make(chan Service)
 	l.newService = newSvc
 	l.delService = make(chan Service)
+	defer l.Stop()
 
 	_, ipNet, err := net.ParseCIDR("192.168.0.0/30")
 	require.NoError(t, err)
@@ -1263,49 +1266,59 @@ func TestCreateServiceDoesNotHoldLockWhileAnnouncing(t *testing.T) {
 		adIdentifier: "snmp",
 		config:       l.config.Configs[0],
 		network:      *ipNet,
-		cacheKey:     "snmp:concurrency-test",
+		cacheKey:     "snmp:contention-test",
 		devices:      map[string]deviceCache{},
 	}
 
-	// Keep exercising an unrelated listener operation in the background and count how often it
-	// completes. It must keep making progress even while nobody is reading newService.
-	var progress atomic.Int64
-	stopPolling := make(chan struct{})
-	pollDone := make(chan struct{})
-	go func() {
-		defer close(pollDone)
-		for {
-			select {
-			case <-stopPolling:
-				return
-			default:
-			}
-			l.getDevicesFoundInSubnet(subnet.cacheKey)
-			progress.Add(1)
-			time.Sleep(time.Millisecond)
-		}
-	}()
-
 	entityID := subnet.config.Digest("192.168.0.1")
-	created := make(chan struct{})
+	done := make(chan struct{})
 	go func() {
-		defer close(created)
+		defer close(done)
 		l.createService(entityID, subnet, "192.168.0.1", devicededuper.DeviceInfo{}, 0, 0, false)
 	}()
 
-	// Long enough for createService to reach the send and block there: nothing else in the call
-	// is slow, and the channel has no reader yet.
-	time.Sleep(300 * time.Millisecond)
-	mark := progress.Load()
-	time.Sleep(300 * time.Millisecond)
-	stalled := progress.Load() == mark
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("createService blocked while no autodiscovery consumer was reading: discovery is coupled to the consumer's speed")
+	}
+}
 
-	// Unblock createService before asserting, so a failure does not leak a stuck goroutine.
-	<-newSvc
-	<-created
-	close(stopPolling)
-	<-pollDone
+// TestServiceEventsPublishedInOrder pins the ordering guarantee that publishing off the listener
+// lock has to preserve. Autodiscovery reads additions and deletions from two independent channels
+// and selects between them, so if a device's re-addition can overtake its pending deletion the
+// device ends up in l.services but unscheduled, and is never re-registered.
+func TestServiceEventsPublishedInOrder(t *testing.T) {
+	l, _ := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+	}, nil)
 
-	assert.False(t, stalled,
-		"getDevicesFoundInSubnet stopped making progress while createService was announcing: the listener lock is held across the unbuffered channel send")
+	// Unbuffered, like the real autodiscovery channels.
+	newSvc := make(chan Service)
+	delSvc := make(chan Service)
+	l.newService = newSvc
+	l.delService = delSvc
+	defer l.Stop()
+
+	svc := &SNMPService{entityID: "entity-1", deviceIP: "192.168.0.1"}
+
+	// A deletion followed by a re-addition of the same entity.
+	l.enqueueService(svc, true)
+	l.enqueueService(svc, false)
+
+	// Consume exactly as autodiscovery does: select across both channels.
+	var got []string
+	for i := 0; i < 2; i++ {
+		select {
+		case <-newSvc:
+			got = append(got, "add")
+		case <-delSvc:
+			got = append(got, "del")
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out waiting for event %d/2, got %v", i+1, got)
+		}
+	}
+
+	assert.Equal(t, []string{"del", "add"}, got,
+		"the re-addition overtook the pending deletion: autodiscovery would drop the rediscovered device")
 }

--- a/comp/core/autodiscovery/listeners/snmp_test.go
+++ b/comp/core/autodiscovery/listeners/snmp_test.go
@@ -13,6 +13,8 @@ import (
 	"net"
 	"sort"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -507,7 +509,7 @@ func TestCache(t *testing.T) {
 				devices:  tt.devices,
 			}
 
-			l.writeCache(subnet)
+			l.writeCacheLocked(subnet)
 
 			cacheContent, err := persistentcache.Read(cacheKey)
 			assert.NoError(t, err)
@@ -1098,7 +1100,7 @@ func TestCheckDeviceDeleteAfterAllowedFailures(t *testing.T) {
 	l.config.AllowedFailures = 3
 
 	subnets := l.initializeSubnets()
-	subnet := &subnets[0]
+	subnet := subnets[0]
 
 	// First scan: device is reachable
 	factory.sessions["192.168.0.1"] = makeReachableSession()
@@ -1135,7 +1137,7 @@ func TestCheckDeviceFailureResetOnSuccess(t *testing.T) {
 	l.config.AllowedFailures = 3
 
 	subnets := l.initializeSubnets()
-	subnet := &subnets[0]
+	subnet := subnets[0]
 
 	// First scan: device is reachable
 	factory.sessions["192.168.0.1"] = makeReachableSession()
@@ -1166,4 +1168,144 @@ func TestCheckDeviceFailureResetOnSuccess(t *testing.T) {
 	device, exists := subnet.devices[entityID]
 	assert.True(t, exists)
 	assert.Equal(t, 0, device.Failures)
+}
+
+// TestCheckDeviceConcurrentSubnetAccess exercises many workers scanning a single subnet at once,
+// which is what production does whenever `network_devices.autodiscovery.workers` is above 1.
+//
+// It is a regression test for AGENT-16950: checkDevice used to read, write and iterate
+// subnet.devices (through writeCache) with no lock held, while deleteService and registerService
+// mutated the same map under the listener lock. That is an unsynchronized concurrent map access
+// and the Go runtime aborts the process with
+// "fatal error: concurrent map iteration and map write".
+//
+// Must be run with -race to be meaningful.
+func TestCheckDeviceConcurrentSubnetAccess(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/24", "community": "public"},
+	}, nil)
+
+	newSvc := make(chan Service)
+	delSvc := make(chan Service)
+	l.newService = newSvc
+	l.delService = delSvc
+	l.config.AllowedFailures = 2
+
+	// Drain the service channels. They are unbuffered in production, so this also covers the
+	// case where a send happens while a lock is held.
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for {
+			select {
+			case <-newSvc:
+			case <-delSvc:
+			case <-l.stop:
+				return
+			}
+		}
+	}()
+
+	subnets := l.initializeSubnets()
+	require.Len(t, subnets, 1)
+	subnet := subnets[0]
+
+	// Half of the IPs answer, half do not, so both the failure-reset path in checkDevice and the
+	// eviction path in deleteService run concurrently against the same devices map.
+	const numIPs = 40
+	for i := 1; i <= numIPs; i += 2 {
+		factory.mu.Lock()
+		factory.sessions[fmt.Sprintf("192.168.0.%d", i)] = makeReachableSession()
+		factory.mu.Unlock()
+	}
+
+	const rounds = 5
+	var wg sync.WaitGroup
+	for i := 1; i <= numIPs; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			job := snmpJob{subnet: subnet, currentIP: net.ParseIP(fmt.Sprintf("192.168.0.%d", i))}
+			for r := 0; r < rounds; r++ {
+				l.checkDevice(job)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	close(l.stop)
+	<-drained
+
+	// Sanity check that the run actually discovered devices rather than no-oping.
+	subnet.devicesMu.Lock()
+	found := len(subnet.devices)
+	subnet.devicesMu.Unlock()
+	assert.NotZero(t, found, "expected the concurrent scan to discover at least one device")
+}
+
+// TestCreateServiceDoesNotHoldLockWhileAnnouncing is a regression test for the lock contention
+// half of AGENT-16950: createService used to send on the unbuffered newService channel while
+// holding the listener lock, so a slow autodiscovery consumer stalled every other listener
+// goroutine (the crash dump showed 421 goroutines blocked on Lock()).
+func TestCreateServiceDoesNotHoldLockWhileAnnouncing(t *testing.T) {
+	l, _ := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+	}, nil)
+
+	newSvc := make(chan Service)
+	l.newService = newSvc
+	l.delService = make(chan Service)
+
+	_, ipNet, err := net.ParseCIDR("192.168.0.0/30")
+	require.NoError(t, err)
+
+	subnet := &snmpSubnet{
+		adIdentifier: "snmp",
+		config:       l.config.Configs[0],
+		network:      *ipNet,
+		cacheKey:     "snmp:concurrency-test",
+		devices:      map[string]deviceCache{},
+	}
+
+	// Keep exercising an unrelated listener operation in the background and count how often it
+	// completes. It must keep making progress even while nobody is reading newService.
+	var progress atomic.Int64
+	stopPolling := make(chan struct{})
+	pollDone := make(chan struct{})
+	go func() {
+		defer close(pollDone)
+		for {
+			select {
+			case <-stopPolling:
+				return
+			default:
+			}
+			l.getDevicesFoundInSubnet(subnet.cacheKey)
+			progress.Add(1)
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	entityID := subnet.config.Digest("192.168.0.1")
+	created := make(chan struct{})
+	go func() {
+		defer close(created)
+		l.createService(entityID, subnet, "192.168.0.1", devicededuper.DeviceInfo{}, 0, 0, false)
+	}()
+
+	// Long enough for createService to reach the send and block there: nothing else in the call
+	// is slow, and the channel has no reader yet.
+	time.Sleep(300 * time.Millisecond)
+	mark := progress.Load()
+	time.Sleep(300 * time.Millisecond)
+	stalled := progress.Load() == mark
+
+	// Unblock createService before asserting, so a failure does not leak a stuck goroutine.
+	<-newSvc
+	<-created
+	close(stopPolling)
+	<-pollDone
+
+	assert.False(t, stalled,
+		"getDevicesFoundInSubnet stopped making progress while createService was announcing: the listener lock is held across the unbuffered channel send")
 }

--- a/releasenotes/notes/[snmp]-fix-autodiscovery-listener-race-c7508debc99fb6e4.yaml
+++ b/releasenotes/notes/[snmp]-fix-autodiscovery-listener-race-c7508debc99fb6e4.yaml
@@ -8,9 +8,10 @@ fixes:
     and its persistent cache entry are now guarded by a dedicated per-subnet lock.
   - |
     Fix SNMP autodiscovery becoming unresponsive on large networks. Service creation and deletion
-    published to autodiscovery, and wrote the discovery cache to disk, while holding the listener
-    lock, so a single slow consumer or cache write serialized every discovery worker. Both the
-    channel sends and the cache writes now happen outside the listener lock.
+    published to autodiscovery while holding the listener lock, so a single slow consumer
+    serialized every discovery worker. Publication is now queued and performed by a dedicated
+    goroutine, preserving event order without blocking on the lock. The per-IP cache writes done
+    when a device is unreachable also no longer take the listener lock.
 other:
   - |
     The SNMP autodiscovery listener now logs a warning when

--- a/releasenotes/notes/[snmp]-fix-autodiscovery-listener-race-c7508debc99fb6e4.yaml
+++ b/releasenotes/notes/[snmp]-fix-autodiscovery-listener-race-c7508debc99fb6e4.yaml
@@ -1,0 +1,18 @@
+---
+fixes:
+  - |
+    Fix a crash in SNMP autodiscovery (``fatal error: concurrent map iteration and map write``)
+    caused by unsynchronized access to a subnet's discovered-device map. Discovery workers read,
+    wrote and serialized that map without holding a lock, so any Agent running
+    ``network_devices.autodiscovery.workers`` above 1 could abort during a scan. The device map
+    and its persistent cache entry are now guarded by a dedicated per-subnet lock.
+  - |
+    Fix SNMP autodiscovery becoming unresponsive on large networks. Service creation and deletion
+    published to autodiscovery, and wrote the discovery cache to disk, while holding the listener
+    lock, so a single slow consumer or cache write serialized every discovery worker. Both the
+    channel sends and the cache writes now happen outside the listener lock.
+other:
+  - |
+    The SNMP autodiscovery listener now logs a warning when
+    ``network_devices.autodiscovery.workers`` is set far above the recommended maximum, and falls
+    back to the default when it is negative. The configured value is still honored.


### PR DESCRIPTION
### What does this PR do?

Fixes a data race in the SNMP autodiscovery listener that crashes the Agent, plus the lock contention on the same code path that makes the listener unresponsive at scale.

**The race (the crash).** `checkDevice` read `subnet.devices`, wrote it, and called `writeCache` (which ranges over the same map) with **no lock held**:

```go
device, exists := job.subnet.devices[entityID]   // read, unlocked
if exists && device.Failures != 0 {
    device.Failures = 0
    job.subnet.devices[entityID] = device        // write, unlocked
    l.writeCache(job.subnet)                     // iteration, unlocked
}
```

Every other mutator (`deleteService`, `registerService`) held `l.Lock()`, so the lock bought nothing — one unlocked writer defeats it. `writeCache` documented the assumption it violated: *"We don't lock the subnet for now, because the listener ought to be already locked."* It is not locked on that path.

`checkDevice` → `registerDedupedDevices` → `registerService` was a second fully unlocked path, while `createService` reached the same function *with* the lock held — so the discipline could not be fixed by adding a lock inside `registerService`.

Fix: a dedicated per-subnet mutex guards `devices` and its persistent cache entry. Lock ownership is now explicit in the names (`writeCacheLocked`, `registerServiceLocked`). Lock order is always listener → subnet.

**The contention.** `l.newService <- svc` and `l.delService <- svc` fired while holding the listener lock, on channels that are unbuffered (`autoconfig.go:216-217`) and drained by a single goroutine shared across every AD listener. One slow consumer serialised every discovery worker.

Service transitions are now appended to a FIFO queue under the listener lock and published by a single goroutine. Enqueuing is non-blocking, so it is safe under the lock; the blocking sends happen on the publisher goroutine and `select` on `stop` so shutdown cannot deadlock. The queue is what makes this safe: autodiscovery selects between two independent channels, so publishing straight from the workers would let a device's re-addition overtake its pending deletion, leaving it in `l.services` but unscheduled and never re-registered (`registerDevice` returns early on a known entity). Queuing under the lock keeps the published order equal to the order `l.services` was mutated in.

`writeCacheLocked` does `os.WriteFile` + `MkdirAll`, and `deleteService` called it for every unreachable IP with the listener lock held. That accounting now runs under `devicesMu` only. The first-discovery write in `registerServiceLocked` deliberately stays under the listener lock: decoupling the snapshot from the write would let an older snapshot overwrite a newer one, and that path only runs once per device.

**A latent bug found on the way.** `initializeSubnets` copied the subnet value into the slice but handed `loadCache` the address of the local, so cache-loaded services and discovery workers referred to two different structs. Only the shared `devices` map hid it. It now returns `[]*snmpSubnet`.

**Config guardrail.** Warn when `network_devices.autodiscovery.workers` is set far above the recommended maximum, and fall back to the default when negative (a negative value previously spawned zero workers silently). The configured value is still honored — see Additional Notes.

### Motivation

AGENT-16950. A customer Agent (7.81.3) crashed with `fatal error: concurrent map iteration and map write`, with three discovery goroutines inside `SNMPListener.writeCache`, all reached from `checkDevice`. Config was `workers: 2000` across 282 subnets, ~110k IPs. The crash-time dump also showed 421 goroutines blocked on the listener's `Lock()`.

The initial triage attributed this to contention from `workers: 2000`. That is the trigger, not the cause: the race is unconditional and reproduces at any worker count above 1. Lowering `workers` reduces crash frequency; it does not remove the bug.

### Describe how you validated your changes

Three tests, the first two of which **fail on the unpatched code** (verified by re-injecting each defect individually and re-running):

- `TestCheckDeviceConcurrentSubnetAccess` — many workers scanning one subnet, half the IPs reachable so both the failure-reset path and the eviction path run concurrently. Under `-race` on unpatched code it trips on exactly the reported pair:

  ```
  WARNING: DATA RACE
  Read at 0x00c000a1e150 by goroutine 925:
    ...listeners.(*SNMPListener).checkDevice()  snmp.go:234
  Previous write at 0x00c000a1e150 by goroutine 923:
    ...listeners.(*SNMPListener).registerService()  snmp.go:570
    ...listeners.(*SNMPListener).createService()    snmp.go:541
  ```

- `TestCreateServiceDoesNotBlockOnAutodiscovery` — covers the contention half deterministically: nothing ever reads the unbuffered channel, and `createService` must still return. Hangs on unpatched code until the test times out.

- `TestServiceEventsPublishedInOrder` — enqueues a deletion then an addition for the same service, consumes both channels with a `select`, and asserts the order is preserved. Guards the ordering property the queue exists for.

All green after the fix:

- `dda inv test --targets=./comp/core/autodiscovery/listeners --race` → 286/286 pass, no races
- `dda inv linter.go --targets=./comp/core/autodiscovery/listeners` → 0 issues (confirms no `copylocks` violation from the new mutex)

Also checked the sibling `pkg/collector/corechecks/snmp/internal/discovery/discovery.go`, which has the same shape but is correctly locked throughout (`discDevMu` covers every `subnet.devices` access and cache write) — no change needed there.

### Additional Notes

**Why no hard cap on `workers`.** Support asked for one. I deliberately warn instead of clamping: a silent cap changes discovery throughput for anyone already tuned above it, and it would have masked this bug rather than surfacing it. The crash was a defect, not a misconfiguration.

**Failure counts still persist on every increment.** I considered dropping those cache writes to cut I/O, but persisting them is deliberate (`dad536e78b7`, NDMII-3569) so the count survives an Agent restart. The write now happens off the listener lock instead.

**Two open questions for review:**

1. **Backport to 7.81.x?** The reporting customer is on 7.81.3 and the change is self-contained.
2. **Does CI run this package with `-race`?** Race detection is opt-in here (`tasks/gotest.py:634`, `race=False` default). If CI does not enable it for this package, the regression test is decorative and this can silently return.

**Follow-up not included:** debouncing the discovery cache writes per subnet (dirty flag flushed on a timer) would be a bigger win than the lock change alone, but it is a larger diff and harder to backport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
