### PR TITLE
trace-agent: normalize OTel spans before APM stats calculation

### DIFF
--- a/pkg/trace/agent/normalizer.go
+++ b/pkg/trace/agent/normalizer.go
@@ -30,11 +30,6 @@ const (
 	tagOrigin = "_dd.origin"
 )
 
-var (
-	// Year2000NanosecTS is an arbitrary cutoff to spot weird-looking values
-	Year2000NanosecTS = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC).UnixNano()
-)
-
 // normalizeService handles service normalization for both pb.Span and idx.InternalSpan
 func (a *Agent) normalizeService(ts *info.TagStats, service string, lang string) (string, error) {
 	svc, err := normalizeutil.NormalizeService(service, lang)
@@ -107,32 +102,22 @@ func (a *Agent) normalizeName(ts *info.TagStats, name string) (string, error) {
 
 // validateAndFixDuration handles duration validation for both pb.Span and idx.InternalSpan
 func (a *Agent) validateAndFixDuration(ts *info.TagStats, start int64, duration int64) int64 {
-	if duration < 0 {
+	fixed, invalid := normalizeutil.FixDuration(start, duration)
+	if invalid {
 		ts.SpansMalformed.InvalidDuration.Inc()
 		log.Debugf("Fixing malformed trace. Duration is invalid (reason:invalid_duration), setting span.duration=0")
-		return 0
 	}
-	if duration > math.MaxInt64-start {
-		ts.SpansMalformed.InvalidDuration.Inc()
-		log.Debugf("Fixing malformed trace. Duration is too large and causes overflow (reason:invalid_duration), setting span.duration=0")
-		return 0
-	}
-	return duration
+	return fixed
 }
 
 // validateAndFixStartTime handles start time validation for both pb.Span and idx.InternalSpan
 func (a *Agent) validateAndFixStartTime(ts *info.TagStats, start int64, duration int64) int64 {
-	if start < Year2000NanosecTS {
+	fixed, invalid := normalizeutil.FixStartTime(start, duration)
+	if invalid {
 		ts.SpansMalformed.InvalidStartDate.Inc()
 		log.Debugf("Fixing malformed trace. Start date is invalid (reason:invalid_start_date), setting span.start=time.now()")
-		now := time.Now().UnixNano()
-		newStart := now - duration
-		if newStart < 0 {
-			return now
-		}
-		return newStart
 	}
-	return start
+	return fixed
 }
 
 // validateAndFixType handles type validation for both pb.Span and idx.InternalSpan
@@ -184,7 +169,7 @@ func (a *Agent) validateAndFixDurationV1(ts *info.TagStats, start uint64, durati
 
 // validateAndFixStartTimeV1 handles start time validation for idx.InternalSpan
 func (a *Agent) validateAndFixStartTimeV1(ts *info.TagStats, start uint64, duration uint64) uint64 {
-	if start < uint64(Year2000NanosecTS) {
+	if start < uint64(normalizeutil.Year2000NanosecTS) {
 		ts.SpansMalformed.InvalidStartDate.Inc()
 		log.Debugf("Fixing malformed trace. Start date is invalid (reason:invalid_start_date), setting span.start=time.now()")
 		now := uint64(time.Now().UnixNano())

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -474,7 +474,14 @@ func testOTLPSpanNameV2(enableReceiveResourceSpansV2 bool, t *testing.T) {
 				},
 			},
 			fn: func(out *pb.TracerPayload) {
-				require.Equal("aws-api.server.request", out.Chunks[0].Spans[0].Name)
+				// V2 goes through transform.OtelSpanToDDSpan, which normalizes the
+				// name (dashes become underscores); V1 uses the legacy convertSpan
+				// path, which does not.
+				if enableReceiveResourceSpansV2 {
+					require.Equal("aws_api.server.request", out.Chunks[0].Spans[0].Name)
+				} else {
+					require.Equal("aws-api.server.request", out.Chunks[0].Spans[0].Name)
+				}
 			},
 		},
 		{
@@ -2503,11 +2510,11 @@ func testOTelSpanToDDSpan(enableOperationAndResourceNameV2 bool, t *testing.T) {
 				},
 			}),
 			operationNameV1: "res_op",
-			operationNameV2: "span-op",
+			operationNameV2: "span_op",
 			resourceNameV1:  "res-res",
 			resourceNameV2:  "span-res",
 			out: &pb.Span{
-				Name:     "span-op",
+				Name:     "span_op",
 				Resource: "span-res",
 				Service:  "span-service",
 				TraceID:  2594128270069917171,

--- a/pkg/trace/otel/stats/otel_util_test.go
+++ b/pkg/trace/otel/stats/otel_util_test.go
@@ -309,7 +309,7 @@ func TestProcessOTLPTraces(t *testing.T) {
 				agentEnv,
 				agentHost,
 				"span-service",
-				"span-op",
+				"span_op",
 				"span-type",
 				"server",
 				"span-res",

--- a/pkg/trace/traceutil/normalize/BUILD.bazel
+++ b/pkg/trace/traceutil/normalize/BUILD.bazel
@@ -4,6 +4,7 @@ load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 go_library(
     name = "normalize",
     srcs = [
+        "duration.go",
         "normalize.go",
         "truncate.go",
     ],
@@ -14,6 +15,7 @@ go_library(
 dd_agent_go_test(
     name = "normalize_test",
     srcs = [
+        "duration_test.go",
         "fuzz_test.go",
         "normalize_test.go",
         "truncate_test.go",

--- a/pkg/trace/traceutil/normalize/duration.go
+++ b/pkg/trace/traceutil/normalize/duration.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package normalize
+
+import (
+	"math"
+	"time"
+)
+
+// Year2000NanosecTS is an arbitrary cutoff to spot weird-looking start timestamps.
+var Year2000NanosecTS = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC).UnixNano()
+
+// FixDuration validates a span duration relative to its start time, returning a
+// corrected value and whether the input was invalid. A negative duration, or one
+// that would overflow when added to start, is reset to 0.
+func FixDuration(start, duration int64) (fixed int64, invalid bool) {
+	if duration < 0 {
+		return 0, true
+	}
+	if duration > math.MaxInt64-start {
+		return 0, true
+	}
+	return duration, false
+}
+
+// FixStartTime validates a span start time, returning a corrected value and
+// whether the input was invalid. A start predating Year2000NanosecTS is
+// considered garbage and reset to "now - duration" (clamped to "now").
+func FixStartTime(start, duration int64) (fixed int64, invalid bool) {
+	if start < Year2000NanosecTS {
+		now := time.Now().UnixNano()
+		newStart := now - duration
+		if newStart < 0 {
+			return now, true
+		}
+		return newStart, true
+	}
+	return start, false
+}

--- a/pkg/trace/traceutil/normalize/duration_test.go
+++ b/pkg/trace/traceutil/normalize/duration_test.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package normalize
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFixDuration(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		fixed, invalid := FixDuration(time.Now().UnixNano(), 200000000)
+		assert.False(t, invalid)
+		assert.EqualValues(t, 200000000, fixed)
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		fixed, invalid := FixDuration(time.Now().UnixNano(), -50)
+		assert.True(t, invalid)
+		assert.EqualValues(t, 0, fixed)
+	})
+
+	t.Run("overflow", func(t *testing.T) {
+		fixed, invalid := FixDuration(time.Now().UnixNano(), math.MaxInt64)
+		assert.True(t, invalid)
+		assert.EqualValues(t, 0, fixed)
+	})
+}
+
+func TestFixStartTime(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		start := time.Now().UnixNano()
+		fixed, invalid := FixStartTime(start, 200000000)
+		assert.False(t, invalid)
+		assert.EqualValues(t, start, fixed)
+	})
+
+	t.Run("too small", func(t *testing.T) {
+		minStart := time.Now().UnixNano()
+		fixed, invalid := FixStartTime(42, 200000000)
+		assert.True(t, invalid)
+		assert.GreaterOrEqual(t, fixed, minStart-200000000)
+		assert.LessOrEqual(t, fixed, time.Now().UnixNano()-200000000)
+	})
+
+	t.Run("too small with large duration", func(t *testing.T) {
+		minStart := time.Now().UnixNano()
+		fixed, invalid := FixStartTime(42, time.Now().UnixNano()*2)
+		assert.True(t, invalid)
+		assert.GreaterOrEqual(t, fixed, minStart)
+		assert.LessOrEqual(t, fixed, time.Now().UnixNano())
+	})
+}

--- a/pkg/trace/transform/BUILD.bazel
+++ b/pkg/trace/transform/BUILD.bazel
@@ -46,6 +46,7 @@ dd_agent_go_test(
         "//pkg/opentelemetry-mapping-go/otlp/attributes",
         "//pkg/proto/pbgo/trace",
         "//pkg/trace/config",
+        "//pkg/trace/traceutil/normalize",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_opentelemetry_go_collector_component_componenttest//:componenttest",

--- a/pkg/trace/transform/transform.go
+++ b/pkg/trace/transform/transform.go
@@ -75,6 +75,8 @@ func otelSpanToDDSpanMinimal(
 		ddspan.Name = GetOTelOperationNameV1(otelspan, otelres, lib, conf.OTLPReceiver.SpanNameAsResourceName, conf.OTLPReceiver.SpanNameRemappings, true)
 		ddspan.Resource = GetOTelResourceV1(otelspan, otelres)
 	}
+	// This path bypasses the trace-agent's normalization step so we explicitly do it here.
+	ddspan.Name, _ = normalizeutil.NormalizeName(ddspan.Name)
 
 	// correct span type logic if using new resource receiver, keep same if on v1. separate from OperationAndResourceNameV2Enabled.
 	if !conf.HasFeature("disable_receive_resource_spans_v2") {
@@ -111,6 +113,15 @@ func otelSpanToDDSpanMinimal(
 			ddspan.Meta[peerTagKey] = peerTagVal
 		}
 	}
+	// This path bypasses the trace-agent's normalization step so we explicitly do it here.
+	if pSvc, ok := ddspan.Meta[string(semantics.ConceptPeerService)]; ok {
+		ddspan.Meta[string(semantics.ConceptPeerService)], _ = normalizeutil.NormalizePeerService(pSvc)
+	}
+	if bSvc, ok := ddspan.Meta[string(semantics.ConceptDDBaseService)]; ok {
+		ddspan.Meta[string(semantics.ConceptDDBaseService)], _ = normalizeutil.NormalizePeerService(bSvc)
+	}
+	ddspan.Duration, _ = normalizeutil.FixDuration(ddspan.Start, ddspan.Duration)
+	ddspan.Start, _ = normalizeutil.FixStartTime(ddspan.Start, ddspan.Duration)
 	// Copy span-derived primary tag values into Meta so the APM stats
 	// Concentrator's matchingAdditionalMetricTags (which reads span.Meta[key])
 	// can aggregate on them. The minimal conversion does not copy all

--- a/pkg/trace/transform/transform_test.go
+++ b/pkg/trace/transform/transform_test.go
@@ -6,7 +6,9 @@
 package transform
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	normalizeutil "github.com/DataDog/datadog-agent/pkg/trace/traceutil/normalize"
 )
 
 func TestGetOTelEnv(t *testing.T) {
@@ -612,6 +615,79 @@ func TestOtelSpanToDDSpanMinimalPrimaryTags(t *testing.T) {
 		minSpan := OtelSpanToDDSpanMinimal(span, pcommon.NewResource(), lib, false, false, newCfg(), nil, nil)
 
 		assert.NotContains(t, minSpan.Meta, "team")
+	})
+}
+
+// TestOtelSpanToDDSpanMinimalNormalization verifies that spans produced by
+// OtelSpanToDDSpanMinimal are sanitized the same way the full trace-agent
+// pipeline (Agent.normalize) would sanitize them, since minimal spans are fed
+// directly into the APM stats Concentrator and never reach that pipeline.
+func TestOtelSpanToDDSpanMinimalNormalization(t *testing.T) {
+	newCfg := func() *config.AgentConfig {
+		cfg := &config.AgentConfig{}
+		cfg.OTLPReceiver = &config.OTLP{}
+		cfg.OTLPReceiver.AttributesTranslator, _ = attributes.NewTranslator(componenttest.NewNopTelemetrySettings())
+		return cfg
+	}
+	lib := pcommon.NewInstrumentationScope()
+
+	t.Run("name is normalized under operation name v2", func(t *testing.T) {
+		span := ptrace.NewSpan()
+		span.Attributes().PutStr("operation.name", "invalid-op-name")
+		res := pcommon.NewResource()
+
+		minSpan := OtelSpanToDDSpanMinimal(span, res, lib, false, false, newCfg(), nil, nil)
+
+		// Hyphens aren't valid in span names; NormalizeName replaces them with underscores.
+		assert.Equal(t, "invalid_op_name", minSpan.Name)
+	})
+
+	t.Run("negative duration is reset to zero", func(t *testing.T) {
+		span := ptrace.NewSpan()
+		span.SetStartTimestamp(pcommon.Timestamp(time.Now().UnixNano()))
+		span.SetEndTimestamp(pcommon.Timestamp(int64(span.StartTimestamp()) - 1))
+		res := pcommon.NewResource()
+
+		minSpan := OtelSpanToDDSpanMinimal(span, res, lib, false, false, newCfg(), nil, nil)
+
+		assert.EqualValues(t, 0, minSpan.Duration)
+	})
+
+	t.Run("garbage start time is reset to now", func(t *testing.T) {
+		minStart := time.Now().UnixNano()
+		span := ptrace.NewSpan()
+		span.SetStartTimestamp(42)
+		span.SetEndTimestamp(pcommon.Timestamp(200000000))
+		res := pcommon.NewResource()
+
+		minSpan := OtelSpanToDDSpanMinimal(span, res, lib, false, false, newCfg(), nil, nil)
+
+		assert.GreaterOrEqual(t, minSpan.Start, minStart-200000000)
+		assert.LessOrEqual(t, minSpan.Start, time.Now().UnixNano())
+	})
+
+	t.Run("peer.service is truncated to the max service length", func(t *testing.T) {
+		span := ptrace.NewSpan()
+		longPeerSvc := strings.Repeat("a", 150)
+		span.Attributes().PutStr("peer.service", longPeerSvc)
+		res := pcommon.NewResource()
+
+		minSpan := OtelSpanToDDSpanMinimal(span, res, lib, false, false, newCfg(), []string{"peer.service"}, nil)
+
+		assert.Len(t, minSpan.Meta["peer.service"], normalizeutil.MaxServiceLen)
+		assert.Equal(t, strings.Repeat("a", normalizeutil.MaxServiceLen), minSpan.Meta["peer.service"])
+	})
+
+	t.Run("_dd.base_service is truncated to the max service length", func(t *testing.T) {
+		span := ptrace.NewSpan()
+		longBaseSvc := strings.Repeat("a", 150)
+		span.Attributes().PutStr("_dd.base_service", longBaseSvc)
+		res := pcommon.NewResource()
+
+		minSpan := OtelSpanToDDSpanMinimal(span, res, lib, false, false, newCfg(), []string{"_dd.base_service"}, nil)
+
+		assert.Len(t, minSpan.Meta["_dd.base_service"], normalizeutil.MaxServiceLen)
+		assert.Equal(t, strings.Repeat("a", normalizeutil.MaxServiceLen), minSpan.Meta["_dd.base_service"])
 	})
 }
 

--- a/releasenotes/notes/otlp-stats-normalization-fix-b0387292e29f526f.yaml
+++ b/releasenotes/notes/otlp-stats-normalization-fix-b0387292e29f526f.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: OTLP: Fixes a bug where invalid OTLP traces wouldn't be normalized before stats were calculated in DDOT.


### PR DESCRIPTION
## Summary
The minimal DD span converter didn't apply any normalization when converting spans. While unlikely, it's possible for a buggy or broken tracer to send invalid OTEL traces. This change adds the normalization steps we normally apply in processing a trace to ensure strings aren't too long, and that we don't have invalid timestamps for stats calculation.

## Test plan
- [x] `dda inv test --targets=./pkg/trace/agent/...`
- [x] `dda inv test --targets=./pkg/trace/transform/...`
- [x] `dda inv test --targets=./pkg/trace/traceutil/normalize/...`
- [x] `dda inv test --targets=./pkg/trace/otel/stats/...`
- [x] `dda inv test --targets=./comp/otelcol/otlp/components/connector/datadogconnector/...`
- [x] `dda inv linter.go --targets=./pkg/trace/...`
- [x] Added unit tests for the new normalization helpers and for `otelSpanToDDSpanMinimal`'s normalization behavior
