### PR TITLE
fix(serverless-init): align MicroVM lifecycle metric names

### DIFF
--- a/cmd/serverless-init/lifecycle/heartbeat.go
+++ b/cmd/serverless-init/lifecycle/heartbeat.go
@@ -22,7 +22,7 @@ import (
 const DefaultHeartbeatInterval = 10 * time.Second
 
 const (
-	activeInstancesMetricName = "aws.lambda.enhanced.microvm.active_instances"
+	activeInstancesMetricName = "aws.lambda.microvm.enhanced.active_instances"
 
 	// UnknownTagValue is the placeholder used when a tag value has not yet
 	// been observed (e.g. MicroVM ID before /run, or ARN fields that

--- a/cmd/serverless-init/lifecycle/heartbeat_test.go
+++ b/cmd/serverless-init/lifecycle/heartbeat_test.go
@@ -79,6 +79,10 @@ func TestNewHeartbeat_NonPositiveIntervalFallsBackToDefault(t *testing.T) {
 	}
 }
 
+func TestHeartbeatMetricName(t *testing.T) {
+	assert.Equal(t, "aws.lambda.microvm.enhanced.active_instances", activeInstancesMetricName)
+}
+
 // TestHeartbeat_EmitsImmediatelyOnStart verifies that a heartbeat metric is
 // recorded as soon as the goroutine starts, before the first ticker interval
 // elapses. This guarantees at least one emission for very short-lived instances.

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -83,7 +83,7 @@ const (
 	postResume    = "POST " + pathResume
 	postTerminate = "POST " + pathTerminate
 
-	baseMetricPrefix    = "aws.lambda.enhanced.microvm."
+	baseMetricPrefix    = "aws.lambda.microvm.enhanced."
 	runMetricName       = baseMetricPrefix + "run"
 	suspendMetricName   = baseMetricPrefix + "suspend"
 	resumeMetricName    = baseMetricPrefix + "resume"

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -101,6 +101,14 @@ func newTestServer() (*Server, *mockFlusher, *mockFlusher, *mockLogsAgent, *mock
 	return srv, metric, trace, logs, emitter, drainer
 }
 
+func TestLifecycleMetricNames(t *testing.T) {
+	assert.Equal(t, "aws.lambda.microvm.enhanced.run", runMetricName)
+	assert.Equal(t, "aws.lambda.microvm.enhanced.suspend", suspendMetricName)
+	assert.Equal(t, "aws.lambda.microvm.enhanced.resume", resumeMetricName)
+	assert.Equal(t, "aws.lambda.microvm.enhanced.terminate", terminateMetricName)
+	assert.Equal(t, "aws.lambda.microvm.enhanced.validate", validateMetricName)
+}
+
 // /ready with a nil ChildHandle is a wiring bug. The handler logs WARN and
 // returns 503. Production setup() always constructs a non-nil handle (real
 // *Child in init mode, NoopChildHandle in sidecar mode); only legacy unit

--- a/releasenotes/notes/rename-microvm-lifecycle-metrics-bee235ad741d72d8.yaml
+++ b/releasenotes/notes/rename-microvm-lifecycle-metrics-bee235ad741d72d8.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    AWS Lambda MicroVM lifecycle and heartbeat metrics now use the
+    ``aws.lambda.microvm.enhanced.*`` namespace instead of
+    ``aws.lambda.enhanced.microvm.*``. Update any dashboards, monitors, or
+    metric queries that use the previous names.


### PR DESCRIPTION
### What does this PR do?

Moves MicroVM lifecycle and heartbeat metrics to the `aws.lambda.microvm.enhanced.*` namespace. Tests now cover every lifecycle metric name.

### Motivation

[SVLS-9801](https://datadoghq.atlassian.net/browse/SVLS-9801) brings the MicroVM metrics in line with the Azure, GCP, and LMI naming convention.

### Describe how you validated your changes

Passed: `bazel test //cmd/serverless-init/lifecycle:lifecycle_test`

[Integration test](https://ddserverless.datadoghq.com/metric/explorer?fromUser=true&graph_layout=stacked&session_id=292c8c99-2e4a-4602-ba4d-aa0809c93713&start=1789143789889&end=1789145323000&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMgYYBoAdJiqAEbJ9aoQmdo4Far1cCKMGCLZUPUYmRIVcE6iGgjD2RrAAFQ8IHygkdG5sVgATInJC2kZ2cr5hcUge+VVNXWNUa0Y7Z3dvf2Di3Bj2ngiVbrHgAXSornceEwoXCENUUIwMVK8Q2FFAcIRSJ0Bw2YJA8ywaByoHkGCJCAQOSSOBgTky0I0nUSbgE2iczRouQqZLM1zQohmckUynS-KgiX5Ihm9CYyhEbg8aFRSQg9kwWCcQqpzQw2ksoJ4fHx8n5CAAwlJhDAUCIoWgeEA) shows the metrics are under the expected prefix
<img width="1245" height="716" alt="image" src="https://github.com/user-attachments/assets/644d1634-f07d-43cd-9607-952de3afa1aa" />



[SVLS-9801]: https://datadoghq.atlassian.net/browse/SVLS-9801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ