### PR TITLE
[oracle] Add collection intervals for custom queries

### DIFF
--- a/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
@@ -22,6 +22,7 @@ init_config:
   #   - query: <QUERY>
   #     columns: <COLUMNS>
   #     tags: <TAGS>
+  #     collection_interval: <COLLECTION_INTERVAL>
   #
   ## @param service - string - optional
   ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
@@ -347,7 +348,7 @@ instances:
     # use_global_custom_queries: 'true'
 
     ## @param custom_queries - list of mappings - optional
-    ## Each query must have 2 fields, and can have a third optional field:
+    ## Each query must define `query` and `columns`. The other fields are optional:
     ##
     ## 1. metric_prefix - Each metric starts with the chosen prefix. The default is `oracle`.
     ## 2. query - The SQL to execute. It can be a simple statement or a multi-line script.
@@ -370,6 +371,11 @@ instances:
     ## 5. pdb (optional) - A PDB against which the query will be run. Default is CDB$ROOT.
     ##                     The parameter can be defined on a self-managed instance, which
     ##                     connects to CDB.
+    ## 6. collection_interval (optional) - The frequency, in seconds, at which to run the query.
+    ##                     If omitted, the query runs on every check run. If the interval is shorter
+    ##                     than the check interval, the query runs on every check run. Longer intervals
+    ##                     are evaluated on each check run, so execution occurs on the first run after
+    ##                     the configured interval has elapsed.
     #
     ## WARNING: Running custom queries may result in additional costs or fees assessed by Oracle.
     #
@@ -384,6 +390,7 @@ instances:
     #     tags:
     #     - test:tag_value_1
     #     pdb: <MYPDB>
+    #     collection_interval: 60
 
     ## Start an SQL trace for Agent queries. This feature is only meant for Agent troubleshooting, and
     ## should normally be switched off.

--- a/pkg/collector/corechecks/oracle/BUILD.bazel
+++ b/pkg/collector/corechecks/oracle/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "oracle",
@@ -58,4 +59,13 @@ go_library(
         "@com_github_patrickmn_go_cache//:go-cache",
         "@com_github_sijms_go_ora_v2//:go-ora",
     ],
+)
+
+dd_agent_go_test(
+    name = "oracle_test",
+    srcs = ["custom_query_schedule_test.go"],
+    embed = [":oracle"],
+    gotags_sets = [["oracle"]],
+    include_default = False,
+    deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/pkg/collector/corechecks/oracle/config/BUILD.bazel
+++ b/pkg/collector/corechecks/oracle/config/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "config",
@@ -16,5 +17,17 @@ go_library(
         "//pkg/obfuscate",
         "//pkg/util/log",
         "@in_yaml_go_yaml_v3//:yaml",
+    ],
+)
+
+dd_agent_go_test(
+    name = "config_test",
+    srcs = ["config_test.go"],
+    embed = [":config"],
+    gotags_sets = [["oracle"]],
+    include_default = False,
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/collector/corechecks/oracle/config/config.go
+++ b/pkg/collector/corechecks/oracle/config/config.go
@@ -119,11 +119,12 @@ type CustomQueryColumns struct {
 
 //nolint:revive // TODO(DBM) Fix revive linter
 type CustomQuery struct {
-	MetricPrefix string               `yaml:"metric_prefix"`
-	Pdb          string               `yaml:"pdb"`
-	Query        string               `yaml:"query"`
-	Columns      []CustomQueryColumns `yaml:"columns"`
-	Tags         []string             `yaml:"tags"`
+	MetricPrefix       string               `yaml:"metric_prefix"`
+	Pdb                string               `yaml:"pdb"`
+	Query              string               `yaml:"query"`
+	Columns            []CustomQueryColumns `yaml:"columns"`
+	Tags               []string             `yaml:"tags"`
+	CollectionInterval *int64               `yaml:"collection_interval"`
 }
 
 type asmConfig struct {
@@ -291,6 +292,13 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		return nil, err
 	}
 
+	if err := validateCustomQueryCollectionIntervals("custom_queries", instance.CustomQueries); err != nil {
+		return nil, err
+	}
+	if err := validateCustomQueryCollectionIntervals("global_custom_queries", initCfg.CustomQueries); err != nil {
+		return nil, err
+	}
+
 	serverSlice := strings.Split(instance.Server, ":")
 	instance.Server = serverSlice[0]
 
@@ -398,6 +406,15 @@ func shouldPropagateAgentTags(instancePropagateTags, initConfigPropagateTags *bo
 	}
 	// if neither the instance nor the init_config has set the value, return False
 	return false
+}
+
+func validateCustomQueryCollectionIntervals(configName string, queries []CustomQuery) error {
+	for i, query := range queries {
+		if query.CollectionInterval != nil && *query.CollectionInterval <= 0 {
+			return fmt.Errorf("%s[%d].collection_interval must be greater than zero", configName, i)
+		}
+	}
+	return nil
 }
 
 func warnDeprecated(old string, new string) {

--- a/pkg/collector/corechecks/oracle/config/config_test.go
+++ b/pkg/collector/corechecks/oracle/config/config_test.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomQueryCollectionIntervalConfiguration(t *testing.T) {
+	tests := []struct {
+		name      string
+		instance  string
+		init      string
+		wantError string
+	}{
+		{
+			name: "omitted",
+			instance: `username: datadog
+custom_queries:
+  - query: SELECT 1 FROM dual
+`,
+		},
+		{
+			name: "positive",
+			instance: `username: datadog
+custom_queries:
+  - query: SELECT 1 FROM dual
+    collection_interval: 30
+`,
+		},
+		{
+			name: "zero",
+			instance: `username: datadog
+custom_queries:
+  - query: SELECT 1 FROM dual
+    collection_interval: 0
+`,
+			wantError: "custom_queries[0].collection_interval must be greater than zero",
+		},
+		{
+			name: "negative global interval",
+			instance: `username: datadog
+`,
+			init: `global_custom_queries:
+  - query: SELECT 1 FROM dual
+    collection_interval: -1
+`,
+			wantError: "global_custom_queries[0].collection_interval must be greater than zero",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := NewCheckConfig([]byte(tt.instance), []byte(tt.init))
+			if tt.wantError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantError)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.name == "omitted" {
+				assert.Nil(t, cfg.InstanceConfig.CustomQueries[0].CollectionInterval)
+			}
+			if tt.name == "positive" {
+				require.NotNil(t, cfg.InstanceConfig.CustomQueries[0].CollectionInterval)
+				assert.EqualValues(t, 30, *cfg.InstanceConfig.CustomQueries[0].CollectionInterval)
+			}
+		})
+	}
+}

--- a/pkg/collector/corechecks/oracle/custom_queries.go
+++ b/pkg/collector/corechecks/oracle/custom_queries.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -38,8 +39,51 @@ func concatenateError(input error, new string) error {
 	return fmt.Errorf("%w %s", input, new)
 }
 
+func shouldExecuteCustomQuery(lastExecutionTime *time.Time, collectionInterval *int64, now time.Time) bool {
+	if collectionInterval == nil {
+		return true
+	}
+	if lastExecutionTime.IsZero() || now.Sub(*lastExecutionTime).Seconds() >= float64(*collectionInterval) {
+		*lastExecutionTime = now
+		return true
+	}
+	return false
+}
+
 //nolint:revive // TODO(DBM) Fix revive linter
 func (c *Check) CustomQueries() error {
+	var customQueries []config.CustomQuery
+
+	if len(c.config.InstanceConfig.CustomQueries) > 0 {
+		customQueries = append(customQueries, c.config.InstanceConfig.CustomQueries...)
+	}
+	if len(c.config.InitConfig.CustomQueries) > 0 {
+		switch c.config.UseGlobalCustomQueries {
+		case "true":
+			customQueries = make([]config.CustomQuery, len(c.config.InitConfig.CustomQueries))
+			copy(customQueries, c.config.InitConfig.CustomQueries)
+		case "false":
+		case "extend":
+			customQueries = append(customQueries, c.config.InitConfig.CustomQueries...)
+		default:
+			return fmt.Errorf(`Wrong value "%s" for the config parameter use_global_custom_queries. Valid values are "true", "false" and "extend"`, c.config.UseGlobalCustomQueries)
+		}
+	}
+
+	if len(c.customQueryLastRuns) != len(customQueries) {
+		c.customQueryLastRuns = make([]time.Time, len(customQueries))
+	}
+	queriesToRun := make([]config.CustomQuery, 0, len(customQueries))
+	now := c.clock.Now()
+	for i, query := range customQueries {
+		if shouldExecuteCustomQuery(&c.customQueryLastRuns[i], query.CollectionInterval, now) {
+			queriesToRun = append(queriesToRun, query)
+		}
+	}
+	if len(queriesToRun) == 0 {
+		return nil
+	}
+
 	/*
 	 * We are creating a dedicated DB connection for custom queries. Custom queries is
 	 * the only feature that switches to PDBs (all other queries are running against the
@@ -60,25 +104,7 @@ func (c *Check) CustomQueries() error {
 
 	var metricRows []metricRow
 	var allErrors error
-	var customQueries []config.CustomQuery
-
-	if len(c.config.InstanceConfig.CustomQueries) > 0 {
-		customQueries = append(customQueries, c.config.InstanceConfig.CustomQueries...)
-	}
-	if len(c.config.InitConfig.CustomQueries) > 0 {
-		switch c.config.UseGlobalCustomQueries {
-		case "true":
-			customQueries = make([]config.CustomQuery, len(c.config.InitConfig.CustomQueries))
-			copy(customQueries, c.config.InitConfig.CustomQueries)
-		case "false":
-		case "extend":
-			customQueries = append(customQueries, c.config.InitConfig.CustomQueries...)
-		default:
-			return fmt.Errorf(`Wrong value "%s" for the config parameter use_global_custom_queries. Valid values are "true", "false" and "extend"`, c.config.UseGlobalCustomQueries)
-		}
-	}
-
-	for _, q := range customQueries {
+	for _, q := range queriesToRun {
 		metricRows = metricRows[:0]
 		var errInQuery bool
 		metricPrefix := q.MetricPrefix

--- a/pkg/collector/corechecks/oracle/custom_queries_test.go
+++ b/pkg/collector/corechecks/oracle/custom_queries_test.go
@@ -10,8 +10,10 @@ package oracle
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/benbjohnson/clock"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -55,6 +57,100 @@ func TestCustomQueries(t *testing.T) {
 	err = chk.CustomQueries()
 	assert.NoError(t, err, "failed to execute custom query")
 	sender.AssertMetricTaggedWith(t, "Gauge", "oracle.custom_query.test.c1", []string{"c2:A"})
+}
+
+func TestCustomQueriesRespectIndependentCollectionIntervals(t *testing.T) {
+	db, dbMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	shortInterval := int64(30)
+	longInterval := int64(60)
+	columns := []config.CustomQueryColumns{{Name: "value", Type: "gauge"}}
+	queries := []config.CustomQuery{
+		{
+			MetricPrefix:       "oracle.short_interval",
+			Query:              "SELECT 1 FROM short_interval",
+			Columns:            columns,
+			CollectionInterval: &shortInterval,
+		},
+		{
+			MetricPrefix:       "oracle.long_interval",
+			Query:              "SELECT 1 FROM long_interval",
+			Columns:            columns,
+			CollectionInterval: &longInterval,
+		},
+	}
+
+	expectQuery := func(query string) {
+		dbMock.ExpectExec("alter.*").WillReturnResult(sqlmock.NewResult(1, 1))
+		dbMock.ExpectQuery(query).WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(1))
+	}
+
+	// Both queries run immediately, the short query runs after 30 seconds, and
+	// both run after 60 seconds.
+	expectQuery("SELECT 1 FROM short_interval")
+	expectQuery("SELECT 1 FROM long_interval")
+	expectQuery("SELECT 1 FROM short_interval")
+	expectQuery("SELECT 1 FROM short_interval")
+	expectQuery("SELECT 1 FROM long_interval")
+
+	chk, sender := newDbDoesNotExistCheck(t, "", "")
+	sender.SetupAcceptAll()
+	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("Commit").Return()
+	chk.config.InstanceConfig.CustomQueries = queries
+	chk.dbCustomQueries = sqlx.NewDb(db, "sqlmock")
+	mockClock := clock.NewMock()
+	chk.clock = mockClock
+
+	require.NoError(t, chk.CustomQueries())
+	mockClock.Add(29 * time.Second)
+	require.NoError(t, chk.CustomQueries())
+	mockClock.Add(time.Second)
+	require.NoError(t, chk.CustomQueries())
+	mockClock.Add(30 * time.Second)
+	require.NoError(t, chk.CustomQueries())
+
+	assert.NoError(t, dbMock.ExpectationsWereMet())
+	sender.AssertNumberOfCalls(t, "Gauge", 5)
+}
+
+func TestFailedCustomQueryAttemptConsumesCollectionInterval(t *testing.T) {
+	db, dbMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	collectionInterval := int64(30)
+	query := config.CustomQuery{
+		MetricPrefix:       "oracle.failed_interval",
+		Query:              "SELECT 1 FROM failed_interval",
+		Columns:            []config.CustomQueryColumns{{Name: "value", Type: "gauge"}},
+		CollectionInterval: &collectionInterval,
+	}
+
+	dbMock.ExpectExec("alter.*").WillReturnResult(sqlmock.NewResult(1, 1))
+	dbMock.ExpectQuery(query.Query).WillReturnError(fmt.Errorf("query failed"))
+	dbMock.ExpectExec("alter.*").WillReturnResult(sqlmock.NewResult(1, 1))
+	dbMock.ExpectQuery(query.Query).WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(1))
+
+	chk, sender := newDbDoesNotExistCheck(t, "", "")
+	sender.SetupAcceptAll()
+	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("Commit").Return()
+	chk.config.InstanceConfig.CustomQueries = []config.CustomQuery{query}
+	chk.dbCustomQueries = sqlx.NewDb(db, "sqlmock")
+	mockClock := clock.NewMock()
+	chk.clock = mockClock
+
+	require.Error(t, chk.CustomQueries())
+	mockClock.Add(29 * time.Second)
+	require.NoError(t, chk.CustomQueries())
+	mockClock.Add(time.Second)
+	require.NoError(t, chk.CustomQueries())
+
+	assert.NoError(t, dbMock.ExpectationsWereMet())
+	sender.AssertNumberOfCalls(t, "Gauge", 1)
 }
 
 func TestMultipleCustomQueriesNoMetricLeak(t *testing.T) {
@@ -128,6 +224,23 @@ func assertCustomQuery(t *testing.T, c *Check, s *mocksender.MockSender) {
 	s.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	s.AssertMetricTaggedWith(t, "Gauge", "oracle.custom_query.test.value", []string{"name:TAG1"})
 	s.AssertMetric(t, "Gauge", "oracle.custom_query.test.value", 1.012345, c.dbHostname, []string{})
+}
+
+func TestCustomQueriesWithoutIntervalRunEveryCheck(t *testing.T) {
+	c, s := newDefaultCheck(t, `only_custom_queries: true
+custom_queries:
+  - metric_prefix: oracle.custom_query.every_check
+    query: select 1 value from dual
+    columns:
+      - name: value
+        type: gauge
+`, "")
+	defer c.Teardown()
+
+	require.NoError(t, c.Run())
+	require.NoError(t, c.Run())
+
+	s.AssertNumberOfCalls(t, "Gauge", 2)
 }
 
 func TestFloat(t *testing.T) {

--- a/pkg/collector/corechecks/oracle/custom_query_schedule_test.go
+++ b/pkg/collector/corechecks/oracle/custom_query_schedule_test.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle
+
+package oracle
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomQueryWithoutCollectionIntervalAlwaysExecutes(t *testing.T) {
+	var lastExecutionTime time.Time
+	now := time.Unix(100, 0)
+
+	assert.True(t, shouldExecuteCustomQuery(&lastExecutionTime, nil, now))
+	assert.True(t, shouldExecuteCustomQuery(&lastExecutionTime, nil, now))
+	assert.True(t, lastExecutionTime.IsZero())
+}
+
+func TestCustomQueryCollectionInterval(t *testing.T) {
+	collectionInterval := int64(30)
+	var lastExecutionTime time.Time
+	firstRun := time.Unix(100, 0)
+
+	assert.True(t, shouldExecuteCustomQuery(&lastExecutionTime, &collectionInterval, firstRun))
+	assert.Equal(t, firstRun, lastExecutionTime)
+	assert.False(t, shouldExecuteCustomQuery(&lastExecutionTime, &collectionInterval, firstRun.Add(29*time.Second)))
+	assert.True(t, shouldExecuteCustomQuery(&lastExecutionTime, &collectionInterval, firstRun.Add(30*time.Second)))
+}
+
+func TestCustomQueryCollectionIntervalDoesNotOverflow(t *testing.T) {
+	collectionInterval := int64(1<<63 - 1)
+	var lastExecutionTime time.Time
+	firstRun := time.Unix(100, 0)
+
+	assert.True(t, shouldExecuteCustomQuery(&lastExecutionTime, &collectionInterval, firstRun))
+	assert.False(t, shouldExecuteCustomQuery(&lastExecutionTime, &collectionInterval, firstRun.Add(time.Hour)))
+}
+
+func TestCustomQueryCollectionIntervalsAreIndependent(t *testing.T) {
+	shortInterval := int64(30)
+	longInterval := int64(60)
+	var shortLastRun time.Time
+	var longLastRun time.Time
+	firstRun := time.Unix(100, 0)
+
+	assert.True(t, shouldExecuteCustomQuery(&shortLastRun, &shortInterval, firstRun))
+	assert.True(t, shouldExecuteCustomQuery(&longLastRun, &longInterval, firstRun))
+
+	secondRun := firstRun.Add(30 * time.Second)
+	assert.True(t, shouldExecuteCustomQuery(&shortLastRun, &shortInterval, secondRun))
+	assert.False(t, shouldExecuteCustomQuery(&longLastRun, &longInterval, secondRun))
+
+	thirdRun := firstRun.Add(60 * time.Second)
+	assert.True(t, shouldExecuteCustomQuery(&shortLastRun, &shortInterval, thirdRun))
+	assert.True(t, shouldExecuteCustomQuery(&longLastRun, &longInterval, thirdRun))
+}

--- a/pkg/collector/corechecks/oracle/init.go
+++ b/pkg/collector/corechecks/oracle/init.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/benbjohnson/clock"
 )
 
 type vInstance struct {
@@ -178,7 +177,6 @@ func (c *Check) init() error {
 
 	c.fqtEmitted = getFqtEmittedCache()
 	c.planEmitted = getPlanEmittedCache(c)
-	c.clock = clock.New()
 	c.initialized = true
 
 	return nil

--- a/pkg/collector/corechecks/oracle/oracle.go
+++ b/pkg/collector/corechecks/oracle/oracle.go
@@ -95,6 +95,7 @@ type Check struct {
 	dbVersion                               string
 	driver                                  string
 	metricLastRun                           time.Time
+	customQueryLastRuns                     []time.Time
 	statementsLastRun                       time.Time
 	dbInstanceLastRun                       time.Time
 	tablespaceLastRun                       time.Time
@@ -232,49 +233,46 @@ func (c *Check) Run() error {
 			handleServiceCheck(c, nil)
 		}
 
-		if c.config.OnlyCustomQueries {
-			if metricIntervalExpired && (len(c.config.InstanceConfig.CustomQueries) > 0 || len(c.config.InitConfig.CustomQueries) > 0) {
-				err = c.CustomQueries()
-				var message string
-				var status servicecheck.ServiceCheckStatus
-				if allErrors == nil {
-					status = servicecheck.ServiceCheckOK
-				} else {
-					status = servicecheck.ServiceCheckCritical
-					message = allErrors.Error()
-				}
-				sendServiceCheck(c, serviceCheckName, status, message)
-				commit(c)
-				return err
-			}
-		}
-
-		if !c.legacyIntegrationCompatibilityMode {
+		if !c.config.OnlyCustomQueries && !c.legacyIntegrationCompatibilityMode {
 			err := c.OS_Stats()
 			if err != nil {
 				allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect os stats %w", c.logPrompt, err))
 			}
 		}
 
-		if c.config.SysMetrics.Enabled {
-			log.Debugf("%s Entered sysmetrics", c.logPrompt)
-			_, err := c.sysMetrics()
-			if err != nil {
-				allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect sysmetrics %w", c.logPrompt, err))
+		if !c.config.OnlyCustomQueries {
+			if c.config.SysMetrics.Enabled {
+				log.Debugf("%s Entered sysmetrics", c.logPrompt)
+				_, err := c.sysMetrics()
+				if err != nil {
+					allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect sysmetrics %w", c.logPrompt, err))
+				}
+			}
+			if c.config.ProcessMemory.Enabled || c.config.InactiveSessions.Enabled {
+				err := c.ProcessMemory()
+				if err != nil {
+					allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect process memory %w", c.logPrompt, err))
+				}
 			}
 		}
-		if c.config.ProcessMemory.Enabled || c.config.InactiveSessions.Enabled {
-			err := c.ProcessMemory()
-			if err != nil {
-				allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to collect process memory %w", c.logPrompt, err))
-			}
+	}
+
+	if len(c.config.InstanceConfig.CustomQueries) > 0 || len(c.config.InitConfig.CustomQueries) > 0 {
+		if err := c.CustomQueries(); err != nil {
+			allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to execute custom queries %w", c.logPrompt, err))
 		}
-		if metricIntervalExpired && (len(c.config.InstanceConfig.CustomQueries) > 0 || len(c.config.InitConfig.CustomQueries) > 0) {
-			err := c.CustomQueries()
-			if err != nil {
-				allErrors = errors.Join(allErrors, fmt.Errorf("%s failed to execute custom queries %w", c.logPrompt, err))
-			}
+	}
+
+	if c.config.OnlyCustomQueries {
+		var message string
+		status := servicecheck.ServiceCheckOK
+		if allErrors != nil {
+			status = servicecheck.ServiceCheckCritical
+			message = allErrors.Error()
 		}
+		sendServiceCheck(c, serviceCheckName, status, message)
+		commit(c)
+		return allErrors
 	}
 
 	tablespaceIntervalExpired := checkIntervalExpired(&c.tablespaceLastRun, c.config.Tablespaces.CollectionInterval)
@@ -380,6 +378,7 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	if err != nil {
 		return fmt.Errorf("failed to build check config: %w", err)
 	}
+	c.clock = clock.New()
 
 	// Must be called before c.CommonConfigure because this integration supports multiple instances
 	c.BuildID(integrationConfigDigest, rawInstance, rawInitConfig)

--- a/releasenotes/notes/oracle-custom-query-interval-a2db0310dfaafff3.yaml
+++ b/releasenotes/notes/oracle-custom-query-interval-a2db0310dfaafff3.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add support for configuring collection intervals on individual Oracle custom queries.


### PR DESCRIPTION
### What does this PR do?

Adds optional per-query `collection_interval` support to Oracle custom queries.

Custom queries now:
- run independently from the built-in `metric_collection_interval`
- run on every check when `collection_interval` is omitted
- run immediately and then at their configured cadence when an interval is set
- reject zero and negative collection intervals during configuration

Below you can see submitting a custom metric every minute and another every check:

<img width="1245" height="574" alt="image" src="https://github.com/user-attachments/assets/25414c13-2f41-42a2-a4f0-c241a044bdc7" />

### Motivation

Bring Oracle custom-query scheduling in line with PostgreSQL semantics and allow users to control expensive custom-query cadence independently from built-in Oracle metrics.

Jira: [FRSDBM-529](https://datadoghq.atlassian.net/browse/FRSDBM-529)

### Describe how you validated your changes

- Added configuration-validation tests.
- Added deterministic scheduler tests, including independent intervals and `int64` overflow boundaries.
- Added SQL-mock tests for skipped queries and failed-attempt cadence.
- Added a functional test covering consecutive `Check.Run()` calls against Oracle.
- Ran the targeted Oracle tests and Go linter.
- Built the Agent with `dda inv agent.build --build-exclude=systemd`.
- Ran the Agent against a local Oracle Free container for 10 minutes. The query without an interval emitted 60 points at the 10-second check cadence, while the 60-second query emitted 10 points. Both series were confirmed through the US1 Metrics API.

### Additional Notes

The repository's amd64 Oracle XE image could not run under arm64 emulation, so local functional validation used Oracle Free's native arm64 image. The full Oracle test run reached one unrelated memory-threshold assertion; all tests added by this PR passed.


[FRSDBM-529]: https://datadoghq.atlassian.net/browse/FRSDBM-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ