### PR TITLE
Group `moby/moby` Renovate updates to avoid conflicting PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -118,6 +118,11 @@
       },
       {
         "matchManagers": ["gomod"],
+        "matchDepNames": ["github.com/moby/moby{,/**}"],
+        "groupName": "moby/moby"
+      },
+      {
+        "matchManagers": ["gomod"],
         "matchDepNames": ["github.com/twmb/franz-go{,/**}"],
         "groupName": "franz-go"
       },


### PR DESCRIPTION
### What does this PR do?
Add a Renovate group rule for `github.com/moby/moby{,/**}` so `github.com/moby/moby/api` and `github.com/moby/moby/client` bump together in a single PR.

### Motivation
Renovate currently opens one PR per module.
Since `moby/api` and `moby/client` are pinned to the same version in `go.mod` and move in lockstep upstream (they are Go submodules of the same `moby/moby` GitHub repo, released together), 2 separate PRs bumping them independently would conflict with each other.

### Describe how you validated your changes
`python3 -m json.tool renovate.json` and `npx -p renovate renovate-config-validator renovate.json` both pass.