### PR TITLE
test(e2e/npm): bump EKS Helm release timeout to 600s

### DIFF
--- a/test/new-e2e/tests/npm/eks_1host_test.go
+++ b/test/new-e2e/tests/npm/eks_1host_test.go
@@ -71,7 +71,10 @@ func eksHttpbinEnvProvisioner(opts ...eks.RunOption) provisioners.PulumiEnvRunFu
 
 		provisionerOpts := []eks.RunOption{
 			eks.WithEKSOptions(eks.WithLinuxNodeGroup()),
-			eks.WithAgentOptions(kubernetesagentparams.WithHelmValues(systemProbeConfigNPMHelmValues)),
+			eks.WithAgentOptions(
+				kubernetesagentparams.WithHelmValues(systemProbeConfigNPMHelmValues),
+				kubernetesagentparams.WithTimeout(600),
+			),
 			eks.WithWorkloadApp(npmToolsWorkload),
 		}
 		provisionerOpts = append(provisionerOpts, opts...)


### PR DESCRIPTION
### What does this PR do?

Bumps the Helm release readiness timeout for the npm EKS E2E suite (`TestEKSVMSuite`) from the 5-minute default to 10 minutes, via `kubernetesagentparams.WithTimeout(600)`.

### Motivation

On a freshly provisioned EKS cluster the agent DaemonSet pods can take longer than 5 minutes to pull the image and become ready. When that happens the Helm release fails with `context deadline exceeded`, which matches a `ReCreate` known-error pattern — the framework destroys the entire EKS cluster and rebuilds it from scratch. An observed CI run burned ~32 minutes on destroy+rebuild for slowness that resolves cleanly on retry. Sibling EKS suites already bump this timeout (sbom 900s, ssi and autoscaling/spot 600s); npm was the only one leaving it at the default.