### PR TITLE
privateactionrunner/rshell: log effective settings at Info level

### DIFF
--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
@@ -300,7 +300,7 @@ func (h *RunCommandHandler) Run(
 	if inputs.EffectivePermissions != "" {
 		switch inputs.EffectivePermissions {
 		case privilegedhelper.EscalationAllowed:
-			return h.runPrivileged(ctx, task)
+			return h.runPrivileged(ctx, task, inputs)
 		case "Root":
 			return nil, errors.New("whole-script root execution is not supported")
 		default:
@@ -318,8 +318,8 @@ func (h *RunCommandHandler) Run(
 	if runtime.GOOS == "linux" {
 		systemdTarget = resolveSystemdTarget()
 	}
-	log.Infof("rshell runCommand (mode=%s): command=%q backendAllowedCommands=%v effectiveAllowedCommands=%v elevatableCommands=%v backendAllowedPaths=%v effectiveAllowedPaths=%v backendAllowedSystemServices=%v effectiveAllowedSystemServices=%v procPath=%s systemdTarget=%+v disableDetailedTelemetry=%v",
-		h.mode, inputs.Command, backendCommands, effectiveAllowedCommands, inputs.ElevatableCommands, backendPaths, effectiveAllowedPaths, backendAllowedSystemServices, effectiveAllowedSystemServices, procPath, systemdTarget, h.disableCommandTelemetry)
+	log.Infof("rshell runCommand (mode=%s): backendAllowedCommands=%v effectiveAllowedCommands=%v elevatableCommands=%v backendAllowedPaths=%v effectiveAllowedPaths=%v backendAllowedSystemServices=%v effectiveAllowedSystemServices=%v procPath=%s systemdTarget=%+v disableDetailedTelemetry=%v",
+		h.mode, backendCommands, effectiveAllowedCommands, inputs.ElevatableCommands, backendPaths, effectiveAllowedPaths, backendAllowedSystemServices, effectiveAllowedSystemServices, procPath, systemdTarget, h.disableCommandTelemetry)
 
 	prog, err := syntax.NewParser().Parse(strings.NewReader(inputs.Command), "")
 	if err != nil {
@@ -378,13 +378,9 @@ func (h *RunCommandHandler) Run(
 	}, nil
 }
 
-func (h *RunCommandHandler) runPrivileged(ctx context.Context, task *types.Task) (interface{}, error) {
-	inputs, err := types.ExtractInputs[RunCommandInputs](task)
-	if err != nil {
-		return nil, err
-	}
-	log.Infof("rshell runPrivileged (mode=%s): command=%q elevatableCommands=%v privilegedEnabled=%v privilegedSocket=%s disableDetailedTelemetry=%v",
-		h.mode, inputs.Command, inputs.ElevatableCommands, h.privilegedEnabled, h.privilegedSocket, h.disableCommandTelemetry)
+func (h *RunCommandHandler) runPrivileged(ctx context.Context, task *types.Task, inputs RunCommandInputs) (interface{}, error) {
+	log.Infof("rshell runPrivileged (mode=%s): elevatableCommands=%v privilegedEnabled=%v privilegedSocket=%s disableDetailedTelemetry=%v",
+		h.mode, inputs.ElevatableCommands, h.privilegedEnabled, h.privilegedSocket, h.disableCommandTelemetry)
 	if !h.privilegedEnabled {
 		return nil, errors.New("privileged rshell execution is disabled by local configuration")
 	}

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
@@ -313,8 +313,13 @@ func (h *RunCommandHandler) Run(
 	effectiveAllowedPaths := h.filterAllowedPaths(backendPaths)
 	backendAllowedSystemServices := backendSystemServiceGrants(backendSystemServices)
 	effectiveAllowedSystemServices := h.filterSystemServiceGrants(backendAllowedSystemServices)
-	log.Debugf("rshell runCommand (mode=%s): command=%q backendAllowedCommands=%v effectiveAllowedCommands=%v backendAllowedPaths=%v effectiveAllowedPaths=%v backendAllowedSystemServices=%v effectiveAllowedSystemServices=%v",
-		h.mode, inputs.Command, backendCommands, effectiveAllowedCommands, backendPaths, effectiveAllowedPaths, backendAllowedSystemServices, effectiveAllowedSystemServices)
+	procPath := resolveProcPath()
+	var systemdTarget interp.SystemdTargetConfig
+	if runtime.GOOS == "linux" {
+		systemdTarget = resolveSystemdTarget()
+	}
+	log.Infof("rshell runCommand (mode=%s): command=%q backendAllowedCommands=%v effectiveAllowedCommands=%v elevatableCommands=%v backendAllowedPaths=%v effectiveAllowedPaths=%v backendAllowedSystemServices=%v effectiveAllowedSystemServices=%v procPath=%s systemdTarget=%+v disableDetailedTelemetry=%v",
+		h.mode, inputs.Command, backendCommands, effectiveAllowedCommands, inputs.ElevatableCommands, backendPaths, effectiveAllowedPaths, backendAllowedSystemServices, effectiveAllowedSystemServices, procPath, systemdTarget, h.disableCommandTelemetry)
 
 	prog, err := syntax.NewParser().Parse(strings.NewReader(inputs.Command), "")
 	if err != nil {
@@ -336,7 +341,7 @@ func (h *RunCommandHandler) Run(
 		interp.WarningsWriter(io.Discard),
 		interp.Script(inputs.Command),
 		interp.AllowedPaths(effectiveAllowedPaths),
-		interp.ProcPath(resolveProcPath()),
+		interp.ProcPath(procPath),
 		interp.AllowedCommands(effectiveAllowedCommands),
 		interp.AllowedSystemServices(effectiveAllowedSystemServices),
 		interp.WithMode(h.mode),
@@ -345,7 +350,7 @@ func (h *RunCommandHandler) Run(
 		runnerOptions = append(runnerOptions, interp.DisableDetailedTelemetry())
 	}
 	if runtime.GOOS == "linux" {
-		runnerOptions = append(runnerOptions, interp.WithSystemdTarget(resolveSystemdTarget()))
+		runnerOptions = append(runnerOptions, interp.WithSystemdTarget(systemdTarget))
 	}
 	runner, err := interp.New(runnerOptions...)
 	if err != nil {
@@ -374,6 +379,12 @@ func (h *RunCommandHandler) Run(
 }
 
 func (h *RunCommandHandler) runPrivileged(ctx context.Context, task *types.Task) (interface{}, error) {
+	inputs, err := types.ExtractInputs[RunCommandInputs](task)
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("rshell runPrivileged (mode=%s): command=%q elevatableCommands=%v privilegedEnabled=%v privilegedSocket=%s disableDetailedTelemetry=%v",
+		h.mode, inputs.Command, inputs.ElevatableCommands, h.privilegedEnabled, h.privilegedSocket, h.disableCommandTelemetry)
 	if !h.privilegedEnabled {
 		return nil, errors.New("privileged rshell execution is disabled by local configuration")
 	}

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
@@ -660,6 +660,32 @@ func TestPrivilegedExecutionRequiresLocalOptIn(t *testing.T) {
 	}
 }
 
+// TestRunPrivilegedLogsSettingsAtInfoLevel pins that runPrivileged also emits
+// an Info-level settings summary line before it is rejected by local
+// configuration, so a rejected privileged attempt is still visible in
+// journalctl.
+func TestRunPrivilegedLogsSettingsAtInfoLevel(t *testing.T) {
+	var logBuffer bytes.Buffer
+	logger, err := log.LoggerFromWriterWithMinLevelAndLvlMsgFormat(&logBuffer, log.InfoLvl)
+	require.NoError(t, err)
+	previousLogger := log.Default()
+	t.Cleanup(func() { log.SetupLogger(previousLogger, "info") })
+	log.SetupLogger(logger, "info")
+
+	handler := newDefaultRunCommandHandler()
+	task := makeTask("sudo cat /root/secret", []string{"rshell:cat"})
+	task.Data.Attributes.Inputs["effectivePermissions"] = "EscalationAllowed"
+	task.Data.Attributes.Inputs["elevatableCommands"] = []string{"rshell:cat"}
+
+	_, err = handler.Run(context.Background(), task, nil)
+	require.ErrorContains(t, err, "disabled by local configuration")
+
+	logs := logBuffer.String()
+	assert.Contains(t, logs, "[INFO] rshell runPrivileged")
+	assert.Contains(t, logs, "elevatableCommands=[rshell:cat]")
+	assert.Contains(t, logs, "privilegedEnabled=false")
+}
+
 func TestWholeScriptRootIsRejected(t *testing.T) {
 	handler := newDefaultRunRemediationCommandHandler()
 	task := makeTask("truncate -s 0 /var/log/app.log", []string{"rshell:truncate"})
@@ -826,6 +852,39 @@ func TestRunCommandLogsBackendAndEffectiveSystemServicePolicies(t *testing.T) {
 	logs := logBuffer.String()
 	assert.Contains(t, logs, "backendAllowedSystemServices=[{mysql.service [read restart]} {nginx.service [reload]}]")
 	assert.Contains(t, logs, "effectiveAllowedSystemServices=[{mysql.service [read]}]")
+}
+
+// TestRunCommandLogsSettingsAtInfoLevel pins that the settings summary line
+// is emitted at Info level (visible in journalctl without opting into debug
+// logging), and that it reports every effective rshell setting: allowed
+// commands, elevatable commands, allowed paths, allowed system services,
+// proc path, systemd target, and the detailed-telemetry toggle.
+func TestRunCommandLogsSettingsAtInfoLevel(t *testing.T) {
+	var logBuffer bytes.Buffer
+	logger, err := log.LoggerFromWriterWithMinLevelAndLvlMsgFormat(&logBuffer, log.InfoLvl)
+	require.NoError(t, err)
+	previousLogger := log.Default()
+	t.Cleanup(func() { log.SetupLogger(previousLogger, "info") })
+	log.SetupLogger(logger, "info")
+
+	handler := NewRunCommandHandler(RunCommandHandlerConfig{
+		OperatorAllowedPaths:     []string{setup.RShellPathAllowAll},
+		OperatorAllowedCommands:  []string{rShellCommandAllowAllWildcard},
+		DisableDetailedTelemetry: true,
+	})
+	task := makeTask("echo hello", []string{"rshell:echo"})
+	task.Data.Attributes.Inputs["elevatableCommands"] = []string{"rshell:echo"}
+
+	_, err = handler.Run(context.Background(), task, nil)
+	require.NoError(t, err)
+
+	logs := logBuffer.String()
+	assert.Contains(t, logs, "[INFO] rshell runCommand")
+	assert.Contains(t, logs, "effectiveAllowedCommands=[rshell:echo]")
+	assert.Contains(t, logs, "elevatableCommands=[rshell:echo]")
+	assert.Contains(t, logs, "procPath=")
+	assert.Contains(t, logs, "systemdTarget=")
+	assert.Contains(t, logs, "disableDetailedTelemetry=true")
 }
 
 func TestRunCommandDisallowedCommandBlocked(t *testing.T) {

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
@@ -660,10 +660,6 @@ func TestPrivilegedExecutionRequiresLocalOptIn(t *testing.T) {
 	}
 }
 
-// TestRunPrivilegedLogsSettingsAtInfoLevel pins that runPrivileged also emits
-// an Info-level settings summary line before it is rejected by local
-// configuration, so a rejected privileged attempt is still visible in
-// journalctl.
 func TestRunPrivilegedLogsSettingsAtInfoLevel(t *testing.T) {
 	var logBuffer bytes.Buffer
 	logger, err := log.LoggerFromWriterWithMinLevelAndLvlMsgFormat(&logBuffer, log.InfoLvl)
@@ -854,11 +850,6 @@ func TestRunCommandLogsBackendAndEffectiveSystemServicePolicies(t *testing.T) {
 	assert.Contains(t, logs, "effectiveAllowedSystemServices=[{mysql.service [read]}]")
 }
 
-// TestRunCommandLogsSettingsAtInfoLevel pins that the settings summary line
-// is emitted at Info level (visible in journalctl without opting into debug
-// logging), and that it reports every effective rshell setting: allowed
-// commands, elevatable commands, allowed paths, allowed system services,
-// proc path, systemd target, and the detailed-telemetry toggle.
 func TestRunCommandLogsSettingsAtInfoLevel(t *testing.T) {
 	var logBuffer bytes.Buffer
 	logger, err := log.LoggerFromWriterWithMinLevelAndLvlMsgFormat(&logBuffer, log.InfoLvl)


### PR DESCRIPTION
Bump the rshell runCommand settings summary from Debugf to Infof so it is visible in `journalctl -u datadog-agent-action` without opting into debug logging, and fill in settings that were previously missing from the line: elevatableCommands, procPath, systemdTarget, and disableDetailedTelemetry.

Also add an equivalent Infof line to runPrivileged, which previously logged nothing, so selectively-elevated (sudo) execution attempts are observable too.

<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
