### PR TITLE
chore(agent-data-plane): make agent-data-plane sole owner of the ADP version pin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -97,7 +97,11 @@
 /bazel/                     @DataDog/agent-build
 /bazel/configs/rust.bazelrc @DataDog/agent-discovery @DataDog/agent-runtimes @DataDog/agent-build
 /deps/                      @DataDog/agent-build
-/deps/agent_data_plane/     @DataDog/agent-data-plane @DataDog/agent-build
+# agent-data-plane owns the pinned version and hashes (bumped frequently, and only
+# they can validate the release being pinned); agent-build stays a co-owner of the
+# packaging scaffolding in BUILD.bazel.
+/deps/agent_data_plane/            @DataDog/agent-data-plane
+/deps/agent_data_plane/BUILD.bazel @DataDog/agent-data-plane @DataDog/agent-build
 
 # The owner should really be to a team that does not exist yet. It would cover supply chain in general.
 # For now, agent-build are the experts in that.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -97,9 +97,6 @@
 /bazel/                     @DataDog/agent-build
 /bazel/configs/rust.bazelrc @DataDog/agent-discovery @DataDog/agent-runtimes @DataDog/agent-build
 /deps/                      @DataDog/agent-build
-# agent-data-plane owns the pinned version and hashes (bumped frequently, and only
-# they can validate the release being pinned); agent-build stays a co-owner of the
-# packaging scaffolding in BUILD.bazel.
 /deps/agent_data_plane/            @DataDog/agent-data-plane
 /deps/agent_data_plane/BUILD.bazel @DataDog/agent-data-plane @DataDog/agent-build
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -97,8 +97,7 @@
 /bazel/                     @DataDog/agent-build
 /bazel/configs/rust.bazelrc @DataDog/agent-discovery @DataDog/agent-runtimes @DataDog/agent-build
 /deps/                      @DataDog/agent-build
-/deps/agent_data_plane/            @DataDog/agent-data-plane
-/deps/agent_data_plane/BUILD.bazel @DataDog/agent-data-plane @DataDog/agent-build
+/deps/agent_data_plane/agent_data_plane.MODULE.bazel @DataDog/agent-data-plane
 
 # The owner should really be to a team that does not exist yet. It would cover supply chain in general.
 # For now, agent-build are the experts in that.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,13 +90,13 @@
 /go.work                                        @DataDog/agent-runtimes
 
 # Bazel configuration
-/*.bazel*                   @DataDog/agent-build
-/.adms/                     @DataDog/agent-build @DataDog/agent-devx
-/.bazel*                    @DataDog/agent-build
-/.buildifier.json           @DataDog/agent-build
-/bazel/                     @DataDog/agent-build
-/bazel/configs/rust.bazelrc @DataDog/agent-discovery @DataDog/agent-runtimes @DataDog/agent-build
-/deps/                      @DataDog/agent-build
+/*.bazel*                                            @DataDog/agent-build
+/.adms/                                              @DataDog/agent-build @DataDog/agent-devx
+/.bazel*                                             @DataDog/agent-build
+/.buildifier.json                                    @DataDog/agent-build
+/bazel/                                              @DataDog/agent-build
+/bazel/configs/rust.bazelrc                          @DataDog/agent-discovery @DataDog/agent-runtimes @DataDog/agent-build
+/deps/                                               @DataDog/agent-build
 /deps/agent_data_plane/agent_data_plane.MODULE.bazel @DataDog/agent-data-plane
 
 # The owner should really be to a team that does not exist yet. It would cover supply chain in general.


### PR DESCRIPTION
### What does this PR do?

Re-assigns codeownership of the file that contains the agent-data-plane version and hashes to just DataDog/agent-data-plane (dropping DataDog/agent-build).

### Motivation

When bumping the ADP version, agent-build is always tagged for review even though they are unlikely to have the context to do anything more than rubber stamp the PR.

### Describe how you validated your changes

`dda inv github.lint-codeowner` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
