### PR TITLE
[CWS] Fix TestDNSResponse/catch-dns-response-ip-only flakiness

### DIFF
--- a/pkg/security/tests/dns_response_test.go
+++ b/pkg/security/tests/dns_response_test.go
@@ -114,7 +114,9 @@ func TestDNSResponse(t *testing.T) {
 
 	t.Run("catch-dns-response-ip-only", func(t *testing.T) {
 		test.WaitSignalFromRule(t, func() error {
-			hexDump := "00000000000000000000000008004500004ef53c40000111862c7f0000357f00000115b18bb0003a96af5ac281800001000100000000037777770964617461646f6768710265750000010001c00c000100010000003c00042295739e"
+			// Same packet as catch-dns-rcode-zero with a different DNS transaction id, because
+			// the kernel drops a response whose (id, size) pair was already sent less than a second ago.
+			hexDump := "00000000000000000000000008004500004ef53c40000111862c7f0000357f00000115b18bb0003a96ae5ac381800001000100000000037777770964617461646f6768710265750000010001c00c000100010000003c00042295739e"
 			err = injectHexDump("lo", hexDump)
 
 			return nil


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Use a different DNS transaction id than catch-dns-rcode-zero, because the
kernel drops a response whose (id, size) pair was already sent less than a
second ago.

The two subtests injected byte-identical packets, so whenever the ruleset
reload between them took under a second the second injection was filtered out
in the classifier and the test waited out its 10s timeout. Over 9 recent main
pipelines that was 197 failures in 612 runs, 9/9 on every cws_docker leg.

### Motivation

Fix test flakiness
