### PR TITLE
privateactionrunner: fix duplicate action_fqn/task_id log fields

### DIFF
--- a/pkg/privateactionrunner/observability/metrics.go
+++ b/pkg/privateactionrunner/observability/metrics.go
@@ -30,14 +30,20 @@ const (
 )
 
 func ReportExecutionStart(metricsClient statsd.ClientInterface, client actionsclientpb.Client, fqn, taskID string, logger log.Logger) time.Time {
-	logger.Info("Running private action", log.String(ActionFqnTagName, fqn), log.String(ActionClientTagName, client.String()), log.String(TaskIDTagName, taskID))
+	// action_fqn and task_id are already bound on logger's context fields (see
+	// WorkflowRunner.handleTask), so only action_client is added here to avoid
+	// duplicate fields in the log output.
+	logger.Info("Running private action", log.String(ActionClientTagName, client.String()))
 	tags := []string{fmt.Sprintf("%s:%s", ActionClientTagName, client), fmt.Sprintf("%s:%s", ActionFqnTagName, fqn)}
 	_ = metricsClient.Incr(ActionExecutionStartedMetric, tags, 1.0)
 	return time.Now()
 }
 
 func ReportExecutionCompleted(metricsClient statsd.ClientInterface, client actionsclientpb.Client, fqn, taskId string, startTime time.Time, err error, logger log.Logger) {
-	logger = logger.With(log.String(ActionFqnTagName, fqn), log.String(ActionClientTagName, client.String()), log.String(TaskIDTagName, taskId))
+	// action_fqn and task_id are already bound on logger's context fields (see
+	// WorkflowRunner.handleTask), so only action_client is added here to avoid
+	// duplicate fields in the log output.
+	logger = logger.With(log.String(ActionClientTagName, client.String()))
 	tags := []string{fmt.Sprintf("%s:%s", ActionClientTagName, client), fmt.Sprintf("%s:%s", ActionFqnTagName, fqn)}
 	if err != nil {
 		logger.Warn("Private actions completed with failure", log.ErrorField(err))

--- a/pkg/privateactionrunner/runners/workflow_runner.go
+++ b/pkg/privateactionrunner/runners/workflow_runner.go
@@ -208,7 +208,9 @@ func (n *WorkflowRunner) startHeartbeat(ctx context.Context, task *types.Task, l
 	for {
 		select {
 		case <-ctx.Done():
-			logger.Info("Heartbeat stopped for task", log.String("task_id", task.Data.ID))
+			// task_id is already bound on logger's context fields (set by the caller
+			// in handleTask), so it is not passed again here.
+			logger.Info("Heartbeat stopped for task")
 			return
 		case <-ticker.C:
 			err := n.opmsClient.Heartbeat(ctx, task.Data.Attributes.Client, task.Data.ID, task.GetFQN(), task.Data.Attributes.JobId)


### PR DESCRIPTION
## What does this PR do?

Fixes duplicate `action_fqn` (and `task_id`) fields in logs emitted by the Private Action Runner, visible e.g. via `journalctl` on the `datadog-agent-action` service:

```
runner_id:...,runner_version:...,modes:[pull],task_id:...,action_fqn:com.datadoghq.remoteaction.rshell.runRemediationCommand,action_fqn:com.datadoghq.remoteaction.rshell.runRemediationCommand,action_client:RSHELL_TERMINAL
```

## Motivation

`WorkflowRunner.handleTask` binds `task_id` and `action_fqn` onto the context logger for the lifetime of a task (`pkg/privateactionrunner/runners/workflow_runner.go`). That enriched logger/context flows down into `WorkflowTaskExecutor.RunTask`.

However, `ReportExecutionStart` / `ReportExecutionCompleted` (`pkg/privateactionrunner/observability/metrics.go`) re-added the same `action_fqn`/`task_id` fields explicitly on every call. The logging adapter (`log_adapter.go`) appends fields without deduping, so these keys were emitted twice per log line.

A similar issue existed in the `ctx.Done()` branch of `startHeartbeat`, which re-added `task_id` even though the `logger` parameter passed in already had it bound (it is the same logger created in `handleTask`).

## Changes

- `observability/metrics.go`: `ReportExecutionStart`/`ReportExecutionCompleted` now only add `action_client` (the one field not already bound on the context logger), instead of re-adding `action_fqn`/`task_id`.
- `runners/workflow_runner.go`: the `ctx.Done()` heartbeat-stop log no longer re-adds `task_id`.

Note: the ticker branch inside `startHeartbeat` is intentionally unchanged — it derives from the un-enriched outer context (`heartbeatCtx`), so explicitly adding `task_id`/`action_fqn`/`job_id` there is correct and necessary.

## Testing

- `dda inv privateactionrunner.build` — succeeds
- `dda inv test --targets=./pkg/privateactionrunner/observability/...` — all tests pass
