### PR TITLE
bazel: package the embedded Python runtime with rtloader

### DIFF
--- a/packages/agent/dependencies/BUILD.bazel
+++ b/packages/agent/dependencies/BUILD.bazel
@@ -47,6 +47,7 @@ pkg_filegroup(
         "//conditions:default": [],
     }) + select({
         "@platforms//os:macos": [
+            ":collected_libs",
             "//deps/agent_data_plane:all_files",
         ],
         "//conditions:default": [],
@@ -72,6 +73,7 @@ dd_collect_dependencies(
     srcs = select({
         "//packages/agent:linux_default": [
             "//deps/msodbcsql18:installed_libs",
+            "//rtloader:three_pkg",
             "@curl//:curl_pkg",
             "@freetds//:tdsodbc_pkg",
             "@jemalloc//:jemalloc_pkg",
@@ -81,6 +83,7 @@ dd_collect_dependencies(
         ],
         "//packages/agent:linux_fips": [
             "//deps/msodbcsql18:installed_libs",
+            "//rtloader:three_pkg",
             "@curl//:curl_pkg",
             "@freetds//:tdsodbc_pkg",
             "@jemalloc//:jemalloc_pkg",
@@ -89,9 +92,13 @@ dd_collect_dependencies(
             "@openscap//:openscap_sce_pkg",
         ],
         "//packages/agent:linux_heroku": [
+            "//rtloader:three_pkg",
             "@curl//:curl_pkg",
             "@freetds//:tdsodbc_pkg",
             "@jemalloc//:jemalloc_pkg",
+        ],
+        "@platforms//os:macos": [
+            "//rtloader:three_pkg",
         ],
         "//conditions:default": [],
     }),

--- a/packages/agent/product/BUILD.bazel
+++ b/packages/agent/product/BUILD.bazel
@@ -31,7 +31,6 @@ pkg_filegroup(
         ":example_config",
         "//cmd/agent/dist:all_files",
         "//cmd/agent/dist:all_python_files",
-        "//rtloader:all_files",
         ":dda_built_agent_binary",
 
         # TODO: sysprobe - windows
@@ -77,6 +76,7 @@ pkg_filegroup(
             "//packages/windows:all_files",
             "//pkg/privateactionrunner/par-control:all_files",
             "//pkg/procmgr/rust:all_files_windows",
+            "//rtloader:all_files",
         ],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
### What does this PR do?
Package python files along with rtloader.

### Motivation

Currently our bazel generated packages don't include python binaries nor headers.

This is causing the bazel healthcheck to fail (not to mention any kind of feature that would require python), so we need that fixed before being able to introduce the bazel healthcheck.

### Describe how you validated your changes

Running the healthcheck as part of https://github.com/DataDog/datadog-agent/pull/56086
Verified in a locally built package

### Additional Notes
