### PR TITLE
Update Process Collector Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -839,7 +839,7 @@
 /comp/core/workloadmeta/collectors/internal/kubemetadata              @DataDog/container-platform @DataDog/container-integrations
 /comp/core/workloadmeta/collectors/internal/nvml                      @DataDog/gpu-monitoring-agent
 /comp/core/workloadmeta/collectors/internal/podman                    @DataDog/container-platform @DataDog/container-integrations
-/comp/core/workloadmeta/collectors/internal/process                   @DataDog/container-experiences @DataDog/container-platform
+/comp/core/workloadmeta/collectors/internal/process                   @DataDog/container-experiences
 /comp/core/workloadmeta/collectors/internal/remote/sbomcollector      @DataDog/agent-security
 /comp/core/workloadmeta/collectors/sbomutil                           @DataDog/agent-security
 /comp/core/tagger/collectors                                          @DataDog/container-platform @DataDog/container-integrations


### PR DESCRIPTION
### What does this PR do?

Leaves sole ownership of `/comp/core/workloadmeta/collectors/internal/process` to `@DataDog/container-experiences`.

`@DataDog/container-platform` hasn't provided a meaningful review since the collector was bootstrapped a year ago. Follows similar pattern of ECS team owning ECS collector, GPU team owning NVML collector, etc.

