### PR TITLE
Add hermetic fixtures for bazel-driven symbol uploader tests

### DIFF
--- a/comp/host-profiler/symboluploader/BUILD.bazel
+++ b/comp/host-profiler/symboluploader/BUILD.bazel
@@ -77,6 +77,16 @@ go_binary(
     target_compatible_with = ["@platforms//os:linux"],
 )
 
+go_binary(
+    name = "helloworld_external_raw",
+    srcs = ["testdata/helloworld.go"],
+    gc_linkopts = ["-linkmode=external"],
+    linkmode = "normal",
+    pure = "off",
+    race = "off",
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
 objcopy_go_fixture(
     name = "helloworld_no_symbols",
     src = ":helloworld_no_symbols_raw",
@@ -89,19 +99,9 @@ objcopy_go_fixture(
     target_compatible_with = ["@platforms//os:linux"],
 )
 
-go_binary(
-    name = "helloworld_dynsym_raw",
-    srcs = ["testdata/helloworld.go"],
-    gc_linkopts = ["-linkmode=external"],
-    linkmode = "normal",
-    pure = "off",
-    race = "off",
-    target_compatible_with = ["@platforms//os:linux"],
-)
-
 objcopy_go_fixture(
     name = "helloworld_dynsym",
-    src = ":helloworld_dynsym_raw",
+    src = ":helloworld_external_raw",
     out = "helloworld_dynsym.out",
     objcopy_args = [
         "-R",
@@ -111,19 +111,9 @@ objcopy_go_fixture(
     target_compatible_with = ["@platforms//os:linux"],
 )
 
-go_binary(
-    name = "helloworld_symtab_raw",
-    srcs = ["testdata/helloworld.go"],
-    gc_linkopts = ["-linkmode=external"],
-    linkmode = "normal",
-    pure = "off",
-    race = "off",
-    target_compatible_with = ["@platforms//os:linux"],
-)
-
 objcopy_go_fixture(
     name = "helloworld_symtab",
-    src = ":helloworld_symtab_raw",
+    src = ":helloworld_external_raw",
     out = "helloworld_symtab.out",
     objcopy_args = [
         "-R",
@@ -133,19 +123,9 @@ objcopy_go_fixture(
     target_compatible_with = ["@platforms//os:linux"],
 )
 
-go_binary(
-    name = "helloworld_debug_infos_raw",
-    srcs = ["testdata/helloworld.go"],
-    gc_linkopts = ["-linkmode=external"],
-    linkmode = "normal",
-    pure = "off",
-    race = "off",
-    target_compatible_with = ["@platforms//os:linux"],
-)
-
 objcopy_go_fixture(
     name = "helloworld_debug_infos",
-    src = ":helloworld_debug_infos_raw",
+    src = ":helloworld_external_raw",
     out = "helloworld_debug_infos.out",
     objcopy_args = [
         "-R",
@@ -154,19 +134,9 @@ objcopy_go_fixture(
     target_compatible_with = ["@platforms//os:linux"],
 )
 
-go_binary(
-    name = "helloworld_dynsym_corrupt_gopclntab_raw",
-    srcs = ["testdata/helloworld.go"],
-    gc_linkopts = ["-linkmode=external"],
-    linkmode = "normal",
-    pure = "off",
-    race = "off",
-    target_compatible_with = ["@platforms//os:linux"],
-)
-
 objcopy_go_fixture(
     name = "helloworld_dynsym_corrupt_gopclntab",
-    src = ":helloworld_dynsym_corrupt_gopclntab_raw",
+    src = ":helloworld_external_raw",
     out = "helloworld_dynsym_corrupt_gopclntab.out",
     objcopy_args = [
         "-R",
@@ -178,19 +148,9 @@ objcopy_go_fixture(
     target_compatible_with = ["@platforms//os:linux"],
 )
 
-go_binary(
-    name = "helloworld_debug_infos_corrupt_gopclntab_raw",
-    srcs = ["testdata/helloworld.go"],
-    gc_linkopts = ["-linkmode=external"],
-    linkmode = "normal",
-    pure = "off",
-    race = "off",
-    target_compatible_with = ["@platforms//os:linux"],
-)
-
 objcopy_go_fixture(
     name = "helloworld_debug_infos_corrupt_gopclntab",
-    src = ":helloworld_debug_infos_corrupt_gopclntab_raw",
+    src = ":helloworld_external_raw",
     out = "helloworld_debug_infos_corrupt_gopclntab.out",
     objcopy_args = [
         "-R",

--- a/comp/host-profiler/symboluploader/BUILD.bazel
+++ b/comp/host-profiler/symboluploader/BUILD.bazel
@@ -1,5 +1,6 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
 load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+load(":symbol_uploader_test.bzl", "objcopy_go_fixture")
 
 # gazelle:go_test file
 
@@ -67,15 +68,167 @@ dd_agent_go_test(
     }),
 )
 
-# TODO: This test can't work from CI as written because it depends on direct
-# access to the go compiler outside of bazel control. It does work from the
-# developer command line.
+go_binary(
+    name = "helloworld_no_symbols_raw",
+    srcs = ["testdata/helloworld.go"],
+    linkmode = "normal",
+    pure = "on",
+    race = "off",
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+objcopy_go_fixture(
+    name = "helloworld_no_symbols",
+    src = ":helloworld_no_symbols_raw",
+    out = "helloworld_no_symbols.out",
+    objcopy_args = [
+        "-R",
+        ".note.gnu.build-id",
+        "-S",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+go_binary(
+    name = "helloworld_dynsym_raw",
+    srcs = ["testdata/helloworld.go"],
+    gc_linkopts = ["-linkmode=external"],
+    linkmode = "normal",
+    pure = "off",
+    race = "off",
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+objcopy_go_fixture(
+    name = "helloworld_dynsym",
+    src = ":helloworld_dynsym_raw",
+    out = "helloworld_dynsym.out",
+    objcopy_args = [
+        "-R",
+        ".note.gnu.build-id",
+        "-S",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+go_binary(
+    name = "helloworld_symtab_raw",
+    srcs = ["testdata/helloworld.go"],
+    gc_linkopts = ["-linkmode=external"],
+    linkmode = "normal",
+    pure = "off",
+    race = "off",
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+objcopy_go_fixture(
+    name = "helloworld_symtab",
+    src = ":helloworld_symtab_raw",
+    out = "helloworld_symtab.out",
+    objcopy_args = [
+        "-R",
+        ".note.gnu.build-id",
+        "-g",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+go_binary(
+    name = "helloworld_debug_infos_raw",
+    srcs = ["testdata/helloworld.go"],
+    gc_linkopts = ["-linkmode=external"],
+    linkmode = "normal",
+    pure = "off",
+    race = "off",
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+objcopy_go_fixture(
+    name = "helloworld_debug_infos",
+    src = ":helloworld_debug_infos_raw",
+    out = "helloworld_debug_infos.out",
+    objcopy_args = [
+        "-R",
+        ".note.gnu.build-id",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+go_binary(
+    name = "helloworld_dynsym_corrupt_gopclntab_raw",
+    srcs = ["testdata/helloworld.go"],
+    gc_linkopts = ["-linkmode=external"],
+    linkmode = "normal",
+    pure = "off",
+    race = "off",
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+objcopy_go_fixture(
+    name = "helloworld_dynsym_corrupt_gopclntab",
+    src = ":helloworld_dynsym_corrupt_gopclntab_raw",
+    out = "helloworld_dynsym_corrupt_gopclntab.out",
+    objcopy_args = [
+        "-R",
+        ".note.gnu.build-id",
+        "-S",
+        "-R",
+        ".gopclntab",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+go_binary(
+    name = "helloworld_debug_infos_corrupt_gopclntab_raw",
+    srcs = ["testdata/helloworld.go"],
+    gc_linkopts = ["-linkmode=external"],
+    linkmode = "normal",
+    pure = "off",
+    race = "off",
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+objcopy_go_fixture(
+    name = "helloworld_debug_infos_corrupt_gopclntab",
+    src = ":helloworld_debug_infos_corrupt_gopclntab_raw",
+    out = "helloworld_debug_infos_corrupt_gopclntab.out",
+    objcopy_args = [
+        "-R",
+        ".note.gnu.build-id",
+        "-R",
+        ".gopclntab",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+# Note: these tests are still not hermetic because they rely on system objcopy for the code
+# under test itself.
 dd_agent_go_test(
     name = "symbol_uploader_test",
     srcs = ["symbol_uploader_test.go"],
-    data = glob(["testdata/**"]),
+    data = glob(["testdata/**"]) + select({
+        "@platforms//os:linux": [
+            ":helloworld_debug_infos",
+            ":helloworld_debug_infos_corrupt_gopclntab",
+            ":helloworld_dynsym",
+            ":helloworld_dynsym_corrupt_gopclntab",
+            ":helloworld_no_symbols",
+            ":helloworld_symtab",
+        ],
+        "//conditions:default": [],
+    }),
     embed = [":symboluploader"],
-    tags = ["manual"],
+    env = select({
+        "@platforms//os:linux": {
+            "SYMBOL_UPLOADER_FIXTURE_DEBUG_INFOS": "$(rlocationpath :helloworld_debug_infos)",
+            "SYMBOL_UPLOADER_FIXTURE_DEBUG_INFOS_CORRUPT_GOPCLNTAB": "$(rlocationpath :helloworld_debug_infos_corrupt_gopclntab)",
+            "SYMBOL_UPLOADER_FIXTURE_DYNSYM": "$(rlocationpath :helloworld_dynsym)",
+            "SYMBOL_UPLOADER_FIXTURE_DYNSYM_CORRUPT_GOPCLNTAB": "$(rlocationpath :helloworld_dynsym_corrupt_gopclntab)",
+            "SYMBOL_UPLOADER_FIXTURE_NO_SYMBOLS": "$(rlocationpath :helloworld_no_symbols)",
+            "SYMBOL_UPLOADER_FIXTURE_SYMTAB": "$(rlocationpath :helloworld_symtab)",
+        },
+        "//conditions:default": {},
+    }),
     deps = select({
         "@rules_go//go/platform:android": [
             "//comp/host-profiler/symboluploader/symbol",
@@ -90,6 +243,7 @@ dd_agent_go_test(
             "@io_opentelemetry_go_ebpf_profiler//process",
             "@io_opentelemetry_go_ebpf_profiler//remotememory",
             "@io_opentelemetry_go_ebpf_profiler//reporter",
+            "@rules_go//go/runfiles",
         ],
         "@rules_go//go/platform:linux": [
             "//comp/host-profiler/symboluploader/symbol",
@@ -104,6 +258,7 @@ dd_agent_go_test(
             "@io_opentelemetry_go_ebpf_profiler//process",
             "@io_opentelemetry_go_ebpf_profiler//remotememory",
             "@io_opentelemetry_go_ebpf_profiler//reporter",
+            "@rules_go//go/runfiles",
         ],
         "//conditions:default": [],
     }),

--- a/comp/host-profiler/symboluploader/symbol_uploader_test.bzl
+++ b/comp/host-profiler/symboluploader/symbol_uploader_test.bzl
@@ -1,0 +1,66 @@
+load("@rules_cc//cc:action_names.bzl", "OBJ_COPY_ACTION_NAME")
+load("@rules_cc//cc:defs.bzl", "cc_common")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain", "use_cc_toolchain")
+
+# Bazel's default --strip=sometimes strips rules_go binaries in fastbuild mode.
+# These fixture binaries deliberately exercise symbol/debug-section handling, so
+# build them with --strip=never and let the test-specific objcopy action below
+# apply the exact transformations the test needs.
+def _strip_never_transition_impl(_settings, _attr):
+    return {"//command_line_option:strip": "never"}
+
+_strip_never_transition = transition(
+    implementation = _strip_never_transition_impl,
+    inputs = [],
+    outputs = ["//command_line_option:strip"],
+)
+
+def _objcopy_go_fixture_impl(ctx):
+    cc_toolchain = find_cc_toolchain(ctx)
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = [],
+        unsupported_features = [],
+    )
+    objcopy = cc_common.get_tool_for_action(
+        feature_configuration = feature_configuration,
+        action_name = OBJ_COPY_ACTION_NAME,
+    )
+
+    args = ctx.actions.args()
+    args.add_all(ctx.attr.objcopy_args)
+    args.add(ctx.file.src)
+    args.add(ctx.outputs.out)
+
+    ctx.actions.run(
+        executable = objcopy,
+        inputs = depset(
+            direct = [ctx.file.src],
+            transitive = [cc_toolchain.all_files],
+        ),
+        outputs = [ctx.outputs.out],
+        arguments = [args],
+        mnemonic = "ObjcopyGoFixture",
+        progress_message = "Post-processing Go fixture {}".format(ctx.label),
+    )
+
+    return [DefaultInfo(files = depset([ctx.outputs.out]))]
+
+objcopy_go_fixture = rule(
+    implementation = _objcopy_go_fixture_impl,
+    attrs = {
+        "src": attr.label(
+            allow_single_file = True,
+            cfg = _strip_never_transition,
+            mandatory = True,
+        ),
+        "out": attr.output(mandatory = True),
+        "objcopy_args": attr.string_list(),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    fragments = ["cpp"],
+    toolchains = use_cc_toolchain(),
+)

--- a/comp/host-profiler/symboluploader/symbol_uploader_test.go
+++ b/comp/host-profiler/symboluploader/symbol_uploader_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/DataDog/jsonapi"
 	"github.com/DataDog/zstd"
+	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -300,11 +301,69 @@ func newTestUploader(ctx context.Context, opts uploaderOpts) (*DatadogSymbolUplo
 	return NewDatadogSymbolUploader(ctx, cfg)
 }
 
+type fixtureKind string
+
+const (
+	fixtureNoSymbols                  fixtureKind = "NO_SYMBOLS"
+	fixtureDynsym                     fixtureKind = "DYNSYM"
+	fixtureSymtab                     fixtureKind = "SYMTAB"
+	fixtureDebugInfos                 fixtureKind = "DEBUG_INFOS"
+	fixtureDynsymCorruptGoPCLnTab     fixtureKind = "DYNSYM_CORRUPT_GOPCLNTAB"
+	fixtureDebugInfosCorruptGoPCLnTab fixtureKind = "DEBUG_INFOS_CORRUPT_GOPCLNTAB"
+)
+
 type buildOptions struct {
 	dynsym           bool
 	symtab           bool
 	debugInfos       bool
 	corruptGoPCLnTab bool
+}
+
+func (kind fixtureKind) buildOptions(t *testing.T) buildOptions {
+	t.Helper()
+
+	switch kind {
+	case fixtureNoSymbols:
+		return buildOptions{dynsym: false, symtab: false, debugInfos: false}
+	case fixtureDynsym:
+		return buildOptions{dynsym: true, symtab: false, debugInfos: false}
+	case fixtureSymtab:
+		return buildOptions{dynsym: true, symtab: true, debugInfos: false}
+	case fixtureDebugInfos:
+		return buildOptions{dynsym: true, symtab: true, debugInfos: true}
+	case fixtureDynsymCorruptGoPCLnTab:
+		return buildOptions{dynsym: true, symtab: false, debugInfos: false, corruptGoPCLnTab: true}
+	case fixtureDebugInfosCorruptGoPCLnTab:
+		return buildOptions{dynsym: true, symtab: true, debugInfos: true, corruptGoPCLnTab: true}
+	default:
+		require.Failf(t, "unknown Go fixture", "unknown Go fixture kind %q", kind)
+		return buildOptions{}
+	}
+}
+
+func isBazelTest() bool {
+	return os.Getenv("TEST_SRCDIR") != "" || os.Getenv("RUNFILES_DIR") != "" || os.Getenv("RUNFILES_MANIFEST_FILE") != ""
+}
+
+func bazelGoFixture(t *testing.T, kind fixtureKind) string {
+	t.Helper()
+
+	envName := "SYMBOL_UPLOADER_FIXTURE_" + string(kind)
+	loc := os.Getenv(envName)
+	require.NotEmptyf(t, loc, "expected %s to be set by the Bazel test rule", envName)
+
+	fixture, err := runfiles.Rlocation(loc)
+	require.NoError(t, err)
+	return fixture
+}
+
+func goFixture(t *testing.T, tmpDir, buildID string, kind fixtureKind) string {
+	t.Helper()
+
+	if isBazelTest() {
+		return bazelGoFixture(t, kind)
+	}
+	return buildGo(t, tmpDir, buildID, kind.buildOptions(t))
 }
 
 func buildGo(t *testing.T, tmpDir, buildID string, opts buildOptions) string {
@@ -420,12 +479,12 @@ func TestSymbolUpload(t *testing.T) {
 		checkUploadsWithEncoding(t, expectedSymbolSource, expectedGoPCLnTab, expectedUploads, expectedEncoding)
 	}
 
-	goExeNoSymbols := buildGo(t, t.TempDir(), buildID, buildOptions{dynsym: false, symtab: false, debugInfos: false})
-	goExeyDynsym := buildGo(t, t.TempDir(), buildID, buildOptions{dynsym: true, symtab: false, debugInfos: false})
-	goExeSymtab := buildGo(t, t.TempDir(), buildID, buildOptions{dynsym: true, symtab: true, debugInfos: false})
-	goExeDebugInfos := buildGo(t, t.TempDir(), buildID, buildOptions{dynsym: true, symtab: true, debugInfos: true})
-	goExeyDynsymCorruptGoPCLnTab := buildGo(t, t.TempDir(), buildID, buildOptions{dynsym: true, symtab: false, debugInfos: false, corruptGoPCLnTab: true})
-	goExeDebugInfosCorruptGoPCLnTab := buildGo(t, t.TempDir(), buildID, buildOptions{dynsym: true, symtab: true, debugInfos: true, corruptGoPCLnTab: true})
+	goExeNoSymbols := goFixture(t, t.TempDir(), buildID, fixtureNoSymbols)
+	goExeyDynsym := goFixture(t, t.TempDir(), buildID, fixtureDynsym)
+	goExeSymtab := goFixture(t, t.TempDir(), buildID, fixtureSymtab)
+	goExeDebugInfos := goFixture(t, t.TempDir(), buildID, fixtureDebugInfos)
+	goExeyDynsymCorruptGoPCLnTab := goFixture(t, t.TempDir(), buildID, fixtureDynsymCorruptGoPCLnTab)
+	goExeDebugInfosCorruptGoPCLnTab := goFixture(t, t.TempDir(), buildID, fixtureDebugInfosCorruptGoPCLnTab)
 
 	t.Run("No symbol upload if no symbols", func(t *testing.T) {
 		httpmock.ZeroCallCounters()


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

It makes `symbol_uploader_test` runnable in CI bazel jobs (allowing us to remove the `manual` tag) by making the fixtures originally built by the test code (using a combination of `go build` and `objcopy`) be built by Bazel.

The change is done in such a way that the previous behavior is preserved when the test is not Bazel-driven so as to not break existing workflows.

### Motivation

ABLD-516. This is needed in order to be able to switch off `dda inv test`-based jobs, as it accounts for the biggest remaining gap in coverage-based comparison.

### Describe how you validated your changes

Passing CI.

### Additional Notes

There are two points worth noting.

**The code under test still relies on non-hermetic objcopy**. A first attempt to pass the same `objcopy` from the toolchain to the test so that the code would use it failed because it didn't preserve dynamic symbols. This seems to be a version issue – the hermetic objcopy uses GNU objcopy 2.29.1 vs the dev container's 2.42. I traced the hermetic toolchain's version back to [here](https://github.com/DataDog/datadog-agent-buildimages/blob/c4de8da8719b26238f6d238c88c6924b60faf1b2/toolchains/crosstool-ng/aarch64/config-aarch64-unknown-gnu-linux#L362), so it should technically be possible to update it; but I prefer to postpone this work and land this as it is as a first approximation that lets us keep moving forward.

A transition is required to make sure the `go_binary` targets used for the fixtures don't strip symbols regardless of configuration (see [rules_go source for reference](https://github.com/bazel-contrib/rules_go/blob/7da903b60f6e97643166e56ecd15c46f9aa61a66/go/private/actions/link.bzl#L200-L201)). Some of the tests rely on this and must therefore be deterministic. This can't be added as an attribute like `race` and `pure`, though it might be possible to change that upstream to avoid requiring this transition. In practice the dependency tree "contaminated" by this transition should be small enough that there's no noticeable impact.
