### PR TITLE
Remove build-time dev headers from agent packages to reduce image size

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -57,6 +57,16 @@ build do
             delete "#{install_dir}/embedded/lib/libdbus-1.a"
             delete "#{install_dir}/embedded/include/dbus-1.0"
             delete "#{install_dir}/embedded/lib/dbus-1.0/include"
+
+            # Remove build-time development headers that are not needed at runtime.
+            # The Python headers are kept so users can `pip install` packages with C
+            # extensions at runtime; the systemd headers are already excluded at the
+            # project level. Everything else under embedded/include is only used
+            # during the omnibus build to compile the agent and its embedded libs.
+            Dir.glob("#{install_dir}/embedded/include/*").each do |dir|
+                next if File.basename(dir).start_with?("python3.")
+                delete dir
+            end
         end
 
         # TODO: Rather than move these, let's install them to the right place to start

--- a/releasenotes/notes/remove-build-headers-reduce-image-size-9c3f1a2b4d5e6f7a.yaml
+++ b/releasenotes/notes/remove-build-headers-reduce-image-size-9c3f1a2b4d5e6f7a.yaml
@@ -1,0 +1,9 @@
+---
+other:
+  - |
+    Remove build-time development headers from the ``embedded/include`` directory
+    in Linux and macOS packages. These headers (openssl, libxml2, krb5, curl, rpm,
+    etc.) are only used during the omnibus build to compile the agent and its
+    embedded libraries and are not needed at runtime. The Python headers are kept
+    so users can still ``pip install`` packages with C extensions at runtime. This
+    reduces the on-disk size of the Docker agent image by ~6.9 MiB.


### PR DESCRIPTION
## Summary

Removes build-time C development headers from `embedded/include` in Linux/macOS agent packages to reduce the on-disk size of the Docker agent image (`static_quality_gate_docker_agent_amd64`).

## Motivation

The `embedded/include` directory ships ~9.3 MiB of C headers (openssl, libxml2, krb5, curl, rpm, libxslt, nghttp2, pcap, etc.) that are only used during the omnibus build to compile the agent and its embedded libraries. They are not read at runtime.

The existing finalize step already deletes a handful of build-time artifacts (pkgconfig, cmake, `*.la`, dbus headers, systemd headers) but left the rest of `embedded/include` in place. This extends that cleanup to remove every non-Python subdirectory under `embedded/include`.

## Changes

- `omnibus/config/software/datadog-agent-finalize.rb`: in the existing linux/macOS cleanup block, delete every subdirectory under `embedded/include` except `python3.*` (kept so users can still `pip install` packages with C extensions at runtime). The systemd headers continue to be excluded at the project level.

## Measured impact

Measured against the public `datadog/agent:latest` image:

| Component | Size |
|---|---|
| `embedded/include` total | 9.3 MiB |
| `embedded/include/python3.13` (kept) | 2.4 MiB |
| **Reclaimed (non-Python headers)** | **~6.9 MiB** |

## Why this is a no-op

- No config, check, or runtime code path reads from `embedded/include`. The cgo `#include` directives in the Go source (e.g. `pkg/collector/python`) compile against the rtloader headers in the source tree at build time, not against the shipped `embedded/include`.
- The `.deb`/`.rpm` already exclude most build-time artifacts via the same finalize step; this aligns the docker/OCI tarball with that behavior.
- Python headers are explicitly preserved to keep runtime `pip install` of C-extension packages working.

## Validation

- [ ] Build the agent package and confirm `embedded/include` no longer contains non-Python subdirs.
- [ ] Confirm `embedded/include/python3.*` is preserved.
- [ ] Confirm the built agent runs (`agent version`).
- [ ] Observe the `static_quality_gate_docker_agent_amd64` on-disk size drop by ~6.9 MiB.

## Notes

This is a packaging-only change with no runtime behavior change.