### PR TITLE
[CWS] Fix span context error classification and warn level

### DIFF
--- a/pkg/security/otelprocessctx/process_ctx.go
+++ b/pkg/security/otelprocessctx/process_ctx.go
@@ -33,7 +33,8 @@ const (
 	// headerSize is the size of the OTEP 4719 mapping header.
 	headerSize = 32
 	// headerVersion is the only process context version this reader understands.
-	headerVersion = 2
+	headerVersion       = 2
+	legacyHeaderVersion = 1
 	// maxPayloadSize bounds what is copied out of the target process. The payload is a
 	// handful of resource attributes; anything larger is a misread header.
 	maxPayloadSize = 1 << 20
@@ -61,6 +62,7 @@ var (
 	// ErrUnsupportedVersion means the header is well-formed but names a version
 	// this reader does not speak.
 	ErrUnsupportedVersion = errors.New("unsupported process context version")
+	ErrLegacyVersion      = errors.New("obsolete process context version 1")
 )
 
 var signature = [8]byte{'O', 'T', 'E', 'L', '_', 'C', 'T', 'X'}
@@ -85,6 +87,9 @@ func parseHeader(buf []byte) (header, error) {
 		return h, fmt.Errorf("%w: bad signature %q", ErrMalformed, buf[0:8])
 	}
 	h.version = binary.NativeEndian.Uint32(buf[8:12])
+	if h.version == legacyHeaderVersion {
+		return h, fmt.Errorf("%w", ErrLegacyVersion)
+	}
 	if h.version != headerVersion {
 		return h, fmt.Errorf("%w: %d", ErrUnsupportedVersion, h.version)
 	}

--- a/pkg/security/resolvers/process/go_labels.go
+++ b/pkg/security/resolvers/process/go_labels.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"go/version"
 	"strconv"
+	"strings"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
 
@@ -41,6 +42,15 @@ var (
 	// out of the binary, so we cannot tell whether the runtime keeps g in TLS.
 	errRuntimeIsCgoUnavailable = errors.New("runtime.iscgo value unavailable")
 )
+
+// stripGoVersion reduces a Go buildinfo version string down to its bare
+// "goX.Y.Z" toolchain version.
+func stripGoVersion(goVersion string) string {
+	if i := strings.IndexByte(goVersion, ' '); i >= 0 {
+		return goVersion[:i]
+	}
+	return goVersion
+}
 
 // getGoLabelsOffsets returns the Go runtime struct offsets for pprof label reading,
 // based on the Go version. Kept in sync with the OTel eBPF profiler's
@@ -116,6 +126,7 @@ func (p *EBPFResolver) resolveGoLabels(pid uint32) error {
 	if goVersion == "" {
 		return fmt.Errorf("%w: not a Go binary", errSpanCtxGone)
 	}
+	goVersion = stripGoVersion(goVersion)
 
 	if version.Compare(goVersion, minGoVersion) < 0 || version.Compare(goVersion, maxGoVersion) >= 0 {
 		return fmt.Errorf("%w: Go version %s (need >= %s and < %s)", errSpanCtxUnsupported, goVersion, minGoVersion, maxGoVersion)

--- a/pkg/security/resolvers/process/go_labels_test.go
+++ b/pkg/security/resolvers/process/go_labels_test.go
@@ -60,6 +60,26 @@ func hasSymtab(t *testing.T, path string) bool {
 	return err == nil
 }
 
+// TestStripGoVersion checks that the " X:<experiments>" suffix the toolchain
+// appends to the buildinfo version string.
+func TestStripGoVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "plain", in: "go1.25.11", want: "go1.25.11"},
+		{name: "single experiment", in: "go1.25.11 X:loopvar", want: "go1.25.11"},
+		{name: "multiple experiments", in: "go1.21.0 X:boringcrypto,arenas", want: "go1.21.0"},
+		{name: "no patch", in: "go1.13 X:loopvar", want: "go1.13"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stripGoVersion(tt.in))
+		})
+	}
+}
+
 // TestExtractTLSGOffset checks that the g TLS offset is recovered identically
 // from stripped and unstripped binaries. Stripping removes .symtab but not
 // .gopclntab, so an implementation that looks up runtime.tlsg in the symbol

--- a/pkg/security/resolvers/process/span_ctx_stats.go
+++ b/pkg/security/resolvers/process/span_ctx_stats.go
@@ -10,6 +10,7 @@ package process
 import (
 	"errors"
 	"fmt"
+	"io"
 	"syscall"
 
 	"go.uber.org/atomic"
@@ -43,7 +44,9 @@ type spanCtxStatus int
 
 const (
 	spanCtxOK spanCtxStatus = iota
-	// spanCtxNotApplicable: instrumented, but not through this reader
+	// spanCtxNotApplicable: instrumented, but not through this reader -- a
+	// different mechanism, or a shape (e.g. OTEP 4719's v1 header) this
+	// reader was never meant to support.
 	spanCtxNotApplicable
 	// spanCtxUnsupported: a shape we know and can't handle
 	spanCtxUnsupported
@@ -126,7 +129,7 @@ func classifySpanCtxError(err error) spanCtxStatus {
 	switch {
 	case err == nil:
 		return spanCtxOK
-	case errors.Is(err, errSpanCtxNotApplicable):
+	case errors.Is(err, errSpanCtxNotApplicable), errors.Is(err, otelprocessctx.ErrLegacyVersion):
 		return spanCtxNotApplicable
 	case errors.Is(err, errSpanCtxUnsupported):
 		return spanCtxUnsupported

--- a/pkg/security/resolvers/process/span_ctx_stats.go
+++ b/pkg/security/resolvers/process/span_ctx_stats.go
@@ -113,11 +113,10 @@ func (s spanCtxStatus) Tag() string {
 	return "status:" + s.String()
 }
 
-// expected reports whether s is an outcome we can't act on -- it drives the log
-// level in reportSpanCtxError.
-func (s spanCtxStatus) expected() bool {
+// warn reports whether s is worth surfacing at warn level
+func (s spanCtxStatus) warn() bool {
 	switch s {
-	case spanCtxOK, spanCtxNotApplicable, spanCtxUnpublished, spanCtxGone, spanCtxNoProcessEntry, spanCtxStaleID:
+	case spanCtxUnsupported, spanCtxMalformed, spanCtxTorn, spanCtxUnreadable, spanCtxQueueFull, spanCtxMapError, spanCtxUnknown:
 		return true
 	default:
 		return false
@@ -294,10 +293,10 @@ func (p *EBPFResolver) reportSpanCtxError(step spanCtxStep, pid uint32, err erro
 	status := classifySpanCtxError(err)
 	p.countSpanCtx(step, status)
 
-	if status.expected() {
-		seclog.Debugf("%s for pid %d: %s [%s]", step, pid, err, status)
-	} else {
+	if status.warn() {
 		seclog.Warnf("%s for pid %d: %s [%s]", step, pid, err, status)
+	} else {
+		seclog.Debugf("%s for pid %d: %s [%s]", step, pid, err, status)
 	}
 }
 
@@ -309,10 +308,10 @@ func (p *EBPFResolver) countLookup(step spanCtxStep, err error) {
 	if err == nil {
 		return
 	}
-	if status.expected() {
-		seclog.Debugf("%s: %s [%s]", step, err, status)
-	} else {
+	if status.warn() {
 		seclog.Warnf("%s: %s [%s]", step, err, status)
+	} else {
+		seclog.Debugf("%s: %s [%s]", step, err, status)
 	}
 }
 

--- a/pkg/security/resolvers/process/span_ctx_stats.go
+++ b/pkg/security/resolvers/process/span_ctx_stats.go
@@ -153,7 +153,7 @@ func classifySpanCtxError(err error) spanCtxStatus {
 		return spanCtxStaleID
 	case errors.Is(err, otelattrs.ErrMalformed):
 		return spanCtxMalformed
-	case errors.Is(err, syscall.ESRCH), errors.Is(err, syscall.ENOENT), errors.Is(err, syscall.EIO):
+	case errors.Is(err, syscall.ESRCH), errors.Is(err, syscall.ENOENT), errors.Is(err, syscall.EIO), errors.Is(err, io.EOF):
 		return spanCtxGone
 	case errors.Is(err, syscall.EACCES), errors.Is(err, syscall.EPERM):
 		return spanCtxUnreadable


### PR DESCRIPTION
### What does this PR do?
Classifies legacy OTEP 4719 v1 process-context headers and EOF reads as expected/gone outcomes instead of unrelated errors, and renames the log-level helper from `expected` to `warn` so its polarity matches its name.

Strip the tags `X:[...]` from the Go version and only keep `goX.Y.Z`

### Motivation
Span-context resolution errors were being logged at the wrong level (or misclassified) for cases that are normal rather than actionable: v1 process-context headers, address-space-gone EOF reads.
