### PR TITLE
[CWS][CSPM] Run CSPM and CWS in system-probe by default

### DIFF
--- a/pkg/config/schema/yaml/compliance_config.yaml
+++ b/pkg/config/schema/yaml/compliance_config.yaml
@@ -208,7 +208,7 @@ properties:
   run_in_system_probe:
     node_type: setting
     type: boolean
-    default: false
+    default: true
     tags:
     - full-agent-only:true
   xccdf:

--- a/pkg/config/schema/yaml/runtime_security_config.yaml
+++ b/pkg/config/schema/yaml/runtime_security_config.yaml
@@ -110,7 +110,7 @@ properties:
   direct_send_from_system_probe:
     node_type: setting
     type: boolean
-    default: false
+    default: true
   enabled:
     node_type: setting
     type: boolean

--- a/pkg/config/schema/yaml/system-probe-cws.yaml
+++ b/pkg/config/schema/yaml/system-probe-cws.yaml
@@ -243,7 +243,7 @@ properties:
   direct_send_from_system_probe:
     node_type: setting
     type: boolean
-    default: false
+    default: true
   ebpfless:
     node_type: section
     type: object

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1032,6 +1032,60 @@ func ComputeDataPlaneStopTimeout(config pkgconfigmodel.Config) {
 	config.Set("data_plane.stop_timeout", sum, pkgconfigmodel.SourceDefault)
 }
 
+// Defaults used by EnableAgentIPCForSystemProbeSecurity when it turns the agent
+// IPC config endpoint on. The port matches the one the DDOT installer writes
+// (see pkg/fleet/installer/packages/otel_config_common.go) so that both
+// consumers of the endpoint agree on where it lives.
+const (
+	defaultSecurityAgentIPCPort                  = 5009
+	defaultSecurityAgentIPCConfigRefreshInterval = 60
+)
+
+// EnableAgentIPCForSystemProbeSecurity is a post-load override that turns on the
+// agent IPC config endpoint when CWS or CSPM ship their payloads straight from
+// system-probe instead of from the security-agent.
+//
+// system-probe runs with a no-op secrets resolver, so it cannot expand
+// secret-backed settings such as `api_key` on its own. Its only way to obtain
+// resolved values is configsync, which reads the core agent's IPC config
+// endpoint, and both ends of that link are off by default
+// (`agent_ipc.config_refresh_interval` and `agent_ipc.port` are 0). Enabling
+// them here — rather than flipping the shipped defaults — keeps the endpoint
+// closed on the installs that do not need it.
+//
+// The condition mirrors how the security-agent decides to stand down
+// (cmd/security-agent/subcommands/start/command.go) and how the compliance
+// system-probe module decides to run, so the endpoint opens exactly when the
+// security-agent stops shipping those payloads.
+//
+// Values are set at SourceDefault, so an explicit `agent_ipc` configuration
+// still wins and `IsConfigured` stays false.
+func EnableAgentIPCForSystemProbeSecurity(config pkgconfigmodel.Config) {
+	cwsFromSystemProbe := config.GetBool("runtime_security_config.enabled") &&
+		config.GetBool("runtime_security_config.direct_send_from_system_probe")
+	cspmFromSystemProbe := config.GetBool("compliance_config.enabled") &&
+		config.GetBool("compliance_config.run_in_system_probe")
+	if !cwsFromSystemProbe && !cspmFromSystemProbe {
+		return
+	}
+
+	if config.GetSource("agent_ipc.config_refresh_interval") == pkgconfigmodel.SourceDefault &&
+		config.GetInt("agent_ipc.config_refresh_interval") <= 0 {
+		config.Set("agent_ipc.config_refresh_interval", defaultSecurityAgentIPCConfigRefreshInterval, pkgconfigmodel.SourceDefault)
+	}
+
+	// A unix socket is only served on Linux (comp/api/api/apiimpl/listener) and
+	// would need a volume shared between the agent and system-probe containers,
+	// so fall back to the loopback port unless the user asked for the socket.
+	if config.GetBool("agent_ipc.use_socket") {
+		return
+	}
+	if config.GetSource("agent_ipc.port") == pkgconfigmodel.SourceDefault &&
+		config.GetInt("agent_ipc.port") <= 0 {
+		config.Set("agent_ipc.port", defaultSecurityAgentIPCPort, pkgconfigmodel.SourceDefault)
+	}
+}
+
 // pathExists returns true if the given path exists
 func pathExists(path string) bool {
 	_, err := os.Stat(path)

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -929,6 +929,86 @@ data_plane:
 	})
 }
 
+func TestEnableAgentIPCForSystemProbeSecurity(t *testing.T) {
+	t.Run("stays closed when neither feature is enabled", func(t *testing.T) {
+		cfg := confFromYAML(t, "")
+
+		EnableAgentIPCForSystemProbeSecurity(cfg)
+
+		assert.Equal(t, 0, cfg.GetInt("agent_ipc.config_refresh_interval"))
+		assert.Equal(t, 0, cfg.GetInt("agent_ipc.port"))
+	})
+
+	t.Run("stays closed when the feature runs in the security-agent", func(t *testing.T) {
+		cfg := confFromYAML(t, `
+runtime_security_config:
+  enabled: true
+  direct_send_from_system_probe: false
+`)
+
+		EnableAgentIPCForSystemProbeSecurity(cfg)
+
+		assert.Equal(t, 0, cfg.GetInt("agent_ipc.config_refresh_interval"))
+		assert.Equal(t, 0, cfg.GetInt("agent_ipc.port"))
+	})
+
+	t.Run("opens for CWS shipping from system-probe", func(t *testing.T) {
+		cfg := confFromYAML(t, `
+runtime_security_config:
+  enabled: true
+`)
+
+		EnableAgentIPCForSystemProbeSecurity(cfg)
+
+		assert.Equal(t, defaultSecurityAgentIPCConfigRefreshInterval, cfg.GetInt("agent_ipc.config_refresh_interval"))
+		assert.Equal(t, defaultSecurityAgentIPCPort, cfg.GetInt("agent_ipc.port"))
+		// Derived defaults, so an explicit configuration still wins later.
+		assert.Equal(t, pkgconfigmodel.SourceDefault, cfg.GetSource("agent_ipc.port"))
+		assert.False(t, cfg.IsConfigured("agent_ipc.port"))
+	})
+
+	t.Run("opens for CSPM shipping from system-probe", func(t *testing.T) {
+		cfg := confFromYAML(t, `
+compliance_config:
+  enabled: true
+`)
+
+		EnableAgentIPCForSystemProbeSecurity(cfg)
+
+		assert.Equal(t, defaultSecurityAgentIPCConfigRefreshInterval, cfg.GetInt("agent_ipc.config_refresh_interval"))
+		assert.Equal(t, defaultSecurityAgentIPCPort, cfg.GetInt("agent_ipc.port"))
+	})
+
+	t.Run("explicit agent_ipc settings are preserved", func(t *testing.T) {
+		cfg := confFromYAML(t, `
+runtime_security_config:
+  enabled: true
+agent_ipc:
+  port: 6789
+  config_refresh_interval: 15
+`)
+
+		EnableAgentIPCForSystemProbeSecurity(cfg)
+
+		assert.Equal(t, 15, cfg.GetInt("agent_ipc.config_refresh_interval"))
+		assert.Equal(t, 6789, cfg.GetInt("agent_ipc.port"))
+	})
+
+	t.Run("does not set a port when the socket is requested", func(t *testing.T) {
+		cfg := confFromYAML(t, `
+runtime_security_config:
+  enabled: true
+agent_ipc:
+  use_socket: true
+`)
+
+		EnableAgentIPCForSystemProbeSecurity(cfg)
+
+		assert.Equal(t, defaultSecurityAgentIPCConfigRefreshInterval, cfg.GetInt("agent_ipc.config_refresh_interval"))
+		assert.Equal(t, 0, cfg.GetInt("agent_ipc.port"))
+	})
+}
+
 func TestDataPlaneDefaults(t *testing.T) {
 	cfg := confFromYAML(t, "")
 

--- a/pkg/config/setup/fixup_init.go
+++ b/pkg/config/setup/fixup_init.go
@@ -115,6 +115,7 @@ func fixupInitCommonConfigComponents(config pkgconfigmodel.Config) {
 // called only for full-agent, NOT serverless-init, after declaring settings
 func fixupInitFullAgentOnlyComponents(_ pkgconfigmodel.Config) {
 	pkgconfigmodel.AddOverrideFunc(sanitizeExternalMetricsProviderChunkSize)
+	pkgconfigmodel.AddOverrideFunc(EnableAgentIPCForSystemProbeSecurity)
 }
 
 // postProcessSystemProbe rewrites system-probe repo dir defaults to live under HOST_ETC.

--- a/releasenotes/notes/security-agent-in-system-probe-by-default-d261dbd515a0fec1.yaml
+++ b/releasenotes/notes/security-agent-in-system-probe-by-default-d261dbd515a0fec1.yaml
@@ -1,0 +1,17 @@
+---
+enhancements:
+  - |
+    CSPM and CWS now run entirely inside ``system-probe`` by default:
+    ``compliance_config.run_in_system_probe`` and
+    ``runtime_security_config.direct_send_from_system_probe`` both default to
+    ``true``, so ``system-probe`` collects and ships those payloads directly.
+    Because CSPM and CWS are the only workloads it hosts, the ``security-agent``
+    process no longer has anything to run and exits at startup. Set either
+    setting back to ``false`` to keep running the corresponding feature in the
+    ``security-agent`` process.
+
+    When CSPM or CWS ships from ``system-probe``, the Agent now also enables its
+    IPC configuration endpoint automatically (``agent_ipc.port`` 5009 and
+    ``agent_ipc.config_refresh_interval`` 60 seconds). ``system-probe`` needs it
+    to retrieve resolved settings such as a secret-backed ``api_key`` from the
+    core Agent. Any explicit ``agent_ipc`` configuration is left untouched.

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/flavor v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/util/option v0.76.0-rc.4
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.76.0-rc.4
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.78.3
 	github.com/DataDog/datadog-agent/pkg/util/testutil v0.72.0-devel
 	github.com/DataDog/datadog-agent/pkg/version v0.78.3
 	github.com/DataDog/datadog-agent/test/e2e-framework v0.0.6-0.20251107170748-5d4ea60490c6
@@ -98,7 +99,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.72.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.78.3 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.78.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system v0.72.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.72.0-rc.5 // indirect
 	github.com/DataDog/go-acl v1.0.1 // indirect

--- a/test/new-e2e/tests/agent-configuration/BUILD.bazel
+++ b/test/new-e2e/tests/agent-configuration/BUILD.bazel
@@ -30,6 +30,7 @@ dd_agent_go_test(
         "api_test.go",
         "configrefresh_api_key_refresh_test.go",
         "configrefresh_nix_test.go",
+        "configrefresh_systemprobe_secret_nix_test.go",
         "configrefresh_win_test.go",
         "gui_nix_test.go",
         "gui_win_test.go",
@@ -45,10 +46,12 @@ dd_agent_go_test(
     ],
     embed = [":agent-configuration"],
     embedsrcs = [
+        "config-refresh/fixtures/systemprobe-secret-config.yaml.tmpl",
         "secret/fixtures/secret_script.py",
         "//test/new-e2e/tests/agent-configuration/sgc-embedded:fixtures/secrets.yaml",  # keep
     ],
     deps = [
+        "//pkg/util/scrubber",
         "//test/e2e-framework/components/datadog/agentparams",
         "//test/e2e-framework/components/datadog/agentparams/filepermissions",
         "//test/e2e-framework/components/datadog/agentparams/msi",
@@ -63,5 +66,6 @@ dd_agent_go_test(
         "//test/new-e2e/tests/agent-configuration/secretsutils",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@in_yaml_go_yaml_v2//:yaml",
     ],
 )

--- a/test/new-e2e/tests/agent-configuration/config-refresh/fixtures/systemprobe-secret-config.yaml.tmpl
+++ b/test/new-e2e/tests/agent-configuration/config-refresh/fixtures/systemprobe-secret-config.yaml.tmpl
@@ -1,0 +1,15 @@
+api_key: ENC[api_key]
+log_level: debug
+
+secret_backend_command: {{.SecretResolver}}
+secret_backend_arguments:
+  - {{.SecretDirectory}}
+secret_backend_remove_trailing_line_break: true
+# weakens permissions on the secret backend command to allow group execution
+secret_backend_command_allow_group_exec_perm: true
+
+# There is deliberately no agent_ipc section here. Enabling CSPM is expected to
+# open the IPC config endpoint on its own, because compliance_config.run_in_system_probe
+# defaults to true and system-probe has no secret resolver of its own.
+compliance_config:
+  enabled: true

--- a/test/new-e2e/tests/agent-configuration/configrefresh_systemprobe_secret_nix_test.go
+++ b/test/new-e2e/tests/agent-configuration/configrefresh_systemprobe_secret_nix_test.go
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agentconfiguration
+
+import (
+	_ "embed"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v2"
+
+	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-configuration/secretsutils"
+)
+
+//go:embed config-refresh/fixtures/systemprobe-secret-config.yaml.tmpl
+var systemProbeSecretConfigTmpl string
+
+// Defaults applied by EnableAgentIPCForSystemProbeSecurity in pkg/config/setup/config.go
+// when CSPM or CWS ships its payloads from system-probe.
+const (
+	autoAgentIPCPort                 = 5009
+	autoConfigRefreshIntervalSeconds = 60
+)
+
+const systemProbeLogPath = "/var/log/datadog/system-probe.log"
+
+// TestSystemProbeResolvesSecretAPIKey covers the path that lets CSPM ship from
+// system-probe when the api_key is secret-backed.
+//
+// system-probe runs with a no-op secrets resolver, so it cannot expand
+// ENC[api_key] itself; it can only learn the resolved value from the core agent
+// over the IPC config endpoint. Enabling CSPM is expected to open that endpoint
+// automatically, because compliance_config.run_in_system_probe now defaults to
+// true. If any link in that chain breaks, system-probe builds its intake
+// endpoints with the literal "ENC[api_key]" string and silently fails to ship.
+func (v *configRefreshLinuxSuite) TestSystemProbeResolvesSecretAPIKey() {
+	rootDir := "/tmp/" + v.T().Name()
+	v.Env().RemoteHost.MkdirAll(rootDir)
+
+	secretResolverPath := filepath.Join(rootDir, "secret-resolver.py")
+
+	v.T().Log("Setting up the secret resolver and the api key file")
+	secretClient := secretsutils.NewClient(v.T(), v.Env().RemoteHost, rootDir)
+	secretClient.SetSecret("api_key", apiKey1)
+
+	coreconfig := fillTmplConfig(v.T(), systemProbeSecretConfigTmpl, map[string]interface{}{
+		"SecretDirectory": rootDir,
+		"SecretResolver":  secretResolverPath,
+	})
+
+	v.UpdateEnv(awshost.Provisioner(
+		awshost.WithRunOptions(scenec2.WithAgentOptions(
+			secretsutils.WithUnixSetupScript(secretResolverPath, true),
+			agentparams.WithAgentConfig(coreconfig),
+			// Nothing is needed here: the compliance module is enabled from the
+			// core config, and that alone is what makes system-probe run.
+			agentparams.WithSystemProbeConfig("# intentionally empty\n"),
+			agentparams.WithSkipAPIKeyInConfig(), // api_key is already provided in the config
+		)),
+	))
+
+	v.T().Log("Checking that the core agent opened its IPC config endpoint")
+	var runtimeConfig struct {
+		AgentIPC struct {
+			Port                  int `yaml:"port"`
+			ConfigRefreshInterval int `yaml:"config_refresh_interval"`
+		} `yaml:"agent_ipc"`
+	}
+	require.NoError(v.T(), yaml.Unmarshal([]byte(v.Env().Agent.Client.Config()), &runtimeConfig))
+	assert.Equal(v.T(), autoAgentIPCPort, runtimeConfig.AgentIPC.Port,
+		"enabling CSPM should have opened the agent IPC config endpoint")
+	assert.Equal(v.T(), autoConfigRefreshIntervalSeconds, runtimeConfig.AgentIPC.ConfigRefreshInterval,
+		"enabling CSPM should have turned on config refresh")
+
+	v.T().Log("Checking that system-probe stayed up")
+	// system-probe synchronizes its configuration at init and fails to start if
+	// the core agent is not reachable, so this also covers the startup ordering
+	// between the two services.
+	require.EventuallyWithT(v.T(), func(c *assert.CollectT) {
+		state, _ := v.Env().RemoteHost.Execute("systemctl is-active datadog-agent-sysprobe")
+		assert.Equal(c, "active", strings.TrimSpace(state), "system-probe is not running")
+	}, 2*time.Minute, 5*time.Second)
+
+	v.T().Log("Checking that system-probe resolved the api key")
+	// The logs pipeline redacts the key it is about to use through the scrubber,
+	// so reuse it rather than reimplementing how many characters stay visible.
+	resolved := scrubber.HideKeyExceptLastChars(apiKey1)
+	unresolved := scrubber.HideKeyExceptLastChars("ENC[api_key]")
+	require.EventuallyWithT(v.T(), func(c *assert.CollectT) {
+		logs := v.Env().RemoteHost.MustExecuteOn(c, "sudo cat "+systemProbeLogPath)
+		assert.Contains(c, logs, "(API Key: "+resolved+")",
+			"system-probe did not build its intake endpoints with the resolved api key")
+		assert.NotContains(c, logs, unresolved,
+			"system-probe used the unresolved ENC[api_key] literal, so config sync did not reach it")
+	}, 2*time.Minute, 5*time.Second)
+
+	v.T().Log("Checking that the security-agent stood down")
+	// CSPM is the only workload the security-agent had to run, and it now runs
+	// in system-probe, so the process is expected to exit cleanly at startup.
+	require.EventuallyWithT(v.T(), func(c *assert.CollectT) {
+		state, _ := v.Env().RemoteHost.Execute("systemctl is-active datadog-agent-security")
+		// Exiting with ErrAllComponentsDisabled is a clean exit, so systemd
+		// parks the unit as inactive rather than failed or restarting.
+		assert.Equal(c, "inactive", strings.TrimSpace(state),
+			"the security-agent should have stood down when CSPM runs in system-probe")
+	}, 2*time.Minute, 5*time.Second)
+}


### PR DESCRIPTION
### What does this PR do?

Run CSPM and CWS in system-probe by default

Default compliance_config.run_in_system_probe and
runtime_security_config.direct_send_from_system_probe to true, so
system-probe collects and ships those payloads directly.

### Motivation

With this change, security-agent doesn't need to run.

### Describe how you validated your changes

### Additional Notes
