### PR TITLE
[oracle] Schedule custom queries from individual start times

### DIFF
--- a/pkg/collector/corechecks/oracle/custom_queries.go
+++ b/pkg/collector/corechecks/oracle/custom_queries.go
@@ -73,38 +73,36 @@ func (c *Check) CustomQueries() error {
 	if len(c.customQueryLastRuns) != len(customQueries) {
 		c.customQueryLastRuns = make([]time.Time, len(customQueries))
 	}
-	queriesToRun := make([]config.CustomQuery, 0, len(customQueries))
-	now := c.clock.Now()
-	for i, query := range customQueries {
-		if shouldExecuteCustomQuery(&c.customQueryLastRuns[i], query.CollectionInterval, now) {
-			queriesToRun = append(queriesToRun, query)
-		}
-	}
-	if len(queriesToRun) == 0 {
-		return nil
-	}
-
-	/*
-	 * We are creating a dedicated DB connection for custom queries. Custom queries is
-	 * the only feature that switches to PDBs (all other queries are running against the
-	 * root container). Switching to PDB and subsequent query execution isn't atomic, so
-	 * there's no guarantee the both operations would get the same connection from the pool.
-	 */
-	if c.dbCustomQueries == nil {
-		db, err := c.Connect()
-		if err != nil {
-			closeDatabase(c, db)
-			return err
-		}
-		if db == nil {
-			return errors.New("empty connection")
-		}
-		c.dbCustomQueries = db
-	}
 
 	var metricRows []metricRow
 	var allErrors error
-	for _, q := range queriesToRun {
+	for i, q := range customQueries {
+		// Evaluate each query immediately before starting it. Using one timestamp for the
+		// entire batch would let an earlier slow query shorten the effective interval of
+		// every query that follows it.
+		if !shouldExecuteCustomQuery(&c.customQueryLastRuns[i], q.CollectionInterval, c.clock.Now()) {
+			continue
+		}
+
+		/*
+		 * We are creating a dedicated DB connection for custom queries. Custom queries is
+		 * the only feature that switches to PDBs (all other queries are running against the
+		 * root container). Switching to PDB and subsequent query execution isn't atomic, so
+		 * there's no guarantee the both operations would get the same connection from the pool.
+		 * The connection is created lazily so skipped queries do not open one unnecessarily.
+		 */
+		if c.dbCustomQueries == nil {
+			db, err := c.Connect()
+			if err != nil {
+				closeDatabase(c, db)
+				return err
+			}
+			if db == nil {
+				return errors.New("empty connection")
+			}
+			c.dbCustomQueries = db
+		}
+
 		metricRows = metricRows[:0]
 		var errInQuery bool
 		metricPrefix := q.MetricPrefix

--- a/pkg/collector/corechecks/oracle/custom_queries_test.go
+++ b/pkg/collector/corechecks/oracle/custom_queries_test.go
@@ -59,6 +59,20 @@ func TestCustomQueries(t *testing.T) {
 	sender.AssertMetricTaggedWith(t, "Gauge", "oracle.custom_query.test.c1", []string{"c2:A"})
 }
 
+type customQuerySequenceClock struct {
+	clock.Clock
+	times []time.Time
+}
+
+func (c *customQuerySequenceClock) Now() time.Time {
+	if len(c.times) == 0 {
+		panic("custom query sequence clock has no remaining times")
+	}
+	now := c.times[0]
+	c.times = c.times[1:]
+	return now
+}
+
 func TestCustomQueriesRespectIndependentCollectionIntervals(t *testing.T) {
 	db, dbMock, err := sqlmock.New()
 	require.NoError(t, err)
@@ -114,6 +128,106 @@ func TestCustomQueriesRespectIndependentCollectionIntervals(t *testing.T) {
 
 	assert.NoError(t, dbMock.ExpectationsWereMet())
 	sender.AssertNumberOfCalls(t, "Gauge", 5)
+}
+
+func TestCustomQueryIntervalsStartWhenEachQueryStarts(t *testing.T) {
+	db, dbMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	firstInterval := int64(300)
+	secondInterval := int64(60)
+	queries := []config.CustomQuery{
+		{
+			MetricPrefix:       "oracle.slow_first",
+			Query:              "SELECT 1 FROM slow_first",
+			Columns:            []config.CustomQueryColumns{{Name: "value", Type: "gauge"}},
+			CollectionInterval: &firstInterval,
+		},
+		{
+			MetricPrefix:       "oracle.later_query",
+			Query:              "SELECT 1 FROM later_query",
+			Columns:            []config.CustomQueryColumns{{Name: "value", Type: "gauge"}},
+			CollectionInterval: &secondInterval,
+		},
+	}
+
+	for _, query := range queries {
+		dbMock.ExpectExec("alter.*").WillReturnResult(sqlmock.NewResult(1, 1))
+		dbMock.ExpectQuery(query.Query).WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(1))
+	}
+
+	base := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	chk, sender := newDbDoesNotExistCheck(t, "", "")
+	sender.SetupAcceptAll()
+	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("Commit").Return()
+	chk.config.InstanceConfig.CustomQueries = queries
+	chk.dbCustomQueries = sqlx.NewDb(db, "sqlmock")
+	chk.clock = &customQuerySequenceClock{
+		Clock: clock.New(),
+		times: []time.Time{
+			base,                        // First query starts.
+			base.Add(120 * time.Second), // Second query starts after the first query completes.
+			base.Add(130 * time.Second), // Next check evaluates the first query.
+			base.Add(130 * time.Second), // Only 10 seconds have elapsed for the second query.
+		},
+	}
+
+	require.NoError(t, chk.CustomQueries())
+	require.NoError(t, chk.CustomQueries())
+
+	assert.NoError(t, dbMock.ExpectationsWereMet())
+	sender.AssertNumberOfCalls(t, "Gauge", 2)
+}
+
+func TestCustomQueryCanBecomeDueWhileEarlierQueryRuns(t *testing.T) {
+	db, dbMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	firstInterval := int64(300)
+	secondInterval := int64(60)
+	queries := []config.CustomQuery{
+		{
+			MetricPrefix:       "oracle.slow_first",
+			Query:              "SELECT 1 FROM slow_first",
+			Columns:            []config.CustomQueryColumns{{Name: "value", Type: "gauge"}},
+			CollectionInterval: &firstInterval,
+		},
+		{
+			MetricPrefix:       "oracle.later_query",
+			Query:              "SELECT 1 FROM later_query",
+			Columns:            []config.CustomQueryColumns{{Name: "value", Type: "gauge"}},
+			CollectionInterval: &secondInterval,
+		},
+	}
+
+	for _, query := range queries {
+		dbMock.ExpectExec("alter.*").WillReturnResult(sqlmock.NewResult(1, 1))
+		dbMock.ExpectQuery(query.Query).WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow(1))
+	}
+
+	base := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	chk, sender := newDbDoesNotExistCheck(t, "", "")
+	sender.SetupAcceptAll()
+	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("Commit").Return()
+	chk.config.InstanceConfig.CustomQueries = queries
+	chk.customQueryLastRuns = []time.Time{{}, base}
+	chk.dbCustomQueries = sqlx.NewDb(db, "sqlmock")
+	chk.clock = &customQuerySequenceClock{
+		Clock: clock.New(),
+		times: []time.Time{
+			base.Add(30 * time.Second), // The first query starts before the second query is due.
+			base.Add(61 * time.Second), // The second query becomes due while the first query runs.
+		},
+	}
+
+	require.NoError(t, chk.CustomQueries())
+
+	assert.NoError(t, dbMock.ExpectationsWereMet())
+	sender.AssertNumberOfCalls(t, "Gauge", 2)
 }
 
 func TestFailedCustomQueryAttemptConsumesCollectionInterval(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Evaluates each Oracle custom query's `collection_interval` immediately before that query starts instead of recording one shared timestamp for all due queries before sequential execution.

This ensures that:
- a slow earlier query does not shorten a later query's effective interval
- a later query that becomes due while an earlier query runs can execute during the same check run
- skipped queries do not create the dedicated custom-query connection unnecessarily

### Motivation

Follow-up to #56153. Automated review correctly identified that recording one timestamp before executing the entire query batch could make a later query run again before its configured interval had elapsed from its actual start.

### Describe how you validated your changes

- Added deterministic SQL-mock regressions covering both timing directions.
- Ran the focused Oracle custom-query tests.
- Ran the targeted Oracle Go linter.
- Built the Agent.
- Ran the Agent against a local Oracle Free sandbox with a 65-second first query followed by a query configured for a 60-second interval. The later query did not run on the check immediately after its delayed first execution; its first two emissions were at 22:36:25 and 22:37:29 UTC.
- Confirmed all sandbox metrics through the US1 Metrics API.

### Additional Notes

This corrects scheduling for the custom-query interval feature introduced by #56153 before release, so it does not need a separate customer-facing release note.
