### PR TITLE
CWS-6919 attribute DNS responses to the querying process

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -102,6 +102,12 @@ var (
 	MetricDNSSameIDDifferentSize = newRuntimeMetric(".dns_response_collector.dns_same_id_different_size")
 	// MetricDiscardedDNSPackets DNS responses that were discarded because of not matching a rule
 	MetricDiscardedDNSPackets = newRuntimeMetric(".dns_response_collector.dns_discarded_packets")
+	// MetricDNSADCorrelationHits DNS responses attributed back to the process that asked the question
+	MetricDNSADCorrelationHits = newRuntimeMetric(".dns_response_collector.ad_correlation_hits")
+	// MetricDNSADCorrelationMisses DNS responses whose question was unknown, stale, or ambiguous
+	MetricDNSADCorrelationMisses = newRuntimeMetric(".dns_response_collector.ad_correlation_misses")
+	// MetricDNSADCorrelationCollisions DNS questions dropped because two processes were in flight on the same key
+	MetricDNSADCorrelationCollisions = newRuntimeMetric(".dns_response_collector.ad_correlation_collisions")
 
 	// filtering metrics
 

--- a/pkg/security/probe/BUILD.bazel
+++ b/pkg/security/probe/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "discarders.go",
         "discarders_linux.go",
         "discarders_windows.go",
+        "dns_request_tracker.go",
         "enrich_rule_event.go",
         "errors.go",
         "eventconsumer.go",
@@ -345,6 +346,7 @@ dd_agent_go_test(
     name = "probe_test",
     srcs = [
         "discarders_test.go",
+        "dns_request_tracker_test.go",
         "field_handlers_test.go",
         "fuzz_test.go",
         "model_test.go",

--- a/pkg/security/probe/dns_request_tracker.go
+++ b/pkg/security/probe/dns_request_tracker.go
@@ -22,9 +22,11 @@ import (
 )
 
 const (
-	// dnsRequestTrackerSize bounds how many in-flight DNS questions are remembered at once. Only
-	// questions asked by a process an activity dump is tracing are recorded, so this is sized for
-	// concurrent lookups from traced workloads rather than for host-wide DNS volume.
+	// dnsRequestTrackerSize bounds how many in-flight DNS questions are remembered at once. The
+	// tracked population is normally just the processes an activity dump traces (5 cgroups by
+	// default), which is what this is sized for. Rate-limited DNS sampling, when enabled, adds
+	// untraced requests to the same table; over-subscription then costs correlation hits, never
+	// correctness, because an evicted key simply stops matching.
 	dnsRequestTrackerSize = 1024
 	// dnsRequestTrackerTTL is how long a question stays correlatable. It matches the timeout a
 	// typical stub resolver gives up after, so an answer arriving later than this belongs to a

--- a/pkg/security/probe/dns_request_tracker.go
+++ b/pkg/security/probe/dns_request_tracker.go
@@ -152,14 +152,27 @@ func (t *dnsRequestTracker) matchResponse(id uint16, name string, qtype uint16, 
 	return pending.entry
 }
 
+// len reports how many questions are currently being tracked.
+func (t *dnsRequestTracker) len() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.pending.Len()
+}
+
 // newCorrelatedDNSEvent fills ev with a DNS event carrying the answers of a response together with
 // the process context of the request that asked for them.
 //
-// The activity dump manager drops any event without EventFlagsActivityDumpSample. The kernel sets
-// that flag on the request, where a pid is available; it cannot set it on the response, so it is
-// set here on the correlated event instead.
+// The V1 activity dump manager drops any event without EventFlagsActivityDumpSample (V2 has no
+// such gate; see correlateDNSResponseForActivityDump). The kernel sets that flag on the request,
+// where a pid is available; it cannot set it on the response, so it is set here on the correlated
+// event instead.
+//
+// The source is EventSourceRelated, as for every other event synthesized in user space rather than
+// received from the kernel: ManagerV2.ProcessEvent resolves it to bucket its per-source metrics, so
+// leaving it empty would file these under the runtime source and hide them.
 func newCorrelatedDNSEvent(ev *model.Event, entry *model.ProcessCacheEntry, id uint16, question model.DNSQuestion, response *model.DNSResponse, ts time.Time, tsRaw uint64) {
 	ev.Type = uint32(model.DNSEventType)
+	ev.Source = model.EventSourceRelated
 	ev.Timestamp = ts
 	ev.TimestampRaw = tsRaw
 	ev.ProcessCacheEntry = entry
@@ -179,7 +192,22 @@ func newCorrelatedDNSEvent(ev *model.Event, entry *model.ProcessCacheEntry, id u
 // This calls ProcessEvent directly rather than going through DispatchEvent. Dump enrichment is the
 // only thing wanted here: routing a synthesized event through DispatchEvent would expose it to rule
 // evaluation, so a rule on dns.question.name would fire a second time for dump-traced workloads
-// only, which is a config-dependent change in rule semantics.
+// only, which is a config-dependent change in rule semantics. It also keeps the event away from
+// event-monitor consumers and from LookupEventInProfiles.
+//
+// What ProcessEvent then does depends on which profile manager is running:
+//
+//   - V1 (security_profile/ad.go) drops anything without EventFlagsActivityDumpSample, which is why
+//     newCorrelatedDNSEvent sets that flag. The gate is V1-specific; V2 has no equivalent.
+//   - V2 (security_profile/manager_v2.go, the default since security_profile.v2.enabled defaults to
+//     true) ignores the flag and runs the event through tag resolution — deep-copying it into a
+//     pending queue when the workload's tags are not ready yet — and then through profile insertion.
+//
+// So under V2 this synthesized event does reach a profile. It stays off anomaly detection only
+// because InsertDNSEvent (security_profile/activity_tree/process_node.go) reports inserted == false
+// for a response-only merge, which is the deliberate "enrichment, not drift" choice made when
+// mergeDNSResponse was added. That is load-bearing: making mergeDNSResponse report a change would
+// silently start raising anomaly signals from this path.
 func (p *EBPFProbe) correlateDNSResponseForActivityDump(dnsLayer *layers.DNS, ips []net.IPNet, cnames []string) {
 	if p.profileManager == nil || p.dnsRequests == nil {
 		return
@@ -195,8 +223,17 @@ func (p *EBPFProbe) correlateDNSResponseForActivityDump(dnsLayer *layers.DNS, ip
 	}
 	question := dnsLayer.Questions[0]
 
+	// Nothing is being tracked, so there is no question this response could correlate to. Counting
+	// it as a miss would only measure host DNS volume: every response from a process in no traced
+	// cgroup would land in ad_correlation_misses and pin it at ~100%, which is unalertable.
+	if p.dnsRequests.len() == 0 {
+		return
+	}
+
+	questionName := string(question.Name)
+
 	now := time.Now()
-	entry := p.dnsRequests.matchResponse(dnsLayer.ID, string(question.Name), uint16(question.Type), now)
+	entry := p.dnsRequests.matchResponse(dnsLayer.ID, questionName, uint16(question.Type), now)
 	if entry == nil {
 		return
 	}
@@ -205,7 +242,7 @@ func (p *EBPFProbe) correlateDNSResponseForActivityDump(dnsLayer *layers.DNS, ip
 	defer p.putBackPoolEvent(ev)
 
 	newCorrelatedDNSEvent(ev, entry, dnsLayer.ID, model.DNSQuestion{
-		Name:  string(question.Name),
+		Name:  questionName,
 		Type:  uint16(question.Type),
 		Class: uint16(question.Class),
 	}, &model.DNSResponse{

--- a/pkg/security/probe/dns_request_tracker.go
+++ b/pkg/security/probe/dns_request_tracker.go
@@ -9,10 +9,12 @@
 package probe
 
 import (
+	"net"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/google/gopacket/layers"
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -148,4 +150,71 @@ func (t *dnsRequestTracker) matchResponse(id uint16, name string, qtype uint16, 
 
 	t.hits.Inc()
 	return pending.entry
+}
+
+// newCorrelatedDNSEvent fills ev with a DNS event carrying the answers of a response together with
+// the process context of the request that asked for them.
+//
+// The activity dump manager drops any event without EventFlagsActivityDumpSample. The kernel sets
+// that flag on the request, where a pid is available; it cannot set it on the response, so it is
+// set here on the correlated event instead.
+func newCorrelatedDNSEvent(ev *model.Event, entry *model.ProcessCacheEntry, id uint16, question model.DNSQuestion, response *model.DNSResponse, ts time.Time, tsRaw uint64) {
+	ev.Type = uint32(model.DNSEventType)
+	ev.Timestamp = ts
+	ev.TimestampRaw = tsRaw
+	ev.ProcessCacheEntry = entry
+	ev.ProcessContext = &entry.ProcessContext
+	ev.DNS = model.DNSEvent{
+		ID:       id,
+		Question: question,
+		Response: response,
+	}
+	ev.AddToFlags(model.EventFlagsActivityDumpSample)
+}
+
+// correlateDNSResponseForActivityDump attributes a decoded DNS response to the process that asked
+// the question and feeds it to the activity dump manager, so the dump records what the question
+// resolved to.
+//
+// This calls ProcessEvent directly rather than going through DispatchEvent. Dump enrichment is the
+// only thing wanted here: routing a synthesized event through DispatchEvent would expose it to rule
+// evaluation, so a rule on dns.question.name would fire a second time for dump-traced workloads
+// only, which is a config-dependent change in rule semantics.
+func (p *EBPFProbe) correlateDNSResponseForActivityDump(dnsLayer *layers.DNS, ips []net.IPNet, cnames []string) {
+	if p.profileManager == nil || p.dnsRequests == nil {
+		return
+	}
+
+	// NODATA: a NOERROR response with no answers has nothing to enrich the dump with
+	if len(ips) == 0 && len(cnames) == 0 {
+		return
+	}
+
+	if len(dnsLayer.Questions) == 0 {
+		return
+	}
+	question := dnsLayer.Questions[0]
+
+	now := time.Now()
+	entry := p.dnsRequests.matchResponse(dnsLayer.ID, string(question.Name), uint16(question.Type), now)
+	if entry == nil {
+		return
+	}
+
+	ev := p.getPoolEvent()
+	defer p.putBackPoolEvent(ev)
+
+	newCorrelatedDNSEvent(ev, entry, dnsLayer.ID, model.DNSQuestion{
+		Name:  string(question.Name),
+		Type:  uint16(question.Type),
+		Class: uint16(question.Class),
+	}, &model.DNSResponse{
+		ResponseCode: uint8(dnsLayer.ResponseCode),
+		IPs:          ips,
+		CNames:       cnames,
+	}, now, uint64(p.Resolvers.TimeResolver.ComputeMonotonicTimestamp(now)))
+
+	// Returning the event to the pool as soon as this returns is safe: the insert path deep-copies
+	// everything it keeps, precisely because events are pooled and reused.
+	p.profileManager.ProcessEvent(ev)
 }

--- a/pkg/security/probe/dns_request_tracker.go
+++ b/pkg/security/probe/dns_request_tracker.go
@@ -1,0 +1,151 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package probe holds probe related files
+package probe
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils/lru/simplelru"
+)
+
+const (
+	// dnsRequestTrackerSize bounds how many in-flight DNS questions are remembered at once. Only
+	// questions asked by a process an activity dump is tracing are recorded, so this is sized for
+	// concurrent lookups from traced workloads rather than for host-wide DNS volume.
+	dnsRequestTrackerSize = 1024
+	// dnsRequestTrackerTTL is how long a question stays correlatable. It matches the timeout a
+	// typical stub resolver gives up after, so an answer arriving later than this belongs to a
+	// query the requester has already abandoned.
+	dnsRequestTrackerTTL = 5 * time.Second
+)
+
+// dnsRequestKey identifies one in-flight DNS question. A DNS response carries no network context
+// on the short path, so the transaction ID, the question name, and the query type are all we have
+// to correlate on. The name is lowercased because DNS names are case-insensitive and resolvers may
+// apply 0x20 randomisation, echoing the question with randomised capitalisation.
+type dnsRequestKey struct {
+	id    uint16
+	qtype uint16
+	name  string
+}
+
+func newDNSRequestKey(id uint16, name string, qtype uint16) dnsRequestKey {
+	return dnsRequestKey{id: id, qtype: qtype, name: strings.ToLower(name)}
+}
+
+// dnsPendingRequest is the process that asked a question, held until the answer arrives or the
+// question goes stale. A nil entry is a tombstone: two different processes were in flight on the
+// same key, so the answer can no longer be attributed to either of them.
+type dnsPendingRequest struct {
+	entry    *model.ProcessCacheEntry
+	deadline time.Time
+}
+
+// dnsRequestTracker remembers which process asked each in-flight DNS question so that the matching
+// response can be attributed back to it.
+//
+// A DNS request leaves from within the querying process, so the egress hook resolves a pid. A
+// response arrives inbound on the softirq path with no current process, and for container traffic
+// the packet's pid resolves to 0. Rather than attributing the response independently, this
+// correlates it back to its request.
+//
+// Process cache entries are garbage collected through runtime.AddCleanup rather than refcounted,
+// so holding one here is safe; the bounded LRU caps how long entries stay pinned.
+type dnsRequestTracker struct {
+	mu      sync.Mutex
+	pending *simplelru.LRU[dnsRequestKey, dnsPendingRequest]
+	ttl     time.Duration
+
+	hits       *atomic.Uint64
+	misses     *atomic.Uint64
+	collisions *atomic.Uint64
+}
+
+func newDNSRequestTracker(size int, ttl time.Duration) (*dnsRequestTracker, error) {
+	pending, err := simplelru.NewLRU[dnsRequestKey, dnsPendingRequest](size, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dnsRequestTracker{
+		pending:    pending,
+		ttl:        ttl,
+		hits:       atomic.NewUint64(0),
+		misses:     atomic.NewUint64(0),
+		collisions: atomic.NewUint64(0),
+	}, nil
+}
+
+// recordRequest remembers that entry asked this question.
+//
+// When a live entry already exists for the key under a different process, the key is poisoned with
+// a tombstone for the remainder of the original entry's life. Deleting instead would let a third
+// request re-occupy the key and claim the first request's answer, which is exactly the
+// mis-attribution this exists to avoid. The tombstone keeps the original deadline so that a run of
+// colliding requests cannot keep a key poisoned indefinitely.
+func (t *dnsRequestTracker) recordRequest(id uint16, name string, qtype uint16, entry *model.ProcessCacheEntry, now time.Time) {
+	if entry == nil {
+		return
+	}
+
+	key := newDNSRequestKey(id, name, qtype)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if existing, ok := t.pending.Peek(key); ok && now.Before(existing.deadline) {
+		if existing.entry != entry {
+			t.collisions.Inc()
+			t.pending.Add(key, dnsPendingRequest{entry: nil, deadline: existing.deadline})
+			return
+		}
+	}
+
+	t.pending.Add(key, dnsPendingRequest{entry: entry, deadline: now.Add(t.ttl)})
+}
+
+// matchResponse returns the process that asked the question this response answers, or nil when the
+// question is unknown, stale, or ambiguous. Ambiguity resolves as a miss and never as a guess: a
+// dump losing one resolved IP is a far better outcome than a dump crediting it to the wrong
+// process.
+//
+// The entry is deliberately not consumed. A duplicated or retransmitted response then merges
+// idempotently rather than being dropped.
+func (t *dnsRequestTracker) matchResponse(id uint16, name string, qtype uint16, now time.Time) *model.ProcessCacheEntry {
+	key := newDNSRequestKey(id, name, qtype)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	pending, ok := t.pending.Get(key)
+	if !ok {
+		t.misses.Inc()
+		return nil
+	}
+
+	if !now.Before(pending.deadline) {
+		t.pending.Remove(key)
+		t.misses.Inc()
+		return nil
+	}
+
+	if pending.entry == nil {
+		// poisoned by a colliding request
+		t.misses.Inc()
+		return nil
+	}
+
+	t.hits.Inc()
+	return pending.entry
+}

--- a/pkg/security/probe/dns_request_tracker_test.go
+++ b/pkg/security/probe/dns_request_tracker_test.go
@@ -172,3 +172,25 @@ func TestDNSRequestTrackerIgnoresNilProcessCacheEntry(t *testing.T) {
 
 	assert.Nil(t, tracker.matchResponse(0x1234, "one.one.one.one", testQTypeA, now))
 }
+
+// A tombstone must keep rejecting through the whole intermediate window, not only once its
+// deadline has passed. Ambiguity resolving as a miss is the safety property the feature rests on.
+func TestDNSRequestTrackerPoisonHoldsThroughIntermediateCollisions(t *testing.T) {
+	tracker := newTestDNSRequestTracker(t)
+	first := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+	second := model.NewPlaceholderProcessCacheEntry(43, 43, false)
+	third := model.NewPlaceholderProcessCacheEntry(44, 44, false)
+	now := time.Now()
+
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, first, now)
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, second, now.Add(time.Second))
+
+	// still poisoned partway through the original entry's life
+	assert.Nil(t, tracker.matchResponse(0x1234, "one.one.one.one", testQTypeA, now.Add(2*time.Second)))
+
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, third, now.Add(3*time.Second))
+
+	// a third colliding request must not lift the tombstone or hand the answer to anyone
+	assert.Nil(t, tracker.matchResponse(0x1234, "one.one.one.one", testQTypeA, now.Add(4*time.Second)))
+	assert.Equal(t, uint64(2), tracker.collisions.Load())
+}

--- a/pkg/security/probe/dns_request_tracker_test.go
+++ b/pkg/security/probe/dns_request_tracker_test.go
@@ -1,0 +1,174 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package probe holds probe related files
+package probe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+const (
+	testQTypeA    = uint16(1)
+	testQTypeAAAA = uint16(28)
+)
+
+func newTestDNSRequestTracker(t *testing.T) *dnsRequestTracker {
+	t.Helper()
+	tracker, err := newDNSRequestTracker(dnsRequestTrackerSize, dnsRequestTrackerTTL)
+	require.NoError(t, err)
+	return tracker
+}
+
+func TestDNSRequestTrackerMatchesRecordedRequest(t *testing.T) {
+	tracker := newTestDNSRequestTracker(t)
+	entry := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+	now := time.Now()
+
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, entry, now)
+
+	assert.Same(t, entry, tracker.matchResponse(0x1234, "one.one.one.one", testQTypeA, now))
+	assert.Equal(t, uint64(1), tracker.hits.Load())
+}
+
+func TestDNSRequestTrackerMissesUnknownKey(t *testing.T) {
+	tracker := newTestDNSRequestTracker(t)
+	entry := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+	now := time.Now()
+
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, entry, now)
+
+	// wrong transaction ID
+	assert.Nil(t, tracker.matchResponse(0x9999, "one.one.one.one", testQTypeA, now))
+	// wrong name
+	assert.Nil(t, tracker.matchResponse(0x1234, "example.com", testQTypeA, now))
+	assert.Equal(t, uint64(2), tracker.misses.Load())
+}
+
+func TestDNSRequestTrackerExpiresAfterTTL(t *testing.T) {
+	tracker := newTestDNSRequestTracker(t)
+	entry := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+	now := time.Now()
+
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, entry, now)
+
+	assert.Nil(t, tracker.matchResponse(0x1234, "one.one.one.one", testQTypeA, now.Add(dnsRequestTrackerTTL)))
+	assert.Equal(t, uint64(1), tracker.misses.Load())
+}
+
+// A colliding transaction ID must lose the answer, never attribute it to the wrong process.
+func TestDNSRequestTrackerCollisionPoisonsTheKey(t *testing.T) {
+	tracker := newTestDNSRequestTracker(t)
+	first := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+	second := model.NewPlaceholderProcessCacheEntry(43, 43, false)
+	now := time.Now()
+
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, first, now)
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, second, now)
+
+	assert.Nil(t, tracker.matchResponse(0x1234, "one.one.one.one", testQTypeA, now))
+	assert.Equal(t, uint64(1), tracker.collisions.Load())
+}
+
+// A tombstone must not be extended indefinitely by further colliding requests.
+func TestDNSRequestTrackerPoisonDoesNotOutliveOriginalDeadline(t *testing.T) {
+	tracker := newTestDNSRequestTracker(t)
+	first := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+	second := model.NewPlaceholderProcessCacheEntry(43, 43, false)
+	third := model.NewPlaceholderProcessCacheEntry(44, 44, false)
+	now := time.Now()
+
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, first, now)
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, second, now.Add(time.Second))
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, third, now.Add(2*time.Second))
+
+	// the tombstone still expires on the first request's deadline
+	later := now.Add(dnsRequestTrackerTTL)
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, third, later)
+	assert.Same(t, third, tracker.matchResponse(0x1234, "one.one.one.one", testQTypeA, later))
+}
+
+// Some stub resolvers retransmit with the same transaction ID; that is not a collision.
+func TestDNSRequestTrackerRetransmitRefreshesDeadline(t *testing.T) {
+	tracker := newTestDNSRequestTracker(t)
+	entry := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+	now := time.Now()
+
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, entry, now)
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, entry, now.Add(4*time.Second))
+
+	assert.Same(t, entry, tracker.matchResponse(0x1234, "one.one.one.one", testQTypeA, now.Add(6*time.Second)))
+	assert.Equal(t, uint64(0), tracker.collisions.Load())
+}
+
+// nslookup issues A and AAAA for the same name; they must correlate independently.
+func TestDNSRequestTrackerSeparatesQueryTypes(t *testing.T) {
+	tracker := newTestDNSRequestTracker(t)
+	a := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+	aaaa := model.NewPlaceholderProcessCacheEntry(43, 43, false)
+	now := time.Now()
+
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, a, now)
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeAAAA, aaaa, now)
+
+	assert.Same(t, a, tracker.matchResponse(0x1234, "one.one.one.one", testQTypeA, now))
+	assert.Same(t, aaaa, tracker.matchResponse(0x1234, "one.one.one.one", testQTypeAAAA, now))
+	assert.Equal(t, uint64(0), tracker.collisions.Load())
+}
+
+// Resolvers may apply 0x20 randomisation and echo the question with randomised capitalisation.
+func TestDNSRequestTrackerMatchesCaseInsensitively(t *testing.T) {
+	tracker := newTestDNSRequestTracker(t)
+	entry := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+	now := time.Now()
+
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, entry, now)
+
+	assert.Same(t, entry, tracker.matchResponse(0x1234, "OnE.oNe.ONE.one", testQTypeA, now))
+}
+
+// The entry is deliberately not consumed, so a duplicated response merges idempotently.
+func TestDNSRequestTrackerDoesNotConsumeOnMatch(t *testing.T) {
+	tracker := newTestDNSRequestTracker(t)
+	entry := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+	now := time.Now()
+
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, entry, now)
+
+	assert.Same(t, entry, tracker.matchResponse(0x1234, "one.one.one.one", testQTypeA, now))
+	assert.Same(t, entry, tracker.matchResponse(0x1234, "one.one.one.one", testQTypeA, now))
+	assert.Equal(t, uint64(2), tracker.hits.Load())
+}
+
+func TestDNSRequestTrackerEvictsWhenFull(t *testing.T) {
+	tracker, err := newDNSRequestTracker(2, dnsRequestTrackerTTL)
+	require.NoError(t, err)
+	entry := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+	now := time.Now()
+
+	tracker.recordRequest(1, "a.example.com", testQTypeA, entry, now)
+	tracker.recordRequest(2, "b.example.com", testQTypeA, entry, now)
+	tracker.recordRequest(3, "c.example.com", testQTypeA, entry, now)
+
+	assert.Nil(t, tracker.matchResponse(1, "a.example.com", testQTypeA, now))
+	assert.Same(t, entry, tracker.matchResponse(3, "c.example.com", testQTypeA, now))
+}
+
+func TestDNSRequestTrackerIgnoresNilProcessCacheEntry(t *testing.T) {
+	tracker := newTestDNSRequestTracker(t)
+	now := time.Now()
+
+	tracker.recordRequest(0x1234, "one.one.one.one", testQTypeA, nil, now)
+
+	assert.Nil(t, tracker.matchResponse(0x1234, "one.one.one.one", testQTypeA, now))
+}

--- a/pkg/security/probe/dns_request_tracker_test.go
+++ b/pkg/security/probe/dns_request_tracker_test.go
@@ -10,13 +10,21 @@ package probe
 
 import (
 	"net"
+	"slices"
 	"testing"
 	"time"
 
+	"github.com/google/gopacket/layers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	pconfig "github.com/DataDog/datadog-agent/pkg/security/probe/config"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	securityprofile "github.com/DataDog/datadog-agent/pkg/security/security_profile"
+	"github.com/DataDog/datadog-agent/pkg/util/ktime"
+	ddsync "github.com/DataDog/datadog-agent/pkg/util/sync"
 )
 
 const (
@@ -211,6 +219,8 @@ func TestNewCorrelatedDNSEvent(t *testing.T) {
 	newCorrelatedDNSEvent(ev, entry, 0x1234, question, response, ts, 99)
 
 	assert.Equal(t, model.DNSEventType, ev.GetEventType())
+	// derived in user space, not received from the kernel
+	assert.Equal(t, model.EventSourceRelated, ev.Source)
 	assert.Equal(t, ts, ev.Timestamp)
 	assert.Equal(t, uint64(99), ev.TimestampRaw)
 	assert.Same(t, entry, ev.ProcessCacheEntry)
@@ -221,4 +231,189 @@ func TestNewCorrelatedDNSEvent(t *testing.T) {
 
 	// the activity dump manager drops anything not flagged as a sample
 	assert.True(t, ev.IsActivityDumpSample())
+}
+
+// capturedDNSEvent holds everything the assertions need from a correlated event. It has to be
+// copied out inside the stub: correlateDNSResponseForActivityDump returns the event to the pool as
+// soon as it returns, and the pool hands the same *model.Event out again.
+type capturedDNSEvent struct {
+	eventType    model.EventType
+	source       string
+	entry        *model.ProcessCacheEntry
+	id           uint16
+	question     model.DNSQuestion
+	responseCode uint8
+	ips          []net.IPNet
+	cnames       []string
+	isADSample   bool
+}
+
+// stubProfileManager records the events the correlation path hands to the profile manager.
+//
+// securityprofile.ProfileManager is a wide interface, so it is embedded rather than implemented:
+// only ProcessEvent is defined, and any other method the correlation path might start calling
+// would panic on the nil embedded interface rather than pass silently.
+type stubProfileManager struct {
+	securityprofile.ProfileManager
+
+	events []capturedDNSEvent
+}
+
+func (m *stubProfileManager) ProcessEvent(ev *model.Event) {
+	captured := capturedDNSEvent{
+		eventType:  ev.GetEventType(),
+		source:     ev.Source,
+		entry:      ev.ProcessCacheEntry,
+		id:         ev.DNS.ID,
+		question:   ev.DNS.Question,
+		isADSample: ev.IsActivityDumpSample(),
+	}
+	if ev.DNS.Response != nil {
+		captured.responseCode = ev.DNS.Response.ResponseCode
+		captured.ips = slices.Clone(ev.DNS.Response.IPs)
+		captured.cnames = slices.Clone(ev.DNS.Response.CNames)
+	}
+	m.events = append(m.events, captured)
+}
+
+// newTestCorrelationProbe builds the smallest EBPFProbe correlateDNSResponseForActivityDump needs:
+// an event pool, field handlers, a time resolver, the tracker and a profile manager. NewEBPFProbe
+// is not usable here, it attaches to the kernel.
+func newTestCorrelationProbe(t *testing.T) (*EBPFProbe, *stubProfileManager) {
+	t.Helper()
+
+	timeResolver, err := ktime.NewResolver()
+	require.NoError(t, err)
+
+	fieldHandlers, err := NewEBPFFieldHandlers(&config.Config{
+		Probe:           &pconfig.Config{},
+		RuntimeSecurity: &config.RuntimeSecurityConfig{},
+	}, nil, "test-host", nil)
+	require.NoError(t, err)
+
+	profileManager := &stubProfileManager{}
+
+	p := &EBPFProbe{
+		Resolvers:      &resolvers.EBPFResolvers{TimeResolver: timeResolver},
+		fieldHandlers:  fieldHandlers,
+		profileManager: profileManager,
+		dnsRequests:    newTestDNSRequestTracker(t),
+	}
+	p.eventPool = ddsync.NewTypedPool(func() *model.Event {
+		return newEBPFEvent(p.fieldHandlers)
+	})
+
+	return p, profileManager
+}
+
+func newTestDNSResponseLayer(id uint16, name string, qtype layers.DNSType) *layers.DNS {
+	return &layers.DNS{
+		ID:           id,
+		QR:           true,
+		ResponseCode: layers.DNSResponseCodeNoErr,
+		Questions: []layers.DNSQuestion{{
+			Name:  []byte(name),
+			Type:  qtype,
+			Class: layers.DNSClassIN,
+		}},
+	}
+}
+
+func TestCorrelateDNSResponseForActivityDumpAttributesToTheRequester(t *testing.T) {
+	p, profileManager := newTestCorrelationProbe(t)
+	entry := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+
+	p.dnsRequests.recordRequest(0x1234, "one.one.one.one", testQTypeA, entry, time.Now())
+
+	ips := []net.IPNet{{IP: net.IPv4(1, 1, 1, 1), Mask: net.CIDRMask(32, 32)}}
+	cnames := []string{"cdn.example.com"}
+	p.correlateDNSResponseForActivityDump(newTestDNSResponseLayer(0x1234, "one.one.one.one", layers.DNSTypeA), ips, cnames)
+
+	require.Len(t, profileManager.events, 1)
+	got := profileManager.events[0]
+
+	assert.Equal(t, model.DNSEventType, got.eventType)
+	// derived in user space, not received from the kernel
+	assert.Equal(t, model.EventSourceRelated, got.source)
+	assert.Same(t, entry, got.entry, "the response must be attributed to the process that asked")
+	assert.Equal(t, uint16(0x1234), got.id)
+	assert.Equal(t, model.DNSQuestion{Name: "one.one.one.one", Type: testQTypeA, Class: 1}, got.question)
+	assert.Equal(t, uint8(0), got.responseCode)
+	assert.Equal(t, ips, got.ips)
+	assert.Equal(t, cnames, got.cnames)
+	// the V1 activity dump manager drops anything not flagged as a sample
+	assert.True(t, got.isADSample)
+
+	assert.Equal(t, uint64(1), p.dnsRequests.hits.Load())
+	assert.Equal(t, uint64(0), p.dnsRequests.misses.Load())
+}
+
+// A response the tracker knows nothing about is dropped, and it is only a miss when something was
+// actually being tracked. Otherwise every DNS response on the host — none of which this correlator
+// could ever claim — would count as a miss and pin the metric at ~100%.
+func TestCorrelateDNSResponseForActivityDumpIgnoresUnmatchedResponse(t *testing.T) {
+	t.Run("nothing tracked", func(t *testing.T) {
+		p, profileManager := newTestCorrelationProbe(t)
+
+		p.correlateDNSResponseForActivityDump(
+			newTestDNSResponseLayer(0x1234, "one.one.one.one", layers.DNSTypeA),
+			[]net.IPNet{{IP: net.IPv4(1, 1, 1, 1), Mask: net.CIDRMask(32, 32)}}, nil)
+
+		assert.Empty(t, profileManager.events)
+		assert.Equal(t, uint64(0), p.dnsRequests.misses.Load(), "an idle correlator must not count host DNS volume as misses")
+	})
+
+	t.Run("another question tracked", func(t *testing.T) {
+		p, profileManager := newTestCorrelationProbe(t)
+		entry := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+
+		p.dnsRequests.recordRequest(0x1234, "one.one.one.one", testQTypeA, entry, time.Now())
+
+		p.correlateDNSResponseForActivityDump(
+			newTestDNSResponseLayer(0x4321, "example.com", layers.DNSTypeA),
+			[]net.IPNet{{IP: net.IPv4(93, 184, 216, 34), Mask: net.CIDRMask(32, 32)}}, nil)
+
+		assert.Empty(t, profileManager.events)
+		assert.Equal(t, uint64(1), p.dnsRequests.misses.Load())
+	})
+}
+
+// NODATA: a NOERROR response with no answers has nothing to enrich a dump with, so it must not
+// reach the profile manager even when its question is being tracked.
+func TestCorrelateDNSResponseForActivityDumpSkipsEmptyAnswers(t *testing.T) {
+	p, profileManager := newTestCorrelationProbe(t)
+	entry := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+
+	p.dnsRequests.recordRequest(0x1234, "one.one.one.one", testQTypeAAAA, entry, time.Now())
+
+	p.correlateDNSResponseForActivityDump(newTestDNSResponseLayer(0x1234, "one.one.one.one", layers.DNSTypeAAAA), nil, nil)
+
+	assert.Empty(t, profileManager.events)
+	assert.Equal(t, uint64(0), p.dnsRequests.hits.Load())
+	assert.Equal(t, uint64(0), p.dnsRequests.misses.Load())
+}
+
+// The correlated event goes straight back to the pool, so the next one must not inherit anything
+// from it. Reusing the pooled event is the whole reason the insert path deep-copies.
+func TestCorrelateDNSResponseForActivityDumpReusesPooledEvents(t *testing.T) {
+	p, profileManager := newTestCorrelationProbe(t)
+	a := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+	b := model.NewPlaceholderProcessCacheEntry(43, 43, false)
+	now := time.Now()
+
+	p.dnsRequests.recordRequest(0x1234, "one.one.one.one", testQTypeA, a, now)
+	p.dnsRequests.recordRequest(0x4321, "example.com", testQTypeA, b, now)
+
+	first := []net.IPNet{{IP: net.IPv4(1, 1, 1, 1), Mask: net.CIDRMask(32, 32)}}
+	p.correlateDNSResponseForActivityDump(newTestDNSResponseLayer(0x1234, "one.one.one.one", layers.DNSTypeA), first, []string{"cdn.example.com"})
+
+	second := []net.IPNet{{IP: net.IPv4(93, 184, 216, 34), Mask: net.CIDRMask(32, 32)}}
+	p.correlateDNSResponseForActivityDump(newTestDNSResponseLayer(0x4321, "example.com", layers.DNSTypeA), second, nil)
+
+	require.Len(t, profileManager.events, 2)
+	assert.Same(t, a, profileManager.events[0].entry)
+	assert.Same(t, b, profileManager.events[1].entry)
+	assert.Equal(t, "example.com", profileManager.events[1].question.Name)
+	assert.Equal(t, second, profileManager.events[1].ips)
+	assert.Empty(t, profileManager.events[1].cnames, "the second event must not inherit the first one's CNAMEs")
 }

--- a/pkg/security/probe/dns_request_tracker_test.go
+++ b/pkg/security/probe/dns_request_tracker_test.go
@@ -9,6 +9,7 @@
 package probe
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -193,4 +194,31 @@ func TestDNSRequestTrackerPoisonHoldsThroughIntermediateCollisions(t *testing.T)
 	// a third colliding request must not lift the tombstone or hand the answer to anyone
 	assert.Nil(t, tracker.matchResponse(0x1234, "one.one.one.one", testQTypeA, now.Add(4*time.Second)))
 	assert.Equal(t, uint64(2), tracker.collisions.Load())
+}
+
+func TestNewCorrelatedDNSEvent(t *testing.T) {
+	entry := model.NewPlaceholderProcessCacheEntry(42, 42, false)
+	ev := model.NewFakeEvent()
+	ts := time.Unix(1757520000, 0)
+
+	question := model.DNSQuestion{Name: "one.one.one.one", Type: testQTypeA, Class: 1}
+	response := &model.DNSResponse{
+		ResponseCode: 0,
+		IPs:          []net.IPNet{{IP: net.IPv4(1, 1, 1, 1), Mask: net.CIDRMask(32, 32)}},
+		CNames:       []string{"cdn.example.com"},
+	}
+
+	newCorrelatedDNSEvent(ev, entry, 0x1234, question, response, ts, 99)
+
+	assert.Equal(t, model.DNSEventType, ev.GetEventType())
+	assert.Equal(t, ts, ev.Timestamp)
+	assert.Equal(t, uint64(99), ev.TimestampRaw)
+	assert.Same(t, entry, ev.ProcessCacheEntry)
+	assert.Same(t, &entry.ProcessContext, ev.ProcessContext)
+	assert.Equal(t, uint16(0x1234), ev.DNS.ID)
+	assert.Equal(t, question, ev.DNS.Question)
+	assert.Same(t, response, ev.DNS.Response)
+
+	// the activity dump manager drops anything not flagged as a sample
+	assert.True(t, ev.IsActivityDumpSample())
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1205,6 +1205,21 @@ func (p *EBPFProbe) SendStats() error {
 		return err
 	}
 
+	if p.dnsRequests != nil {
+		for _, m := range []struct {
+			name    string
+			counter *atomic.Uint64
+		}{
+			{metrics.MetricDNSADCorrelationHits, p.dnsRequests.hits},
+			{metrics.MetricDNSADCorrelationMisses, p.dnsRequests.misses},
+			{metrics.MetricDNSADCorrelationCollisions, p.dnsRequests.collisions},
+		} {
+			if err := p.statsdClient.Count(m.name, int64(m.counter.Swap(0)), []string{}, 1.0); err != nil {
+				return err
+			}
+		}
+	}
+
 	if err := p.eventStream.SendStats(); err != nil {
 		return err
 	}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -125,6 +125,7 @@ type EBPFProbe struct {
 	// internals
 	event           *model.Event
 	dnsLayer        *layers.DNS
+	dnsRequests     *dnsRequestTracker
 	monitors        *EBPFMonitors
 	profileManager  securityprofile.ProfileManager
 	fieldHandlers   *EBPFFieldHandlers
@@ -1839,6 +1840,12 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 			}
 		}
 
+		// Remember who asked, so the matching response can be attributed back to this process.
+		// Only questions from a process an activity dump is tracing are worth recording.
+		if event.Error == nil && event.IsActivityDumpSample() && p.dnsRequests != nil {
+			p.dnsRequests.recordRequest(event.DNS.ID, event.DNS.Question.Name, event.DNS.Question.Type, event.ProcessCacheEntry, time.Now())
+		}
+
 	case model.FullDNSResponseEventType:
 		if p.config.Probe.DNSResolutionEnabled {
 			if read, err = event.NetworkContext.UnmarshalBinary(data[offset:]); err != nil {
@@ -2139,7 +2146,8 @@ func (p *EBPFProbe) handleEarlyReturnEvents(event *model.Event, offset int, data
 	case model.ShortDNSResponseEventType:
 		if p.config.Probe.DNSResolutionEnabled {
 			if err := p.dnsLayer.DecodeFromBytes(data[offset:], gopacket.NilDecodeFeedback); err == nil {
-				p.addToDNSResolver(p.dnsLayer)
+				ips, cnames := p.addToDNSResolver(p.dnsLayer)
+				p.correlateDNSResponseForActivityDump(p.dnsLayer, ips, cnames)
 				return false
 			}
 
@@ -3454,6 +3462,12 @@ func NewEBPFProbe(probe *Probe, config *config.Config, hostname string, opts Opt
 
 	ctx, cancelFnc := context.WithCancel(context.Background())
 
+	dnsRequests, err := newDNSRequestTracker(dnsRequestTrackerSize, dnsRequestTrackerTTL)
+	if err != nil {
+		cancelFnc()
+		return nil, fmt.Errorf("couldn't create the DNS request tracker: %w", err)
+	}
+
 	p := &EBPFProbe{
 		probe:                probe,
 		config:               config,
@@ -3469,6 +3483,7 @@ func NewEBPFProbe(probe *Probe, config *config.Config, hostname string, opts Opt
 		onDemandRateLimiter:  rate.NewLimiter(onDemandRate, onDemandBurst),
 		replayEventsState:    atomic.NewBool(false),
 		dnsLayer:             new(layers.DNS),
+		dnsRequests:          dnsRequests,
 		hostname:             hostname,
 		BPFFilterTruncated:   atomic.NewUint64(0),
 		MetricNameTruncated:  atomic.NewUint64(0),

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1856,7 +1856,13 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 		}
 
 		// Remember who asked, so the matching response can be attributed back to this process.
-		// Only questions from a process an activity dump is tracing are worth recording.
+		// The sample flag covers two kernel-side cases (reset_dns_event in
+		// helpers/network/dns.h): a pid an activity dump is tracing, and a rate-limited sample of
+		// everything else, taken by approve_dns_sample when
+		// runtime_security_config.event_sampling.dns.enabled is set (off by default, rate 500/s).
+		// Both genuinely feed profiles under the V2 manager, so both are recorded. Under sampling
+		// those extra requests do compete for the tracker's 1024 slots, but the cost of losing one
+		// is only a miss, never a misattribution: an evicted key simply stops matching.
 		if event.Error == nil && event.IsActivityDumpSample() && p.dnsRequests != nil {
 			p.dnsRequests.recordRequest(event.DNS.ID, event.DNS.Question.Name, event.DNS.Question.Type, event.ProcessCacheEntry, time.Now())
 		}
@@ -2160,13 +2166,14 @@ func (p *EBPFProbe) handleEarlyReturnEvents(event *model.Event, offset int, data
 		return false
 	case model.ShortDNSResponseEventType:
 		if p.config.Probe.DNSResolutionEnabled {
-			if err := p.dnsLayer.DecodeFromBytes(data[offset:], gopacket.NilDecodeFeedback); err == nil {
+			decodeErr := p.dnsLayer.DecodeFromBytes(data[offset:], gopacket.NilDecodeFeedback)
+			if decodeErr == nil {
 				ips, cnames := p.addToDNSResolver(p.dnsLayer)
 				p.correlateDNSResponseForActivityDump(p.dnsLayer, ips, cnames)
 				return false
 			}
 
-			seclog.Warnf("failed to decode the short DNS response: %s", err)
+			seclog.Warnf("failed to decode the short DNS response: %s", decodeErr)
 			event.Error = model.ErrFailedDNSPacketDecoding
 			event.FailedDNS = model.FailedDNSEvent{
 				Payload: trimRightZeros(data[offset:]),

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -306,8 +306,11 @@ func TestActivityDumps(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// The resolved IPs come from the DNS response packet, which reaches the tree as a
-		// regular DNS event carrying DNS.Response (see FullDNSResponseEventType in probe_ebpf.go).
+		// The resolved IPs do not reach the tree on their own: an inbound response has no process
+		// context, and for container traffic its pid resolves to 0. They arrive on the short
+		// response path (ShortDNSResponseEventType in probe_ebpf.go), where user space correlates
+		// the answer back to the request that asked for it on (txid, qname, qtype) and synthesizes
+		// a DNS event carrying nslookup's own process context. See dns_request_tracker.go.
 		validateActivityDumpOutputs(t, test, expectedFormats, ad.OutputFiles, func(ad *dump.ActivityDump) bool {
 			nodes := ad.Profile.ActivityTree.FindMatchingRootNodes("nslookup")
 			if nodes == nil {

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -282,23 +282,6 @@ func TestActivityDumps(t *testing.T) {
 	})
 
 	t.Run("activity-dump-cgroup-dns-response", func(t *testing.T) {
-		// TODO(CWS-6919): the activity tree can hold and serialize DNS answers, but nothing
-		// feeds them to it yet, so this cannot pass.
-		//
-		// A DNS response is never attributed to the process that asked the question when the
-		// query comes from a container: responses arrive inbound on the network softirq path,
-		// where there is no current process, so fill_network_process_context_from_pkt yields
-		// pid 0 (confirmed in KMT: host-side lookups report real pids, the container's
-		// nslookup reports pid=0). lookup_or_delete_traced_pid can therefore never match a
-		// traced pid, EVENT_FLAGS_ACTIVITY_DUMP_SAMPLE is never set on the response, and
-		// Manager.ProcessEvent drops it before it reaches the tree.
-		//
-		// Fixing this needs the response correlated back to its request rather than attributed
-		// independently — the DNS transaction ID is already tracked in-kernel in the
-		// dns_responses_sent_to_userspace LRU. That is a CWS network-path design change,
-		// tracked in CWS-6919; removing this skip is that ticket's acceptance test.
-		t.Skip("CWS-6919: DNS responses are not attributed to a traced process for container queries")
-
 		checkKernelCompatibility(t, "RHEL, SLES and Oracle kernels", func(kv *kernel.Version) bool {
 			// TODO: Oracle because we are missing offsets. See dns_test.go
 			return kv.IsRH7Kernel() || kv.IsOracleUEKKernel() || kv.IsSLESKernel()


### PR DESCRIPTION
> **Stacked on #55843** — base branch is `daniel.zhou/CWS-6595-dns-response-activity-dumps`, not `main`. #55843 contributes the consuming side (`DNSRequestNode`, `DNSResponseAggregate`, proto encode/decode); this PR is the producer that feeds it. Please merge #55843 first.

### What does this PR do?

Attributes inbound DNS responses to the process that asked the question, so CWS activity dumps record the IPs and CNAMEs a containerised lookup resolved to — not just the question asked.

A bounded LRU in the probe remembers which process asked each in-flight DNS question, keyed on `(transaction ID, lowercased qname, qtype)`. When the matching response arrives, a synthesized DNS event carrying the answers plus the requester's process context goes straight to the activity dump manager.

**No eBPF changes.**

```mermaid
sequenceDiagram
    participant C as Container process
    participant K as eBPF (TC)
    participant P as EBPFProbe
    participant T as dnsRequestTracker
    participant A as Activity dump

    C->>K: DNS question (egress — runs in sender's context, pid resolves)
    K->>P: EVENT_DNS (+ activity-dump sample flag)
    P->>T: recordRequest(txid, qname, qtype, pce)
    P->>A: question recorded
    Note over K: response arrives on the softirq path,<br/>no current process, pid resolves to 0
    K->>P: EVENT_DNS_RESPONSE_SHORT (no process context)
    P->>T: matchResponse(txid, qname, qtype)
    T-->>P: the requesting process
    P->>A: ProcessEvent(correlated DNS event)
    Note over A: answers merged into<br/>the existing DNS node
```

### Motivation

CWS-6919. Blocks CWS-6595.

A DNS request leaves from within the querying process, so the eBPF egress hook resolves a pid and the kernel sets `EVENT_FLAGS_ACTIVITY_DUMP_SAMPLE`. A response arrives inbound on the network softirq path where there is no current process — `fill_network_process_context_from_pkt` yields **pid 0** for container traffic, `lookup_or_delete_traced_pid` can never match, and `Manager.ProcessEvent` drops the event one call short of the activity tree. The answers were decoding correctly the whole time; they just had no process to belong to.

**Why user space rather than a kernel-side map.** The ticket proposed carrying the request's process context forward in a BPF map. That turned out to be more machinery than the problem needs: for every NOERROR response — the only kind carrying answers — the kernel *already* ships the complete DNS message to user space on the short path, where `handleEarlyReturnEvents` decodes it, feeds the DNS resolver cache, and discards the rest. The request event already carries the transaction ID, question, process context, and sample flag. So the correlation needs no new BPF map, no eviction policy, no verifier risk, and no widening of the deliberately-tested NOERROR discard (`noerror-packet-is-discarded` in `dns_response_test.go` is untouched).

**Ambiguity is a miss, never a guess.** The short response carries no network context, so the key is `(txid, qname, qtype)`. When two processes are in flight on the same key, the entry is poisoned with a tombstone and *both* lose the answer. A dump missing a resolved IP is a far better outcome than a dump crediting one to the wrong process.

### Describe how you validated your changes

- **Unit tests** — 16 new tests in `pkg/security/probe/dns_request_tracker_test.go`: hit, miss, TTL expiry, collision poisoning (including that a tombstone keeps rejecting through its whole window and cannot be extended indefinitely), same-PCE retransmit refresh, A/AAAA independence, case-insensitive match (0x20 randomisation), LRU eviction, plus coverage of `correlateDNSResponseForActivityDump` itself against a stub profile manager — matched response, unmatched response, NODATA short-circuit, and pooled-event reuse.
- **Acceptance test** — `TestActivityDumps/activity-dump-cgroup-dns-response` had its `t.Skip` removed. It was written alongside #55843 and already asserts resolved IPs reach the dump. **This is the ticket's acceptance criterion and needs a KMT run** (`kmt_run_secagent_tests_*_ad`, `ubuntu_22.04, cws_ad`).
- `dda inv test --targets=./pkg/security/probe,./pkg/security/metrics` → 206 passed, 1 pre-existing skip, 0 failures.
- `dda inv linter.go --targets=./pkg/security/probe` → 0 issues. `bazel test //pkg/security/probe:probe_test` → PASSED. `dda inv security-agent.build-functional-tests` → exit 0.

### Additional Notes

**⚠️ Reviewer attention: behaviour under the V2 profile manager.** The `ProcessEvent`-not-`DispatchEvent` call is deliberate — routing a synthesized event through `DispatchEvent` would expose it to rule evaluation, so a rule on `dns.question.name` would fire twice for dump-traced workloads only. Under **V1** that call is just the sample-flag gate plus the dump insert. Under **V2** — which is the shipping default — `ProcessEvent` has no sample-flag gate and additionally performs tag resolution and profile insertion, and reaches `sendAnomalyDetection` when the insert reports `inserted == true`.

What keeps correlated responses off the anomaly path today is that `InsertDNSEvent` returns `false` for a response-only merge (#55843's deliberate "enrichment, not drift" choice). That is now documented in the code as a load-bearing assumption, but note that **every functional test in this repo hard-codes `security_profile.v2.enabled: false`** (`module_tester_linux.go`), so the acceptance test exercises V1 only. A future change to `mergeDNSResponse` would silently start raising anomaly signals from this path. Worth a second opinion.

**Observability.** Three counters in the existing `.dns_response_collector.` namespace: `ad_correlation_hits`, `_misses`, `_collisions`. The correlator drops silently by design, so the collision counter is what makes the cost of that trade-off measurable rather than assumed.

**Known and deliberate:**
- `Question.Size`/`Count` are 0 when a correlated response *creates* the DNS node rather than merging into an existing one (reachable on dump rotation). This matches the pre-existing full-response path, which already emits `Count: 0`.
- Up to 1024 process cache entries can stay pinned after a traced container goes DNS-idle — deadlines are checked lazily on lookup. Bounded by the LRU; flagged since this repo has static memory quality gates.
- Per-dump DNS `processedCount` roughly doubles for traced workloads (the response is a second processed event); `addedCount` correctly does not.
- One drive-by fix: in `handleEarlyReturnEvents`, the short-DNS-response decode warning logged an if-scoped `err` that is always nil in that arm, so it always printed `%!s(<nil>)` — the one diagnostic for the path this feature depends on was dead. Fixed because this PR edits two lines inside that same block.

A release note is being written separately and is intentionally not in this PR.

<details>
<summary>Design document (click to expand)</summary>

# CWS-6919 — Attribute DNS responses to the querying process

Design, 2026-09-10. Ticket: https://datadoghq.atlassian.net/browse/CWS-6919
Depends on PR https://github.com/DataDog/datadog-agent/pull/55843 (CWS-6595 consumer side).

## Problem

An activity dump records the DNS *questions* a containerised process asks, but never
what those questions resolved to. The consuming side already exists and is unit
tested — `DNSRequestNode`, `DNSResponseAggregate`, bounded IP/CNAME accumulation,
proto round-trip — and nothing feeds it.

The cause is attribution, not decoding. A DNS request leaves from within the
querying process, so the egress TC hook resolves a pid and `reset_dns_event`
(`helpers/network/dns.h:48`) sets `EVENT_FLAGS_ACTIVITY_DUMP_SAMPLE` when a dump
traces that pid. A response arrives inbound on the softirq path with no current
process; `fill_network_process_context_from_pkt` yields pid 0 for container
traffic, `lookup_or_delete_traced_pid` cannot match, and
`Manager.ProcessEvent` (`security_profile/ad.go:40`) drops the event at
`if !event.IsActivityDumpSample()`.

## Why not the kernel-side correlation the ticket proposes

The ticket proposes carrying the request's process context forward in a BPF map
keyed by DNS transaction ID. Exploring the current code showed that is more
machinery than the problem needs, because **the answers already reach user space
attached to nothing**:

- For every NOERROR response — the only kind that carries answers — the kernel
  already ships the complete DNS message on the *short* path.
  `hooks/network/dns.h:186` loads the header, `:234` the remainder, `:244` sends
  `EVENT_DNS_RESPONSE_SHORT`. This is what the default rcode discarder produces;
  it needs no config or discarder change.
- `probe_ebpf.go:2139` (`handleEarlyReturnEvents`) already decodes that message
  into `p.dnsLayer` and calls `addToDNSResolver`, which already returns
  `(ips, cnames)`. Both return values are discarded today.
- The *request* event arrives in user space with the transaction ID
  (`model.DNSEvent.ID`), `Question.Name`/`Type`, a resolved
  `ProcessCacheEntry`, and the activity-dump sample flag already set. That is why
  `TestActivityDumps/activity-dump-cgroup-dns` passes for containers today.

So the correlation can happen entirely in user space: no eBPF change, no new BPF
map, no eviction or memory-ceiling question, no verifier or KMT kernel-matrix
risk, and the deliberately tested `noerror-packet-is-discarded` behaviour is
untouched.

Two approaches recorded in the ticket as tried-and-reverted stay rejected, for the
same reasons given there: widening the rcode discarder mask is necessary only for
the full-response path, which this design does not use; and setting the sample
flag on the full response sits downstream of the pid-0 lookup.

### Trade-off accepted

The short response carries no network context, so the correlation key is
`(txid, qname, qtype)` rather than a 5-tuple. Two processes querying the same name
with a colliding 16-bit transaction ID inside the TTL is possible. **Ambiguity is
resolved as a miss, never as a guess**: a collision loses an answer rather than
attributing it to the wrong process. In a security product a missing IP beats a
wrong one.

## Scope

In scope: feeding resolved IPs and CNAMEs of container DNS lookups into activity
dumps, unblocking CWS-6595.

Out of scope, and worth its own ticket: ingress packets in a container network
namespace resolve to pid 0 in general. That also prevents `dns.response.*` SECL
rules from matching on process fields. Fixing it is an open-ended eBPF
investigation across the KMT matrix (`resolve_pid_from_sk_lookup`,
`helpers/network/pid_resolver.h:57`) and is not required for this ticket.

## Design

### New component

`pkg/security/probe/dns_request_tracker.go` (+ `_test.go`), `//go:build linux`.
Holds the tracker and the probe's correlation method rather than growing
`probe_ebpf.go` past its current ~4,300 lines.

```go
type dnsRequestKey struct {
    id    uint16 // DNS transaction ID
    qtype uint16
    name  string // lowercased
}

type dnsPendingRequest struct {
    entry    *model.ProcessCacheEntry // nil once poisoned by a colliding request
    deadline time.Time
}

type dnsRequestTracker struct {
    mu      sync.Mutex
    pending *simplelru.LRU[dnsRequestKey, dnsPendingRequest]
    ttl     time.Duration
}
```

`simplelru` (`pkg/security/utils/lru/simplelru`, already used by
`field_handlers_ebpf.go`) is not thread-safe and `handleEvent` runs per-CPU, hence
the mutex. `ProcessCacheEntry` is GC-managed through `runtime.AddCleanup`, with no
manual refcounting, so holding one in the map is safe; the bounded LRU caps how
long entries are pinned.

Constants, not configuration: TTL 5s (a typical stub-resolver timeout), capacity
1024 entries. No new config knob — the path is inert unless a dump is tracing DNS
for the workload.

### Recording requests

In `handleRegularEvent`, `case model.DNSEventType:` — requests only, since
`FullDNSResponseEventType` is a separate case. After the DNS unmarshal succeeds and
if `event.IsActivityDumpSample()`, record the key against
`event.ProcessCacheEntry`. `setProcessContext` has already run at that point, so
the PCE is resolved.

Gating on the sample flag keeps the table proportional to what dumps are tracing,
not to host DNS volume.

### Matching responses

In `handleEarlyReturnEvents`, `case model.ShortDNSResponseEventType:`. The message
is already decoded and `addToDNSResolver` already returns `(ips, cnames)`. On a
unique hit:

```go
ev := p.getPoolEvent()
defer p.putBackPoolEvent(ev)
ev.Type = uint32(model.DNSEventType)
ev.Timestamp, ev.TimestampRaw = ...
ev.ProcessCacheEntry = entry
ev.ProcessContext = &entry.ProcessContext
ev.DNS = model.DNSEvent{ID: ..., Question: ..., Response: &model.DNSResponse{...}}
ev.AddToFlags(model.EventFlagsActivityDumpSample)
p.profileManager.ProcessEvent(ev)
```

then `return false`, as today.

Returning the event to the pool immediately is safe: the insert path deep-copies
everything it keeps (`newDNSResponseAggregate` copies IPs and CNAMEs precisely
because events are pooled and reused). `ddsync.TypedPool` is `sync.Pool`-backed and
goroutine-safe.

Calling `ProcessEvent` directly rather than `DispatchEvent` is the load-bearing
choice. Dump enrichment happens while rule evaluation, event-monitor consumers,
`LookupEventInProfiles`, and anomaly detection stay untouched. Routing through
`DispatchEvent` — for example by appending to `p.relatedEvents` — would make a
synthesized DNS event visible to rules, so a rule on `dns.question.name` would fire
twice for dump-traced workloads only. That is a config-dependent change in rule
semantics and is explicitly not wanted; `handleEarlyReturnEvents` returns false
today for the same reason.

The synthesized event needs no special handling downstream: `isEventValid`
(`activity_tree.go:436`) has no DNS-specific gate, and `ActivityDump.Insert`
needs only `ProcessCacheEntry`, type, timestamp, and the sample flag.

### Reaching the tree

No change. `InsertDNSEvent` (`process_node.go:443`) finds the `DNSNode` the request
created, matches the request entry by `Question.Type`, and calls
`mergeDNSResponse`, which unions IPs and CNAMEs up to their caps and deliberately
reports "nothing new" so answer rotation is not treated as profile drift.

## Correctness and edge cases

**Collision — poison, do not delete.** If a live entry exists for the key with a
different PCE, set its `entry` to `nil`: a tombstone that lives out the TTL, and
lookups on it return nil. Deleting instead would let a third request re-occupy the
key and claim the first request's answer, which is the mis-attribution this design
exists to avoid. Re-recording with the *same* PCE (a stub resolver retransmitting
with the same transaction ID) refreshes the deadline and stays live.

**Case normalisation.** DNS names are case-insensitive and some resolvers apply
0x20 randomisation, echoing the question with randomised capitalisation. The
request name comes from the kernel via `decodeDNSName`, the response name from
gopacket. Keying on the raw string would silently stop matching; the key lowercases
the name on both sides.

**Empty answers.** Skip correlation when the response carries no IPs and no CNAMEs
(NODATA). There is nothing to enrich and no reason to touch the table.

**Duplicate responses.** The entry is not consumed on match, so a duplicate or
retransmitted response merges idempotently — `mergeDNSResponse` already dedups.

**Question count.** Use `Questions[0]`, matching the existing full-response path.
qdcount > 1 does not occur in practice.

**Query types.** A and AAAA are distinct keys, so `nslookup`'s two queries
correlate independently.

**Process exit between request and response.** The map holds the PCE, so
`MatchesSelector` still works and the process node already exists in the tree.

**Expiry.** Checked lazily on lookup; the LRU capacity bounds memory regardless.

## Observability

Three counters in the existing `.dns_response_collector.` metric namespace, emitted
from `EBPFProbe.SendStats` alongside the existing `BPFFilterTruncated` pattern:

- `.dns_response_collector.ad_correlation_hits`
- `.dns_response_collector.ad_correlation_misses`
- `.dns_response_collector.ad_correlation_collisions`

A correlator that drops silently cannot be debugged in production; the collision
counter in particular is what tells us whether the accepted trade-off is costing
anything real.

## Testing

**Unit** (`dns_request_tracker_test.go`, pure Go, no eBPF): record-then-match hit;
miss on an unknown key; miss after TTL expiry; collision poisons and both sides
drop; same-PCE re-record refreshes the deadline; A and AAAA correlate
independently; case-insensitive match (0x20 randomisation); LRU capacity eviction.

**Acceptance**: remove the `t.Skip` from
`TestActivityDumps/activity-dump-cgroup-dns-response`
(`pkg/security/tests/activity_dumps_test.go:300`), which already asserts resolved
IPs reach the dump. Verified in KMT `kmt_run_secagent_tests_*_ad` on
`ubuntu_22.04, cws_ad`. Note that retrying a single KMT job does not re-provision
the metal instance — a failed run needs a fresh pipeline.

**Build**: gazelle to update `pkg/security/probe/BUILD.bazel`.

## Delivery

Stacked on PR 55843, which holds the consumer side and the skipped test. Branch
`daniel.zhou/CWS-6919-dns-response-attribution`, rebased onto main once 55843
merges.

Unlike 55843, this change is user-visible — activity dumps begin carrying resolved
IPs and CNAMEs — so it needs a reno release note.


</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
