### PR TITLE
[PROF-15962] Add support for reading OTEL_RESOURCE_ATTRIBUTES env vars in the profiler

### DIFF
--- a/comp/host-profiler/collector/impl/receiver/config.go
+++ b/comp/host-profiler/collector/impl/receiver/config.go
@@ -32,7 +32,10 @@ type Config struct {
 // defaultEnvVars lists environment variables read from profiled processes to populate
 // unified service tags (service, env, version) in OTLP resource attributes.
 // The order indicates which environment variable takes precedence.
-var defaultEnvVars = []string{"DD_SERVICE", "OTEL_SERVICE_NAME", "DD_ENV", "DD_VERSION"}
+var defaultEnvVars = []string{
+	"DD_SERVICE", "OTEL_SERVICE_NAME", "DD_ENV", "DD_VERSION",
+	"OTEL_RESOURCE_ATTRIBUTES", // TODO: remove once we rebase our fork on upstream.
+}
 
 var _ confmap.Validator = (*Config)(nil)
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Add support for reading `OTEL_RESOURCE_ATTRIBUTES`. A backend PR is in progress to parse what we send.

### Motivation

If a process sets `deployment.environment.name`, we currently miss this information (along with other attributes) because we only retrieve `DD_SERVICE`, `OTEL_SERVICE_NAME`, `DD_ENV`, and `DD_VERSION`.

This behavior is already present upstream, but until we rebase our fork, we need to support it here. Backporting just this change to `preview-v2` is much easier than carrying over a full rebase.

### Describe how you validated your changes

### Additional Notes