### PR TITLE
fix(collector): stop cloud_cost_only unknown config key warnings

### DIFF
--- a/pkg/collector/BUILD.bazel
+++ b/pkg/collector/BUILD.bazel
@@ -58,6 +58,7 @@ dd_agent_go_test(
         "//pkg/config/mock",
         "//pkg/config/model",
         "//pkg/util/infratags",
+        "//pkg/util/log",
         "//pkg/util/option",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/collector/infra_mode.go
+++ b/pkg/collector/infra_mode.go
@@ -34,6 +34,11 @@ func IsCheckAllowed(checkName string, cfg pkgconfigmodel.Reader) bool {
 		return true
 	}
 
+	// cloud_cost_only is tagging-only; check allowlisting uses integration.<mode>.tagged elsewhere.
+	if infraMode == "cloud_cost_only" {
+		return true
+	}
+
 	// If allowed checks is empty, all checks are allowed
 	if allowedChecks := cfg.GetStringSlice("integration." + infraMode + ".allowed"); len(allowedChecks) == 0 || slices.Contains(allowedChecks, checkName) {
 		return true

--- a/pkg/collector/infra_mode_test.go
+++ b/pkg/collector/infra_mode_test.go
@@ -6,12 +6,16 @@
 package collector
 
 import (
+	"bufio"
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func TestIsCheckAllowed(t *testing.T) {
@@ -99,6 +103,15 @@ func TestIsCheckAllowed(t *testing.T) {
 			wantResult: true,
 		},
 		{
+			name:      "cloud_cost_only mode allows checks without an allowlist",
+			checkName: "postgres",
+			setupCfg: func(cfg pkgconfigmodel.Config) {
+				cfg.Set("integration.enabled", true, pkgconfigmodel.SourceFile)
+				cfg.Set("infrastructure_mode", "cloud_cost_only", pkgconfigmodel.SourceFile)
+			},
+			wantResult: true,
+		},
+		{
 			name:      "excluded takes precedence over allowed",
 			checkName: "disk",
 			setupCfg: func(cfg pkgconfigmodel.Config) {
@@ -120,4 +133,36 @@ func TestIsCheckAllowed(t *testing.T) {
 			assert.Equal(t, tt.wantResult, result)
 		})
 	}
+}
+
+func TestIsCheckAllowedCloudCostOnlyNoUnknownKeyWarning(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.Set("integration.enabled", true, pkgconfigmodel.SourceFile)
+	cfg.Set("infrastructure_mode", "cloud_cost_only", pkgconfigmodel.SourceFile)
+
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	logger, err := log.LoggerFromWriterWithMinLevelAndLvlFuncMsgFormat(w, log.WarnLvl)
+	require.NoError(t, err)
+	log.SetupLogger(logger, "warn")
+	t.Cleanup(func() { log.SetupLogger(log.Default(), "info") })
+
+	assert.True(t, IsCheckAllowed("postgres", cfg))
+
+	logger.Close()
+	require.NoError(t, w.Flush())
+	assert.NotContains(t, b.String(), "integration.cloud_cost_only.allowed")
+
+	// Re-open capture and prove the missing key still warns if looked up directly.
+	b.Reset()
+	w.Reset(&b)
+	logger, err = log.LoggerFromWriterWithMinLevelAndLvlFuncMsgFormat(w, log.WarnLvl)
+	require.NoError(t, err)
+	log.SetupLogger(logger, "warn")
+
+	_ = cfg.GetStringSlice("integration.cloud_cost_only.allowed")
+
+	logger.Close()
+	require.NoError(t, w.Flush())
+	assert.Contains(t, b.String(), "integration.cloud_cost_only.allowed")
 }

--- a/releasenotes/notes/fix-cloud-cost-only-allowed-warning-a913e3a2bb4aa136.yaml
+++ b/releasenotes/notes/fix-cloud-cost-only-allowed-warning-a913e3a2bb4aa136.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed repeated config warnings when ``infrastructure_mode`` is set to
+    ``cloud_cost_only``. The Agent no longer looks up the non-existent
+    ``integration.cloud_cost_only.allowed`` key. Check tagging via
+    ``integration.cloud_cost_only.tagged`` is unchanged.


### PR DESCRIPTION
### What does this PR do?

Stops `IsCheckAllowed()` from looking up `integration.cloud_cost_only.allowed` when `infrastructure_mode` is `cloud_cost_only`.

`cloud_cost_only` is tagging-only. Check eligibility is handled via `integration.cloud_cost_only.tagged` in `pkg/util/infratags`, not an allowlist. The missing `.allowed` key triggered repeated config warnings without changing behavior.

### Motivation

With `infrastructure_mode: cloud_cost_only`, the agent logs:

- `config key integration.cloud_cost_only.allowed is unknown`
- `failed to get configuration value for key "integration.cloud_cost_only.allowed": unable to cast <nil> of type <nil> to []string`

This was introduced when generic `.allowed` lookup was added for infrastructure modes. `cloud_cost_only` only defines `integration.cloud_cost_only.tagged` in the schema.

### Describe how you validated your changes

- Added unit tests in `pkg/collector/infra_mode_test.go`:
  - `cloud_cost_only` allows checks such as `postgres` without an allowlist
  - `IsCheckAllowed()` does not emit warnings for the missing `.allowed` key
- Ran:
  - `bazel test //pkg/collector:collector_test`
  - `bazel test //pkg/util/infratags:infratags_test`
  - `bazel test //pkg/collector:collector_test --test_filter='TestIsCheckAllowed'`
- Added release note (`fixes`)

### Additional Notes

- No schema changes. No behavior change beyond removing noisy warnings.
- Tagging via `integration.cloud_cost_only.tagged` is unchanged.