### PR TITLE
fix(dogstatsd): reject context dumps when ADP owns traffic

### DIFF
--- a/comp/aggregator/demultiplexerendpoint/impl/BUILD.bazel
+++ b/comp/aggregator/demultiplexerendpoint/impl/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "impl",
@@ -10,7 +11,15 @@ go_library(
         "//comp/api/api/def",
         "//comp/core/config",
         "//comp/core/log/def",
+        "//comp/dogstatsd/config",
         "//pkg/util/http",
         "@com_github_datadog_zstd//:zstd",
     ],
+)
+
+dd_agent_go_test(
+    name = "impl_test",
+    srcs = ["endpoint_test.go"],
+    embed = [":impl"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/comp/aggregator/demultiplexerendpoint/impl/endpoint.go
+++ b/comp/aggregator/demultiplexerendpoint/impl/endpoint.go
@@ -9,6 +9,7 @@ package demultiplexerendpointimpl
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"os"
 	"path"
@@ -19,8 +20,11 @@ import (
 	api "github.com/DataDog/datadog-agent/comp/api/api/def"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	dogstatsdconfig "github.com/DataDog/datadog-agent/comp/dogstatsd/config"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 )
+
+var errDogstatsdOnDataPlane = errors.New("DogStatsD traffic is being served by the Agent Data Plane; run DogStatsD diagnostic commands against the agent-data-plane process instead")
 
 // Requires defines the dependencies for the demultiplexerendpoint component
 type Requires struct {
@@ -30,9 +34,10 @@ type Requires struct {
 }
 
 type demultiplexerEndpoint struct {
-	demux  demultiplexerComp.Component
-	config config.Component
-	log    log.Component
+	demux                demultiplexerComp.Component
+	config               config.Component
+	dogstatsdOnDataPlane bool
+	log                  log.Component
 }
 
 // Provides defines the output of the demultiplexerendpoint component
@@ -43,9 +48,10 @@ type Provides struct {
 // NewComponent creates a new demultiplexerendpoint component
 func NewComponent(reqs Requires) Provides {
 	endpoint := demultiplexerEndpoint{
-		demux:  reqs.Demultiplexer,
-		config: reqs.Config,
-		log:    reqs.Log,
+		demux:                reqs.Demultiplexer,
+		config:               reqs.Config,
+		dogstatsdOnDataPlane: dogstatsdconfig.NewConfig(reqs.Config).EnabledDataPlane(),
+		log:                  reqs.Log,
 	}
 
 	return Provides{
@@ -54,6 +60,11 @@ func NewComponent(reqs Requires) Provides {
 }
 
 func (demuxendpoint demultiplexerEndpoint) dumpDogstatsdContexts(w http.ResponseWriter, _ *http.Request) {
+	if demuxendpoint.dogstatsdOnDataPlane {
+		httputils.SetJSONError(w, errDogstatsdOnDataPlane, http.StatusServiceUnavailable)
+		return
+	}
+
 	path, err := demuxendpoint.writeDogstatsdContexts()
 	if err != nil {
 		httputils.SetJSONError(w, demuxendpoint.log.Errorf("Failed to create dogstatsd contexts dump: %v", err), 500)

--- a/comp/aggregator/demultiplexerendpoint/impl/endpoint.go
+++ b/comp/aggregator/demultiplexerendpoint/impl/endpoint.go
@@ -61,7 +61,7 @@ func NewComponent(reqs Requires) Provides {
 
 func (demuxendpoint demultiplexerEndpoint) dumpDogstatsdContexts(w http.ResponseWriter, _ *http.Request) {
 	if demuxendpoint.dogstatsdOnDataPlane {
-		httputils.SetJSONError(w, errDogstatsdOnDataPlane, http.StatusServiceUnavailable)
+		httputils.SetJSONError(w, errDogstatsdOnDataPlane, http.StatusNotFound)
 		return
 	}
 

--- a/comp/aggregator/demultiplexerendpoint/impl/endpoint_test.go
+++ b/comp/aggregator/demultiplexerendpoint/impl/endpoint_test.go
@@ -19,6 +19,6 @@ func TestDumpDogstatsdContextsRejectsWhenDataPlaneOwnsDogstatsd(t *testing.T) {
 
 	endpoint.dumpDogstatsdContexts(recorder, httptest.NewRequest(http.MethodPost, "/dogstatsd-contexts-dump", nil))
 
-	require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	require.Equal(t, http.StatusNotFound, recorder.Code)
 	require.Contains(t, recorder.Body.String(), "Agent Data Plane")
 }

--- a/comp/aggregator/demultiplexerendpoint/impl/endpoint_test.go
+++ b/comp/aggregator/demultiplexerendpoint/impl/endpoint_test.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package demultiplexerendpointimpl
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDumpDogstatsdContextsRejectsWhenDataPlaneOwnsDogstatsd(t *testing.T) {
+	endpoint := demultiplexerEndpoint{dogstatsdOnDataPlane: true}
+	recorder := httptest.NewRecorder()
+
+	endpoint.dumpDogstatsdContexts(recorder, httptest.NewRequest(http.MethodPost, "/dogstatsd-contexts-dump", nil))
+
+	require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "Agent Data Plane")
+}


### PR DESCRIPTION
### What does this PR do?

Makes the authenticated DogStatsD context-dump endpoint return `503 Service Unavailable` when Agent Data Plane owns DogStatsD traffic, instead of reading the dormant Core Agent demultiplexer.

### Motivation

The DogStatsD CLI already checks this ownership boundary, but direct endpoint callers do not. Enforcing it at the endpoint prevents those callers from receiving a successful but empty or misleading dump.

### Describe how you validated your changes

- `bzl test //comp/aggregator/demultiplexerendpoint/impl:impl_test`
- `dda inv -- -e linter.go --targets=./comp/aggregator/demultiplexerendpoint/impl`

### Additional Notes

This is a prerequisite for https://github.com/DataDog/datadog-agent/pull/56140 and intentionally excludes the remote action and dump serialization changes.